### PR TITLE
fix(keychain): isolate dev and test storage

### DIFF
--- a/Sources/Ayna/App/AynaIOSApp.swift
+++ b/Sources/Ayna/App/AynaIOSApp.swift
@@ -18,7 +18,7 @@ private let handoffActivityType = "com.sertacozercan.ayna.conversation"
 @main
 struct AynaIOSApp: App {
     @StateObject private var conversationManager: ConversationManager
-    @StateObject private var aiService = AIService.shared
+    @StateObject private var aiService: AIService
     @Environment(\.scenePhase) private var scenePhase
 
     init() {
@@ -33,6 +33,8 @@ struct AynaIOSApp: App {
         Message.attachmentAsyncLoader = { path in
             await AttachmentStorage.shared.loadData(path: path)
         }
+
+        _aiService = StateObject(wrappedValue: AIService.shared)
 
         // Initialize conversation manager (use test store in UI test mode)
         let manager: ConversationManager = if UITestEnvironment.isEnabled {

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -39,7 +39,7 @@ enum APIEndpointType: String, CaseIterable, Codable {
 @MainActor
 class AIService: ObservableObject {
     static let shared = AIService()
-    static var keychain: KeychainStoring = KeychainStorage.shared
+    static var keychain: KeychainStoring = KeychainStorage.standard
 
     private enum KeychainKeys {
         static let modelAPIKeys = "model_api_keys"

--- a/Sources/Ayna/Services/EncryptedConversationStore.swift
+++ b/Sources/Ayna/Services/EncryptedConversationStore.swift
@@ -79,12 +79,9 @@ final class EncryptedConversationStore: Sendable {
     init(
         directoryURL: URL? = nil,
         keyIdentifier: String = "conversation_encryption_key",
-        keychain: KeychainStoring = KeychainStorage.shared
+        keychain: KeychainStoring = KeychainStorage.standard
     ) {
-        let appSupport =
-            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-                .first ?? URL(fileURLWithPath: NSTemporaryDirectory())
-        let baseDirectory = appSupport.appendingPathComponent("Ayna", isDirectory: true)
+        let baseDirectory = RuntimeEnvironment.defaultApplicationSupportDirectoryURL
 
         if !FileManager.default.fileExists(atPath: baseDirectory.path) {
             try? FileManager.default.createDirectory(at: baseDirectory, withIntermediateDirectories: true)

--- a/Sources/Ayna/Services/EncryptedMemoryStore.swift
+++ b/Sources/Ayna/Services/EncryptedMemoryStore.swift
@@ -40,11 +40,9 @@ final class EncryptedMemoryStore: Sendable {
     init(
         directoryURL: URL? = nil,
         keyIdentifier: String = "memory_encryption_key",
-        keychain: KeychainStoring = KeychainStorage.shared
+        keychain: KeychainStoring = KeychainStorage.standard
     ) {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first ?? URL(fileURLWithPath: NSTemporaryDirectory())
-        let baseDirectory = appSupport.appendingPathComponent("Ayna", isDirectory: true)
+        let baseDirectory = RuntimeEnvironment.defaultApplicationSupportDirectoryURL
 
         if !FileManager.default.fileExists(atPath: baseDirectory.path) {
             try? FileManager.default.createDirectory(at: baseDirectory, withIntermediateDirectories: true)

--- a/Sources/Ayna/Services/GitHubOAuthService.swift
+++ b/Sources/Ayna/Services/GitHubOAuthService.swift
@@ -209,8 +209,8 @@ enum GitHubAuthError: LocalizedError {
 class GitHubOAuthService: NSObject, ObservableObject {
     static let shared = GitHubOAuthService()
 
-    /// Injectable for tests. Defaults to the system keychain.
-    static var keychain: KeychainStoring = KeychainStorage.shared
+    /// Injectable for tests. Defaults to standard app keychain storage (in-memory during tests).
+    static var keychain: KeychainStoring = KeychainStorage.standard
 
     // Configuration
     private let clientId = "Iv23liyO8rlOYBXFGZXW"

--- a/Sources/Ayna/Services/KeychainStorage.swift
+++ b/Sources/Ayna/Services/KeychainStorage.swift
@@ -34,12 +34,24 @@ enum KeychainStorageError: LocalizedError {
 final class KeychainStorage: Sendable {
     nonisolated static let shared = KeychainStorage()
 
-    private let serviceIdentifier = "com.sertacozercan.ayna"
-    // Note: Keychain access groups require a paid Apple Developer account.
-    // For free accounts, keychain items are tied to the app's code signature
-    // and won't persist across rebuilds. See AIService for file-based fallback.
+    /// Default storage used by app services. Tests/UI tests use an in-memory store
+    /// so SwiftPM/XCTest helpers never prompt for access to the app's Keychain items.
+    nonisolated static let standard: KeychainStoring = {
+        if RuntimeEnvironment.isRunningUnitTests || RuntimeEnvironment.isUITesting {
+            return EphemeralKeychainStorage()
+        }
+        return KeychainStorage.shared
+    }()
 
-    private init() {}
+    private let serviceIdentifier: String
+    // Note: Keychain access groups require a paid Apple Developer account.
+    // For free accounts, keychain items are tied to the app's code signature.
+    // SwiftPM/dev helper tools use a stable, separate service identifier so they
+    // do not collide with credentials created by the signed app bundle.
+
+    private init(serviceIdentifier: String = RuntimeEnvironment.defaultKeychainServiceIdentifier) {
+        self.serviceIdentifier = serviceIdentifier
+    }
 
     private nonisolated func log(
         _ message: String,
@@ -239,8 +251,6 @@ final class KeychainStorage: Sendable {
             kSecAttrAccount as String: key,
         ]
     }
-
-
 }
 
 extension KeychainStorage: KeychainStoring {}

--- a/Sources/Ayna/Services/TavilyService.swift
+++ b/Sources/Ayna/Services/TavilyService.swift
@@ -58,7 +58,7 @@ final class TavilyService: ObservableObject {
     // MARK: - Initialization
 
     init(keychain: KeychainStoring? = nil, urlSession: URLSession = .shared) {
-        let effectiveKeychain = keychain ?? KeychainStorage.shared
+        let effectiveKeychain = keychain ?? KeychainStorage.standard
         self.keychain = effectiveKeychain
         self.urlSession = urlSession
 

--- a/Sources/Ayna/Utilities/RuntimeEnvironment.swift
+++ b/Sources/Ayna/Utilities/RuntimeEnvironment.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+/// Process/runtime detection used to keep tests and SwiftPM helper tools away from
+/// the production Keychain namespace.
+enum RuntimeEnvironment {
+    static let productionKeychainServiceIdentifier = "com.sertacozercan.ayna"
+    static let developmentKeychainServiceIdentifier = "com.sertacozercan.ayna.dev"
+    static let unitTestKeychainServiceIdentifier = "com.sertacozercan.ayna.tests"
+    static let uiTestKeychainServiceIdentifier = "com.sertacozercan.ayna.ui-tests"
+
+    static let productionApplicationSupportDirectoryName = "Ayna"
+    static let developmentApplicationSupportDirectoryName = "Ayna-Dev"
+    static let unitTestApplicationSupportDirectoryName = "Ayna-Tests"
+    static let uiTestApplicationSupportDirectoryName = "Ayna-UITests"
+
+    private static let uiTestFlag = "AYNA_UI_TESTING"
+    private static let uiTestLaunchArgument = "--ui-testing"
+    private static let uiTestUserDefaultsArgument = "-AYNA_UI_TESTING"
+
+    static var isUITesting: Bool {
+        isUITesting(
+            arguments: ProcessInfo.processInfo.arguments,
+            environment: ProcessInfo.processInfo.environment
+        )
+    }
+
+    static var isRunningUnitTests: Bool {
+        isRunningUnitTests(
+            processName: ProcessInfo.processInfo.processName,
+            environment: ProcessInfo.processInfo.environment,
+            bundlePath: Bundle.main.bundleURL.path,
+            hasSwiftTestingRuntime: hasSwiftTestingRuntime
+        )
+    }
+
+    static var defaultKeychainServiceIdentifier: String {
+        defaultKeychainServiceIdentifier(
+            bundleIdentifier: Bundle.main.bundleIdentifier,
+            processName: ProcessInfo.processInfo.processName,
+            environment: ProcessInfo.processInfo.environment,
+            bundlePath: Bundle.main.bundleURL.path,
+            isUITesting: isUITesting,
+            isRunningUnitTests: isRunningUnitTests
+        )
+    }
+
+    static var defaultApplicationSupportDirectoryURL: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        return appSupport.appendingPathComponent(defaultApplicationSupportDirectoryName, isDirectory: true)
+    }
+
+    static var defaultApplicationSupportDirectoryName: String {
+        defaultApplicationSupportDirectoryName(
+            bundleIdentifier: Bundle.main.bundleIdentifier,
+            processName: ProcessInfo.processInfo.processName,
+            environment: ProcessInfo.processInfo.environment,
+            bundlePath: Bundle.main.bundleURL.path,
+            isUITesting: isUITesting,
+            isRunningUnitTests: isRunningUnitTests
+        )
+    }
+
+    static func isUITesting(arguments: [String], environment: [String: String]) -> Bool {
+        environment[uiTestFlag] == "1" ||
+            arguments.contains(uiTestLaunchArgument) ||
+            arguments.contains(uiTestUserDefaultsArgument)
+    }
+
+    static func isRunningUnitTests(
+        processName: String,
+        environment: [String: String],
+        bundlePath: String,
+        hasSwiftTestingRuntime: Bool
+    ) -> Bool {
+        processName == "swiftpm-testing-helper" ||
+            environment["XCTestConfigurationFilePath"] != nil ||
+            environment["SWIFT_TESTING_ENABLED"] == "1" ||
+            bundlePath.hasSuffix(".xctest") ||
+            bundlePath.contains("/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Xcode/Agents") ||
+            hasSwiftTestingRuntime
+    }
+
+    static func defaultKeychainServiceIdentifier(
+        bundleIdentifier: String?,
+        processName: String,
+        environment: [String: String],
+        bundlePath: String,
+        isUITesting: Bool,
+        isRunningUnitTests: Bool
+    ) -> String {
+        if let override = environment["AYNA_KEYCHAIN_SERVICE_IDENTIFIER"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !override.isEmpty
+        {
+            return override
+        }
+
+        if isRunningUnitTests {
+            return unitTestKeychainServiceIdentifier
+        }
+
+        if isUITesting {
+            return uiTestKeychainServiceIdentifier
+        }
+
+        if isProductionAppBundle(bundleIdentifier: bundleIdentifier) {
+            return productionKeychainServiceIdentifier
+        }
+
+        // SwiftPM/dev command-line launches do not have the app bundle's stable
+        // code-signing identity. Give them a stable, separate namespace so they
+        // never ask to access credentials created by Ayna.app.
+        if isSwiftPMOrDevelopmentLaunch(
+            bundleIdentifier: bundleIdentifier,
+            processName: processName,
+            bundlePath: bundlePath
+        ) {
+            return developmentKeychainServiceIdentifier
+        }
+
+        return productionKeychainServiceIdentifier
+    }
+
+    static func defaultApplicationSupportDirectoryName(
+        bundleIdentifier: String?,
+        processName: String,
+        environment: [String: String],
+        bundlePath: String,
+        isUITesting: Bool,
+        isRunningUnitTests: Bool
+    ) -> String {
+        if let override = environment["AYNA_APPLICATION_SUPPORT_DIRECTORY_NAME"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !override.isEmpty
+        {
+            return override
+        }
+
+        if isRunningUnitTests {
+            return unitTestApplicationSupportDirectoryName
+        }
+
+        if isUITesting {
+            return uiTestApplicationSupportDirectoryName
+        }
+
+        if isProductionAppBundle(bundleIdentifier: bundleIdentifier) {
+            return productionApplicationSupportDirectoryName
+        }
+
+        if isSwiftPMOrDevelopmentLaunch(
+            bundleIdentifier: bundleIdentifier,
+            processName: processName,
+            bundlePath: bundlePath
+        ) {
+            return developmentApplicationSupportDirectoryName
+        }
+
+        return productionApplicationSupportDirectoryName
+    }
+
+    private static func isProductionAppBundle(bundleIdentifier: String?) -> Bool {
+        bundleIdentifier == productionKeychainServiceIdentifier ||
+            bundleIdentifier == "com.sertacozercan.ayna.watchkitapp"
+    }
+
+    private static func isSwiftPMOrDevelopmentLaunch(
+        bundleIdentifier: String?,
+        processName: String,
+        bundlePath: String
+    ) -> Bool {
+        bundleIdentifier == nil ||
+            processName == "Ayna" ||
+            bundlePath.contains("/.build/")
+    }
+
+    private static var hasSwiftTestingRuntime: Bool {
+        NSClassFromString("Testing.Test") != nil ||
+            NSClassFromString("_Testing.Case") != nil
+    }
+}

--- a/Sources/Ayna/Utilities/UITestEnvironment.swift
+++ b/Sources/Ayna/Utilities/UITestEnvironment.swift
@@ -3,18 +3,10 @@ import os
 
 /// Handles deterministic configuration when the app is launched from UI tests.
 enum UITestEnvironment {
-    private static let flag = "AYNA_UI_TESTING"
-    private static let launchArgument = "--ui-testing"
-    private static let userDefaultsArgument = "-\(flag)"
     private static let defaultModel = "ui-test-model"
 
     static var isEnabled: Bool {
-        let processInfo = ProcessInfo.processInfo
-        if processInfo.environment[flag] == "1" { return true }
-        if processInfo.arguments.contains(launchArgument) { return true }
-        if processInfo.arguments.contains(userDefaultsArgument) { return true }
-        // Avoid persisting UI-test mode across launches via UserDefaults.
-        return false
+        RuntimeEnvironment.isUITesting
     }
 
     /// Call once during app initialization to swap out side-effectful dependencies.
@@ -61,7 +53,9 @@ enum UITestEnvironment {
 
     @MainActor
     private static func configureKeychain() {
-        AIService.keychain = EphemeralKeychainStorage()
+        let keychain = EphemeralKeychainStorage()
+        AIService.keychain = keychain
+        GitHubOAuthService.keychain = keychain
     }
 
     @MainActor

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
@@ -313,10 +313,9 @@ extension MacChatView {
         var responseGroup = ResponseGroup(id: responseGroupId, userMessageId: userMessageId)
 
         // Create placeholder messages for each model
-        var messageIds: [String: UUID] = [:]
+        let messageIds = Dictionary(uniqueKeysWithValues: models.map { ($0, UUID()) })
         for model in models {
-            let messageId = UUID()
-            messageIds[model] = messageId
+            guard let messageId = messageIds[model] else { continue }
             responseGroup.addResponse(messageId: messageId, modelName: model, status: .streaming)
 
             let placeholderMessage = Message(

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -788,10 +788,9 @@ struct MacNewChatView: View {
         var responseGroup = ResponseGroup(id: responseGroupId, userMessageId: userMessageId)
 
         // Create placeholder messages for each model
-        var messageIds: [String: UUID] = [:]
+        let messageIds = Dictionary(uniqueKeysWithValues: models.map { ($0, UUID()) })
         for model in models {
-            let messageId = UUID()
-            messageIds[model] = messageId
+            guard let messageId = messageIds[model] else { continue }
             responseGroup.addResponse(messageId: messageId, modelName: model, status: .streaming)
 
             let placeholderMessage = Message(

--- a/Tests/AynaTests/RuntimeEnvironmentTests.swift
+++ b/Tests/AynaTests/RuntimeEnvironmentTests.swift
@@ -1,0 +1,110 @@
+@testable import Ayna
+import Testing
+
+@Suite("Runtime Environment Tests")
+struct RuntimeEnvironmentTests {
+    @Test
+    func `swiftPM testing helper is detected as unit test process`() {
+        #expect(RuntimeEnvironment.isRunningUnitTests(
+            processName: "swiftpm-testing-helper",
+            environment: [:],
+            bundlePath: "/tmp/swiftpm-testing-helper",
+            hasSwiftTestingRuntime: false
+        ))
+    }
+
+    @Test
+    func `unit tests use a separate keychain service identifier`() {
+        let identifier = RuntimeEnvironment.defaultKeychainServiceIdentifier(
+            bundleIdentifier: nil,
+            processName: "swiftpm-testing-helper",
+            environment: [:],
+            bundlePath: "/tmp/swiftpm-testing-helper",
+            isUITesting: false,
+            isRunningUnitTests: true
+        )
+
+        #expect(identifier == RuntimeEnvironment.unitTestKeychainServiceIdentifier)
+        #expect(identifier != RuntimeEnvironment.productionKeychainServiceIdentifier)
+    }
+
+    @Test
+    func `ui tests are detected from launch environment`() {
+        #expect(RuntimeEnvironment.isUITesting(
+            arguments: [],
+            environment: ["AYNA_UI_TESTING": "1"]
+        ))
+    }
+
+    @Test
+    func `ui tests use a separate keychain service identifier`() {
+        let identifier = RuntimeEnvironment.defaultKeychainServiceIdentifier(
+            bundleIdentifier: RuntimeEnvironment.productionKeychainServiceIdentifier,
+            processName: "Ayna",
+            environment: [:],
+            bundlePath: "/Applications/Ayna.app",
+            isUITesting: true,
+            isRunningUnitTests: false
+        )
+
+        #expect(identifier == RuntimeEnvironment.uiTestKeychainServiceIdentifier)
+        #expect(identifier != RuntimeEnvironment.productionKeychainServiceIdentifier)
+    }
+
+    @Test
+    func `swiftPM development launches use stable development keychain service`() {
+        let identifier = RuntimeEnvironment.defaultKeychainServiceIdentifier(
+            bundleIdentifier: nil,
+            processName: "Ayna",
+            environment: [:],
+            bundlePath: "/Users/example/ayna/.build/debug/Ayna",
+            isUITesting: false,
+            isRunningUnitTests: false
+        )
+
+        #expect(identifier == RuntimeEnvironment.developmentKeychainServiceIdentifier)
+    }
+
+    @Test
+    func `dev keychain namespace uses separate encrypted storage directory`() {
+        let directoryName = RuntimeEnvironment.defaultApplicationSupportDirectoryName(
+            bundleIdentifier: nil,
+            processName: "Ayna",
+            environment: [:],
+            bundlePath: "/Users/example/ayna/.build/debug/Ayna",
+            isUITesting: false,
+            isRunningUnitTests: false
+        )
+
+        #expect(directoryName == RuntimeEnvironment.developmentApplicationSupportDirectoryName)
+        #expect(directoryName != RuntimeEnvironment.productionApplicationSupportDirectoryName)
+    }
+
+    @Test
+    func `production keychain namespace uses production encrypted storage directory`() {
+        let directoryName = RuntimeEnvironment.defaultApplicationSupportDirectoryName(
+            bundleIdentifier: RuntimeEnvironment.productionKeychainServiceIdentifier,
+            processName: "Ayna",
+            environment: [:],
+            bundlePath: "/Applications/Ayna.app",
+            isUITesting: false,
+            isRunningUnitTests: false
+        )
+
+        #expect(directoryName == RuntimeEnvironment.productionApplicationSupportDirectoryName)
+    }
+
+    @Test
+    func `signed app bundle uses production keychain service`() {
+        let identifier = RuntimeEnvironment.defaultKeychainServiceIdentifier(
+            bundleIdentifier: RuntimeEnvironment.productionKeychainServiceIdentifier,
+            processName: "Ayna",
+            environment: [:],
+            bundlePath: "/Applications/Ayna.app",
+            isUITesting: false,
+            isRunningUnitTests: false
+        )
+
+        #expect(identifier == RuntimeEnvironment.productionKeychainServiceIdentifier)
+    }
+}


### PR DESCRIPTION
## Summary
- Add runtime environment detection for signed app, SwiftPM/dev, unit test, and UI test contexts.
- Route default keychain storage through environment-aware production/dev/test namespaces.
- Keep encrypted conversation and memory files in matching production/dev/test Application Support directories so keys and files do not mix.
- Ensure UI-test keychain injection happens before `AIService.shared` initialization, and make multi-model message ID maps immutable for Swift 6 sendability.

## Root cause
SwiftPM and test helpers can access the same Keychain service and encrypted app data paths as the signed app while running under a different process/code-signing identity. That can trigger macOS Keychain prompts from `swiftpm-testing-helper`, and a dev/test keychain namespace must also be paired with isolated encrypted file storage.

## Validation
- `swift test` — 551 tests passed
- `swift build --triple arm64-apple-ios26.0`
- `swift build --triple arm64-apple-watchos26.0`
- `swiftlint --strict`
- `git diff --check`
- `autoreview --mode local` — clean, no accepted/actionable findings
