### PR TITLE
Improve performance hot paths across the app

### DIFF
--- a/Sources/Ayna/App/AynaIOSApp.swift
+++ b/Sources/Ayna/App/AynaIOSApp.swift
@@ -30,6 +30,9 @@ struct AynaIOSApp: App {
         Message.attachmentLoader = { path in
             AttachmentStorage.shared.load(path: path)
         }
+        Message.attachmentAsyncLoader = { path in
+            await AttachmentStorage.shared.loadData(path: path)
+        }
 
         // Initialize conversation manager (use test store in UI test mode)
         let manager: ConversationManager = if UITestEnvironment.isEnabled {

--- a/Sources/Ayna/App/aynaApp.swift
+++ b/Sources/Ayna/App/aynaApp.swift
@@ -34,6 +34,9 @@ struct aynaApp: App {
         Message.attachmentLoader = { path in
             AttachmentStorage.shared.load(path: path)
         }
+        Message.attachmentAsyncLoader = { path in
+            await AttachmentStorage.shared.loadData(path: path)
+        }
 
         let manager: ConversationManager = if UITestEnvironment.isEnabled {
             UITestEnvironment.makeConversationManager()

--- a/Sources/Ayna/Models/Conversation.swift
+++ b/Sources/Ayna/Models/Conversation.swift
@@ -15,7 +15,7 @@ extension UTType {
 }
 
 /// Defines how the system prompt is resolved for a conversation.
-enum SystemPromptMode: Equatable {
+enum SystemPromptMode: Equatable, Sendable {
     /// Use the global system prompt from AppPreferences
     case inheritGlobal
     /// Use a custom system prompt specific to this conversation
@@ -66,7 +66,7 @@ enum SystemPromptMode: Equatable {
 
 extension SystemPromptMode: Codable {}
 
-struct Conversation: Identifiable, Equatable {
+struct Conversation: Identifiable, Equatable, Sendable {
     let id: UUID
     var title: String
     var messages: [Message]

--- a/Sources/Ayna/Models/Message.swift
+++ b/Sources/Ayna/Models/Message.swift
@@ -24,7 +24,7 @@ struct CitationReference: Codable, Equatable, Sendable {
     }
 }
 
-struct Message: Identifiable, Codable, Equatable {
+struct Message: Identifiable, Codable, Equatable, Sendable {
     let id: UUID
     var role: Role
     var content: String
@@ -64,7 +64,7 @@ struct Message: Identifiable, Codable, Equatable {
         case image
     }
 
-    struct FileAttachment: Codable, Equatable {
+    struct FileAttachment: Codable, Equatable, Sendable {
         let fileName: String
         let mimeType: String
         var data: Data?
@@ -78,6 +78,13 @@ struct Message: Identifiable, Codable, Equatable {
                 return Message.attachmentLoader?(path)
             }
             return nil
+        }
+
+        /// Async loader that avoids blocking the current actor on disk I/O.
+        func loadContent() async -> Data? {
+            if let data { return data }
+            guard let path = localPath else { return nil }
+            return await Message.loadAttachmentData(at: path)
         }
     }
 
@@ -242,6 +249,23 @@ struct Message: Identifiable, Codable, Equatable {
         return nil
     }
 
+    /// Async loader that avoids blocking the current actor on attachment I/O.
+    func loadEffectiveImageData() async -> Data? {
+        if let data = imageData { return data }
+        guard let path = imagePath else { return nil }
+        return await Message.loadAttachmentData(at: path)
+    }
+
     /// Static loader to decouple from AttachmentStorage
     @MainActor static var attachmentLoader: ((String) -> Data?)?
+    @MainActor static var attachmentAsyncLoader: (@Sendable (String) async -> Data?)?
+
+    private static func loadAttachmentData(at path: String) async -> Data? {
+        if let asyncLoader = await MainActor.run(body: { attachmentAsyncLoader }) {
+            return await asyncLoader(path)
+        }
+        return await MainActor.run {
+            attachmentLoader?(path)
+        }
+    }
 }

--- a/Sources/Ayna/Models/ResponseGroup.swift
+++ b/Sources/Ayna/Models/ResponseGroup.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Status of a response in a multi-model response group
-enum ResponseGroupStatus: String, Codable, Equatable {
+enum ResponseGroupStatus: String, Codable, Equatable, Sendable {
     case streaming // Currently receiving chunks
     case completed // Finished streaming
     case failed // Error occurred
@@ -16,7 +16,7 @@ enum ResponseGroupStatus: String, Codable, Equatable {
 }
 
 /// An entry tracking a single model's response within a ResponseGroup
-struct ResponseGroupEntry: Identifiable, Codable, Equatable {
+struct ResponseGroupEntry: Identifiable, Codable, Equatable, Sendable {
     let id: UUID // Same as the Message.id
     let modelName: String
     var status: ResponseGroupStatus
@@ -24,7 +24,7 @@ struct ResponseGroupEntry: Identifiable, Codable, Equatable {
 
 /// Represents a group of parallel responses from multiple AI models
 /// for a single user prompt in multi-model mode.
-struct ResponseGroup: Identifiable, Codable, Equatable {
+struct ResponseGroup: Identifiable, Codable, Equatable, Sendable {
     let id: UUID
     let userMessageId: UUID // The user message that triggered these responses
     var responses: [ResponseGroupEntry] // All model responses in this group

--- a/Sources/Ayna/Services/AnthropicStreamParser.swift
+++ b/Sources/Ayna/Services/AnthropicStreamParser.swift
@@ -8,6 +8,12 @@
 import Foundation
 import os
 
+private enum AnthropicStreamParserLimits {
+    static let initialBlockBufferCapacity = 1024
+    static let maxToolInputSize = 10_485_760 // 10MB
+    static let maxSignatureSize = 65_536 // 64KB
+}
+
 /// Result from parsing Anthropic SSE events
 struct AnthropicStreamResult: Sendable {
     let shouldComplete: Bool
@@ -51,7 +57,7 @@ struct AnthropicBlockState {
 
     init(type: AnthropicContentBlockType, toolName: String? = nil, toolId: String? = nil) {
         self.type = type
-        buffer = Data()
+        buffer = Data(capacity: AnthropicStreamParserLimits.initialBlockBufferCapacity)
         self.toolName = toolName
         self.toolId = toolId
     }
@@ -73,8 +79,8 @@ struct AnthropicBlockState {
 /// - Error events
 ///
 /// Note: This parser maintains mutable state and should only be used from a single
-/// task/actor context. It is used exclusively within `AnthropicProvider` which is
-/// `@MainActor`, ensuring sequential access to the parser's state.
+/// task context. `AnthropicProvider` drives it from a single streaming task, ensuring
+/// sequential access to the parser's state.
 final class AnthropicStreamParser {
     // MARK: - State
 
@@ -276,8 +282,7 @@ final class AnthropicStreamParser {
             if let partialJson = delta["partial_json"] as? String,
                let partialData = partialJson.data(using: .utf8)
             {
-                let maxToolInputSize = 10_485_760 // 10MB
-                if (activeBlocks[index]?.buffer.count ?? 0) + partialData.count <= maxToolInputSize {
+                if (activeBlocks[index]?.buffer.count ?? 0) + partialData.count <= AnthropicStreamParserLimits.maxToolInputSize {
                     activeBlocks[index]?.buffer.append(partialData)
                 }
             }
@@ -287,7 +292,9 @@ final class AnthropicStreamParser {
             if let signature = delta["signature"] as? String,
                let sigData = signature.data(using: .utf8)
             {
-                activeBlocks[index]?.buffer.append(sigData)
+                if (activeBlocks[index]?.buffer.count ?? 0) + sigData.count <= AnthropicStreamParserLimits.maxSignatureSize {
+                    activeBlocks[index]?.buffer.append(sigData)
+                }
             }
 
         default:

--- a/Sources/Ayna/Services/AttachmentStorage.swift
+++ b/Sources/Ayna/Services/AttachmentStorage.swift
@@ -58,16 +58,25 @@ final class AttachmentStorage: Sendable {
     static let shared = AttachmentStorage()
 
     private let attachmentsDirectory: URL
-    private let dataCache = AttachmentDataCache.shared
+    private let dataCache: AttachmentDataCache
 
-    init() {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+    init(
+        directoryURL: URL? = nil,
+        dataCache: AttachmentDataCache = .shared
+    ) {
+        self.dataCache = dataCache
+        let fileManager = FileManager.default
 
-        attachmentsDirectory = appSupport.appendingPathComponent("Ayna/Attachments", isDirectory: true)
+        if let directoryURL {
+            attachmentsDirectory = directoryURL
+        } else {
+            let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+                .first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+            attachmentsDirectory = appSupport.appendingPathComponent("Ayna/Attachments", isDirectory: true)
+        }
 
         do {
-            try FileManager.default.createDirectory(
+            try fileManager.createDirectory(
                 at: attachmentsDirectory, withIntermediateDirectories: true
             )
             DiagnosticsLogger.log(
@@ -93,6 +102,7 @@ final class AttachmentStorage: Sendable {
 
         do {
             try data.write(to: fileURL, options: .atomic)
+            dataCache.set(data, forKey: filename)
             DiagnosticsLogger.log(
                 .attachmentStorage,
                 level: .info,
@@ -111,6 +121,11 @@ final class AttachmentStorage: Sendable {
         }
     }
 
+    /// Returns cached data without touching disk.
+    func cachedData(path: String) -> Data? {
+        dataCache.get(path)
+    }
+
     /// Loads data from a relative path, using cache to avoid repeated disk I/O
     func load(path: String) -> Data? {
         // Check cache first
@@ -118,22 +133,21 @@ final class AttachmentStorage: Sendable {
             return cached
         }
 
-        // Load from disk
         let fileURL = attachmentsDirectory.appendingPathComponent(path)
-        do {
-            let data = try Data(contentsOf: fileURL)
-            // Cache the data for future access
-            dataCache.set(data, forKey: path)
-            return data
-        } catch {
-            DiagnosticsLogger.log(
-                .attachmentStorage,
-                level: .error,
-                message: "Failed to load attachment",
-                metadata: ["error": error.localizedDescription, "path": path]
-            )
-            return nil
+        return Self.readData(at: fileURL, path: path, cache: dataCache)
+    }
+
+    /// Loads data from disk off the caller's actor, caching the result for future access.
+    func loadData(path: String) async -> Data? {
+        if let cached = dataCache.get(path) {
+            return cached
         }
+
+        let fileURL = attachmentsDirectory.appendingPathComponent(path)
+        let dataCache = dataCache
+        return await Task.detached(priority: .userInitiated) {
+            Self.readData(at: fileURL, path: path, cache: dataCache)
+        }.value
     }
 
     /// Deletes a file at the given relative path
@@ -163,5 +177,25 @@ final class AttachmentStorage: Sendable {
     /// Returns the full URL for a relative path (useful for QuickLook or sharing)
     func fileURL(for path: String) -> URL {
         attachmentsDirectory.appendingPathComponent(path)
+    }
+
+    private nonisolated static func readData(
+        at fileURL: URL,
+        path: String,
+        cache: AttachmentDataCache
+    ) -> Data? {
+        do {
+            let data = try Data(contentsOf: fileURL)
+            cache.set(data, forKey: path)
+            return data
+        } catch {
+            DiagnosticsLogger.log(
+                .attachmentStorage,
+                level: .error,
+                message: "Failed to load attachment",
+                metadata: ["error": error.localizedDescription, "path": path]
+            )
+            return nil
+        }
     }
 }

--- a/Sources/Ayna/Services/BuiltinToolService+WebFetch.swift
+++ b/Sources/Ayna/Services/BuiltinToolService+WebFetch.swift
@@ -25,233 +25,40 @@ import os.log
 
             log(.info, "web_fetch requested", metadata: ["url": url])
 
-            // Validate URL
-            guard let parsedURL = URL(string: url),
-                  let host = parsedURL.host,
-                  parsedURL.scheme == "https" || parsedURL.scheme == "http"
-            else {
-                throw ToolExecutionError.invalidPath(path: url, reason: "Invalid URL format")
-            }
-
-            // SSRF protection: Block internal/private IPs
-            // Also resolves DNS to prevent DNS rebinding attacks
-            if await resolveAndCheckHost(host) {
-                throw ToolExecutionError.invalidPath(path: url, reason: "Access to internal addresses is not allowed")
-            }
-
-            // Fetch with timeout
-            var request = URLRequest(url: parsedURL)
-            request.httpMethod = "GET"
-            request.timeoutInterval = TimeInterval(commandTimeoutSeconds)
-            request.setValue("Ayna/1.0", forHTTPHeaderField: "User-Agent")
-
-            let session = URLSession(configuration: .ephemeral, delegate: SSRFRedirectValidator(), delegateQueue: nil)
-            defer { session.invalidateAndCancel() }
-            let (data, response) = try await session.data(for: request)
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw ToolExecutionError.commandFailed(command: "web_fetch", exitCode: -1, stderr: "Invalid response")
-            }
-
-            guard (200 ... 299).contains(httpResponse.statusCode) else {
-                throw ToolExecutionError.commandFailed(
-                    command: "web_fetch",
-                    exitCode: Int32(httpResponse.statusCode),
-                    stderr: "HTTP \(httpResponse.statusCode)"
+            do {
+                let result = try await WebFetchRequestExecutor.fetchText(
+                    from: url,
+                    timeoutSeconds: TimeInterval(commandTimeoutSeconds),
+                    maxResponseSize: maxReadSize
                 )
-            }
 
-            // Check content size (10 MB limit)
-            guard data.count <= maxReadSize else {
-                throw ToolExecutionError.resourceLimitExceeded(
-                    resource: "response size",
-                    limit: "\(maxReadSize / 1024 / 1024) MB"
-                )
-            }
-
-            guard let content = String(data: data, encoding: .utf8) else {
-                throw ToolExecutionError.binaryFileUnsupported(path: url)
-            }
-
-            // Convert HTML to plain text if content appears to be HTML
-            let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type") ?? ""
-            let result = if contentType.contains("text/html") || content.contains("<html") {
-                htmlToPlainText(content)
-            } else {
-                content
-            }
-
-            log(.info, "web_fetch completed", metadata: ["url": url, "size": "\(result.count)"])
-            return result
-        }
-
-        /// Checks if a host is a private/internal address (SSRF protection)
-        func isPrivateHost(_ host: String) -> Bool {
-            let lowercased = host.lowercased()
-
-            // Localhost variants
-            if lowercased == "localhost" || lowercased == "127.0.0.1" || lowercased == "::1" {
-                return true
-            }
-
-            // Block 0.0.0.0 (binds to all interfaces)
-            if lowercased == "0.0.0.0" {
-                return true
-            }
-
-            // Check if it's an IP address in private ranges
-            if isPrivateIPAddress(lowercased) {
-                return true
-            }
-
-            return false
-        }
-
-        /// Checks if an IP address string is in private/internal ranges
-        func isPrivateIPAddress(_ address: String) -> Bool {
-            let lowercased = address.lowercased()
-
-            // IPv6 private/local ranges
-            // fd00::/8 - Unique local addresses
-            if lowercased.hasPrefix("fd") {
-                return true
-            }
-            // fe80::/10 - Link-local addresses
-            if lowercased.hasPrefix("fe80:") {
-                return true
-            }
-            // fc00::/7 - Unique local addresses (includes fd00::/8)
-            if lowercased.hasPrefix("fc") {
-                return true
-            }
-            // ::1 - IPv6 loopback
-            if lowercased == "::1" {
-                return true
-            }
-
-            // Check for IPv4 addresses in private ranges
-            let parts = lowercased.split(separator: ".")
-            if parts.count == 4, let first = Int(parts[0]), let second = Int(parts[1]) {
-                // 127.x.x.x - Loopback
-                if first == 127 { return true }
-                // 10.x.x.x
-                if first == 10 { return true }
-                // 172.16.x.x - 172.31.x.x
-                if first == 172, (16 ... 31).contains(second) { return true }
-                // 192.168.x.x
-                if first == 192, second == 168 { return true }
-                // 169.254.x.x (link-local, includes cloud metadata 169.254.169.254)
-                if first == 169, second == 254 { return true }
-                // 0.x.x.x - "This" network
-                if first == 0 { return true }
-                // RFC 6598 CGNAT (100.64.0.0/10)
-                if first == 100, (64 ... 127).contains(second) { return true }
-                // RFC 2544 Benchmark (198.18.0.0/15)
-                if first == 198, (18 ... 19).contains(second) { return true }
-            }
-
-            return false
-        }
-
-        /// Resolves a hostname to IP addresses and checks if any are private (DNS rebinding protection)
-        func resolveAndCheckHost(_ host: String) async -> Bool {
-            // First check the hostname string itself
-            if isPrivateHost(host) {
-                return true
-            }
-
-            // Resolve DNS and check all returned IP addresses
-            // This prevents DNS rebinding attacks where a hostname initially resolves
-            // to a public IP but later resolves to a private IP
-            let hostRef = CFHostCreateWithName(nil, host as CFString).takeRetainedValue()
-            var resolved = DarwinBoolean(false)
-
-            CFHostStartInfoResolution(hostRef, .addresses, nil)
-            guard let addresses = CFHostGetAddressing(hostRef, &resolved)?.takeUnretainedValue() as? [Data],
-                  resolved.boolValue
-            else {
-                // If DNS resolution fails, allow the request to proceed
-                // URLSession will handle the error appropriately
-                return false
-            }
-
-            for addressData in addresses {
-                let ipString = addressData.withUnsafeBytes { pointer -> String? in
-                    guard let sockaddr = pointer.baseAddress?.assumingMemoryBound(to: sockaddr.self) else {
-                        return nil
-                    }
-
-                    if sockaddr.pointee.sa_family == UInt8(AF_INET) {
-                        // IPv4
-                        var addr = sockaddr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee }
-                        var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
-                        inet_ntop(AF_INET, &addr.sin_addr, &buffer, socklen_t(INET_ADDRSTRLEN))
-                        return String(cString: buffer)
-                    } else if sockaddr.pointee.sa_family == UInt8(AF_INET6) {
-                        // IPv6
-                        var addr = sockaddr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { $0.pointee }
-                        var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
-                        inet_ntop(AF_INET6, &addr.sin6_addr, &buffer, socklen_t(INET6_ADDRSTRLEN))
-                        return String(cString: buffer)
-                    }
-                    return nil
-                }
-
-                if let ip = ipString, isPrivateIPAddress(ip) {
-                    log(.default, "DNS rebinding protection: \(host) resolved to private IP \(ip)")
-                    return true
+                log(.info, "web_fetch completed", metadata: ["url": url, "size": "\(result.count)"])
+                return result
+            } catch let error as WebFetchError {
+                switch error {
+                case .serviceDisabled:
+                    throw ToolExecutionError.serviceDisabled
+                case .invalidURL:
+                    throw ToolExecutionError.invalidPath(path: url, reason: "Invalid URL format")
+                case .ssrfBlocked:
+                    throw ToolExecutionError.invalidPath(path: url, reason: "Access to internal addresses is not allowed")
+                case let .httpError(statusCode):
+                    throw ToolExecutionError.commandFailed(
+                        command: "web_fetch",
+                        exitCode: Int32(statusCode),
+                        stderr: "HTTP \(statusCode)"
+                    )
+                case .responseToLarge:
+                    throw ToolExecutionError.resourceLimitExceeded(
+                        resource: "response size",
+                        limit: "\(maxReadSize / 1024 / 1024) MB"
+                    )
+                case .binaryContent:
+                    throw ToolExecutionError.binaryFileUnsupported(path: url)
+                case let .networkError(underlying):
+                    throw ToolExecutionError.commandFailed(command: "web_fetch", exitCode: -1, stderr: underlying)
                 }
             }
-
-            return false
-        }
-
-        /// Converts HTML to plain text by stripping tags
-        func htmlToPlainText(_ html: String) -> String {
-            var text = html
-
-            // Remove script and style content
-            text = text.replacingOccurrences(
-                of: "(?s)<script[^>]*>.*?</script>",
-                with: "",
-                options: [.regularExpression, .caseInsensitive]
-            )
-            text = text.replacingOccurrences(
-                of: "(?s)<style[^>]*>.*?</style>",
-                with: "",
-                options: [.regularExpression, .caseInsensitive]
-            )
-
-            // Replace block elements with newlines
-            text = text.replacingOccurrences(
-                of: "<(br|p|div|h[1-6]|li|tr)[^>]*>",
-                with: "\n",
-                options: [.regularExpression, .caseInsensitive]
-            )
-
-            // Remove all remaining tags
-            text = text.replacingOccurrences(
-                of: "<[^>]+>",
-                with: "",
-                options: .regularExpression
-            )
-
-            // Decode HTML entities
-            text = text.replacingOccurrences(of: "&nbsp;", with: " ")
-            text = text.replacingOccurrences(of: "&amp;", with: "&")
-            text = text.replacingOccurrences(of: "&lt;", with: "<")
-            text = text.replacingOccurrences(of: "&gt;", with: ">")
-            text = text.replacingOccurrences(of: "&quot;", with: "\"")
-            text = text.replacingOccurrences(of: "&#39;", with: "'")
-
-            // Collapse multiple newlines
-            text = text.replacingOccurrences(
-                of: "\n{3,}",
-                with: "\n\n",
-                options: .regularExpression
-            )
-
-            return text.trimmingCharacters(in: .whitespacesAndNewlines)
         }
     }
 #endif

--- a/Sources/Ayna/Services/ConversationPersistenceCoordinator.swift
+++ b/Sources/Ayna/Services/ConversationPersistenceCoordinator.swift
@@ -109,24 +109,12 @@ actor ConversationPersistenceCoordinator {
         let conversationsToSave = pendingSaves
         pendingSaves.removeAll()
 
-        for (id, conversation) in conversationsToSave {
-            do {
-                try await store.save(conversation)
-                DiagnosticsLogger.log(
-                    .conversationManager,
-                    level: .info,
-                    message: "💾 Flushed pending conversation save on shutdown",
-                    metadata: ["id": id.uuidString]
-                )
-            } catch {
-                DiagnosticsLogger.log(
-                    .conversationManager,
-                    level: .error,
-                    message: "❌ Failed to flush conversation on shutdown",
-                    metadata: ["id": id.uuidString, "error": error.localizedDescription]
-                )
-            }
-        }
+        await persistConversations(
+            conversationsToSave,
+            successMessage: "💾 Flushed pending conversation save on shutdown",
+            failureMessage: "❌ Failed to flush conversation on shutdown",
+            notifyOnFailure: false
+        )
     }
 
     /// Returns the set of conversation IDs that currently have a pending save queued.
@@ -142,51 +130,77 @@ actor ConversationPersistenceCoordinator {
         let conversationsToSave = pendingSaves
         pendingSaves.removeAll()
 
-        // B39: Track which items were saved or error-handled so we can requeue the rest on cancellation.
-        var handledIds = Set<UUID>()
-
-        for (id, conversation) in conversationsToSave {
-            // B39: Break (not continue) so unprocessed items can be requeued below.
-            guard !Task.isCancelled else { break }
-
-            do {
-                try await store.save(conversation)
-                handledIds.insert(id)
-                DiagnosticsLogger.log(
-                    .conversationManager,
-                    level: .debug,
-                    message: "💾 Saved conversation (debounced)",
-                    metadata: ["id": id.uuidString]
-                )
-            } catch {
-                handledIds.insert(id)
-                DiagnosticsLogger.log(
-                    .conversationManager,
-                    level: .error,
-                    message: "❌ Failed to save conversation",
-                    metadata: ["id": id.uuidString, "error": error.localizedDescription]
-                )
-                // Post notification so ConversationManager can reload from disk
-                // This ensures in-memory state doesn't diverge from persisted state
-                await MainActor.run {
-                    NotificationCenter.default.post(
-                        name: .conversationSaveFailed,
-                        object: nil,
-                        userInfo: ["conversationId": id]
-                    )
-                }
-            }
+        guard !Task.isCancelled else {
+            requeuePendingConversations(conversationsToSave)
+            return
         }
 
-        // B39: Requeue any items skipped due to Task cancellation, unless a newer
-        // version was already enqueued by enqueueSave during a suspension point.
-        for (id, conversation) in conversationsToSave where !handledIds.contains(id) {
-            if pendingSaves[id] == nil {
-                pendingSaves[id] = conversation
-            }
-        }
+        await persistConversations(
+            conversationsToSave,
+            successMessage: "💾 Saved conversation (debounced)",
+            failureMessage: "❌ Failed to save conversation",
+            notifyOnFailure: true
+        )
+
         // B32: activeSaveTasks entries are NOT removed here. enqueueSave is the sole
         // writer to activeSaveTasks[id], ensuring a newer task is never accidentally
         // removed after an await suspension in store.save().
+    }
+
+    private func persistConversations(
+        _ conversationsToSave: [UUID: Conversation],
+        successMessage: String,
+        failureMessage: String,
+        notifyOnFailure: Bool
+    ) async {
+        guard !conversationsToSave.isEmpty else { return }
+
+        let persistenceStore = store
+        await withTaskGroup(of: (UUID, Result<Void, Error>).self) { group in
+            for (id, conversation) in conversationsToSave {
+                group.addTask {
+                    do {
+                        try await persistenceStore.save(conversation)
+                        return (id, .success(()))
+                    } catch {
+                        return (id, .failure(error))
+                    }
+                }
+            }
+
+            for await (id, result) in group {
+                switch result {
+                case .success:
+                    DiagnosticsLogger.log(
+                        .conversationManager,
+                        level: .debug,
+                        message: successMessage,
+                        metadata: ["id": id.uuidString]
+                    )
+                case let .failure(error):
+                    DiagnosticsLogger.log(
+                        .conversationManager,
+                        level: .error,
+                        message: failureMessage,
+                        metadata: ["id": id.uuidString, "error": error.localizedDescription]
+                    )
+
+                    guard notifyOnFailure else { continue }
+                    await MainActor.run {
+                        NotificationCenter.default.post(
+                            name: .conversationSaveFailed,
+                            object: nil,
+                            userInfo: ["conversationId": id]
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private func requeuePendingConversations(_ conversationsToSave: [UUID: Conversation]) {
+        for (id, conversation) in conversationsToSave where pendingSaves[id] == nil {
+            pendingSaves[id] = conversation
+        }
     }
 }

--- a/Sources/Ayna/Services/DuckDuckGoSearchService.swift
+++ b/Sources/Ayna/Services/DuckDuckGoSearchService.swift
@@ -53,19 +53,23 @@ final class DuckDuckGoSearchService {
 
     // MARK: - Private Properties
 
+    private static let defaultSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = Constants.timeoutSeconds
+        config.timeoutIntervalForResource = Constants.timeoutSeconds
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.urlCache = nil
+        config.httpCookieAcceptPolicy = .never
+        config.httpShouldSetCookies = false
+        return URLSession(configuration: config)
+    }()
+
     private let urlSession: URLSession
 
     // MARK: - Initialization
 
     init(urlSession: URLSession? = nil) {
-        if let urlSession {
-            self.urlSession = urlSession
-        } else {
-            let config = URLSessionConfiguration.ephemeral
-            config.timeoutIntervalForRequest = Constants.timeoutSeconds
-            config.timeoutIntervalForResource = Constants.timeoutSeconds
-            self.urlSession = URLSession(configuration: config)
-        }
+        self.urlSession = urlSession ?? Self.defaultSession
     }
 
     // MARK: - Public Methods
@@ -178,7 +182,7 @@ final class DuckDuckGoSearchService {
         let linkMatches = html.matches(of: linkRegex)
         var results: [WebSearchResult] = []
 
-        for (i, linkMatch) in linkMatches.prefix(maxResults).enumerated() {
+        for (index, linkMatch) in linkMatches.prefix(maxResults).enumerated() {
             let rawURL = String(linkMatch.output.1)
             let rawTitle = String(linkMatch.output.2)
 
@@ -190,7 +194,7 @@ final class DuckDuckGoSearchService {
 
             // Find snippet between this link and the next link (or end of HTML)
             let searchStart = linkMatch.range.upperBound
-            let searchEnd = (i + 1 < linkMatches.count) ? linkMatches[i + 1].range.lowerBound : html.endIndex
+            let searchEnd = (index + 1 < linkMatches.count) ? linkMatches[index + 1].range.lowerBound : html.endIndex
             let searchRange = searchStart ..< searchEnd
             let searchSlice = html[searchRange]
 
@@ -245,22 +249,7 @@ final class DuckDuckGoSearchService {
 
     /// Strips HTML tags and decodes common HTML entities.
     func stripHTMLTags(_ string: String) -> String {
-        let tagRegex = /<[^>]+>/
-        var result = string.replacing(tagRegex, with: "")
-
-        let entities: [(String, String)] = [
-            ("&amp;", "&"),
-            ("&lt;", "<"),
-            ("&gt;", ">"),
-            ("&quot;", "\""),
-            ("&#39;", "'"),
-            ("&nbsp;", " "),
-        ]
-        for (entity, replacement) in entities {
-            result = result.replacingOccurrences(of: entity, with: replacement)
-        }
-
-        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+        WebTextExtractor.plainText(fromHTMLFragment: string)
     }
 
     // MARK: - Logging

--- a/Sources/Ayna/Services/EncryptedConversationStore.swift
+++ b/Sources/Ayna/Services/EncryptedConversationStore.swift
@@ -30,6 +30,51 @@ final class EncryptedConversationStore: Sendable {
     private let legacyFileURL: URL
     private let keyIdentifier: String
     private let keychain: KeychainStoring
+    private let encryptionKeyCache: EncryptionKeyCache
+
+    private final class EncryptionKeyCache: @unchecked Sendable {
+        private let keyIdentifier: String
+        private let keychain: KeychainStoring
+        private let lock = NSLock()
+        private var cachedKeyData: Data?
+
+        init(keyIdentifier: String, keychain: KeychainStoring) {
+            self.keyIdentifier = keyIdentifier
+            self.keychain = keychain
+        }
+
+        func keyData() throws -> Data {
+            lock.lock()
+            defer { lock.unlock() }
+
+            if let cachedKeyData {
+                return cachedKeyData
+            }
+
+            let flagKey = "\(keyIdentifier)_initialized"
+
+            if let existing = try keychain.data(for: keyIdentifier) {
+                cachedKeyData = existing
+                return existing
+            }
+
+            if (try? keychain.string(for: flagKey)) != nil {
+                DiagnosticsLogger.log(
+                    .encryptedStore,
+                    level: .error,
+                    message: "❌ Encryption key missing but initialization flag exists - possible key loss"
+                )
+                throw EncryptedStoreError.keyLost
+            }
+
+            let newKey = SymmetricKey(size: .bits256)
+            let newKeyData = newKey.withUnsafeBytes { Data($0) }
+            try keychain.setData(newKeyData, for: keyIdentifier)
+            try keychain.setString("1", for: flagKey)
+            cachedKeyData = newKeyData
+            return newKeyData
+        }
+    }
 
     init(
         directoryURL: URL? = nil,
@@ -60,6 +105,7 @@ final class EncryptedConversationStore: Sendable {
         legacyFileURL = baseDirectory.appendingPathComponent("conversations.enc")
         self.keyIdentifier = keyIdentifier
         self.keychain = keychain
+        encryptionKeyCache = EncryptionKeyCache(keyIdentifier: keyIdentifier, keychain: keychain)
     }
 
     private func log(
@@ -73,23 +119,23 @@ final class EncryptedConversationStore: Sendable {
     func loadConversations() async throws -> [Conversation] {
         let directoryURL = directoryURL
         let legacyFileURL = legacyFileURL
-        let keyIdentifier = keyIdentifier
-        let keychain = keychain
+        let keyCache = encryptionKeyCache
 
         return try await Task.detached(priority: .userInitiated) {
             // 1. Check for legacy file and migrate if needed
             if FileManager.default.fileExists(atPath: legacyFileURL.path) {
+                let keyData = try keyCache.keyData()
                 DiagnosticsLogger.log(
                     .encryptedStore, level: .info, message: "Found legacy conversation file, migrating..."
                 )
                 do {
                     let conversations = try Self.loadLegacyFile(
-                        at: legacyFileURL, keyIdentifier: keyIdentifier, keychain: keychain
+                        at: legacyFileURL, keyData: keyData
                     )
                     // Save all to new format
                     for conversation in conversations {
                         try Self.save(
-                            conversation, to: directoryURL, keyIdentifier: keyIdentifier, keychain: keychain
+                            conversation, to: directoryURL, keyData: keyData
                         )
                     }
                     // Delete legacy file
@@ -109,13 +155,20 @@ final class EncryptedConversationStore: Sendable {
             let fileURLs = try FileManager.default.contentsOfDirectory(
                 at: directoryURL, includingPropertiesForKeys: nil
             )
+            let encryptedFileURLs = fileURLs.filter { $0.pathExtension == "enc" }
+
+            guard !encryptedFileURLs.isEmpty else {
+                return []
+            }
+
+            let keyData = try keyCache.keyData()
 
             return await withTaskGroup(of: Conversation?.self) { group in
-                for url in fileURLs where url.pathExtension == "enc" {
+                for url in encryptedFileURLs {
                     group.addTask {
                         do {
                             return try Self.load(
-                                from: url, keyIdentifier: keyIdentifier, keychain: keychain
+                                from: url, keyData: keyData
                             )
                         } catch {
                             DiagnosticsLogger.log(
@@ -150,12 +203,12 @@ final class EncryptedConversationStore: Sendable {
 
     func save(_ conversation: Conversation) async throws {
         let directoryURL = directoryURL
-        let keyIdentifier = keyIdentifier
-        let keychain = keychain
+        let keyCache = encryptionKeyCache
 
         try await Task.detached(priority: .userInitiated) {
+            let keyData = try keyCache.keyData()
             try Self.save(
-                conversation, to: directoryURL, keyIdentifier: keyIdentifier, keychain: keychain
+                conversation, to: directoryURL, keyData: keyData
             )
         }.value
     }
@@ -193,61 +246,32 @@ final class EncryptedConversationStore: Sendable {
 
     // MARK: - Helpers
 
-    private nonisolated static func getEncryptionKey(keyIdentifier: String, keychain: KeychainStoring) throws
-        -> SymmetricKey
-    {
-        let flagKey = "\(keyIdentifier)_initialized"
-
-        if let existing = try keychain.data(for: keyIdentifier) {
-            return SymmetricKey(data: existing)
-        }
-
-        // Check if we previously had a key (flag exists but key is missing)
-        if (try? keychain.string(for: flagKey)) != nil {
-            // Key was deleted/corrupted but flag exists - don't silently generate new key
-            // This would orphan all existing encrypted data
-            DiagnosticsLogger.log(
-                .encryptedStore,
-                level: .error,
-                message: "❌ Encryption key missing but initialization flag exists - possible key loss"
-            )
-            throw EncryptedStoreError.keyLost
-        }
-
-        // First-time setup: generate new key and set initialization flag
-        let newKey = SymmetricKey(size: .bits256)
-        let keyData = newKey.withUnsafeBytes { Data($0) }
-        try keychain.setData(keyData, for: keyIdentifier)
-        try keychain.setString("1", for: flagKey)
-        return newKey
-    }
-
-    private nonisolated static func loadLegacyFile(at url: URL, keyIdentifier: String, keychain: KeychainStoring)
+    private nonisolated static func loadLegacyFile(at url: URL, keyData: Data)
         throws -> [Conversation]
     {
         let encryptedData = try Data(contentsOf: url)
         let box = try AES.GCM.SealedBox(combined: encryptedData)
-        let key = try getEncryptionKey(keyIdentifier: keyIdentifier, keychain: keychain)
+        let key = SymmetricKey(data: keyData)
         let plaintext = try AES.GCM.open(box, using: key)
         return try JSONDecoder().decode([Conversation].self, from: plaintext)
     }
 
-    private nonisolated static func load(from url: URL, keyIdentifier: String, keychain: KeychainStoring) throws
-        -> Conversation
+    private nonisolated static func load(from url: URL, keyData: Data) throws -> Conversation
     {
         let encryptedData = try Data(contentsOf: url)
         let box = try AES.GCM.SealedBox(combined: encryptedData)
-        let key = try getEncryptionKey(keyIdentifier: keyIdentifier, keychain: keychain)
+        let key = SymmetricKey(data: keyData)
         let plaintext = try AES.GCM.open(box, using: key)
         return try JSONDecoder().decode(Conversation.self, from: plaintext)
     }
 
     private nonisolated static func save(
-        _ conversation: Conversation, to directory: URL, keyIdentifier: String,
-        keychain: KeychainStoring
+        _ conversation: Conversation,
+        to directory: URL,
+        keyData: Data
     ) throws {
         let encoded = try JSONEncoder().encode(conversation)
-        let key = try getEncryptionKey(keyIdentifier: keyIdentifier, keychain: keychain)
+        let key = SymmetricKey(data: keyData)
         let sealed = try AES.GCM.seal(encoded, using: key)
         guard let combined = sealed.combined else {
             throw KeychainStorageError.unexpectedStatus(errSecParam)

--- a/Sources/Ayna/Services/MCPService.swift
+++ b/Sources/Ayna/Services/MCPService.swift
@@ -32,6 +32,94 @@ protocol MCPServiceDelegate: AnyObject {
     func mcpService(_ service: MCPServicing, didTerminateWithError error: String?)
 }
 
+private final class PendingMCPRequestStore: @unchecked Sendable {
+    private struct Entry {
+        let continuation: CheckedContinuation<MCPResponse, Error>
+        let timeoutTask: Task<Void, Never>
+    }
+
+    private let timeoutSeconds: TimeInterval
+    private let lock = NSLock()
+    private var entries: [Int: Entry] = [:]
+
+    init(timeoutSeconds: TimeInterval) {
+        self.timeoutSeconds = timeoutSeconds
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries.count
+    }
+
+    func insert(id: Int, method: String, continuation: CheckedContinuation<MCPResponse, Error>) {
+        let timeoutSeconds = self.timeoutSeconds
+        let timeoutTask = Task.detached { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: .seconds(timeoutSeconds))
+            guard !Task.isCancelled else { return }
+            self.timeoutRequest(id: id, method: method)
+        }
+
+        lock.lock()
+        entries[id] = Entry(continuation: continuation, timeoutTask: timeoutTask)
+        lock.unlock()
+    }
+
+    @discardableResult
+    func resume(id: Int, with response: MCPResponse) -> Bool {
+        guard let entry = take(id: id) else { return false }
+        entry.continuation.resume(returning: response)
+        return true
+    }
+
+    @discardableResult
+    func fail(id: Int, error: Error) -> Bool {
+        guard let entry = take(id: id) else { return false }
+        entry.continuation.resume(throwing: error)
+        return true
+    }
+
+    func failAll(error: Error) {
+        let continuations: [CheckedContinuation<MCPResponse, Error>] = lock.withLock {
+            let allEntries = Array(entries.values)
+            entries.removeAll()
+            allEntries.forEach { $0.timeoutTask.cancel() }
+            return allEntries.map(\.continuation)
+        }
+
+        continuations.forEach { $0.resume(throwing: error) }
+    }
+
+    private func timeoutRequest(id: Int, method: String) {
+        guard let entry = take(id: id) else { return }
+
+        DiagnosticsLogger.log(
+            .mcpService,
+            level: .error,
+            message: "MCP request timed out",
+            metadata: ["id": "\(id)", "method": method]
+        )
+        entry.continuation.resume(throwing: MCPServiceError.timeout)
+    }
+
+    private func take(id: Int) -> Entry? {
+        lock.withLock {
+            guard let entry = entries.removeValue(forKey: id) else { return nil }
+            entry.timeoutTask.cancel()
+            return entry
+        }
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return body()
+    }
+}
+
 /// Service for communicating with MCP servers via stdio
 class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
     private var process: Process?
@@ -43,8 +131,7 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
     private var isDisconnectingManually = false
 
     private var requestId = 0
-    private var pendingRequests: [Int: CheckedContinuation<MCPResponse, Error>] = [:]
-    // requestQueue removed to use MainActor for thread safety
+    private let pendingRequests: PendingMCPRequestStore
 
     let serverConfig: MCPServerConfig
     @Published var isConnected = false
@@ -62,8 +149,13 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
         return body()
     }
 
-    init(serverConfig: MCPServerConfig) {
+    var pendingRequestCount: Int {
+        pendingRequests.count
+    }
+
+    init(serverConfig: MCPServerConfig, requestTimeoutSeconds: TimeInterval = 30) {
         self.serverConfig = serverConfig
+        pendingRequests = PendingMCPRequestStore(timeoutSeconds: requestTimeoutSeconds)
     }
 
     deinit {
@@ -249,9 +341,9 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
 
         // Capture process reference before clearing
         let processToTerminate = withLock {
-            let p = process
+            let processReference = process
             process = nil
-            return p
+            return processReference
         }
 
         // Unregister from process tracker
@@ -387,32 +479,31 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
         }
 
         return try await withCheckedThrowingContinuation { continuation in
-            withLock { pendingRequests[id] = continuation }
+            pendingRequests.insert(id: id, method: method, continuation: continuation)
 
             let request = MCPRequest(id: id, method: method, params: params)
 
             do {
                 let data = try JSONEncoder().encode(request)
                 guard var jsonString = String(data: data, encoding: .utf8) else {
-                    withLock { pendingRequests.removeValue(forKey: id) }
-                    continuation.resume(throwing: MCPServiceError.encodingFailed)
+                    pendingRequests.fail(id: id, error: MCPServiceError.encodingFailed)
                     return
                 }
 
                 jsonString += "\n"
 
                 guard let inputHandle = withLock({ standardInput?.fileHandleForWriting }) else {
-                    withLock { pendingRequests.removeValue(forKey: id) }
-                    continuation.resume(throwing: MCPServiceError.notConnected)
+                    pendingRequests.fail(id: id, error: MCPServiceError.notConnected)
                     return
                 }
 
                 if let data = jsonString.data(using: .utf8) {
                     inputHandle.write(data)
+                } else {
+                    pendingRequests.fail(id: id, error: MCPServiceError.encodingFailed)
                 }
             } catch {
-                withLock { pendingRequests.removeValue(forKey: id) }
-                continuation.resume(throwing: error)
+                pendingRequests.fail(id: id, error: error)
             }
         }
     }
@@ -488,9 +579,7 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
 
             if let id = response.id {
                 Task { @MainActor in
-                    if let continuation = self.withLock({ self.pendingRequests.removeValue(forKey: id) }) {
-                        continuation.resume(returning: response)
-                    } else {
+                    if !self.pendingRequests.resume(id: id, with: response) {
                         DiagnosticsLogger.log(
                             .mcpService,
                             level: .error,
@@ -764,20 +853,15 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
     }
 
     private func cleanupProcessResources() {
-        let pending: [Int: CheckedContinuation<MCPResponse, Error>] = withLock {
+        withLock {
             standardOutput?.fileHandleForReading.readabilityHandler = nil
             standardError?.fileHandleForReading.readabilityHandler = nil
             standardInput = nil
             standardOutput = nil
             standardError = nil
-            let p = pendingRequests
-            pendingRequests.removeAll()
-            return p
         }
 
-        for (_, continuation) in pending {
-            continuation.resume(throwing: MCPServiceError.notConnected)
-        }
+        pendingRequests.failAll(error: MCPServiceError.notConnected)
     }
 }
 

--- a/Sources/Ayna/Services/OpenAIStreamParser.swift
+++ b/Sources/Ayna/Services/OpenAIStreamParser.swift
@@ -40,6 +40,12 @@ private struct SendableToolArguments: @unchecked Sendable {
     let value: [String: Any]
 }
 
+private enum ToolCallBufferKey {
+    static let name = "name"
+    static let argumentsData = "argumentsData"
+    static let legacyArguments = "arguments"
+}
+
 /// Callbacks for streaming response events
 struct StreamCallbacks {
     let onChunk: @Sendable (String) -> Void
@@ -238,11 +244,14 @@ enum OpenAIStreamParser {
             }
             if let function = toolCall["function"] as? [String: Any] {
                 if let name = function["name"] as? String {
-                    buffer["name"] = name
+                    buffer[ToolCallBufferKey.name] = name
                 }
                 if let argsChunk = function["arguments"] as? String {
-                    let currentArgs = buffer["arguments"] as? String ?? ""
-                    buffer["arguments"] = currentArgs + argsChunk
+                    var argumentsData = buffer[ToolCallBufferKey.argumentsData] as? Data
+                        ?? Data(capacity: max(256, argsChunk.utf8.count))
+                    argumentsData.reserveCapacity(argumentsData.count + argsChunk.utf8.count)
+                    argumentsData.append(contentsOf: argsChunk.utf8)
+                    buffer[ToolCallBufferKey.argumentsData] = argumentsData
                 }
             }
 
@@ -273,9 +282,8 @@ enum OpenAIStreamParser {
 
         for index in toolCallBuffers.keys.sorted() {
             guard let toolCallBuffer = toolCallBuffers[index],
-                  let toolName = toolCallBuffer["name"] as? String,
-                  let argsString = toolCallBuffer["arguments"] as? String,
-                  let argsData = argsString.data(using: .utf8),
+                  let toolName = toolCallBuffer[ToolCallBufferKey.name] as? String,
+                  let argsData = toolArgumentsData(from: toolCallBuffer),
                   let arguments = try? JSONSerialization.jsonObject(with: argsData) as? [String: Any]
             else {
                 continue
@@ -302,6 +310,18 @@ enum OpenAIStreamParser {
         }
 
         return ToolCallCompletionResult(buffers: remainingBuffers, ids: remainingIds, content: content)
+    }
+
+    private static func toolArgumentsData(from toolCallBuffer: [String: Any]) -> Data? {
+        if let argumentsData = toolCallBuffer[ToolCallBufferKey.argumentsData] as? Data {
+            return argumentsData
+        }
+
+        if let arguments = toolCallBuffer[ToolCallBufferKey.legacyArguments] as? String {
+            return Data(arguments.utf8)
+        }
+
+        return nil
     }
 
     // MARK: - Text Extraction

--- a/Sources/Ayna/Services/Providers/AIProviderProtocol.swift
+++ b/Sources/Ayna/Services/Providers/AIProviderProtocol.swift
@@ -72,12 +72,13 @@ struct AIProviderStreamCallbacks: Sendable {
 ///
 /// Each provider (OpenAI, GitHub Models, etc.) implements this protocol
 /// to handle chat completions with their specific API requirements.
-@MainActor
 protocol AIProviderProtocol: AnyObject, Sendable {
     /// The provider type this implementation handles
+    @MainActor
     var providerType: AIProvider { get }
 
     /// Whether this provider requires an API key
+    @MainActor
     var requiresAPIKey: Bool { get }
 
     /// Send a chat message to the provider
@@ -88,6 +89,7 @@ protocol AIProviderProtocol: AnyObject, Sendable {
     ///   - stream: Whether to stream the response
     ///   - tools: Optional tool definitions for function calling
     ///   - callbacks: Callbacks for handling the response
+    @MainActor
     func sendMessage(
         messages: [Message],
         config: AIProviderRequestConfig,
@@ -97,6 +99,7 @@ protocol AIProviderProtocol: AnyObject, Sendable {
     )
 
     /// Cancel any in-progress request
+    @MainActor
     func cancelRequest()
 
     /// Check if the provider is ready to handle requests
@@ -104,11 +107,13 @@ protocol AIProviderProtocol: AnyObject, Sendable {
     /// - Parameters:
     ///   - config: The request configuration to validate
     /// - Returns: nil if ready, or an error describing why not ready
+    @MainActor
     func validateConfiguration(_ config: AIProviderRequestConfig) -> Error?
 }
 
 /// Default implementations for AIProviderProtocol
 extension AIProviderProtocol {
+    @MainActor
     func validateConfiguration(_ config: AIProviderRequestConfig) -> Error? {
         if requiresAPIKey, config.apiKey.isEmpty {
             return AynaError.missingAPIKey(provider: String(describing: providerType))

--- a/Sources/Ayna/Services/Providers/AnthropicProvider.swift
+++ b/Sources/Ayna/Services/Providers/AnthropicProvider.swift
@@ -245,13 +245,7 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
         let parser = AnthropicStreamParser(
             onChunk: nil,
             onReasoning: nil,
-            onToolCallRequested: { id, name, input in
-                // Convert [String: AnyCodable] to [String: Any] for the callback interface
-                let anyInput = input.mapValues { $0.value }
-                Task { @MainActor in
-                    callbacks.onToolCallRequested?(id, name, anyInput)
-                }
-            },
+            onToolCallRequested: nil,
             onComplete: nil,
             onError: { error in
                 errorFlag.value = true
@@ -320,6 +314,12 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
         let result = parser.processLine(line)
         if let content = result.content { contentBuffer += content }
         if let reasoning = result.reasoning { reasoningBuffer += reasoning }
+        if let toolCall = result.toolCall {
+            let anyInput = toolCall.input.mapValues { $0.value }
+            await MainActor.run {
+                callbacks.onToolCallRequested?(toolCall.id, toolCall.name, anyInput)
+            }
+        }
 
         if result.shouldComplete {
             await flushBuffers(contentBuffer: contentBuffer, reasoningBuffer: reasoningBuffer, callbacks: callbacks)

--- a/Sources/Ayna/Services/Providers/AnthropicProvider.swift
+++ b/Sources/Ayna/Services/Providers/AnthropicProvider.swift
@@ -30,6 +30,11 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
     private var currentStreamTask: Task<Void, Never>?
     private var currentDataTask: URLSessionDataTask?
 
+    private struct StreamProcessingResult: Sendable {
+        let hasReceivedData: Bool
+        let shouldComplete: Bool
+    }
+
     init(urlSession: URLSession) {
         self.urlSession = urlSession
     }
@@ -156,17 +161,26 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
             return
         }
 
-        let task = Task { [weak self] in
+        let session = urlSession
+        let task = Task.detached { [weak self, session] in
             guard let self else { return }
             var hasReceivedData = false
 
             do {
                 try await withTaskCancellationHandler {
-                    hasReceivedData = try await processStreamRequest(
+                    let streamResult = try await self.processStreamRequest(
+                        session: session,
                         request: request,
                         callbacks: callbacks,
                         circuitKey: circuitKey
                     )
+                    hasReceivedData = streamResult.hasReceivedData
+                    await MainActor.run {
+                        self.currentStreamTask = nil
+                        if streamResult.shouldComplete {
+                            callbacks.onComplete()
+                        }
+                    }
                 } onCancel: {}
             } catch is CancellationError {
                 await MainActor.run { self.currentStreamTask = nil }
@@ -180,7 +194,7 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
                 if NetworkCircuitBreaker.shouldRecordFailure(error: error) {
                     NetworkCircuitBreaker.recordFailure(key: circuitKey)
                 }
-                await handleStreamError(
+                await self.handleStreamError(
                     error: error,
                     attempt: attempt,
                     hasReceivedData: hasReceivedData,
@@ -193,12 +207,13 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
         currentStreamTask = task
     }
 
-    private func processStreamRequest(
+    private nonisolated func processStreamRequest(
+        session: URLSession,
         request: URLRequest,
         callbacks: AIProviderStreamCallbacks,
         circuitKey: String
-    ) async throws -> Bool {
-        let (bytes, response) = try await urlSession.bytes(for: request)
+    ) async throws -> StreamProcessingResult {
+        let (bytes, response) = try await session.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AynaError.apiError(message: "Invalid Anthropic response")
@@ -222,10 +237,10 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
         return try await processStreamBytes(bytes: bytes, callbacks: callbacks)
     }
 
-    private func processStreamBytes(
+    private nonisolated func processStreamBytes(
         bytes: URLSession.AsyncBytes,
         callbacks: AIProviderStreamCallbacks
-    ) async throws -> Bool {
+    ) async throws -> StreamProcessingResult {
         let errorFlag = SendableFlag()
         let parser = AnthropicStreamParser(
             onChunk: nil,
@@ -233,14 +248,21 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
             onToolCallRequested: { id, name, input in
                 // Convert [String: AnyCodable] to [String: Any] for the callback interface
                 let anyInput = input.mapValues { $0.value }
-                callbacks.onToolCallRequested?(id, name, anyInput)
+                Task { @MainActor in
+                    callbacks.onToolCallRequested?(id, name, anyInput)
+                }
             },
             onComplete: nil,
-            onError: { error in errorFlag.value = true; callbacks.onError(error) }
+            onError: { error in
+                errorFlag.value = true
+                Task { @MainActor in
+                    callbacks.onError(error)
+                }
+            }
         )
 
         var errorOccurred: Bool { errorFlag.value }
-        var buffer = Data()
+        var buffer = Data(capacity: 4096)
         var contentBuffer = ""
         var reasoningBuffer = ""
         var lastUpdateTime = CFAbsoluteTimeGetCurrent()
@@ -269,23 +291,25 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
                         lastUpdateTime: &lastUpdateTime,
                         callbacks: callbacks
                     )
-                    if completed { return hasReceivedData }
+                    if completed {
+                        return StreamProcessingResult(
+                            hasReceivedData: hasReceivedData,
+                            shouldComplete: !errorOccurred
+                        )
+                    }
                 }
-                buffer.removeAll()
+                buffer.removeAll(keepingCapacity: true)
             }
         }
 
         await flushBuffers(contentBuffer: contentBuffer, reasoningBuffer: reasoningBuffer, callbacks: callbacks)
-        await MainActor.run {
-            self.currentStreamTask = nil
-            if !errorOccurred {
-                callbacks.onComplete()
-            }
-        }
-        return hasReceivedData
+        return StreamProcessingResult(
+            hasReceivedData: hasReceivedData,
+            shouldComplete: !errorOccurred
+        )
     }
 
-    private func processSSELine(
+    private nonisolated func processSSELine(
         line: String,
         parser: AnthropicStreamParser,
         contentBuffer: inout String,
@@ -299,10 +323,6 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
 
         if result.shouldComplete {
             await flushBuffers(contentBuffer: contentBuffer, reasoningBuffer: reasoningBuffer, callbacks: callbacks)
-            await MainActor.run {
-                self.currentStreamTask = nil
-                callbacks.onComplete()
-            }
             return true
         }
 
@@ -478,8 +498,8 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
 
     // MARK: - Error Handling
 
-    private func handleHTTPError(bytes: URLSession.AsyncBytes, statusCode: Int) async -> String {
-        var errorData = Data()
+    private nonisolated func handleHTTPError(bytes: URLSession.AsyncBytes, statusCode: Int) async -> String {
+        var errorData = Data(capacity: 4096)
         do {
             for try await byte in bytes {
                 errorData.append(byte)
@@ -572,7 +592,7 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
         }
     }
 
-    private func flushBuffers(
+    private nonisolated func flushBuffers(
         contentBuffer: String,
         reasoningBuffer: String,
         callbacks: AIProviderStreamCallbacks

--- a/Sources/Ayna/Services/Providers/OpenAIProvider.swift
+++ b/Sources/Ayna/Services/Providers/OpenAIProvider.swift
@@ -135,20 +135,21 @@ final class OpenAIProvider: AIProviderProtocol, @unchecked Sendable {
             return
         }
 
-        let task = Task { [weak self] in
+        let session = urlSession
+        let task = Task.detached { [weak self, session] in
             guard let self else { return }
             var hasReceivedData = false
 
             do {
                 try await withTaskCancellationHandler {
-                    let (bytes, response) = try await urlSession.bytes(for: request)
+                    let (bytes, response) = try await session.bytes(for: request)
 
                     guard let httpResponse = response as? HTTPURLResponse else {
                         throw AynaError.invalidResponse(detail: nil)
                     }
 
                     guard httpResponse.statusCode == 200 else {
-                        let errorMessage = await handleHTTPError(
+                        let errorMessage = await self.handleHTTPError(
                             bytes: bytes,
                             statusCode: httpResponse.statusCode,
                             request: request
@@ -163,12 +164,14 @@ final class OpenAIProvider: AIProviderProtocol, @unchecked Sendable {
 
                     NetworkCircuitBreaker.recordSuccess(key: circuitKey)
 
-                    var buffer = Data()
+                    var buffer = Data(capacity: 4096)
                     var currentToolCallBuffers: [Int: [String: Any]] = [:]
                     var toolCallIds: [Int: String] = [:]
                     var contentBuffer = ""
                     var reasoningBuffer = ""
                     var lastUpdateTime = CFAbsoluteTimeGetCurrent()
+                    let onToolCall = callbacks.onToolCall
+                    let onToolCallRequested = callbacks.onToolCallRequested
 
                     // Maximum line length to prevent OOM from malformed streams without newlines
                     let maxLineLength = 65536 // 64KB
@@ -185,21 +188,12 @@ final class OpenAIProvider: AIProviderProtocol, @unchecked Sendable {
 
                         if byte == 0x0A {
                             if let line = String(data: buffer, encoding: .utf8) {
-                                let streamCallbacks = StreamCallbacks(
-                                    onChunk: callbacks.onChunk,
-                                    onComplete: callbacks.onComplete,
-                                    onError: callbacks.onError,
-                                    onToolCall: callbacks.onToolCall,
-                                    onToolCallRequested: callbacks.onToolCallRequested,
-                                    onReasoning: callbacks.onReasoning
-                                )
-
                                 let result = await OpenAIStreamParser.processStreamLine(
                                     line,
                                     toolCallBuffers: currentToolCallBuffers,
                                     toolCallIds: toolCallIds,
-                                    onToolCall: streamCallbacks.onToolCall,
-                                    onToolCallRequested: streamCallbacks.onToolCallRequested
+                                    onToolCall: onToolCall,
+                                    onToolCallRequested: onToolCallRequested
                                 )
                                 currentToolCallBuffers = result.toolCallBuffers
                                 toolCallIds = result.toolCallIds
@@ -212,7 +206,7 @@ final class OpenAIProvider: AIProviderProtocol, @unchecked Sendable {
                                 }
 
                                 if result.shouldComplete {
-                                    await flushBuffers(
+                                    await self.flushBuffers(
                                         contentBuffer: contentBuffer,
                                         reasoningBuffer: reasoningBuffer,
                                         callbacks: callbacks
@@ -228,7 +222,7 @@ final class OpenAIProvider: AIProviderProtocol, @unchecked Sendable {
                                 if !contentBuffer.isEmpty || !reasoningBuffer.isEmpty {
                                     let timeSinceLastUpdate = CFAbsoluteTimeGetCurrent() - lastUpdateTime
                                     if timeSinceLastUpdate > 0.05 || contentBuffer.count > 100 || reasoningBuffer.count > 100 {
-                                        await flushBuffers(
+                                        await self.flushBuffers(
                                             contentBuffer: contentBuffer,
                                             reasoningBuffer: reasoningBuffer,
                                             callbacks: callbacks
@@ -239,12 +233,12 @@ final class OpenAIProvider: AIProviderProtocol, @unchecked Sendable {
                                     }
                                 }
                             }
-                            buffer.removeAll()
+                            buffer.removeAll(keepingCapacity: true)
                         }
                     }
 
                     // Flush remaining content
-                    await flushBuffers(
+                    await self.flushBuffers(
                         contentBuffer: contentBuffer,
                         reasoningBuffer: reasoningBuffer,
                         callbacks: callbacks
@@ -266,7 +260,7 @@ final class OpenAIProvider: AIProviderProtocol, @unchecked Sendable {
                 if NetworkCircuitBreaker.shouldRecordFailure(error: error) {
                     NetworkCircuitBreaker.recordFailure(key: circuitKey)
                 }
-                await handleStreamError(
+                await self.handleStreamError(
                     error: error,
                     attempt: attempt,
                     hasReceivedData: hasReceivedData,
@@ -387,8 +381,8 @@ final class OpenAIProvider: AIProviderProtocol, @unchecked Sendable {
 
     // MARK: - Error Handling
 
-    private func handleHTTPError(bytes: URLSession.AsyncBytes, statusCode: Int, request: URLRequest) async -> String {
-        var errorData = Data()
+    private nonisolated func handleHTTPError(bytes: URLSession.AsyncBytes, statusCode: Int, request: URLRequest) async -> String {
+        var errorData = Data(capacity: 4096)
         do {
             for try await byte in bytes {
                 errorData.append(byte)
@@ -486,7 +480,7 @@ final class OpenAIProvider: AIProviderProtocol, @unchecked Sendable {
         }
     }
 
-    private func flushBuffers(
+    private nonisolated func flushBuffers(
         contentBuffer: String,
         reasoningBuffer: String,
         callbacks: AIProviderStreamCallbacks

--- a/Sources/Ayna/Services/WebFetchService.swift
+++ b/Sources/Ayna/Services/WebFetchService.swift
@@ -63,6 +63,51 @@ enum SSRFProtection {
 
         return false
     }
+
+    /// Resolves a hostname and returns the first private/internal IP if one is found.
+    static func resolvedPrivateIPAddress(for host: String) async -> String? {
+        #if !os(watchOS)
+        let hostRef = CFHostCreateWithName(nil, host as CFString).takeRetainedValue()
+        var resolved = DarwinBoolean(false)
+
+        CFHostStartInfoResolution(hostRef, .addresses, nil)
+        guard let addresses = CFHostGetAddressing(hostRef, &resolved)?.takeUnretainedValue() as? [Data],
+              resolved.boolValue
+        else {
+            return nil
+        }
+
+        for addressData in addresses {
+            let ipString = addressData.withUnsafeBytes { pointer -> String? in
+                guard let sockaddr = pointer.baseAddress?.assumingMemoryBound(to: sockaddr.self) else {
+                    return nil
+                }
+
+                if sockaddr.pointee.sa_family == UInt8(AF_INET) {
+                    var addr = sockaddr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee }
+                    var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+                    inet_ntop(AF_INET, &addr.sin_addr, &buffer, socklen_t(INET_ADDRSTRLEN))
+                    return String(bytes: buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, encoding: .utf8)
+                } else if sockaddr.pointee.sa_family == UInt8(AF_INET6) {
+                    var addr = sockaddr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { $0.pointee }
+                    var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+                    inet_ntop(AF_INET6, &addr.sin6_addr, &buffer, socklen_t(INET6_ADDRSTRLEN))
+                    return String(bytes: buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, encoding: .utf8)
+                }
+
+                return nil
+            }
+
+            if let ipString, isPrivateHost(ipString) {
+                return ipString
+            }
+        }
+
+        return nil
+        #else
+        return nil
+        #endif
+    }
 }
 
 // MARK: - Web Fetch Error
@@ -147,6 +192,146 @@ final class SSRFRedirectValidator: NSObject, URLSessionTaskDelegate, Sendable {
     }
 }
 
+// MARK: - Shared Web Fetch Helpers
+
+enum WebTextExtractor {
+    private static let scriptRegex = makeRegex("(?is)<script[^>]*>.*?</script>")
+    private static let styleRegex = makeRegex("(?is)<style[^>]*>.*?</style>")
+    private static let blockElementRegex = makeRegex("(?i)<(br|p|div|h[1-6]|li|tr)[^>]*>")
+    private static let tagRegex = makeRegex("<[^>]+>")
+    private static let collapsedNewlineRegex = makeRegex("\n{3,}")
+    private static let htmlEntities: [(entity: String, replacement: String)] = [
+        ("&nbsp;", " "),
+        ("&amp;", "&"),
+        ("&lt;", "<"),
+        ("&gt;", ">"),
+        ("&quot;", "\""),
+        ("&#39;", "'")
+    ]
+
+    static func plainTextIfNeeded(from content: String, contentType: String) -> String {
+        let isHTML = contentType.localizedCaseInsensitiveContains("text/html") ||
+            content.range(of: "<html", options: .caseInsensitive) != nil
+
+        if isHTML {
+            return plainText(fromHTML: content)
+        }
+
+        return content
+    }
+
+    static func plainText(fromHTML html: String) -> String {
+        var text = replace(scriptRegex, in: html, with: "")
+        text = replace(styleRegex, in: text, with: "")
+        text = replace(blockElementRegex, in: text, with: "\n")
+        text = plainText(fromHTMLFragment: text)
+        text = replace(collapsedNewlineRegex, in: text, with: "\n\n")
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func plainText(fromHTMLFragment htmlFragment: String) -> String {
+        let text = replace(tagRegex, in: htmlFragment, with: "")
+        return decodeHTMLEntities(in: text).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func decodeHTMLEntities(in text: String) -> String {
+        htmlEntities.reduce(into: text) { result, entity in
+            result = result.replacingOccurrences(of: entity.entity, with: entity.replacement)
+        }
+    }
+
+    private static func replace(_ regex: NSRegularExpression, in string: String, with template: String) -> String {
+        regex.stringByReplacingMatches(
+            in: string,
+            options: [],
+            range: NSRange(string.startIndex..., in: string),
+            withTemplate: template
+        )
+    }
+
+    private static func makeRegex(_ pattern: String) -> NSRegularExpression {
+        do {
+            return try NSRegularExpression(pattern: pattern)
+        } catch {
+            preconditionFailure("Invalid regex pattern: \(pattern)")
+        }
+    }
+}
+
+enum WebFetchRequestExecutor {
+    private static let userAgent = "Ayna/1.0"
+
+    static let sharedSession: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.httpShouldSetCookies = false
+        configuration.waitsForConnectivity = false
+        return URLSession(configuration: configuration, delegate: SSRFRedirectValidator(), delegateQueue: nil)
+    }()
+
+    static func fetchText(
+        from urlString: String,
+        timeoutSeconds: TimeInterval,
+        maxResponseSize: Int,
+        session: URLSession = sharedSession
+    ) async throws -> String {
+        guard let parsedURL = URL(string: urlString),
+              let host = parsedURL.host,
+              parsedURL.scheme == "https" || parsedURL.scheme == "http"
+        else {
+            throw WebFetchError.invalidURL(url: urlString)
+        }
+
+        if SSRFProtection.isPrivateHost(host) {
+            throw WebFetchError.ssrfBlocked(url: urlString)
+        }
+
+        if let resolvedPrivateIP = await SSRFProtection.resolvedPrivateIPAddress(for: host) {
+            DiagnosticsLogger.log(
+                .aiService,
+                level: .default,
+                message: "🌐 WebFetch: DNS rebinding blocked",
+                metadata: ["host": host, "ip": resolvedPrivateIP]
+            )
+            throw WebFetchError.ssrfBlocked(url: urlString)
+        }
+
+        var request = URLRequest(url: parsedURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeoutSeconds
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw WebFetchError.networkError(underlying: error.localizedDescription)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw WebFetchError.networkError(underlying: "Invalid response")
+        }
+
+        guard (200 ... 299).contains(httpResponse.statusCode) else {
+            throw WebFetchError.httpError(statusCode: httpResponse.statusCode)
+        }
+
+        guard data.count <= maxResponseSize else {
+            throw WebFetchError.responseToLarge(size: data.count, limit: maxResponseSize)
+        }
+
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw WebFetchError.binaryContent
+        }
+
+        let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type") ?? ""
+        return WebTextExtractor.plainTextIfNeeded(from: content, contentType: contentType)
+    }
+}
+
 // MARK: - Web Fetch Service
 
 /// Cross-platform service for fetching web content.
@@ -187,64 +372,11 @@ final class WebFetchService {
 
         log(.info, "web_fetch requested", metadata: ["url": url])
 
-        // Validate URL
-        guard let parsedURL = URL(string: url),
-              let host = parsedURL.host,
-              parsedURL.scheme == "https" || parsedURL.scheme == "http"
-        else {
-            throw WebFetchError.invalidURL(url: url)
-        }
-
-        // SSRF protection: Block internal/private IPs
-        if isPrivateHost(host) {
-            throw WebFetchError.ssrfBlocked(url: url)
-        }
-
-        // DNS rebinding protection: resolve hostname and check resolved IPs
-        if await resolveAndCheckHost(host) {
-            throw WebFetchError.ssrfBlocked(url: url)
-        }
-
-        // Fetch with timeout
-        var request = URLRequest(url: parsedURL)
-        request.httpMethod = "GET"
-        request.timeoutInterval = TimeInterval(timeoutSeconds)
-        request.setValue("Ayna/1.0", forHTTPHeaderField: "User-Agent")
-
-        let data: Data
-        let response: URLResponse
-        do {
-            let session = URLSession(configuration: .ephemeral, delegate: SSRFRedirectValidator(), delegateQueue: nil)
-            defer { session.invalidateAndCancel() }
-            (data, response) = try await session.data(for: request)
-        } catch {
-            throw WebFetchError.networkError(underlying: error.localizedDescription)
-        }
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw WebFetchError.networkError(underlying: "Invalid response")
-        }
-
-        guard (200 ... 299).contains(httpResponse.statusCode) else {
-            throw WebFetchError.httpError(statusCode: httpResponse.statusCode)
-        }
-
-        // Check content size
-        guard data.count <= maxResponseSize else {
-            throw WebFetchError.responseToLarge(size: data.count, limit: maxResponseSize)
-        }
-
-        guard let content = String(data: data, encoding: .utf8) else {
-            throw WebFetchError.binaryContent
-        }
-
-        // Convert HTML to plain text if content appears to be HTML
-        let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type") ?? ""
-        let result = if contentType.contains("text/html") || content.contains("<html") {
-            htmlToPlainText(content)
-        } else {
-            content
-        }
+        let result = try await WebFetchRequestExecutor.fetchText(
+            from: url,
+            timeoutSeconds: TimeInterval(timeoutSeconds),
+            maxResponseSize: maxResponseSize
+        )
 
         log(.info, "web_fetch completed", metadata: ["url": url, "size": "\(result.count)"])
         return result
@@ -313,138 +445,6 @@ final class WebFetchService {
         - Maximum response size is 10 MB
         - Binary content is not supported
         """
-    }
-
-    // MARK: - Private Helpers
-
-    /// Resolves hostname via DNS and checks if any resolved IP is private (DNS rebinding protection)
-    private func resolveAndCheckHost(_ host: String) async -> Bool {
-        #if !os(watchOS)
-        let hostRef = CFHostCreateWithName(nil, host as CFString).takeRetainedValue()
-        var resolved = DarwinBoolean(false)
-
-        CFHostStartInfoResolution(hostRef, .addresses, nil)
-        guard let addresses = CFHostGetAddressing(hostRef, &resolved)?.takeUnretainedValue() as? [Data],
-              resolved.boolValue
-        else {
-            return false // DNS resolution failed; let URLSession handle it
-        }
-
-        for addressData in addresses {
-            let ipString = addressData.withUnsafeBytes { pointer -> String? in
-                guard let sockaddr = pointer.baseAddress?.assumingMemoryBound(to: sockaddr.self) else {
-                    return nil
-                }
-
-                if sockaddr.pointee.sa_family == UInt8(AF_INET) {
-                    var addr = sockaddr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee }
-                    var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
-                    inet_ntop(AF_INET, &addr.sin_addr, &buffer, socklen_t(INET_ADDRSTRLEN))
-                    return String(cString: buffer)
-                } else if sockaddr.pointee.sa_family == UInt8(AF_INET6) {
-                    var addr = sockaddr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { $0.pointee }
-                    var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
-                    inet_ntop(AF_INET6, &addr.sin6_addr, &buffer, socklen_t(INET6_ADDRSTRLEN))
-                    return String(cString: buffer)
-                }
-                return nil
-            }
-
-            if let ip = ipString, isPrivateIPString(ip) {
-                log(.default, "DNS rebinding blocked: \(host) resolved to private IP \(ip)")
-                return true
-            }
-        }
-        return false
-        #else
-        return false // watchOS: hostname-string checks are sufficient
-        #endif
-    }
-
-    /// Checks if a resolved IP address string is in private/internal ranges
-    private func isPrivateIPString(_ ip: String) -> Bool {
-        let lowercased = ip.lowercased()
-
-        if lowercased == "127.0.0.1" || lowercased == "::1" || lowercased == "0.0.0.0" {
-            return true
-        }
-
-        // IPv6 private ranges
-        if lowercased.contains(":") {
-            if lowercased.hasPrefix("fd") || lowercased.hasPrefix("fe80:") || lowercased.hasPrefix("fc") {
-                return true
-            }
-        }
-
-        // IPv4 private ranges
-        let parts = lowercased.split(separator: ".")
-        if parts.count == 4, let first = Int(parts[0]), let second = Int(parts[1]) {
-            if first == 127 { return true }
-            if first == 10 { return true }
-            if first == 172, (16 ... 31).contains(second) { return true }
-            if first == 192, second == 168 { return true }
-            if first == 169, second == 254 { return true }
-            if first == 0 { return true }
-            // RFC 6598 CGNAT (100.64.0.0/10)
-            if first == 100, (64 ... 127).contains(second) { return true }
-            // RFC 2544 Benchmark (198.18.0.0/15)
-            if first == 198, (18 ... 19).contains(second) { return true }
-        }
-
-        return false
-    }
-
-    /// Checks if a host is a private/internal address (SSRF protection)
-    private func isPrivateHost(_ host: String) -> Bool {
-        SSRFProtection.isPrivateHost(host)
-    }
-
-    /// Converts HTML to plain text by stripping tags
-    private func htmlToPlainText(_ html: String) -> String {
-        var text = html
-
-        // Remove script and style content
-        text = text.replacingOccurrences(
-            of: "(?s)<script[^>]*>.*?</script>",
-            with: "",
-            options: [.regularExpression, .caseInsensitive]
-        )
-        text = text.replacingOccurrences(
-            of: "(?s)<style[^>]*>.*?</style>",
-            with: "",
-            options: [.regularExpression, .caseInsensitive]
-        )
-
-        // Replace block elements with newlines
-        text = text.replacingOccurrences(
-            of: "<(br|p|div|h[1-6]|li|tr)[^>]*>",
-            with: "\n",
-            options: [.regularExpression, .caseInsensitive]
-        )
-
-        // Remove all remaining tags
-        text = text.replacingOccurrences(
-            of: "<[^>]+>",
-            with: "",
-            options: .regularExpression
-        )
-
-        // Decode HTML entities
-        text = text.replacingOccurrences(of: "&nbsp;", with: " ")
-        text = text.replacingOccurrences(of: "&amp;", with: "&")
-        text = text.replacingOccurrences(of: "&lt;", with: "<")
-        text = text.replacingOccurrences(of: "&gt;", with: ">")
-        text = text.replacingOccurrences(of: "&quot;", with: "\"")
-        text = text.replacingOccurrences(of: "&#39;", with: "'")
-
-        // Collapse multiple newlines
-        text = text.replacingOccurrences(
-            of: "\n{3,}",
-            with: "\n\n",
-            options: .regularExpression
-        )
-
-        return text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func log(_ level: OSLogType, _ message: String, metadata: [String: String] = [:]) {

--- a/Sources/Ayna/Utilities/MarkdownRenderer.swift
+++ b/Sources/Ayna/Utilities/MarkdownRenderer.swift
@@ -18,6 +18,22 @@ enum MarkdownRenderer {
         }
     }
 
+    private static let inlineMarkdownOptions: AttributedString.MarkdownParsingOptions = {
+        var options = AttributedString.MarkdownParsingOptions()
+        options.interpretedSyntax = .inlineOnlyPreservingWhitespace
+        return options
+    }()
+
+    private static let horizontalRuleCharacters = CharacterSet(charactersIn: "-_* ")
+    private static let unorderedListRegex =
+        try! NSRegularExpression(pattern: #"^\s*[-*+]\s+"#)
+    private static let orderedListRegex =
+        try! NSRegularExpression(pattern: #"^\s*(\d+)\.\s+"#)
+    #if !os(watchOS)
+    private static let tableDividerRegex =
+        try! NSRegularExpression(pattern: #"^\s*:?-+:?\s*$"#)
+    #endif
+
     nonisolated static func parse(_ content: String) -> [ContentBlock] {
         var blocks: [ContentBlock] = []
 
@@ -231,13 +247,18 @@ enum MarkdownRenderer {
 
     private nonisolated static func isHorizontalRule(_ line: String) -> Bool {
         if line.count < 3 { return false }
-        let allowed = CharacterSet(charactersIn: "-_* ")
-        guard line.trimmingCharacters(in: allowed).isEmpty
+        guard line.trimmingCharacters(in: Self.horizontalRuleCharacters).isEmpty
             && line.replacingOccurrences(of: " ", with: "").count >= 3
         else { return false }
         let nonSpace = line.filter { $0 != " " }
         guard let ruleChar = nonSpace.first, nonSpace.allSatisfy({ $0 == ruleChar }) else { return false }
         return true
+    }
+
+    private nonisolated static func firstMatch(using regex: NSRegularExpression, in text: String)
+        -> NSTextCheckingResult?
+    {
+        regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text))
     }
 
     private nonisolated static func parseBlockquote(from lines: [String], startingAt index: Int) -> (
@@ -271,19 +292,35 @@ enum MarkdownRenderer {
         var ordered = true
         var startIndex = 1
 
-        func listItem(from line: String) -> String? {
-            if let range = line.range(of: "^\\s*[-*+]\\s+", options: .regularExpression) {
-                ordered = false
-                return String(line[range.upperBound...])
-            } else if let range = line.range(of: "^\\s*(\\d+)\\.\\s+", options: .regularExpression) {
-                ordered = true
-                let prefix = line[..<range.upperBound]
-                if let number = Int(prefix.trimmingCharacters(in: CharacterSet(charactersIn: ". "))) {
-                    if items.isEmpty {
-                        startIndex = number
-                    }
+        struct ParsedListItem {
+            let text: String
+            let isOrdered: Bool
+            let startNumber: Int?
+        }
+
+        func listItem(from line: String) -> ParsedListItem? {
+            if let match = firstMatch(using: Self.unorderedListRegex, in: line),
+               let fullRange = Range(match.range, in: line)
+            {
+                return ParsedListItem(
+                    text: String(line[fullRange.upperBound...]),
+                    isOrdered: false,
+                    startNumber: nil
+                )
+            } else if let match = firstMatch(using: Self.orderedListRegex, in: line),
+                      let fullRange = Range(match.range, in: line)
+            {
+                let startNumber: Int?
+                if let numberRange = Range(match.range(at: 1), in: line) {
+                    startNumber = Int(String(line[numberRange]))
+                } else {
+                    startNumber = nil
                 }
-                return String(line[range.upperBound...])
+                return ParsedListItem(
+                    text: String(line[fullRange.upperBound...]),
+                    isOrdered: true,
+                    startNumber: startNumber
+                )
             }
             return nil
         }
@@ -291,8 +328,12 @@ enum MarkdownRenderer {
         while current < lines.count {
             let line = lines[current]
             if line.trimmingCharacters(in: .whitespaces).isEmpty { break }
-            guard let itemText = listItem(from: line) else { break }
-            let attributed = makeInlineAttributedString(from: itemText)
+            guard let item = listItem(from: line) else { break }
+            ordered = item.isOrdered
+            if items.isEmpty, let startNumber = item.startNumber {
+                startIndex = startNumber
+            }
+            let attributed = makeInlineAttributedString(from: item.text)
             items.append(attributed)
             current += 1
         }
@@ -316,7 +357,7 @@ enum MarkdownRenderer {
         guard headerCells.count == dividerCells.count else { return nil }
         guard
             dividerCells.allSatisfy({
-                $0.range(of: "^\\s*:?-+:?\\s*$", options: .regularExpression) != nil
+                firstMatch(using: Self.tableDividerRegex, in: $0) != nil
             })
         else { return nil }
 
@@ -378,9 +419,7 @@ enum MarkdownRenderer {
     #endif
 
     private nonisolated static func makeInlineAttributedString(from markdown: String) -> AttributedString {
-        var options = AttributedString.MarkdownParsingOptions()
-        options.interpretedSyntax = .inlineOnlyPreservingWhitespace
-        return (try? AttributedString(markdown: markdown, options: options))
+        return (try? AttributedString(markdown: markdown, options: Self.inlineMarkdownOptions))
             ?? AttributedString(markdown)
     }
 }

--- a/Sources/Ayna/Utilities/MarkdownRenderer.swift
+++ b/Sources/Ayna/Utilities/MarkdownRenderer.swift
@@ -167,6 +167,10 @@ enum MarkdownRenderer {
         return blocks
     }
 
+    nonisolated static func cachedBlocks(for content: String) -> [ContentBlock]? {
+        cache.object(forKey: content as NSString)?.blocks
+    }
+
     private nonisolated static func parseCodeBlock(
         lines: [String],
         index: inout Int,

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -126,7 +126,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
     /// The current conversation being managed.
     var conversation: Conversation? {
         guard let id = conversationId else { return nil }
-        return conversationManager.conversations.first { $0.id == id }
+        return conversationManager.conversation(byId: id)
     }
 
     // MARK: - Configuration Update
@@ -615,7 +615,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                         // Play message received sound
                         SoundEngine.messageReceived()
 
-                        if let finalConversation = self.conversationManager.conversations.first(where: { $0.id == conversationId }) {
+                        if let finalConversation = self.conversationManager.conversation(byId: conversationId) {
                             self.conversationManager.save(finalConversation)
                         }
 
@@ -716,7 +716,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                     let arguments = argumentsWrapper.value
 
                     // Validate conversation still exists
-                    guard self.conversationManager.conversations.contains(where: { $0.id == conversationId }) else {
+                    guard self.conversationManager.conversation(byId: conversationId) != nil else {
                         DiagnosticsLogger.log(
                             .chatView,
                             level: .default,
@@ -892,7 +892,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
 
     /// Get the ID of the last assistant message in the conversation
     private func getLastAssistantMessageId(conversationId: UUID) -> UUID? {
-        guard let conv = conversationManager.conversations.first(where: { $0.id == conversationId }),
+        guard let conv = conversationManager.conversation(byId: conversationId),
               let lastMessage = conv.messages.last,
               lastMessage.role == .assistant
         else {
@@ -1358,7 +1358,7 @@ extension IOSChatViewModel {
             metadata: ["model": model, "error": error.localizedDescription]
         )
 
-        if let conv = conversationManager.conversations.first(where: { $0.id == conversationId }),
+        if let conv = conversationManager.conversation(byId: conversationId),
            let group = conv.getResponseGroup(responseGroupId),
            group.responses.allSatisfy({ $0.status == .failed })
         {
@@ -1370,28 +1370,21 @@ extension IOSChatViewModel {
 // MARK: - Image Generation
 
 extension IOSChatViewModel {
-    /// Finds the most recent generated or selected image in the conversation for editing context.
-    func findPreviousImage() -> Data? {
-        guard let conversation else { return nil }
-
-        // Look for the most recent assistant message with an image
-        // Prioritize selected responses from multi-model groups
+    /// Finds the most recent generated or selected image reference in the conversation for editing context.
+    private func previousImageSource(in conversation: Conversation) -> (data: Data?, path: String?)? {
         for message in conversation.messages.reversed() {
             guard message.role == .assistant, message.mediaType == .image else { continue }
 
-            // If this message is part of a response group, only use it if it was selected
             if let groupId = message.responseGroupId {
                 if let group = conversation.getResponseGroup(groupId),
                    group.selectedResponseId == message.id
                 {
-                    return message.effectiveImageData
+                    return (message.imageData, message.imagePath)
                 }
-                // Skip unselected multi-model responses
                 continue
             }
 
-            // Single-model image - use it
-            return message.effectiveImageData
+            return (message.imageData, message.imagePath)
         }
         return nil
     }
@@ -1402,125 +1395,116 @@ extension IOSChatViewModel {
             return
         }
 
-        // Check if we have a previous image to edit
-        let previousImage = conversation.messages.reversed().first { message in
-            guard message.role == .assistant, message.mediaType == .image else { return false }
-            if let groupId = message.responseGroupId {
-                return conversation.getResponseGroup(groupId)?.selectedResponseId == message.id
-            }
-            return true
-        }?.effectiveImageData
+        let previousImageSource = previousImageSource(in: conversation)
+        let model = conversation.model
+        let assistantMessageId = assistantMessage.id
 
-        DiagnosticsLogger.log(
-            .chatView,
-            level: .info,
-            message: previousImage != nil ? "📝 Starting image edit" : "🎨 Starting image generation",
-            metadata: ["prompt": text, "hasContext": "\(previousImage != nil)"]
-        )
-
-        let onComplete: @Sendable (Data) -> Void = { [weak self] data in
-            let selfRef = self
-            Task { @MainActor in
-                guard let self = selfRef else { return }
-
-                // Save image to disk
-                var imagePath: String?
-                do {
-                    imagePath = try AttachmentStorage.shared.save(data: data, extension: "png")
-                } catch {
-                    DiagnosticsLogger.log(
-                        .chatView,
-                        level: .error,
-                        message: "❌ Failed to save generated image: \(error.localizedDescription)"
-                    )
+        Task { [weak self] in
+            let previousImage: Data? =
+                if let data = previousImageSource?.data {
+                    data
+                } else if let path = previousImageSource?.path {
+                    await AttachmentStorage.shared.loadData(path: path)
+                } else {
+                    nil
                 }
 
-                if let convIndex = self.conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
-                   let msgIndex = self.conversationManager.conversations[convIndex].messages.firstIndex(where: { $0.id == assistantMessage.id })
-                {
-                    var updatedMessage = self.conversationManager.conversations[convIndex].messages[msgIndex]
-                    updatedMessage.mediaType = .image
-                    if let path = imagePath {
-                        updatedMessage.imagePath = path
-                        updatedMessage.imageData = nil
-                    } else {
-                        updatedMessage.imageData = data
-                        updatedMessage.imagePath = nil
-                    }
-                    updatedMessage.content = ""
-                    self.conversationManager.conversations[convIndex].messages[msgIndex] = updatedMessage
-                    self.conversationManager.save(self.conversationManager.conversations[convIndex])
-                }
-                self.isGenerating = false
-
-                // Notify that conversation is ready (for new chat navigation)
-                if self.isNewChatMode {
-                    self.onConversationCreated?(conversationId)
-                }
-
+            await MainActor.run { [weak self] in
+                guard let self else { return }
                 DiagnosticsLogger.log(
                     .chatView,
                     level: .info,
-                    message: "✅ Image generation/edit completed"
+                    message: previousImage != nil ? "📝 Starting image edit" : "🎨 Starting image generation",
+                    metadata: ["prompt": text, "hasContext": "\(previousImage != nil)"]
                 )
-            }
-        }
 
-        let onError: @Sendable (Error) -> Void = { [weak self] error in
-            let selfRef = self
-            Task { @MainActor in
-                guard let self = selfRef else { return }
-                self.isGenerating = false
-                self.errorMessage = error.localizedDescription
+                let onComplete: @Sendable (Data) -> Void = { [weak self] data in
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        var imagePath: String?
+                        do {
+                            imagePath = try AttachmentStorage.shared.save(data: data, extension: "png")
+                        } catch {
+                            DiagnosticsLogger.log(
+                                .chatView,
+                                level: .error,
+                                message: "❌ Failed to save generated image: \(error.localizedDescription)"
+                            )
+                        }
 
-                // Still notify for navigation even on error
-                if self.isNewChatMode {
-                    self.onConversationCreated?(conversationId)
+                        if let convIndex = self.conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
+                           let msgIndex = self.conversationManager.conversations[convIndex].messages.firstIndex(where: { $0.id == assistantMessageId })
+                        {
+                            var updatedMessage = self.conversationManager.conversations[convIndex].messages[msgIndex]
+                            updatedMessage.mediaType = .image
+                            if let path = imagePath {
+                                updatedMessage.imagePath = path
+                                updatedMessage.imageData = nil
+                            } else {
+                                updatedMessage.imageData = data
+                                updatedMessage.imagePath = nil
+                            }
+                            updatedMessage.content = ""
+                            self.conversationManager.conversations[convIndex].messages[msgIndex] = updatedMessage
+                            self.conversationManager.save(self.conversationManager.conversations[convIndex])
+                        }
+                        self.isGenerating = false
+
+                        if self.isNewChatMode {
+                            self.onConversationCreated?(conversationId)
+                        }
+
+                        DiagnosticsLogger.log(
+                            .chatView,
+                            level: .info,
+                            message: "✅ Image generation/edit completed"
+                        )
+                    }
                 }
 
-                DiagnosticsLogger.log(
-                    .chatView,
-                    level: .error,
-                    message: "❌ Image generation/edit failed: \(error.localizedDescription)"
-                )
-            }
-        }
+                let onError: @Sendable (Error) -> Void = { [weak self] error in
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        self.isGenerating = false
+                        self.errorMessage = error.localizedDescription
 
-        if let previousImage {
-            // Use image editing API for follow-up requests
-            aiService.editImage(
-                prompt: text,
-                sourceImage: previousImage,
-                model: conversation.model,
-                onComplete: onComplete,
-                onError: onError
-            )
-        } else {
-            // No previous image - use generation API
-            aiService.generateImage(
-                prompt: text,
-                model: conversation.model,
-                onComplete: onComplete,
-                onError: onError
-            )
+                        if self.isNewChatMode {
+                            self.onConversationCreated?(conversationId)
+                        }
+
+                        DiagnosticsLogger.log(
+                            .chatView,
+                            level: .error,
+                            message: "❌ Image generation/edit failed: \(error.localizedDescription)"
+                        )
+                    }
+                }
+
+                if let previousImage {
+                    aiService.editImage(
+                        prompt: text,
+                        sourceImage: previousImage,
+                        model: model,
+                        onComplete: onComplete,
+                        onError: onError
+                    )
+                } else {
+                    aiService.generateImage(
+                        prompt: text,
+                        model: model,
+                        onComplete: onComplete,
+                        onError: onError
+                    )
+                }
+            }
         }
     }
 
     /// Generates images from multiple models in parallel for comparison
     func generateImagesWithMultipleModels(prompt: String, models: [String], conversation: Conversation) {
         let conversationId = conversation.id
+        let previousImageSource = previousImageSource(in: conversation)
 
-        // Check if we have a previous image to edit (must check BEFORE adding user message)
-        let previousImage = findPreviousImage()
-
-        DiagnosticsLogger.log(
-            .chatView,
-            level: .info,
-            message: previousImage != nil ? "📝 Starting multi-model image edit" : "🎨 Starting multi-model image generation",
-            metadata: ["prompt": prompt, "models": models.joined(separator: ", "), "hasContext": "\(previousImage != nil)"]
-        )
-
-        // Create user message
         let userMessage = Message(role: .user, content: prompt)
         conversationManager.addMessage(to: conversation, message: userMessage)
 
@@ -1528,12 +1512,10 @@ extension IOSChatViewModel {
         isGenerating = true
         errorMessage = nil
 
-        // Create a response group for the multi-model comparison
         let responseGroupId = UUID()
         var responseEntries: [ResponseGroup.ResponseEntry] = []
         var messageIds: [String: UUID] = [:]
 
-        // Create placeholder messages for each model
         for model in models {
             let messageId = UUID()
             messageIds[model] = messageId
@@ -1555,62 +1537,79 @@ extension IOSChatViewModel {
             ))
         }
 
-        // Create response group
         let responseGroup = ResponseGroup(
             id: responseGroupId,
             userMessageId: userMessage.id,
             responses: responseEntries
         )
 
-        // Add response group to conversation
         if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) {
             conversationManager.conversations[index].responseGroups.append(responseGroup)
         }
 
-        // Track completion state using a class to allow mutation in closures
         final class CompletionTracker: @unchecked Sendable {
             var count = 0
         }
         let tracker = CompletionTracker()
         let totalCount = models.count
 
-        // Generate/edit images in parallel
-        for model in models {
-            guard let messageId = messageIds[model] else { continue }
-
-            let onComplete: @Sendable (Data) -> Void = { [weak self] imageData in
-                Task { @MainActor in
-                    guard let self else { return }
-                    self.processImageSuccess(
-                        imageData: imageData,
-                        conversationId: conversationId,
-                        messageId: messageId,
-                        responseGroupId: responseGroupId,
-                        completedCount: &tracker.count,
-                        totalCount: totalCount
-                    )
+        Task { [weak self] in
+            let previousImage: Data? =
+                if let data = previousImageSource?.data {
+                    data
+                } else if let path = previousImageSource?.path {
+                    await AttachmentStorage.shared.loadData(path: path)
+                } else {
+                    nil
                 }
-            }
 
-            let onError: @Sendable (Error) -> Void = { [weak self] error in
-                Task { @MainActor in
-                    guard let self else { return }
-                    self.processImageError(
-                        error: error,
-                        model: model,
-                        conversationId: conversationId,
-                        messageId: messageId,
-                        responseGroupId: responseGroupId,
-                        completedCount: &tracker.count,
-                        totalCount: totalCount
-                    )
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                DiagnosticsLogger.log(
+                    .chatView,
+                    level: .info,
+                    message: previousImage != nil ? "📝 Starting multi-model image edit" : "🎨 Starting multi-model image generation",
+                    metadata: ["prompt": prompt, "models": models.joined(separator: ", "), "hasContext": "\(previousImage != nil)"]
+                )
+
+                for model in models {
+                    guard let messageId = messageIds[model] else { continue }
+
+                    let onComplete: @Sendable (Data) -> Void = { [weak self] imageData in
+                        Task { @MainActor [weak self] in
+                            guard let self else { return }
+                            self.processImageSuccess(
+                                imageData: imageData,
+                                conversationId: conversationId,
+                                messageId: messageId,
+                                responseGroupId: responseGroupId,
+                                completedCount: &tracker.count,
+                                totalCount: totalCount
+                            )
+                        }
+                    }
+
+                    let onError: @Sendable (Error) -> Void = { [weak self] error in
+                        Task { @MainActor [weak self] in
+                            guard let self else { return }
+                            self.processImageError(
+                                error: error,
+                                model: model,
+                                conversationId: conversationId,
+                                messageId: messageId,
+                                responseGroupId: responseGroupId,
+                                completedCount: &tracker.count,
+                                totalCount: totalCount
+                            )
+                        }
+                    }
+
+                    if let previousImage {
+                        aiService.editImage(prompt: prompt, sourceImage: previousImage, model: model, onComplete: onComplete, onError: onError)
+                    } else {
+                        aiService.generateImage(prompt: prompt, model: model, onComplete: onComplete, onError: onError)
+                    }
                 }
-            }
-
-            if let previousImage {
-                aiService.editImage(prompt: prompt, sourceImage: previousImage, model: model, onComplete: onComplete, onError: onError)
-            } else {
-                aiService.generateImage(prompt: prompt, model: model, onComplete: onComplete, onError: onError)
             }
         }
     }
@@ -1696,7 +1695,7 @@ extension IOSChatViewModel {
     /// Finalizes a batch of image generation requests
     func finalizeImageGenerationBatch(conversationId: UUID) {
         isGenerating = false
-        if let conv = conversationManager.conversations.first(where: { $0.id == conversationId }) {
+        if let conv = conversationManager.conversation(byId: conversationId) {
             conversationManager.save(conv)
         }
         if isNewChatMode {

--- a/Sources/Ayna/ViewModels/WatchChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/WatchChatViewModel.swift
@@ -236,6 +236,8 @@
                                 content: self.streamingContent
                             )
                         }
+                        self.conversationStore.persistCurrentState()
+                        self.pendingContent = ""
 
                         self.isLoading = false
                         self.isStreaming = false
@@ -279,6 +281,14 @@
                                 level: .info,
                                 message: "⌚ Request cancelled"
                             )
+                            if !self.pendingContent.isEmpty {
+                                self.streamingContent = self.pendingContent
+                                self.conversationStore.updateLastMessage(
+                                    in: conversationId,
+                                    content: self.streamingContent
+                                )
+                            }
+                            self.conversationStore.persistCurrentState()
                             self.isLoading = false
                             self.isStreaming = false
                             self.currentToolName = nil
@@ -300,6 +310,7 @@
                         self.playHaptic(.failure)
 
                         // Remove the empty assistant message and the user message
+                        self.pendingContent = ""
                         if var conv = self.conversationStore.conversation(for: conversationId),
                            !conv.messages.isEmpty
                         {
@@ -309,9 +320,7 @@
                             if !conv.messages.isEmpty {
                                 conv.messages.removeLast()
                             }
-                            self.conversationStore.updateConversations(
-                                self.conversationStore.conversations.map { $0.id == conversationId ? conv : $0 }
-                            )
+                            _ = self.conversationStore.replaceConversation(conv)
                         }
 
                         DiagnosticsLogger.log(
@@ -393,6 +402,7 @@
                             let continuationMessages = updatedConv.messages.dropLast().map { $0.toMessage() }
 
                             self.streamingContent = ""
+                            self.pendingContent = ""
 
                             self.sendMessageWithToolSupport(
                                 messages: Array(continuationMessages),

--- a/Sources/Ayna/ViewModels/WatchConversationStore.swift
+++ b/Sources/Ayna/ViewModels/WatchConversationStore.swift
@@ -210,6 +210,9 @@
                !conversations[convIndex].messages.isEmpty
             {
                 let lastIndex = conversations[convIndex].messages.count - 1
+                guard conversations[convIndex].messages[lastIndex].content != content else {
+                    return
+                }
                 let role = conversations[convIndex].messages[lastIndex].role
                 DiagnosticsLogger.log(
                     .watchConnectivity,
@@ -217,6 +220,7 @@
                     message: "⌚ updateLastMessage: index=\(lastIndex) role='\(role)' content='\(content.prefix(20))...'"
                 )
                 conversations[convIndex].messages[lastIndex].content = content
+                saveToDisk()
             }
         }
 

--- a/Sources/Ayna/ViewModels/WatchConversationStore.swift
+++ b/Sources/Ayna/ViewModels/WatchConversationStore.swift
@@ -10,6 +10,7 @@
     import Combine
     import Foundation
     import os
+    import SwiftUI
 
     /// Local store for conversations on Apple Watch
     /// Receives updates from iPhone via WatchConnectivity
@@ -87,6 +88,25 @@
                     metadata: ["error": error.localizedDescription]
                 )
             }
+        }
+
+        /// Persist the current in-memory conversation state.
+        func persistCurrentState() {
+            saveToDisk()
+        }
+
+        /// Replace an existing conversation in-place.
+        @discardableResult
+        func replaceConversation(_ conversation: WatchConversation, persist: Bool = true) -> Bool {
+            guard let index = conversations.firstIndex(where: { $0.id == conversation.id }) else {
+                return false
+            }
+
+            conversations[index] = conversation
+            if persist {
+                saveToDisk()
+            }
+            return true
         }
 
         /// Update conversations from WatchConnectivity sync
@@ -175,10 +195,9 @@
                 conversations[index].messages.append(message)
                 conversations[index].updatedAt = Date()
 
-                // Re-sort to put updated conversation at top
-                let updated = conversations[index]
-                conversations.remove(at: index)
-                conversations.insert(updated, at: 0)
+                if index > 0 {
+                    conversations.move(fromOffsets: IndexSet(integer: index), toOffset: 0)
+                }
 
                 // Persist to disk
                 saveToDisk()
@@ -198,7 +217,6 @@
                     message: "⌚ updateLastMessage: index=\(lastIndex) role='\(role)' content='\(content.prefix(20))...'"
                 )
                 conversations[convIndex].messages[lastIndex].content = content
-                saveToDisk()
             }
         }
 

--- a/Sources/Ayna/Views/iOS/IOSMessageView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageView.swift
@@ -232,12 +232,7 @@ struct IOSMessageView: View {
                         ProgressView()
                             .frame(maxWidth: Spacing.Component.bubbleMaxWidth - 20)
                             .task {
-                                // Load image from either imageData or imagePath
-                                if let imageData = message.effectiveImageData {
-                                    decodedImage = await Task.detached(priority: .userInitiated) {
-                                        UIImage(data: imageData)
-                                    }.value
-                                }
+                                loadDecodedImage()
                             }
                     }
                 }
@@ -418,26 +413,14 @@ struct IOSMessageView: View {
             // Reload image when path changes (e.g., after generation completes)
             if newPath != nil {
                 decodedImage = nil
-                Task {
-                    if let imageData = message.effectiveImageData {
-                        decodedImage = await Task.detached(priority: .userInitiated) {
-                            UIImage(data: imageData)
-                        }.value
-                    }
-                }
+                loadDecodedImage()
             }
         }
         .onChange(of: message.imageData) { _, newData in
             // Reload image when data changes
             if newData != nil {
                 decodedImage = nil
-                Task {
-                    if let imageData = message.effectiveImageData {
-                        decodedImage = await Task.detached(priority: .userInitiated) {
-                            UIImage(data: imageData)
-                        }.value
-                    }
-                }
+                loadDecodedImage()
             }
         }
     }
@@ -457,6 +440,15 @@ struct IOSMessageView: View {
         guard newHash != lastContentHash else { return }
         lastContentHash = newHash
         performParse(content: content)
+    }
+
+    private func loadDecodedImage() {
+        Task { @MainActor in
+            guard let imageData = await message.loadEffectiveImageData() else { return }
+            decodedImage = await Task.detached(priority: .userInitiated) {
+                UIImage(data: imageData)
+            }.value
+        }
     }
 
     private func saveImageToPhotos(_ image: UIImage) {

--- a/Sources/Ayna/Views/iOS/IOSMultiModelResponseView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMultiModelResponseView.swift
@@ -264,18 +264,15 @@ struct IOSMultiModelResponseCard: View {
         }
         .onChange(of: message.imageData) { _, newImageData in
             // Reload image when imageData changes
-            if let data = newImageData {
-                Task.detached(priority: .userInitiated) {
-                    let image = UIImage(data: data)
-                    await MainActor.run {
-                        decodedImage = image
-                    }
-                }
+            if newImageData != nil {
+                decodedImage = nil
+                loadImageFromPath()
             }
         }
         .onChange(of: message.imagePath) { _, newPath in
             // Reload image when imagePath changes
             if newPath != nil {
+                decodedImage = nil
                 loadImageFromPath()
             }
         }
@@ -292,14 +289,10 @@ struct IOSMultiModelResponseCard: View {
 
     private func loadImageFromPath() {
         Task { @MainActor in
-            if let data = message.effectiveImageData {
-                Task.detached(priority: .userInitiated) {
-                    let image = UIImage(data: data)
-                    await MainActor.run {
-                        decodedImage = image
-                    }
-                }
-            }
+            guard let data = await message.loadEffectiveImageData() else { return }
+            decodedImage = await Task.detached(priority: .userInitiated) {
+                UIImage(data: data)
+            }.value
         }
     }
 

--- a/Sources/Ayna/Views/iOS/IOSSidebarView.swift
+++ b/Sources/Ayna/Views/iOS/IOSSidebarView.swift
@@ -17,20 +17,7 @@ struct IOSSidebarView: View {
     @State private var showSettings = false
     @State private var isEditing = false
     @State private var selectedConversations = Set<UUID>()
-
-    var filteredConversations: [Conversation] {
-        if searchText.isEmpty {
-            return conversationManager.conversations
-        }
-        return conversationManager.conversations.filter {
-            $0.title.localizedCaseInsensitiveContains(searchText)
-        }
-    }
-
-    /// Grouped conversations for timeline display
-    var groupedConversations: [ConversationTimelineSection] {
-        ConversationTimelineGrouper.sections(from: filteredConversations)
-    }
+    @State private var conversationSections: [ConversationTimelineSection] = []
 
     var body: some View {
         conversationListView
@@ -75,12 +62,19 @@ struct IOSSidebarView: View {
                 }
             }
             .onAppear {
+                refreshConversationSections()
                 DiagnosticsLogger.log(
                     .contentView,
                     level: .info,
                     message: "📱 IOSSidebarView appeared",
                     metadata: ["conversationCount": "\(conversationManager.conversations.count)"]
                 )
+            }
+            .onChange(of: searchText) { _, newValue in
+                refreshConversationSections(searchText: newValue)
+            }
+            .onChange(of: conversationManager.conversations) { _, newValue in
+                refreshConversationSections(conversations: newValue)
             }
     }
 
@@ -136,7 +130,7 @@ struct IOSSidebarView: View {
 
     private var conversationListView: some View {
         List(selection: $conversationManager.selectedConversationId) {
-            ForEach(groupedConversations) { section in
+            ForEach(conversationSections) { section in
                 Section {
                     ForEach(section.conversations) { conversation in
                         conversationRowContent(for: conversation)
@@ -369,6 +363,24 @@ struct IOSSidebarView: View {
             level: .info,
             message: "🆕 New conversation button tapped"
         )
+    }
+
+    private func refreshConversationSections(
+        conversations: [Conversation]? = nil,
+        searchText: String? = nil
+    ) {
+        let sourceConversations = conversations ?? conversationManager.conversations
+        let activeSearchText = searchText ?? self.searchText
+        let filteredConversations: [Conversation]
+        if activeSearchText.isEmpty {
+            filteredConversations = sourceConversations
+        } else {
+            filteredConversations = sourceConversations.filter {
+                $0.title.localizedCaseInsensitiveContains(activeSearchText)
+            }
+        }
+
+        conversationSections = ConversationTimelineGrouper.sections(from: filteredConversations)
     }
 }
 

--- a/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
+++ b/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
@@ -8,6 +8,7 @@
 
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// The chat input/composer area including text editor, attachments, and model selector
 struct ChatInputArea: View {
@@ -35,6 +36,8 @@ struct ChatInputArea: View {
     @ObservedObject private var aiService = AIService.shared
 
     var body: some View {
+        let textHeight = calculateTextHeight()
+
         VStack(spacing: Spacing.sm) {
             MCPToolSummaryView(isExpanded: $isToolSectionExpanded)
 
@@ -50,9 +53,9 @@ struct ChatInputArea: View {
 
             // Main input row
             HStack(spacing: 0) {
-                textEditorWithAttachButton
-                modelSelectorButton
-                sendButton
+                textEditorWithAttachButton(textHeight: textHeight)
+                modelSelectorButton(textHeight: textHeight)
+                sendButton(textHeight: textHeight)
             }
             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Spacing.CornerRadius.pill + Spacing.CornerRadius.sm))
             .overlay(
@@ -146,7 +149,7 @@ struct ChatInputArea: View {
 
     // MARK: - Text Editor with Attach Button
 
-    private var textEditorWithAttachButton: some View {
+    private func textEditorWithAttachButton(textHeight: CGFloat) -> some View {
         ZStack(alignment: .bottomLeading) {
             DynamicTextEditor(
                 text: $messageText,
@@ -154,7 +157,7 @@ struct ChatInputArea: View {
                 onSubmit: onSendMessage,
                 accessibilityIdentifier: textEditorIdentifier
             )
-            .frame(height: calculateTextHeight())
+            .frame(height: textHeight)
             .font(Typography.body)
             .scrollContentBackground(.hidden)
             .padding(.leading, 48)
@@ -192,7 +195,7 @@ struct ChatInputArea: View {
 
     // MARK: - Model Selector Button
 
-    private var modelSelectorButton: some View {
+    private func modelSelectorButton(textHeight: CGFloat) -> some View {
         Button(action: { showModelSelector.toggle() }) {
             HStack(spacing: Spacing.xxs) {
                 Divider()
@@ -217,7 +220,7 @@ struct ChatInputArea: View {
                     .foregroundStyle(Theme.textSecondary)
             }
             .padding(.horizontal, Spacing.md)
-            .frame(height: calculateTextHeight() + Spacing.xxl)
+            .frame(height: textHeight + Spacing.xxl)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -238,7 +241,7 @@ struct ChatInputArea: View {
 
     // MARK: - Send Button
 
-    private var sendButton: some View {
+    private func sendButton(textHeight: CGFloat) -> some View {
         Button(action: onSendMessage) {
             ZStack {
                 if isGenerating {
@@ -257,7 +260,7 @@ struct ChatInputArea: View {
         .allowsHitTesting(isGenerating || !messageText.isEmpty)
         .accessibilityIdentifier(sendButtonIdentifier)
         .padding(.horizontal, Spacing.md)
-        .frame(height: calculateTextHeight() + Spacing.xxl)
+        .frame(height: textHeight + Spacing.xxl)
     }
 
     // MARK: - Text Height Calculation
@@ -285,20 +288,50 @@ struct ChatInputArea: View {
     }
 }
 
+private enum AttachmentThumbnailCache {
+    private nonisolated(unsafe) static let thumbnails: NSCache<NSURL, NSImage> = {
+        let cache = NSCache<NSURL, NSImage>()
+        cache.countLimit = 64
+        return cache
+    }()
+
+    static func image(for fileURL: URL) -> NSImage? {
+        thumbnails.object(forKey: fileURL as NSURL)
+    }
+
+    static func insert(_ image: NSImage, for fileURL: URL) {
+        thumbnails.setObject(image, forKey: fileURL as NSURL)
+    }
+}
+
 /// Row for displaying an attached file
 struct AttachedFileRow: View {
     let fileURL: URL
     let onRemove: () -> Void
+    @State private var thumbnail: NSImage?
+
+    init(fileURL: URL, onRemove: @escaping () -> Void) {
+        self.fileURL = fileURL
+        self.onRemove = onRemove
+        _thumbnail = State(initialValue: AttachmentThumbnailCache.image(for: fileURL))
+    }
+
+    private var isImageFile: Bool {
+        fileURL.isImageFile
+    }
 
     var body: some View {
         HStack(spacing: Spacing.sm) {
-            // Show image thumbnail if it's an image file
-            if let image = NSImage(contentsOf: fileURL) {
-                Image(nsImage: image)
+            if let thumbnail {
+                Image(nsImage: thumbnail)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 48, height: 48)
                     .clipShape(RoundedRectangle(cornerRadius: Spacing.CornerRadius.sm))
+            } else if isImageFile {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: 48, height: 48)
             } else {
                 Image(systemName: "doc.fill")
                     .font(.system(size: Typography.IconSize.lg))
@@ -327,6 +360,76 @@ struct AttachedFileRow: View {
         }
         .padding(Spacing.sm)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Spacing.CornerRadius.md))
+        .task(id: fileURL) {
+            await loadThumbnailIfNeeded()
+        }
+    }
+
+    @MainActor
+    private func loadThumbnailIfNeeded() async {
+        guard thumbnail == nil, isImageFile else { return }
+
+        if let cachedThumbnail = AttachmentThumbnailCache.image(for: fileURL) {
+            thumbnail = cachedThumbnail
+            return
+        }
+
+        let imageData = await Task.detached(priority: .utility) { [fileURL] in
+            try? Data(contentsOf: fileURL)
+        }.value
+
+        guard !Task.isCancelled,
+              let imageData,
+              let image = NSImage(data: imageData)?.scaledThumbnail(maxSize: NSSize(width: 48, height: 48))
+        else {
+            return
+        }
+
+        AttachmentThumbnailCache.insert(image, for: fileURL)
+        thumbnail = image
+    }
+}
+
+private extension URL {
+    var isImageFile: Bool {
+        guard !pathExtension.isEmpty,
+              let contentType = UTType(filenameExtension: pathExtension.lowercased())
+        else {
+            return false
+        }
+
+        return contentType.conforms(to: .image)
+    }
+}
+
+private extension NSImage {
+    func scaledThumbnail(maxSize: NSSize) -> NSImage {
+        guard size.width > maxSize.width || size.height > maxSize.height else {
+            return self
+        }
+
+        let widthScale = maxSize.width / size.width
+        let heightScale = maxSize.height / size.height
+        let scale = max(widthScale, heightScale)
+        let scaledSize = NSSize(width: size.width * scale, height: size.height * scale)
+        let drawRect = NSRect(
+            x: (maxSize.width - scaledSize.width) / 2,
+            y: (maxSize.height - scaledSize.height) / 2,
+            width: scaledSize.width,
+            height: scaledSize.height
+        )
+
+        let thumbnail = NSImage(size: maxSize)
+        thumbnail.lockFocus()
+        NSGraphicsContext.current?.imageInterpolation = .high
+        draw(
+            in: drawRect,
+            from: NSRect(origin: .zero, size: size),
+            operation: .copy,
+            fraction: 1
+        )
+        thumbnail.unlockFocus()
+        return thumbnail
     }
 }
 #endif

--- a/Sources/Ayna/Views/macOS/MacMessageView.swift
+++ b/Sources/Ayna/Views/macOS/MacMessageView.swift
@@ -660,10 +660,11 @@ struct MacMessageView: View {
     /// Note: NSImage is non-Sendable so we create it on @MainActor directly
     private func loadGeneratedImage() {
         guard cachedGeneratedImage == nil else { return }
-        guard let imageData = message.effectiveImageData else { return }
-
-        if let image = NSImage(data: imageData) {
-            cachedGeneratedImage = image
+        Task { @MainActor in
+            guard let imageData = await message.loadEffectiveImageData() else { return }
+            if let image = NSImage(data: imageData) {
+                cachedGeneratedImage = image
+            }
         }
     }
 
@@ -671,10 +672,11 @@ struct MacMessageView: View {
     /// Note: NSImage is non-Sendable so we create it on @MainActor directly
     private func loadAttachmentImage(at index: Int, attachment: Message.FileAttachment) {
         guard cachedAttachmentImages[index] == nil else { return }
-        guard let data = attachment.content else { return }
-
-        if let image = NSImage(data: data) {
-            cachedAttachmentImages[index] = image
+        Task { @MainActor in
+            guard let data = await attachment.loadContent() else { return }
+            if let image = NSImage(data: data) {
+                cachedAttachmentImages[index] = image
+            }
         }
     }
 

--- a/Sources/Ayna/Views/macOS/MacMessageView.swift
+++ b/Sources/Ayna/Views/macOS/MacMessageView.swift
@@ -42,6 +42,9 @@ struct MacMessageView: View {
     @State private var cachedGeneratedImage: NSImage?
     @State private var cachedAttachmentImages: [Int: NSImage] = [:]
 
+    private static let deferredMarkdownCharacterLimit = 6_000
+    private static let deferredMarkdownLineLimit = 180
+
     init(
         message: Message,
         modelName: String? = nil,
@@ -54,23 +57,51 @@ struct MacMessageView: View {
         self.onRetry = onRetry
         self.onSwitchModel = onSwitchModel
         self.onEdit = onEdit
-        // Parse content synchronously on init to avoid flash of empty bubbles
-        // Tool messages start collapsed (preview uses plain text), so defer parsing
-        // to the async background path to avoid blocking the main thread on large results.
+        // Only hydrate from the shared markdown cache in init. Parsing here would
+        // run on every SwiftUI view refresh and can stall the macOS chat UI for
+        // large markdown responses.
         if message.role == .tool {
             _cachedContentBlocks = State(initialValue: [])
             _lastContentHash = State(initialValue: 0)
         } else {
-            _cachedContentBlocks = State(initialValue: MarkdownRenderer.parse(message.content))
+            _cachedContentBlocks = State(initialValue: Self.initialContentBlocks(for: message.content))
             _lastContentHash = State(initialValue: message.content.hashValue)
         }
         if let reasoning = message.reasoning {
-            _cachedReasoningBlocks = State(initialValue: MarkdownRenderer.parse(reasoning))
+            _cachedReasoningBlocks = State(initialValue: Self.initialContentBlocks(for: reasoning))
             _lastReasoningHash = State(initialValue: reasoning.hashValue)
         } else {
             _cachedReasoningBlocks = State(initialValue: [])
             _lastReasoningHash = State(initialValue: 0)
         }
+    }
+
+    private static func initialContentBlocks(for content: String) -> [ContentBlock] {
+        if let cachedBlocks = MarkdownRenderer.cachedBlocks(for: content) {
+            return cachedBlocks
+        }
+
+        guard !shouldDeferMarkdownParsing(content) else {
+            return []
+        }
+
+        return MarkdownRenderer.parse(content)
+    }
+
+    private static func shouldDeferMarkdownParsing(_ content: String) -> Bool {
+        guard !content.isEmpty else { return false }
+        if content.count > deferredMarkdownCharacterLimit {
+            return true
+        }
+
+        var lineCount = 1
+        for character in content where character == "\n" {
+            lineCount += 1
+            if lineCount > deferredMarkdownLineLimit {
+                return true
+            }
+        }
+        return false
     }
 
     private static let timestampFormatter: DateFormatter = {
@@ -488,8 +519,19 @@ struct MacMessageView: View {
             }
         }
 
-        ForEach(cachedContentBlocks, id: \.id) { block in
-            block.view
+        if cachedContentBlocks.isEmpty, Self.shouldDeferMarkdownParsing(message.content) {
+            HStack(spacing: Spacing.xs) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Rendering markdown...")
+                    .font(Typography.bodySecondary)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .padding(.vertical, Spacing.xs)
+        } else {
+            ForEach(cachedContentBlocks, id: \.id) { block in
+                block.view
+            }
         }
 
         // Citation sources footer for web search results
@@ -600,7 +642,8 @@ struct MacMessageView: View {
     private func updateCachedBlocks() {
         let content = message.content
         let newHash = content.hashValue
-        guard newHash != lastContentHash else { return }
+        let needsInitialParse = !content.isEmpty && cachedContentBlocks.isEmpty
+        guard newHash != lastContentHash || needsInitialParse else { return }
         lastContentHash = newHash
 
         // Cancel any pending debounce task
@@ -641,7 +684,8 @@ struct MacMessageView: View {
     private func updateCachedReasoningBlocks() {
         if let reasoning = message.reasoning {
             let newHash = reasoning.hashValue
-            if newHash != lastReasoningHash {
+            let needsInitialParse = !reasoning.isEmpty && cachedReasoningBlocks.isEmpty
+            if newHash != lastReasoningHash || needsInitialParse {
                 lastReasoningHash = newHash
                 reasoningParseTask?.cancel()
                 reasoningParseTask = Task.detached(priority: .userInitiated) {
@@ -833,7 +877,6 @@ extension ContentBlock {
                 .lineSpacing(Typography.bodyLineSpacing)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
 
         case let .heading(level, text):
             let font: Font = switch level {
@@ -850,7 +893,6 @@ extension ContentBlock {
                 .font(font)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, level == 1 ? Spacing.xxs : Spacing.xxxs)
 
         case let .unorderedList(items):
@@ -864,7 +906,6 @@ extension ContentBlock {
                             .font(Typography.body)
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .fixedSize(horizontal: false, vertical: true)
                     }
                     .padding(.leading, Spacing.xxxs)
                     .accessibilityLabel("Bullet item \(index + 1)")
@@ -883,7 +924,6 @@ extension ContentBlock {
                             .font(Typography.body)
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
             }
@@ -901,7 +941,6 @@ extension ContentBlock {
                     .lineSpacing(Typography.bodyLineSpacing)
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(Spacing.md)
             .background(Theme.textSecondary.opacity(0.08))
@@ -966,7 +1005,6 @@ extension ContentBlock {
                     SyntaxHighlightedCodeView(code: code, language: language)
                         .padding(Spacing.md)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             .background(Theme.codeBackground)
@@ -1267,18 +1305,55 @@ private enum SyntaxRegexCache {
     }
 }
 
+private enum SyntaxHighlightCache {
+    private final class HighlightedCodeWrapper: @unchecked Sendable {
+        let value: AttributedString
+
+        init(value: AttributedString) {
+            self.value = value
+        }
+    }
+
+    private nonisolated(unsafe) static let cache: NSCache<NSString, HighlightedCodeWrapper> = {
+        let cache = NSCache<NSString, HighlightedCodeWrapper>()
+        cache.countLimit = 64
+        cache.totalCostLimit = 512_000
+        return cache
+    }()
+
+    static func value(for code: String, language: String) -> AttributedString? {
+        cache.object(forKey: key(for: code, language: language))?.value
+    }
+
+    static func insert(_ value: AttributedString, for code: String, language: String) {
+        cache.setObject(
+            HighlightedCodeWrapper(value: value),
+            forKey: key(for: code, language: language),
+            cost: code.utf16.count
+        )
+    }
+
+    private static func key(for code: String, language: String) -> NSString {
+        "\(language.lowercased())\u{0}\(code)" as NSString
+    }
+}
+
 /// Syntax highlighted code view
 struct SyntaxHighlightedCodeView: View {
     let code: String
     let language: String
 
     var body: some View {
-        Text(AttributedString(highlightedCode()))
+        Text(highlightedCode())
             .font(Typography.codeBlock)
             .textSelection(.enabled)
     }
 
-    private func highlightedCode() -> NSAttributedString {
+    private func highlightedCode() -> AttributedString {
+        if let cached = SyntaxHighlightCache.value(for: code, language: language) {
+            return cached
+        }
+
         let attributedString = NSMutableAttributedString(string: code)
         let fullRange = NSRange(location: 0, length: code.utf16.count)
 
@@ -1322,7 +1397,9 @@ struct SyntaxHighlightedCodeView: View {
             highlightGeneric(attributedString)
         }
 
-        return attributedString
+        let highlighted = AttributedString(NSAttributedString(attributedString: attributedString))
+        SyntaxHighlightCache.insert(highlighted, for: code, language: language)
+        return highlighted
     }
 
     private func highlightSwift(_ attributedString: NSMutableAttributedString) {

--- a/Sources/Ayna/Views/macOS/MacSidebarView.swift
+++ b/Sources/Ayna/Views/macOS/MacSidebarView.swift
@@ -230,19 +230,29 @@ struct MacSidebarView: View {
 struct ConversationRow: View {
     let conversation: Conversation
 
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
     private var lastMessagePreview: String {
         conversation.messages.last(where: { $0.role == .assistant })?.content ?? "No messages"
     }
 
     private var timeString: String {
-        let formatter = DateFormatter()
         if Calendar.current.isDateInToday(conversation.updatedAt) {
-            formatter.dateFormat = "HH:mm"
+            Self.timeFormatter.string(from: conversation.updatedAt)
         } else {
-            formatter.dateStyle = .short
-            formatter.timeStyle = .none
+            Self.dateFormatter.string(from: conversation.updatedAt)
         }
-        return formatter.string(from: conversation.updatedAt)
     }
 
     /// Generate a consistent color based on conversation ID for unique avatars

--- a/Sources/Ayna/Views/macOS/MultiModelResponseView.swift
+++ b/Sources/Ayna/Views/macOS/MultiModelResponseView.swift
@@ -128,6 +128,7 @@ struct MultiModelResponseCard: View {
 
     @State private var isHovered = false
     @State private var cachedContentBlocks: [ContentBlock]
+    @State private var decodedImage: NSImage?
 
     init(
         message: Message,
@@ -207,6 +208,23 @@ struct MultiModelResponseCard: View {
                     }
                 }
             }
+            .onChange(of: message.imageData) { _, newImageData in
+                if newImageData != nil {
+                    decodedImage = nil
+                    loadImage()
+                }
+            }
+            .onChange(of: message.imagePath) { _, newPath in
+                if newPath != nil {
+                    decodedImage = nil
+                    loadImage()
+                }
+            }
+            .task {
+                if message.mediaType == .image, decodedImage == nil {
+                    loadImage()
+                }
+            }
             .accessibilityElement(children: .combine)
             .accessibilityLabel("Response from \(modelName)")
             .accessibilityHint(isSelected ? "Selected" : "Double tap to select")
@@ -272,7 +290,8 @@ struct MultiModelResponseCard: View {
             VStack(alignment: .leading, spacing: Spacing.sm) {
                 if message.mediaType == .image {
                     // Image generation content
-                    if let imageData = message.effectiveImageData, let nsImage = NSImage(data: imageData) {
+                    if let decodedImage {
+                        let nsImage = decodedImage
                         Image(nsImage: nsImage)
                             .resizable()
                             .aspectRatio(contentMode: .fit)
@@ -322,6 +341,13 @@ struct MultiModelResponseCard: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(minHeight: 120, maxHeight: 300)
+    }
+
+    private func loadImage() {
+        Task { @MainActor in
+            guard let imageData = await message.loadEffectiveImageData() else { return }
+            decodedImage = NSImage(data: imageData)
+        }
     }
 
     private var failedContentView: some View {

--- a/Sources/Ayna/Views/watchOS/WatchMessageView.swift
+++ b/Sources/Ayna/Views/watchOS/WatchMessageView.swift
@@ -19,6 +19,19 @@
     struct WatchMessageView: View {
         let message: WatchMessage
         var showTimestamp: Bool = false
+        @State private var renderedContent: AttributedString
+
+        init(message: WatchMessage, showTimestamp: Bool = false) {
+            self.message = message
+            self.showTimestamp = showTimestamp
+            _renderedContent = State(initialValue: WatchMarkdownRenderer.render(message.content))
+        }
+
+        private static let timeFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.timeStyle = .short
+            return formatter
+        }()
 
         private var isUser: Bool {
             message.role.lowercased() == "user"
@@ -32,7 +45,7 @@
                     }
 
                     // Message content
-                    Text(WatchMarkdownRenderer.render(message.content))
+                    Text(renderedContent)
                         .font(Typography.body)
                         .foregroundStyle(isUser ? Theme.userBubbleText : .primary)
                         .padding(.horizontal, Spacing.bubblePaddingH)
@@ -53,6 +66,9 @@
                         .padding(.horizontal, Spacing.xxs)
                 }
             }
+            .onChange(of: message.content) { _, newContent in
+                renderedContent = WatchMarkdownRenderer.render(newContent)
+            }
         }
 
         private var bubbleBackground: Color {
@@ -60,9 +76,7 @@
         }
 
         private var formattedTime: String {
-            let formatter = DateFormatter()
-            formatter.timeStyle = .short
-            return formatter.string(from: message.timestamp)
+            Self.timeFormatter.string(from: message.timestamp)
         }
     }
 
@@ -146,6 +160,13 @@
     struct WatchStreamingMessageView: View {
         let content: String
         let isStreaming: Bool
+        @State private var renderedContent: AttributedString
+
+        init(content: String, isStreaming: Bool) {
+            self.content = content
+            self.isStreaming = isStreaming
+            _renderedContent = State(initialValue: WatchMarkdownRenderer.render(content))
+        }
 
         var body: some View {
             HStack {
@@ -164,7 +185,7 @@
                     .clipShape(RoundedRectangle(cornerRadius: Spacing.CornerRadius.xxl))
                 } else {
                     // Content
-                    Text(WatchMarkdownRenderer.render(content))
+                    Text(renderedContent)
                         .font(Typography.body)
                         .foregroundStyle(.primary)
                         .padding(.horizontal, Spacing.bubblePaddingH)
@@ -174,6 +195,9 @@
                 }
 
                 Spacer(minLength: Spacing.Component.bubbleMinWidth - 20)
+            }
+            .onChange(of: content) { _, newContent in
+                renderedContent = WatchMarkdownRenderer.render(newContent)
             }
         }
     }

--- a/Tests/AynaTests/AnthropicProviderTests.swift
+++ b/Tests/AynaTests/AnthropicProviderTests.swift
@@ -859,6 +859,70 @@ struct AnthropicProviderTests {
         #expect(receivedToolName == "web_search")
     }
 
+    @Test("Streaming tool use is delivered before completion", .timeLimit(.minutes(1)))
+    func streamingToolUseDeliveredBeforeCompletion() async {
+        let provider = makeProvider()
+        let config = makeConfig()
+        let messages = [Message(role: .user, content: "Search for Swift")]
+
+        let sseResponse = """
+        event: message_start
+        data: {"type": "message_start", "message": {"id": "msg_order", "type": "message", "role": "assistant"}}
+
+        event: content_block_start
+        data: {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_order", "name": "web_search"}}
+
+        event: content_block_delta
+        data: {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\\"query\\": \\"Swift\\"}"}}
+
+        event: content_block_stop
+        data: {"type": "content_block_stop", "index": 0}
+
+        event: message_delta
+        data: {"type": "message_delta", "delta": {"stop_reason": "tool_use"}}
+
+        event: message_stop
+        data: {"type": "message_stop"}
+
+        """
+
+        AnthropicMockURLProtocol.requestHandler = { _ in
+            let response = HTTPURLResponse(
+                url: URL(string: "https://api.anthropic.com/v1/messages")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"]
+            )!
+            return (response, Data(sseResponse.utf8))
+        }
+
+        let callbackOrder = CallbackOrderCollector()
+
+        await confirmation("Response completes") { completed in
+            provider.sendMessage(
+                messages: messages,
+                config: config,
+                stream: true,
+                tools: nil,
+                callbacks: AIProviderStreamCallbacks(
+                    onChunk: { _ in },
+                    onComplete: {
+                        callbackOrder.append("complete")
+                        completed()
+                    },
+                    onError: { error in Issue.record("Unexpected error: \(error)") },
+                    onToolCallRequested: { _, _, _ in
+                        callbackOrder.append("tool")
+                    }
+                )
+            )
+
+            try? await Task.sleep(for: .milliseconds(500))
+        }
+
+        #expect(callbackOrder.events == ["tool", "complete"])
+    }
+
     @Test("Thinking budget adds beta header for Claude 4 models", .timeLimit(.minutes(1)))
     func thinkingBudgetAddsBetaHeader() async {
         let provider = makeProvider()
@@ -965,5 +1029,22 @@ private final class ChunkCollector: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return chunks.joined()
+    }
+}
+
+private final class CallbackOrderCollector: @unchecked Sendable {
+    private var recordedEvents: [String] = []
+    private let lock = NSLock()
+
+    func append(_ event: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedEvents.append(event)
+    }
+
+    var events: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedEvents
     }
 }

--- a/Tests/AynaTests/AttachmentStorageTests.swift
+++ b/Tests/AynaTests/AttachmentStorageTests.swift
@@ -1,0 +1,54 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("AttachmentStorage Tests", .tags(.persistence, .async), .serialized)
+@MainActor
+struct AttachmentStorageTests {
+    @Test("Saving primes the in-process attachment cache")
+    func savePrimesAttachmentCache() throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let storage = AttachmentStorage(
+            directoryURL: directory,
+            dataCache: AttachmentDataCache()
+        )
+        let data = Data("cached attachment".utf8)
+
+        let path = try storage.save(data: data, extension: "bin")
+
+        #expect(storage.cachedData(path: path) == data)
+    }
+
+    @Test("Async message and attachment helpers load stored data")
+    func asyncHelpersLoadStoredData() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let storage = AttachmentStorage(
+            directoryURL: directory,
+            dataCache: AttachmentDataCache()
+        )
+        let data = Data("stored attachment".utf8)
+        let path = try storage.save(data: data, extension: "png")
+
+        let originalAsyncLoader = Message.attachmentAsyncLoader
+        defer { Message.attachmentAsyncLoader = originalAsyncLoader }
+        Message.attachmentAsyncLoader = { requestedPath in
+            await storage.loadData(path: requestedPath)
+        }
+
+        let message = Message(
+            role: .assistant,
+            content: "",
+            mediaType: .image,
+            imagePath: path
+        )
+        let attachment = Message.FileAttachment(
+            fileName: "example.png",
+            mimeType: "image/png",
+            data: nil,
+            localPath: path
+        )
+
+        #expect(await message.loadEffectiveImageData() == data)
+        #expect(await attachment.loadContent() == data)
+    }
+}

--- a/Tests/AynaTests/ConversationPersistenceCoordinatorTests.swift
+++ b/Tests/AynaTests/ConversationPersistenceCoordinatorTests.swift
@@ -1,0 +1,46 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("ConversationPersistenceCoordinator Tests", .tags(.persistence, .async), .serialized)
+struct ConversationPersistenceCoordinatorTests {
+    @Test("Flush pending saves persists all queued conversations")
+    func flushPendingSavesPersistsAllQueuedConversations() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let store = TestHelpers.makeTestStore(directory: directory)
+        let coordinator = ConversationPersistenceCoordinator(
+            store: store,
+            debounceDuration: .seconds(10)
+        )
+
+        await coordinator.enqueueSave(TestHelpers.sampleConversation(title: "Alpha"))
+        await coordinator.enqueueSave(TestHelpers.sampleConversation(title: "Beta"))
+        await coordinator.flushPendingSaves()
+
+        let loaded = try await store.loadConversations()
+        #expect(Set(loaded.map(\.title)) == Set(["Alpha", "Beta"]))
+    }
+
+    @Test("Flush pending saves keeps the latest enqueued version")
+    func flushPendingSavesKeepsLatestVersion() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let store = TestHelpers.makeTestStore(directory: directory)
+        let coordinator = ConversationPersistenceCoordinator(
+            store: store,
+            debounceDuration: .seconds(10)
+        )
+
+        let conversationId = UUID()
+        let original = TestHelpers.sampleConversation(id: conversationId, title: "Original")
+        var updated = original
+        updated.title = "Updated"
+
+        await coordinator.enqueueSave(original)
+        await coordinator.enqueueSave(updated)
+        await coordinator.flushPendingSaves()
+
+        let loaded = try await store.loadConversations()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.title == "Updated")
+    }
+}

--- a/Tests/AynaTests/EncryptedConversationStoreTests.swift
+++ b/Tests/AynaTests/EncryptedConversationStoreTests.swift
@@ -4,6 +4,52 @@ import Testing
 
 @Suite("EncryptedConversationStore Tests", .tags(.persistence, .slow))
 struct EncryptedConversationStoreTests {
+    private final class CountingKeychainStorage: KeychainStoring, @unchecked Sendable {
+        private var storage: [String: Data] = [:]
+        private let lock = NSLock()
+        private var dataReads = 0
+        private var stringReads = 0
+
+        func setString(_ value: String, for key: String) throws {
+            lock.lock()
+            defer { lock.unlock() }
+            storage[key] = Data(value.utf8)
+        }
+
+        func string(for key: String) throws -> String? {
+            lock.lock()
+            defer { lock.unlock() }
+            stringReads += 1
+            guard let data = storage[key] else { return nil }
+            return String(data: data, encoding: .utf8)
+        }
+
+        func setData(_ data: Data, for key: String) throws {
+            lock.lock()
+            defer { lock.unlock() }
+            storage[key] = data
+        }
+
+        func data(for key: String) throws -> Data? {
+            lock.lock()
+            defer { lock.unlock() }
+            dataReads += 1
+            return storage[key]
+        }
+
+        func removeValue(for key: String) throws {
+            lock.lock()
+            defer { lock.unlock() }
+            storage[key] = nil
+        }
+
+        func readCounts() -> (dataReads: Int, stringReads: Int) {
+            lock.lock()
+            defer { lock.unlock() }
+            return (dataReads, stringReads)
+        }
+    }
+
     @Test("Save and load round trips conversations")
     func saveAndLoadRoundTripsConversations() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
@@ -50,5 +96,42 @@ struct EncryptedConversationStoreTests {
         let loaded = try await secondStore.loadConversations()
 
         #expect(loaded.first?.title == "Persisted")
+    }
+
+    @Test("Loading an empty store does not create an encryption key")
+    func loadingEmptyStoreDoesNotCreateEncryptionKey() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let keychain = CountingKeychainStorage()
+        let store = EncryptedConversationStore(
+            directoryURL: directory,
+            keyIdentifier: UUID().uuidString,
+            keychain: keychain
+        )
+
+        let loaded = try await store.loadConversations()
+        let counts = keychain.readCounts()
+
+        #expect(loaded.isEmpty)
+        #expect(counts.dataReads == 0)
+        #expect(counts.stringReads == 0)
+    }
+
+    @Test("Encryption key is cached across repeated save and load operations")
+    func encryptionKeyIsCachedAcrossOperations() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let keychain = CountingKeychainStorage()
+        let store = EncryptedConversationStore(
+            directoryURL: directory,
+            keyIdentifier: UUID().uuidString,
+            keychain: keychain
+        )
+
+        try await store.save(TestHelpers.sampleConversation(title: "First"))
+        _ = try await store.loadConversations()
+        try await store.save(TestHelpers.sampleConversation(title: "Second"))
+
+        let counts = keychain.readCounts()
+        #expect(counts.dataReads == 1)
+        #expect(counts.stringReads == 1)
     }
 }

--- a/Tests/AynaTests/MCPServiceTests.swift
+++ b/Tests/AynaTests/MCPServiceTests.swift
@@ -1,0 +1,152 @@
+#if os(macOS)
+    @testable import Ayna
+    import Foundation
+    import Testing
+
+    @Suite("MCPService Tests", .tags(.async, .errorHandling), .serialized)
+    struct MCPServiceTests {
+        @Test("Initialize request times out and clears pending continuation", .timeLimit(.minutes(1)))
+        func initializeRequestTimesOut() async throws {
+            let harness = try MockMCPServerHarness(mode: .initializeTimeout)
+            defer { harness.cleanup() }
+
+            let service = harness.makeService(requestTimeoutSeconds: 1.0)
+            defer { service.disconnect() }
+
+            do {
+                try await service.connect()
+                Issue.record("Expected connect() to time out during initialize")
+            } catch let error as MCPServiceError {
+                switch error {
+                case let .initializationFailed(message):
+                    #expect(message.contains("Operation timed out"))
+                default:
+                    Issue.record("Unexpected MCPServiceError: \(error.localizedDescription)")
+                }
+            } catch {
+                Issue.record("Unexpected error type: \(error.localizedDescription)")
+            }
+
+            #expect(service.pendingRequestCount == 0)
+        }
+
+        @Test("List tools request times out and clears pending continuation", .timeLimit(.minutes(1)))
+        func listToolsRequestTimesOut() async throws {
+            let harness = try MockMCPServerHarness(mode: .listTimeout)
+            defer { harness.cleanup() }
+
+            let service = harness.makeService(requestTimeoutSeconds: 1.0)
+            try await service.connect()
+            defer { service.disconnect() }
+
+            do {
+                _ = try await service.listTools()
+                Issue.record("Expected listTools() to time out")
+            } catch let error as MCPServiceError {
+                guard case .timeout = error else {
+                    Issue.record("Unexpected MCPServiceError: \(error.localizedDescription)")
+                    return
+                }
+            } catch {
+                Issue.record("Unexpected error type: \(error.localizedDescription)")
+            }
+
+            #expect(service.pendingRequestCount == 0)
+        }
+
+        @Test("Tool call request times out and clears pending continuation", .timeLimit(.minutes(1)))
+        func callToolRequestTimesOut() async throws {
+            let harness = try MockMCPServerHarness(mode: .callTimeout)
+            defer { harness.cleanup() }
+
+            let service = harness.makeService(requestTimeoutSeconds: 1.0)
+            try await service.connect()
+            defer { service.disconnect() }
+
+            do {
+                _ = try await service.callTool(name: "echo", arguments: [:])
+                Issue.record("Expected callTool() to time out")
+            } catch let error as MCPServiceError {
+                guard case .timeout = error else {
+                    Issue.record("Unexpected MCPServiceError: \(error.localizedDescription)")
+                    return
+                }
+            } catch {
+                Issue.record("Unexpected error type: \(error.localizedDescription)")
+            }
+
+            #expect(service.pendingRequestCount == 0)
+        }
+    }
+
+    private struct MockMCPServerHarness {
+        enum Mode: String {
+            case initializeTimeout = "initialize-timeout"
+            case listTimeout = "list-timeout"
+            case callTimeout = "call-timeout"
+        }
+
+        let directory: URL
+        let scriptURL: URL
+        let mode: Mode
+
+        init(mode: Mode) throws {
+            self.mode = mode
+            directory = FileManager.default.temporaryDirectory.appendingPathComponent("MCPServiceTests-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+
+            scriptURL = directory.appendingPathComponent("mock-mcp-server.sh")
+            try scriptContents.write(to: scriptURL, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        }
+
+        func makeService(requestTimeoutSeconds: TimeInterval) -> MCPService {
+            let config = MCPServerConfig(
+                name: "mock-\(UUID().uuidString)",
+                command: scriptURL.path,
+                env: ["MCP_TEST_MODE": mode.rawValue]
+            )
+
+            return MCPService(serverConfig: config, requestTimeoutSeconds: requestTimeoutSeconds)
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        private var scriptContents: String {
+            """
+            #!/bin/sh
+            mode="${MCP_TEST_MODE:-ok}"
+
+            while IFS= read -r line; do
+              case "$line" in
+                *'"method":"initialize"'*)
+                  if [ "$mode" = "initialize-timeout" ]; then
+                    sleep 60
+                  else
+                    printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{}}}'
+                  fi
+                  ;;
+                *'"method":"notifications/initialized"'*)
+                  ;;
+                *'"method":"tools/list"'*)
+                  if [ "$mode" = "list-timeout" ]; then
+                    sleep 60
+                  else
+                    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}'
+                  fi
+                  ;;
+                *'"method":"tools/call"'*)
+                  if [ "$mode" = "call-timeout" ]; then
+                    sleep 60
+                  else
+                    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"content":"ok"}}'
+                  fi
+                  ;;
+              esac
+            done
+            """
+        }
+    }
+#endif

--- a/Tests/AynaTests/MarkdownRendererTests.swift
+++ b/Tests/AynaTests/MarkdownRendererTests.swift
@@ -191,4 +191,19 @@ struct MarkdownRendererTests {
             Issue.record("Expected ordered list block")
         }
     }
+
+    @Test("Returns cached blocks after parsing")
+    func returnsCachedBlocksAfterParsing() {
+        let input = """
+        # Cached
+
+        Markdown cache lookup.
+        """
+
+        #expect(MarkdownRenderer.cachedBlocks(for: input) == nil)
+        let parsedBlocks = MarkdownRenderer.parse(input)
+        let cachedBlocks = MarkdownRenderer.cachedBlocks(for: input)
+
+        #expect(cachedBlocks?.count == parsedBlocks.count)
+    }
 }

--- a/Tests/AynaTests/MarkdownRendererTests.swift
+++ b/Tests/AynaTests/MarkdownRendererTests.swift
@@ -174,4 +174,21 @@ struct MarkdownRendererTests {
             #expect(code.trimmingCharacters(in: .whitespacesAndNewlines) == "code")
         }
     }
+
+    @Test("Parses ordered list starting at custom number")
+    func parsesOrderedListStartingAtCustomNumber() {
+        let input = """
+        3. Third
+        4. Fourth
+        """
+        let blocks = MarkdownRenderer.parse(input)
+        #expect(blocks.count == 1)
+        if case let .orderedList(start, items) = blocks.first?.type {
+            #expect(start == 3)
+            #expect(items.count == 2)
+            #expect(String(items[0].characters) == "Third")
+        } else {
+            Issue.record("Expected ordered list block")
+        }
+    }
 }

--- a/Tests/AynaTests/OpenAIStreamParserTests.swift
+++ b/Tests/AynaTests/OpenAIStreamParserTests.swift
@@ -1,0 +1,92 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("OpenAIStreamParser Tests")
+struct OpenAIStreamParserTests {
+    @Test("Tool call arguments accumulate across streamed chunks")
+    func toolCallArgumentsAccumulateAcrossChunks() async {
+        let recorder = ToolCallRecorder()
+        var buffers: [Int: [String: Any]] = [:]
+        var ids: [Int: String] = [:]
+
+        let firstChunk = #"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_123","function":{"name":"web_search","arguments":"{\"query\":\"te"}}]}}]}"#
+        let secondChunk = #"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"st\"}"}}]}}]}"#
+        let completionChunk = #"data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#
+
+        var result = await OpenAIStreamParser.processStreamLine(
+            firstChunk,
+            toolCallBuffers: buffers,
+            toolCallIds: ids,
+            onToolCall: nil,
+            onToolCallRequested: nil
+        )
+        buffers = result.toolCallBuffers
+        ids = result.toolCallIds
+
+        result = await OpenAIStreamParser.processStreamLine(
+            secondChunk,
+            toolCallBuffers: buffers,
+            toolCallIds: ids,
+            onToolCall: nil,
+            onToolCallRequested: nil
+        )
+        buffers = result.toolCallBuffers
+        ids = result.toolCallIds
+
+        _ = await OpenAIStreamParser.processStreamLine(
+            completionChunk,
+            toolCallBuffers: buffers,
+            toolCallIds: ids,
+            onToolCall: { id, name, arguments in
+                recorder.record(id: id, name: name, query: arguments["query"] as? String)
+                return "ok"
+            },
+            onToolCallRequested: nil
+        )
+
+        let call = recorder.firstCall()
+        #expect(call?.id == "call_123")
+        #expect(call?.name == "web_search")
+        #expect(call?.query == "test")
+    }
+
+    @Test("[DONE] marker completes the stream")
+    func doneMarkerCompletesStream() async {
+        let result = await OpenAIStreamParser.processStreamLine(
+            "data: [DONE]",
+            toolCallBuffers: [:],
+            toolCallIds: [:],
+            onToolCall: nil,
+            onToolCallRequested: nil
+        )
+
+        #expect(result.shouldComplete == true)
+    }
+}
+
+private final class ToolCallRecorder: @unchecked Sendable {
+    struct Call: Sendable {
+        let id: String
+        let name: String
+        let query: String?
+    }
+
+    private let lock = NSLock()
+    private var firstRecordedCall: Call?
+
+    func record(id: String, name: String, query: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if firstRecordedCall == nil {
+            firstRecordedCall = Call(id: id, name: name, query: query)
+        }
+    }
+
+    func firstCall() -> Call? {
+        lock.lock()
+        defer { lock.unlock() }
+        return firstRecordedCall
+    }
+}

--- a/Tests/AynaTests/WatchConversationStoreNativeTests.swift
+++ b/Tests/AynaTests/WatchConversationStoreNativeTests.swift
@@ -15,11 +15,11 @@ import Testing
 @MainActor
 struct WatchConversationStoreNativeTests {
     private var store: WatchConversationStore
-    private let testDefaultsKey = "com.sertacozercan.ayna.watch.conversations.test"
+    private let persistenceKey = "com.sertacozercan.ayna.watch.conversations"
 
     init() {
         // Clear any existing test data
-        UserDefaults.standard.removeObject(forKey: testDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: persistenceKey)
         // Note: WatchConversationStore.shared is a singleton, so we test through it
         store = WatchConversationStore.shared
         // Clear existing conversations for clean test state
@@ -119,6 +119,24 @@ struct WatchConversationStoreNativeTests {
 
         let updated = store.conversation(for: conversation.id)
         #expect(updated?.messages.last?.content == "Hello, World!")
+    }
+
+    @Test("Update last message persists streamed content")
+    func updateLastMessagePersistsStreamedContent() throws {
+        let conversation = store.createConversation(model: "gpt-4o")
+        let message = WatchMessage(from: Message(role: .assistant, content: ""))
+
+        store.addMessage(message, to: conversation.id)
+        store.updateLastMessage(in: conversation.id, content: "Persist me")
+
+        guard let data = UserDefaults.standard.data(forKey: persistenceKey) else {
+            Issue.record("Expected persisted watch conversations data")
+            return
+        }
+
+        let decoded = try JSONDecoder().decode([WatchConversation].self, from: data)
+        let persistedConversation = decoded.first { $0.id == conversation.id }
+        #expect(persistedConversation?.messages.last?.content == "Persist me")
     }
 
     // MARK: - Conversation Retrieval Tests


### PR DESCRIPTION
## Summary
- move streaming, parsing, and MCP request hot paths off the main thread where safe, add timeout/cleanup handling, and share web fetch extraction/session helpers
- reduce watchOS/iOS, persistence, and UI rendering hotspots with async attachment/image loading, cached encryption keys, cached markdown/date formatting, and lighter conversation updates
- add focused regression coverage for attachment storage, persistence coordination, MCP request timeouts, stream parsing, markdown rendering, and encrypted conversation storage

## Validation
- swift build --scratch-path /tmp/ayna-macos-final
- swift test --scratch-path /tmp/ayna-serial-test
- xcodebuild -project AynaMobile.xcodeproj -scheme Ayna-iOS -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/ayna-ios-revalidate.vD2fHI CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project AynaMobile.xcodeproj -scheme Ayna-watchOS -destination 'generic/platform=watchOS Simulator' -derivedDataPath /tmp/ayna-watch-revalidate.FZUzyD CODE_SIGNING_ALLOWED=NO build
