### PR TITLE
fix: update deprecated depends_on macos stanza in GitHub Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,7 +351,7 @@ jobs:
           homepage "https://github.com/sozercan/ayna"
 
           auto_updates true
-          depends_on macos: ">= :sonoma"
+          depends_on macos: :sonoma
 
           app "Ayna.app"
 


### PR DESCRIPTION
Should fix https://github.com/sozercan/homebrew-repo/issues/3 in the next release.