### PR TITLE
fix: harden reliability across persistence and requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ on:
       - 'Sources/**'
       - 'Tests/**'
       - 'Scripts/**'
+      - 'AynaMobile.xcodeproj/**'
       - '.github/workflows/tests.yml'
   pull_request:
     branches: [ main ]
@@ -22,6 +23,7 @@ on:
       - 'Sources/**'
       - 'Tests/**'
       - 'Scripts/**'
+      - 'AynaMobile.xcodeproj/**'
       - '.github/workflows/tests.yml'
   workflow_dispatch:
 
@@ -272,7 +274,7 @@ jobs:
         xcrun simctl shutdown "$DEVICE_UDID" 2>/dev/null || true
         sleep 3
 
-    - name: Build watchOS app
+    - name: Run watchOS unit tests
       run: |
         set -o pipefail
         xcodebuild \
@@ -281,10 +283,12 @@ jobs:
           -destination "id=$DEVICE_UDID" \
           -derivedDataPath ./build \
           -configuration Debug \
+          -resultBundlePath ./build/TestResults-watchOS-Unit.xcresult \
+          -parallel-testing-enabled NO \
           CODE_SIGN_IDENTITY="" \
           CODE_SIGNING_REQUIRED=NO \
           CODE_SIGNING_ALLOWED=NO \
-          build
+          test
 
     - name: Install watchOS app on simulator
       run: |

--- a/AynaMobile.xcodeproj/project.pbxproj
+++ b/AynaMobile.xcodeproj/project.pbxproj
@@ -6,9 +6,45 @@
 	objectVersion = 71;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		E7000101 /* AIServiceFlightTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7000201 /* AIServiceFlightTestSupport.swift */; };
+		E7000102 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7000202 /* TestHelpers.swift */; };
+		E7000103 /* TestTags.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7000203 /* TestTags.swift */; };
+		E7000104 /* WatchChatViewModelNativeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7000204 /* WatchChatViewModelNativeTests.swift */; };
+		E7000105 /* WatchChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7000205 /* WatchChatViewModelTests.swift */; };
+		E7000106 /* WatchConversationStoreNativeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7000206 /* WatchConversationStoreNativeTests.swift */; };
+		E7000107 /* WatchConversationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7000207 /* WatchConversationStoreTests.swift */; };
+		E7000108 /* WatchDataModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7000208 /* WatchDataModelTests.swift */; };
+		E7000109 /* WatchMarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7000209 /* WatchMarkdownRendererTests.swift */; };
+		E700010A /* WatchSyncChatViewModelNativeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700020A /* WatchSyncChatViewModelNativeTests.swift */; };
+		E700010B /* WatchSyncConversationStoreNativeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700020B /* WatchSyncConversationStoreNativeTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E7000800 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D6000800 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C5000500;
+			remoteInfo = "Ayna-watchOS";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		B4000200 /* Ayna.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ayna.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5000200 /* Ayna Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Ayna Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E7000201 /* AIServiceFlightTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIServiceFlightTestSupport.swift; sourceTree = "<group>"; };
+		E7000202 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
+		E7000203 /* TestTags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTags.swift; sourceTree = "<group>"; };
+		E7000204 /* WatchChatViewModelNativeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchChatViewModelNativeTests.swift; sourceTree = "<group>"; };
+		E7000205 /* WatchChatViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchChatViewModelTests.swift; sourceTree = "<group>"; };
+		E7000206 /* WatchConversationStoreNativeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConversationStoreNativeTests.swift; sourceTree = "<group>"; };
+		E7000207 /* WatchConversationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConversationStoreTests.swift; sourceTree = "<group>"; };
+		E7000208 /* WatchDataModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchDataModelTests.swift; sourceTree = "<group>"; };
+		E7000209 /* WatchMarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchMarkdownRendererTests.swift; sourceTree = "<group>"; };
+		E700020A /* WatchSyncChatViewModelNativeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSyncChatViewModelNativeTests.swift; sourceTree = "<group>"; };
+		E700020B /* WatchSyncConversationStoreNativeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSyncConversationStoreNativeTests.swift; sourceTree = "<group>"; };
+		E700020C /* Ayna-watchOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Ayna-watchOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -47,6 +83,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E7000300 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -54,6 +97,7 @@
 			isa = PBXGroup;
 			children = (
 				D6000001 /* Sources/Ayna */,
+				E7000401 /* Ayna-watchOSTests */,
 				D6000402 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -63,9 +107,29 @@
 			children = (
 				B4000200 /* Ayna.app */,
 				C5000200 /* Ayna Watch App.app */,
+				E700020C /* Ayna-watchOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
+		};
+		E7000401 /* Ayna-watchOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				E7000201 /* AIServiceFlightTestSupport.swift */,
+				E7000202 /* TestHelpers.swift */,
+				E7000203 /* TestTags.swift */,
+				E7000204 /* WatchChatViewModelNativeTests.swift */,
+				E7000205 /* WatchChatViewModelTests.swift */,
+				E7000206 /* WatchConversationStoreNativeTests.swift */,
+				E7000207 /* WatchConversationStoreTests.swift */,
+				E7000208 /* WatchDataModelTests.swift */,
+				E7000209 /* WatchMarkdownRendererTests.swift */,
+				E700020A /* WatchSyncChatViewModelNativeTests.swift */,
+				E700020B /* WatchSyncConversationStoreNativeTests.swift */,
+			);
+			name = "Ayna-watchOSTests";
+			path = Tests/AynaTests;
+			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */
 
@@ -110,6 +174,24 @@
 			productReference = C5000200 /* Ayna Watch App.app */;
 			productType = "com.apple.product-type.application";
 		};
+		E7000500 /* Ayna-watchOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E7000700 /* Build configuration list for PBXNativeTarget "Ayna-watchOSTests" */;
+			buildPhases = (
+				E7000600 /* Sources */,
+				E7000300 /* Frameworks */,
+				E7000601 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E7000801 /* PBXTargetDependency */,
+			);
+			name = "Ayna-watchOSTests";
+			productName = "Ayna-watchOSTests";
+			productReference = E700020C /* Ayna-watchOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -119,6 +201,12 @@
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+					E7000500 = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = C5000500;
+					};
+				};
 			};
 			buildConfigurationList = D6000900 /* Build configuration list for PBXProject "AynaMobile" */;
 			compatibilityVersion = "Xcode 16.0";
@@ -136,6 +224,7 @@
 			targets = (
 				B4000500 /* Ayna-iOS */,
 				C5000500 /* Ayna-watchOS */,
+				E7000500 /* Ayna-watchOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -149,6 +238,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C5000601 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E7000601 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -172,7 +268,33 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E7000600 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7000101 /* AIServiceFlightTestSupport.swift in Sources */,
+				E7000102 /* TestHelpers.swift in Sources */,
+				E7000103 /* TestTags.swift in Sources */,
+				E7000104 /* WatchChatViewModelNativeTests.swift in Sources */,
+				E7000105 /* WatchChatViewModelTests.swift in Sources */,
+				E7000106 /* WatchConversationStoreNativeTests.swift in Sources */,
+				E7000107 /* WatchConversationStoreTests.swift in Sources */,
+				E7000108 /* WatchDataModelTests.swift in Sources */,
+				E7000109 /* WatchMarkdownRendererTests.swift in Sources */,
+				E700010A /* WatchSyncChatViewModelNativeTests.swift in Sources */,
+				E700010B /* WatchSyncConversationStoreNativeTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E7000801 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C5000500 /* Ayna-watchOS */;
+			targetProxy = E7000800 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		D6000A01 /* Debug */ = {
@@ -388,6 +510,51 @@
 			};
 			name = Release;
 		};
+		E7000B01 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 57QNR9B89Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sertacozercan.ayna.watchOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SWIFT_MODULE_ALIASES = "Ayna=Ayna_Watch_App";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Ayna Watch App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Ayna Watch App";
+				WATCHOS_DEPLOYMENT_TARGET = 26.0;
+			};
+			name = Debug;
+		};
+		E7000B02 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 57QNR9B89Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sertacozercan.ayna.watchOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SWIFT_MODULE_ALIASES = "Ayna=Ayna_Watch_App";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Ayna Watch App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Ayna Watch App";
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 26.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -414,6 +581,15 @@
 			buildConfigurations = (
 				D6000A01 /* Debug */,
 				D6000A02 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E7000700 /* Build configuration list for PBXNativeTarget "Ayna-watchOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E7000B01 /* Debug */,
+				E7000B02 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AynaMobile.xcodeproj/xcshareddata/xcschemes/Ayna-watchOS.xcscheme
+++ b/AynaMobile.xcodeproj/xcshareddata/xcschemes/Ayna-watchOS.xcscheme
@@ -21,6 +21,20 @@
                ReferencedContainer = "container:AynaMobile.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E7000500"
+               BuildableName = "Ayna-watchOSTests.xctest"
+               BlueprintName = "Ayna-watchOSTests"
+               ReferencedContainer = "container:AynaMobile.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -29,6 +43,28 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C5000500"
+            BuildableName = "Ayna Watch App.app"
+            BlueprintName = "Ayna-watchOS"
+            ReferencedContainer = "container:AynaMobile.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E7000500"
+               BuildableName = "Ayna-watchOSTests.xctest"
+               BlueprintName = "Ayna-watchOSTests"
+               ReferencedContainer = "container:AynaMobile.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Sources/Ayna/App/AynaIOSApp.swift
+++ b/Sources/Ayna/App/AynaIOSApp.swift
@@ -52,17 +52,18 @@ struct AynaIOSApp: App {
                 .environmentObject(aiService)
                 .onOpenURL { url in
                     Task {
+                        await conversationManager.loadingTask?.value
+
                         // Handle deep links (including OAuth callbacks)
                         await DeepLinkManager.shared.handle(url: url)
 
-                        // Handle chat deep links by starting a conversation
-                        if let chatRequest = DeepLinkManager.shared.pendingChat {
+                        // Handle the chat request that became ready during this URL.
+                        if let chatRequest = DeepLinkManager.shared.consumeNextReadyChat() {
                             _ = conversationManager.startConversation(
                                 model: chatRequest.model,
                                 prompt: chatRequest.prompt,
                                 systemPrompt: chatRequest.systemPrompt
                             )
-                            DeepLinkManager.shared.clearPendingChat()
                         }
                     }
                 }

--- a/Sources/Ayna/App/aynaApp.swift
+++ b/Sources/Ayna/App/aynaApp.swift
@@ -65,7 +65,7 @@ struct aynaApp: App {
         // Initialize "Work with Apps" if enabled
         Task { @MainActor in
             // Store reference to conversation manager for window creation
-            AynaAppDelegate.conversationManager = manager
+            AynaAppDelegate.attachConversationManager(manager)
             setupWorkWithApps(conversationManager: manager)
         }
     }
@@ -76,7 +76,7 @@ struct aynaApp: App {
                 .environmentObject(conversationManager)
                 .onAppear {
                     // Pass conversation manager to app delegate for deep link handling
-                    AynaAppDelegate.conversationManager = conversationManager
+                    AynaAppDelegate.attachConversationManager(conversationManager)
 
                     // If running UI tests, ensure window is ready
                     if UITestEnvironment.isEnabled {
@@ -189,6 +189,12 @@ final class AynaAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     /// Reference to the conversation manager for window creation
     weak static var conversationManager: ConversationManager?
+
+    private var deepLinkHandlingTask: Task<Void, Never>?
+
+    static func attachConversationManager(_ manager: ConversationManager) {
+        conversationManager = manager
+    }
 
     /// Shared instance for window delegate
     static let shared = AynaAppDelegate()
@@ -330,8 +336,21 @@ final class AynaAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     /// Handle deep link URLs at the app delegate level to prevent new window creation
     func application(_ app: NSApplication, open urls: [URL]) {
-        guard let url = urls.first else { return }
+        for url in urls {
+            enqueueDeepLinkURL(url, app: app)
+        }
+    }
 
+    private func enqueueDeepLinkURL(_ url: URL, app: NSApplication) {
+        let precedingTask = deepLinkHandlingTask
+        deepLinkHandlingTask = Task { @MainActor [weak self] in
+            await precedingTask?.value
+            guard let self else { return }
+            await self.processDeepLinkURL(url, app: app)
+        }
+    }
+
+    private func processDeepLinkURL(_ url: URL, app: NSApplication) async {
         // First, ensure we have a window by activating the app
         app.activate(ignoringOtherApps: true)
 
@@ -345,50 +364,39 @@ final class AynaAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 NSWorkspace.shared.open(mainURL)
             }
             // Small delay to let the window appear before handling the actual deep link
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(300))
-                await self.handleDeepLinkURL(url, app: app)
-            }
-        } else {
-            // Window exists, handle immediately
-            Task { @MainActor in
-                await self.handleDeepLinkURL(url, app: app)
-            }
+            try? await Task.sleep(for: .milliseconds(300))
         }
+        await handleDeepLinkURL(url, app: app)
     }
 
     @MainActor
     private func handleDeepLinkURL(_ url: URL, app: NSApplication) async {
-        await DeepLinkManager.shared.handle(url: url)
+        if let manager = await waitForReadyConversationManager() {
+            await DeepLinkManager.shared.handle(url: url)
 
-        DiagnosticsLogger.log(
-            .app,
-            level: .fault,
-            message: "🔗 DEBUG AppDelegate: after handle - pendingAddModel=\(String(describing: DeepLinkManager.shared.pendingAddModel)), pendingChat=\(String(describing: DeepLinkManager.shared.pendingChat))"
-        )
-
-        // Handle chat deep links by starting a conversation
-        // BUT only if there's no pending add-model confirmation (unified flow)
-        if DeepLinkManager.shared.pendingAddModel == nil,
-           let chatRequest = DeepLinkManager.shared.pendingChat,
-           let manager = Self.conversationManager
-        {
             DiagnosticsLogger.log(
                 .app,
                 level: .fault,
-                message: "🔗 DEBUG AppDelegate: Starting conversation (no pending add model)"
+                message: "🔗 DEBUG AppDelegate: after handle - pendingAddModel=\(String(describing: DeepLinkManager.shared.pendingAddModel)), pendingChat=\(String(describing: DeepLinkManager.shared.pendingChat))"
             )
-            _ = manager.startConversation(
-                model: chatRequest.model,
-                prompt: chatRequest.prompt,
-                systemPrompt: chatRequest.systemPrompt
-            )
-            DeepLinkManager.shared.clearPendingChat()
-        } else if DeepLinkManager.shared.pendingAddModel != nil {
+
+            // Handle the chat request that became ready during this URL.
+            if let chatRequest = DeepLinkManager.shared.consumeNextReadyChat() {
+                Self.startDeepLinkConversation(chatRequest, using: manager)
+            }
+
+            if DeepLinkManager.shared.pendingAddModel != nil {
+                DiagnosticsLogger.log(
+                    .app,
+                    level: .fault,
+                    message: "🔗 DEBUG AppDelegate: NOT starting conversation - waiting for add model confirmation"
+                )
+            }
+        } else {
             DiagnosticsLogger.log(
                 .app,
-                level: .fault,
-                message: "🔗 DEBUG AppDelegate: NOT starting conversation - waiting for add model confirmation"
+                level: .error,
+                message: "Unable to handle deep link before conversation storage became ready"
             )
         }
 
@@ -399,6 +407,33 @@ final class AynaAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
             window.makeKeyAndOrderFront(nil)
         }
+    }
+
+    private func waitForReadyConversationManager() async -> ConversationManager? {
+        for _ in 0..<100 {
+            if let manager = Self.conversationManager {
+                await manager.loadingTask?.value
+                return manager
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return nil
+    }
+
+    private static func startDeepLinkConversation(
+        _ chatRequest: ChatRequest,
+        using manager: ConversationManager
+    ) {
+        DiagnosticsLogger.log(
+            .app,
+            level: .fault,
+            message: "🔗 DEBUG AppDelegate: Starting ready deep-link conversation"
+        )
+        _ = manager.startConversation(
+            model: chatRequest.model,
+            prompt: chatRequest.prompt,
+            systemPrompt: chatRequest.systemPrompt
+        )
     }
 }
 

--- a/Sources/Ayna/Chat/ChatGenerationFinalizer.swift
+++ b/Sources/Ayna/Chat/ChatGenerationFinalizer.swift
@@ -1,0 +1,85 @@
+//
+//  ChatGenerationFinalizer.swift
+//  ayna
+//
+//  Finalizes persisted chat state when an in-flight generation is cancelled.
+//
+
+import Foundation
+
+struct ChatGenerationFinalizationResult: Equatable, Sendable {
+    let appendedCharacterCount: Int
+    let removedAssistantMessageID: UUID?
+    let terminalizedResponseCount: Int
+
+    var didMutate: Bool {
+        appendedCharacterCount > 0 || removedAssistantMessageID != nil || terminalizedResponseCount > 0
+    }
+}
+
+enum ChatGenerationFinalizer {
+    /// Applies cancellation bookkeeping without discarding partial assistant output.
+    ///
+    /// Empty single-response text placeholders are removed. Multi-model placeholders remain so
+    /// their failed terminal state can still be rendered as part of the response group.
+    @discardableResult
+    static func finalize(
+        conversation: inout Conversation,
+        activeAssistantMessageID: UUID?,
+        pendingText: String = "",
+        activeResponseGroupID: UUID?
+    ) -> ChatGenerationFinalizationResult {
+        var appendedCharacterCount = 0
+        var removedAssistantMessageID: UUID?
+        var terminalizedResponseCount = 0
+
+        if let activeAssistantMessageID,
+           !pendingText.isEmpty,
+           let messageIndex = conversation.messages.firstIndex(where: { $0.id == activeAssistantMessageID }),
+           conversation.messages[messageIndex].role == .assistant
+        {
+            conversation.messages[messageIndex].content += pendingText
+            appendedCharacterCount = pendingText.count
+        }
+
+        if let activeResponseGroupID,
+           let groupIndex = conversation.responseGroups.firstIndex(where: { $0.id == activeResponseGroupID })
+        {
+            for responseIndex in conversation.responseGroups[groupIndex].responses.indices
+                where conversation.responseGroups[groupIndex].responses[responseIndex].status == .streaming
+            {
+                conversation.responseGroups[groupIndex].responses[responseIndex].status = .failed
+                terminalizedResponseCount += 1
+            }
+        }
+
+        if let activeAssistantMessageID,
+           let messageIndex = conversation.messages.firstIndex(where: { $0.id == activeAssistantMessageID }),
+           isDiscardableTextPlaceholder(conversation.messages[messageIndex])
+        {
+            conversation.messages.remove(at: messageIndex)
+            removedAssistantMessageID = activeAssistantMessageID
+        }
+
+        if appendedCharacterCount > 0 || removedAssistantMessageID != nil || terminalizedResponseCount > 0 {
+            conversation.updatedAt = Date()
+        }
+
+        return ChatGenerationFinalizationResult(
+            appendedCharacterCount: appendedCharacterCount,
+            removedAssistantMessageID: removedAssistantMessageID,
+            terminalizedResponseCount: terminalizedResponseCount
+        )
+    }
+
+    private static func isDiscardableTextPlaceholder(_ message: Message) -> Bool {
+        message.role == .assistant &&
+            message.responseGroupId == nil &&
+            message.mediaType == nil &&
+            message.content.isEmpty &&
+            (message.reasoning?.isEmpty ?? true) &&
+            (message.citations?.isEmpty ?? true) &&
+            message.imageData == nil &&
+            message.imagePath == nil
+    }
+}

--- a/Sources/Ayna/Chat/ChatGenerationFinalizer.swift
+++ b/Sources/Ayna/Chat/ChatGenerationFinalizer.swift
@@ -77,6 +77,8 @@ enum ChatGenerationFinalizer {
             message.responseGroupId == nil &&
             message.mediaType == nil &&
             message.content.isEmpty &&
+            (message.toolCalls?.isEmpty ?? true) &&
+            (message.attachments?.isEmpty ?? true) &&
             (message.reasoning?.isEmpty ?? true) &&
             (message.citations?.isEmpty ?? true) &&
             message.imageData == nil &&

--- a/Sources/Ayna/Chat/ImageGenerationCoordinator.swift
+++ b/Sources/Ayna/Chat/ImageGenerationCoordinator.swift
@@ -2,208 +2,119 @@
 //  ImageGenerationCoordinator.swift
 //  ayna
 //
-//  Extracted from MacChatView/MacNewChatView - handles image generation logic
+//  Owns every stage of the current image-generation user action.
 //
 
 #if !os(watchOS)
 
-import Foundation
+    import Foundation
 
-/// Coordinates image generation, including multi-model parallel generation
-@MainActor
-final class ImageGenerationCoordinator {
-    /// Callback types for image generation results
-    typealias ImageSuccessHandler = @Sendable (Data, UUID) -> Void
-    typealias ImageErrorHandler = @Sendable (Error, UUID) -> Void
-    typealias CompletionHandler = @Sendable () -> Void
-
-    /// Configuration for multi-model image generation
-    struct MultiModelConfig {
-        let prompt: String
-        let models: [String]
-        let previousImage: Data?
-        let userMessageId: UUID
-        let aiService: AIService
-    }
-
-    /// Result of multi-model image generation setup
-    struct MultiModelResult {
-        let responseGroupId: UUID
-        let messageIds: [String: UUID]
-        let responseGroup: ResponseGroup
-    }
-
-    /// Generates a single image using the AI service
-    /// - Parameters:
-    ///   - prompt: The image generation prompt
-    ///   - model: The model to use
-    ///   - previousImage: Optional previous image for editing context
-    ///   - aiService: The AI service instance
-    ///   - onSuccess: Called with image data and message ID on success
-    ///   - onError: Called with error and message ID on failure
-    /// - Returns: The message ID of the placeholder message
-    static func generateSingleImage(
-        prompt: String,
-        model: String,
-        previousImage: Data?,
-        aiService: AIService,
-        onSuccess: @escaping ImageSuccessHandler,
-        onError: @escaping ImageErrorHandler
-    ) -> UUID {
-        let messageId = UUID()
-
-        if let previousImage {
-            // Use image editing API for follow-up requests
-            aiService.editImage(
-                prompt: prompt,
-                sourceImage: previousImage,
-                model: model,
-                onComplete: { imageData in
-                    onSuccess(imageData, messageId)
-                },
-                onError: { error in
-                    onError(error, messageId)
-                }
-            )
-        } else {
-            // Use generation API
-            aiService.generateImage(
-                prompt: prompt,
-                model: model,
-                onComplete: { imageData in
-                    onSuccess(imageData, messageId)
-                },
-                onError: { error in
-                    onError(error, messageId)
-                }
-            )
+    /// Fences and cancels the tasks and transport children belonging to one image action.
+    @MainActor
+    final class ImageGenerationCoordinator {
+        struct OperationID: Hashable, Sendable {
+            private let rawValue = UUID()
         }
 
-        return messageId
-    }
-
-    /// Creates a placeholder message for image generation
-    static func createImagePlaceholder(
-        messageId: UUID,
-        model: String,
-        responseGroupId: UUID? = nil
-    ) -> Message {
-        Message(
-            id: messageId,
-            role: .assistant,
-            content: "",
-            model: model,
-            responseGroupId: responseGroupId,
-            mediaType: .image
-        )
-    }
-
-    /// Generates images from multiple models in parallel
-    /// - Parameters:
-    ///   - config: Configuration for multi-model generation
-    ///   - onImageSuccess: Called for each successful image generation
-    ///   - onImageError: Called for each failed image generation
-    ///   - onAllComplete: Called when all generations have finished
-    /// - Returns: Result containing responseGroupId, messageIds, and responseGroup
-    static func generateMultiModelImages(
-        config: MultiModelConfig,
-        onImageSuccess: @escaping ImageSuccessHandler,
-        onImageError: @escaping ImageErrorHandler,
-        onAllComplete: @escaping CompletionHandler
-    ) -> MultiModelResult {
-        let responseGroupId = UUID()
-        var responseEntries: [ResponseGroup.ResponseEntry] = []
-        var messageIds: [String: UUID] = [:]
-
-        // Create message IDs and response entries for each model
-        for model in config.models {
-            let messageId = UUID()
-            messageIds[model] = messageId
-
-            responseEntries.append(ResponseGroup.ResponseEntry(
-                id: messageId,
-                modelName: model,
-                status: .streaming
-            ))
+        private struct Cancellation {
+            let cancel: @MainActor () -> Void
         }
 
-        // Create response group
-        let responseGroup = ResponseGroup(
-            id: responseGroupId,
-            userMessageId: config.userMessageId,
-            responses: responseEntries
-        )
+        private struct ActiveOperation {
+            let id: OperationID
+            var cancellations: [Cancellation] = []
+        }
 
-        // Track completion with thread-safe counter
-        let remainingCount = AsyncCounter(total: config.models.count)
+        private var activeOperation: ActiveOperation?
 
-        // Generate images in parallel
-        for model in config.models {
-            guard let messageId = messageIds[model] else { continue }
+        var hasActiveOperation: Bool {
+            activeOperation != nil
+        }
 
-            let wrappedOnComplete: @Sendable (Data) -> Void = { imageData in
-                Task { @MainActor in
-                    onImageSuccess(imageData, messageId)
-                    if await remainingCount.decrementAndCheck() {
-                        onAllComplete()
-                    }
-                }
-            }
+        /// Starts a new logical image operation and atomically fences/cancels its predecessor.
+        func beginOperation() -> OperationID {
+            cancelCurrentOperation()
+            let id = OperationID()
+            activeOperation = ActiveOperation(id: id)
+            return id
+        }
 
-            let wrappedOnError: @Sendable (Error) -> Void = { error in
-                Task { @MainActor in
-                    onImageError(error, messageId)
-                    if await remainingCount.decrementAndCheck() {
-                        onAllComplete()
-                    }
-                }
-            }
+        func owns(_ id: OperationID) -> Bool {
+            activeOperation?.id == id
+        }
 
-            if let previousImage = config.previousImage {
-                config.aiService.editImage(
-                    prompt: config.prompt,
-                    sourceImage: previousImage,
-                    model: model,
-                    onComplete: wrappedOnComplete,
-                    onError: wrappedOnError
-                )
-            } else {
-                config.aiService.generateImage(
-                    prompt: config.prompt,
-                    model: model,
-                    onComplete: wrappedOnComplete,
-                    onError: wrappedOnError
-                )
+        static func pendingMessageIDs(
+            in responseGroup: ResponseGroup,
+            candidates: [UUID]
+        ) -> [UUID] {
+            let streamingIDs = Set(responseGroup.responses.filter { $0.status == .streaming }.map(\.id))
+            return candidates.filter { streamingIDs.contains($0) }
+        }
+
+        /// Adds one AI transport child to a single- or multi-model logical operation.
+        func track(_ request: AIImageRequest?, for id: OperationID) {
+            guard let request else { return }
+            trackCancellation(for: id) {
+                request.cancel()
             }
         }
 
-        return MultiModelResult(
-            responseGroupId: responseGroupId,
-            messageIds: messageIds,
-            responseGroup: responseGroup
-        )
+        /// Adds an auxiliary stage such as image loading or post-processing.
+        func track(_ task: Task<Void, Never>, for id: OperationID) {
+            trackCancellation(for: id) {
+                task.cancel()
+            }
+        }
+
+        func onCancel(
+            for id: OperationID,
+            perform action: @escaping @MainActor () -> Void
+        ) {
+            trackCancellation(for: id, cancellation: action)
+        }
+
+        /// Schedules actor-isolated work from a sendable transport callback and owns the task.
+        nonisolated func schedule(
+            for id: OperationID,
+            operation: @escaping @MainActor @Sendable () async -> Void
+        ) {
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let task = Task { @MainActor [weak self] in
+                    guard let self, self.owns(id), !Task.isCancelled else { return }
+                    await operation()
+                }
+                self.track(task, for: id)
+            }
+        }
+
+        /// Completes only the matching operation; stale completions cannot clear a replacement.
+        @discardableResult
+        func finishOperation(_ id: OperationID) -> Bool {
+            guard owns(id) else { return false }
+            activeOperation = nil
+            return true
+        }
+
+        @discardableResult
+        func cancelCurrentOperation() -> Bool {
+            guard let operation = activeOperation else { return false }
+            activeOperation = nil
+            operation.cancellations.forEach { $0.cancel() }
+            return true
+        }
+
+        private func trackCancellation(
+            for id: OperationID,
+            cancellation: @escaping @MainActor () -> Void
+        ) {
+            guard var operation = activeOperation, operation.id == id else {
+                cancellation()
+                return
+            }
+            operation.cancellations.append(Cancellation(cancel: cancellation))
+            activeOperation = operation
+        }
     }
-
-    /// Saves image data to storage and returns the path
-    static func saveImageToStorage(imageData: Data) throws -> String {
-        try AttachmentStorage.shared.save(data: imageData, extension: "png")
-    }
-}
-
-// MARK: - Async Counter
-
-/// Thread-safe counter for tracking async completion
-private actor AsyncCounter {
-    private var remaining: Int
-
-    init(total: Int) {
-        remaining = total
-    }
-
-    func decrementAndCheck() -> Bool {
-        remaining -= 1
-        return remaining <= 0
-    }
-}
 
 #endif

--- a/Sources/Ayna/Chat/ToolCallRequestRoundCoordinator.swift
+++ b/Sources/Ayna/Chat/ToolCallRequestRoundCoordinator.swift
@@ -1,0 +1,246 @@
+//
+//  ToolCallRequestRoundCoordinator.swift
+//  ayna
+//
+//  Coordinates provider request rounds that can emit multiple tool calls.
+//
+
+import Foundation
+
+/// Joins provider completion with every tool completion for one request round.
+///
+/// Start a distinct round for every provider request and capture its ID in that
+/// request's callbacks. Tool registrations retain callback order, while tool
+/// results may arrive in any order. Exactly one event receives
+/// ``Resolution/launchContinuation(_:)`` once the provider has completed and all
+/// registered tools have completed.
+@MainActor
+final class ToolCallRequestRoundCoordinator<ResultPayload: Sendable> {
+    typealias OperationID = ToolChainCoordinator.OperationID
+
+    /// Identifies one provider request within a longer tool-chain operation.
+    struct RequestRoundID: Hashable, Sendable {
+        fileprivate let rawValue = UUID()
+    }
+
+    /// Opaque handle returned for one tool callback in a request round.
+    struct ToolToken: Hashable, Sendable {
+        let operationID: OperationID
+        let requestRoundID: RequestRoundID
+        let registrationIndex: Int
+
+        fileprivate init(
+            operationID: OperationID,
+            requestRoundID: RequestRoundID,
+            registrationIndex: Int
+        ) {
+            self.operationID = operationID
+            self.requestRoundID = requestRoundID
+            self.registrationIndex = registrationIndex
+        }
+    }
+
+    /// One completed tool paired with its registration token.
+    struct CompletedTool: Sendable {
+        let token: ToolToken
+        let result: ResultPayload
+    }
+
+    /// Ordered tool results needed to launch the next provider request.
+    struct Continuation: Sendable {
+        let operationID: OperationID
+        let completedRequestRoundID: RequestRoundID
+        let toolResults: [CompletedTool]
+    }
+
+    /// Observable result of closing a provider round or completing a tool.
+    enum Resolution: Sendable {
+        /// More events are required before the round can resolve.
+        case pending
+
+        /// The provider completed without requesting tools.
+        case responseCompleted
+
+        /// The caller receiving this value is the sole continuation launcher.
+        case launchContinuation(Continuation)
+
+        /// The event was duplicate, stale, cancelled, or for another round.
+        case ignored
+    }
+
+    private enum ToolCompletion {
+        case pending
+        case completed(ResultPayload)
+    }
+
+    private struct RegisteredTool {
+        let token: ToolToken
+        var completion: ToolCompletion
+    }
+
+    private struct RequestRound {
+        let id: RequestRoundID
+        let operationID: OperationID
+        var providerCompleted = false
+        var tools: [RegisteredTool] = []
+    }
+
+    private final class OwnershipProbe {
+        var isOwned = true
+    }
+
+    private var activeOperationID: OperationID?
+    private var activeRound: RequestRound?
+    private var canBeginRound = false
+
+    /// Starts the next provider request round for an operation.
+    ///
+    /// Passing a different operation ID replaces any previous state. The round
+    /// also registers with `ToolChainCoordinator`, so cancelling or replacing
+    /// that operation immediately fences all later round and tool callbacks.
+    /// Returns `nil` for a stale operation or when the current round has not yet
+    /// produced a continuation decision.
+    @discardableResult
+    func beginRequestRound(
+        for operationID: OperationID,
+        coordinatedBy toolChainCoordinator: ToolChainCoordinator
+    ) -> RequestRoundID? {
+        if activeOperationID != operationID {
+            // Registration runs its cancellation immediately when the operation is
+            // no longer owned, giving us an ownership check before replacing state.
+            let ownershipProbe = OwnershipProbe()
+            toolChainCoordinator.onCancel(for: operationID) { [weak self] in
+                ownershipProbe.isOwned = false
+                self?.cancelOperation(operationID)
+            }
+            guard ownershipProbe.isOwned else { return nil }
+
+            activeOperationID = operationID
+            activeRound = nil
+            canBeginRound = true
+        }
+
+        guard canBeginRound, activeRound == nil else { return nil }
+
+        let requestRoundID = RequestRoundID()
+        activeRound = RequestRound(id: requestRoundID, operationID: operationID)
+        canBeginRound = false
+
+        guard activeOperationID == operationID,
+              activeRound?.id == requestRoundID
+        else {
+            return nil
+        }
+
+        return requestRoundID
+    }
+
+    /// Registers a tool callback in provider callback order.
+    ///
+    /// Registration is rejected after provider completion closes the round.
+    func registerTool(
+        for operationID: OperationID,
+        requestRoundID: RequestRoundID
+    ) -> ToolToken? {
+        guard activeOperationID == operationID,
+              var round = activeRound,
+              round.operationID == operationID,
+              round.id == requestRoundID,
+              !round.providerCompleted
+        else {
+            return nil
+        }
+
+        let token = ToolToken(
+            operationID: operationID,
+            requestRoundID: requestRoundID,
+            registrationIndex: round.tools.count
+        )
+        round.tools.append(RegisteredTool(token: token, completion: .pending))
+        activeRound = round
+        return token
+    }
+
+    /// Marks the provider callback stream complete and closes tool registration.
+    func providerDidComplete(
+        operationID: OperationID,
+        requestRoundID: RequestRoundID
+    ) -> Resolution {
+        guard activeOperationID == operationID,
+              var round = activeRound,
+              round.operationID == operationID,
+              round.id == requestRoundID,
+              !round.providerCompleted
+        else {
+            return .ignored
+        }
+
+        round.providerCompleted = true
+        activeRound = round
+        return resolveIfReady()
+    }
+
+    /// Records a tool result. Results are returned in registration order.
+    func toolDidComplete(_ token: ToolToken, result: ResultPayload) -> Resolution {
+        guard activeOperationID == token.operationID,
+              var round = activeRound,
+              round.operationID == token.operationID,
+              round.id == token.requestRoundID,
+              round.tools.indices.contains(token.registrationIndex),
+              round.tools[token.registrationIndex].token == token
+        else {
+            return .ignored
+        }
+
+        guard case .pending = round.tools[token.registrationIndex].completion else {
+            return .ignored
+        }
+
+        round.tools[token.registrationIndex].completion = .completed(result)
+        activeRound = round
+        return resolveIfReady()
+    }
+
+    /// Explicitly clears state for an operation. Normally invoked automatically
+    /// by the cancellation hook registered with `ToolChainCoordinator`.
+    @discardableResult
+    func cancelOperation(_ operationID: OperationID) -> Bool {
+        guard activeOperationID == operationID else { return false }
+        activeOperationID = nil
+        activeRound = nil
+        canBeginRound = false
+        return true
+    }
+
+    private func resolveIfReady() -> Resolution {
+        guard let round = activeRound, round.providerCompleted else {
+            return .pending
+        }
+
+        guard !round.tools.isEmpty else {
+            activeRound = nil
+            canBeginRound = false
+            return .responseCompleted
+        }
+
+        var completedTools: [CompletedTool] = []
+        completedTools.reserveCapacity(round.tools.count)
+
+        for tool in round.tools {
+            guard case let .completed(result) = tool.completion else {
+                return .pending
+            }
+            completedTools.append(CompletedTool(token: tool.token, result: result))
+        }
+
+        activeRound = nil
+        canBeginRound = true
+        return .launchContinuation(
+            Continuation(
+                operationID: round.operationID,
+                completedRequestRoundID: round.id,
+                toolResults: completedTools
+            )
+        )
+    }
+}

--- a/Sources/Ayna/Chat/ToolCallRequestRoundCoordinator.swift
+++ b/Sources/Ayna/Chat/ToolCallRequestRoundCoordinator.swift
@@ -7,6 +7,82 @@
 
 import Foundation
 
+/// Hard safety bounds for one provider request round.
+enum ToolCallRequestRoundPolicy {
+    static let maximumToolCallsPerRound = 8
+
+    static func canonicalArguments(_ arguments: [String: AnyCodable]) -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return (try? encoder.encode(arguments)) ?? Data()
+    }
+}
+
+/// Rejects excess provider callbacks before they enter the main-actor callback queue.
+final class ToolCallRequestAdmissionGate: @unchecked Sendable {
+    private enum CallbackIdentity: Hashable {
+        case providerID(String)
+        case idLess(toolName: String, encodedArguments: Data)
+    }
+
+    private let lock = NSLock()
+    private var admittedCallbacks: Set<CallbackIdentity> = []
+    private var admittedCount = 0
+
+    func admit(providerID: String) -> Bool {
+        let normalizedProviderID = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
+        return admit(identity: .providerID(normalizedProviderID))
+    }
+
+    private func admit(
+        providerID: String,
+        toolName: String,
+        arguments: [String: Any]
+    ) -> Bool {
+        let normalizedProviderID = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !normalizedProviderID.isEmpty {
+            return admit(identity: .providerID(normalizedProviderID))
+        }
+
+        let codableArguments = arguments.mapValues(AnyCodable.init)
+        return admit(
+            identity: .idLess(
+                toolName: toolName,
+                encodedArguments: ToolCallRequestRoundPolicy.canonicalArguments(codableArguments)
+            )
+        )
+    }
+
+    private func admit(identity: CallbackIdentity) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !admittedCallbacks.contains(identity) else { return false }
+        guard admittedCount < ToolCallRequestRoundPolicy.maximumToolCallsPerRound else {
+            return false
+        }
+
+        admittedCount += 1
+        admittedCallbacks.insert(identity)
+        return true
+    }
+
+    func admittedCallback(
+        _ callback: @escaping @Sendable (String, String, [String: Any]) -> Void
+    ) -> @Sendable (String, String, [String: Any]) -> Void {
+        { providerID, toolName, arguments in
+            guard self.admit(
+                providerID: providerID,
+                toolName: toolName,
+                arguments: arguments
+            ) else {
+                return
+            }
+            callback(providerID, toolName, arguments)
+        }
+    }
+}
+
 /// Joins provider completion with every tool completion for one request round.
 ///
 /// Start a distinct round for every provider request and capture its ID in that
@@ -146,7 +222,8 @@ final class ToolCallRequestRoundCoordinator<ResultPayload: Sendable> {
               var round = activeRound,
               round.operationID == operationID,
               round.id == requestRoundID,
-              !round.providerCompleted
+              !round.providerCompleted,
+              round.tools.count < ToolCallRequestRoundPolicy.maximumToolCallsPerRound
         else {
             return nil
         }

--- a/Sources/Ayna/Chat/ToolChainCoordinator.swift
+++ b/Sources/Ayna/Chat/ToolChainCoordinator.swift
@@ -1,0 +1,215 @@
+//
+//  ToolChainCoordinator.swift
+//  ayna
+//
+//  Owns every asynchronous stage of the current tool-call chain.
+//
+
+import Foundation
+
+/// Fences and cancels tool execution, callback, and continuation work for one chat action.
+@MainActor
+final class ToolChainCoordinator {
+    struct OperationID: Hashable, Sendable {
+        private let rawValue = UUID()
+    }
+
+    private struct Cancellation {
+        let cancel: @MainActor () -> Void
+    }
+
+    private struct ActiveOperation {
+        let id: OperationID
+        let conversationID: UUID
+        var cancellations: [Cancellation] = []
+    }
+
+    private struct QueuedCallback: Sendable {
+        let operationID: OperationID
+        let conversationID: UUID
+        let operation: @MainActor @Sendable () -> Void
+    }
+
+    /// Thread-safe FIFO storage used by sendable provider callbacks.
+    private final class OrderedCallbackHandoff: @unchecked Sendable {
+        private let lock = NSLock()
+        private var callbacks: [QueuedCallback] = []
+        private var nextCallbackIndex = 0
+        private var isDrainScheduled = false
+
+        /// Returns true when the caller must schedule the single MainActor drain.
+        func enqueue(_ callback: QueuedCallback) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+
+            callbacks.append(callback)
+            guard !isDrainScheduled else { return false }
+            isDrainScheduled = true
+            return true
+        }
+
+        func dequeue() -> QueuedCallback? {
+            lock.lock()
+            defer { lock.unlock() }
+
+            guard callbacks.indices.contains(nextCallbackIndex) else {
+                callbacks.removeAll(keepingCapacity: true)
+                nextCallbackIndex = 0
+                isDrainScheduled = false
+                return nil
+            }
+
+            let callback = callbacks[nextCallbackIndex]
+            nextCallbackIndex += 1
+            return callback
+        }
+    }
+
+    private nonisolated let callbackHandoff = OrderedCallbackHandoff()
+    private var activeOperation: ActiveOperation?
+
+    var hasActiveOperation: Bool {
+        activeOperation != nil
+    }
+
+    /// Starts a new logical tool chain and atomically fences/cancels its predecessor.
+    func beginOperation(conversationID: UUID) -> OperationID {
+        cancelCurrentOperation()
+        let id = OperationID()
+        activeOperation = ActiveOperation(id: id, conversationID: conversationID)
+        return id
+    }
+
+    func owns(_ id: OperationID, conversationID: UUID) -> Bool {
+        activeOperation?.id == id && activeOperation?.conversationID == conversationID
+    }
+
+    /// Adds an owner-specific AI transport child to the active chain.
+    func track(_ request: AITextRequest, for id: OperationID) {
+        trackCancellation(for: id) {
+            request.cancel()
+        }
+    }
+
+    /// Adds an asynchronous callback or tool-execution child to the active chain.
+    func track(_ task: Task<Void, Never>, for id: OperationID) {
+        trackCancellation(for: id) {
+            task.cancel()
+        }
+    }
+
+    func onCancel(
+        for id: OperationID,
+        perform action: @escaping @MainActor () -> Void
+    ) {
+        trackCancellation(for: id, cancellation: action)
+    }
+
+    /// Enqueues synchronous provider callback bookkeeping in one deterministic FIFO handoff.
+    ///
+    /// Provider callbacks may arrive from any thread. The handoff orders them at enqueue time,
+    /// then a single MainActor drain checks ownership immediately before each callback runs.
+    nonisolated func enqueueCallback(
+        for id: OperationID,
+        conversationID: UUID,
+        operation: @escaping @MainActor @Sendable () -> Void
+    ) {
+        let callback = QueuedCallback(
+            operationID: id,
+            conversationID: conversationID,
+            operation: operation
+        )
+        guard callbackHandoff.enqueue(callback) else { return }
+
+        Task { @MainActor [weak self] in
+            self?.drainCallbacks()
+        }
+    }
+
+    /// Launches and owns asynchronous work without serializing it behind other callbacks.
+    nonisolated func schedule(
+        for id: OperationID,
+        conversationID: UUID,
+        operation: @escaping @MainActor @Sendable () async -> Void
+    ) {
+        enqueueCallback(for: id, conversationID: conversationID) { [weak self] in
+            guard let self else { return }
+            let task = Task { @MainActor [weak self] in
+                guard let self,
+                      self.owns(id, conversationID: conversationID),
+                      !Task.isCancelled
+                else {
+                    return
+                }
+                await operation()
+            }
+            self.track(task, for: id)
+        }
+    }
+
+    private func drainCallbacks() {
+        while let callback = callbackHandoff.dequeue() {
+            guard owns(callback.operationID, conversationID: callback.conversationID) else {
+                continue
+            }
+            callback.operation()
+        }
+    }
+
+    /// Completes only the matching operation; stale completions cannot clear a replacement.
+    @discardableResult
+    func finishOperation(_ id: OperationID) -> Bool {
+        guard activeOperation?.id == id else { return false }
+        activeOperation = nil
+        return true
+    }
+
+    /// Cancels and fences all work belonging to the current chain.
+    @discardableResult
+    func cancelCurrentOperation() -> Bool {
+        guard let operation = activeOperation else { return false }
+        activeOperation = nil
+        operation.cancellations.forEach { $0.cancel() }
+        return true
+    }
+
+    /// Drains already-enqueued provider bookkeeping, finalizes persisted state while ownership
+    /// is still valid, then fences and cancels the matching operation.
+    ///
+    /// A terminal provider callback may finish the operation while the queue drains. In that case
+    /// its normal completion bookkeeping wins and this method does not cancel a replacement.
+    @discardableResult
+    func cancelCurrentOperation(
+        finalizing finalization: @MainActor () -> Void
+    ) -> Bool {
+        guard let operation = activeOperation else {
+            finalization()
+            return false
+        }
+
+        drainCallbacks()
+
+        guard let currentOperation = activeOperation,
+              currentOperation.id == operation.id
+        else {
+            return true
+        }
+
+        finalization()
+        activeOperation = nil
+        currentOperation.cancellations.forEach { $0.cancel() }
+        return true
+    }
+
+    private func trackCancellation(
+        for id: OperationID,
+        cancellation: @escaping @MainActor () -> Void
+    ) {
+        guard var operation = activeOperation, operation.id == id else {
+            cancellation()
+            return
+        }
+        operation.cancellations.append(Cancellation(cancel: cancellation))
+        activeOperation = operation
+    }
+}

--- a/Sources/Ayna/Chat/ToolExecutionResult.swift
+++ b/Sources/Ayna/Chat/ToolExecutionResult.swift
@@ -1,0 +1,60 @@
+//
+//  ToolExecutionResult.swift
+//  ayna
+//
+//  Shared result data for one completed provider-requested tool call.
+//
+
+import Foundation
+
+/// The completed output and display metadata for one provider-requested tool call.
+struct ToolExecutionResult: Sendable {
+    let callID: String
+    let toolName: String
+    let arguments: [String: AnyCodable]
+    let output: String
+    let citations: [CitationReference]
+
+    init(
+        callID: String,
+        toolName: String,
+        arguments: [String: AnyCodable],
+        output: String,
+        citations: [CitationReference] = []
+    ) {
+        self.callID = callID
+        self.toolName = toolName
+        self.arguments = arguments
+        self.output = output
+        self.citations = citations
+    }
+
+    /// Creates the persisted tool-result message used as provider history.
+    func makeMessage() -> Message {
+        var message = Message(role: .tool, content: output)
+        message.toolCalls = [
+            MCPToolCall(
+                id: callID,
+                toolName: toolName,
+                arguments: arguments,
+                result: output
+            )
+        ]
+        return message
+    }
+
+    /// Combines citation lists in callback registration order and assigns stable numbers.
+    static func combinedCitations(from results: [ToolExecutionResult]) -> [CitationReference] {
+        results
+            .flatMap(\.citations)
+            .enumerated()
+            .map { index, citation in
+                CitationReference(
+                    number: index + 1,
+                    title: citation.title,
+                    url: citation.url,
+                    favicon: citation.favicon
+                )
+            }
+    }
+}

--- a/Sources/Ayna/Chat/ToolTranscriptSanitizer.swift
+++ b/Sources/Ayna/Chat/ToolTranscriptSanitizer.swift
@@ -1,0 +1,64 @@
+//
+//  ToolTranscriptSanitizer.swift
+//  ayna
+//
+//  Keeps only complete, locally paired tool-call rounds in persisted history.
+//
+
+import Foundation
+
+enum ToolTranscriptSanitizer {
+    static func sanitize(_ messages: [Message]) -> [Message] {
+        var sanitized: [Message] = []
+        var index = 0
+
+        while index < messages.count {
+            let message = messages[index]
+
+            guard message.role == .assistant,
+                  let toolCalls = message.toolCalls,
+                  !toolCalls.isEmpty
+            else {
+                if message.role != .tool,
+                   message.role != .assistant || message.hasMeaningfulNonToolTranscriptContent
+                {
+                    sanitized.append(message)
+                }
+                index += 1
+                continue
+            }
+
+            var resultByCallID: [String: Message] = [:]
+            var nextIndex = index + 1
+            while nextIndex < messages.count, messages[nextIndex].role == .tool {
+                let result = messages[nextIndex]
+                if let callID = result.toolCalls?.first?.id,
+                   resultByCallID[callID] == nil
+                {
+                    resultByCallID[callID] = result
+                }
+                nextIndex += 1
+            }
+
+            var seenCallIDs: Set<String> = []
+            let validCalls = toolCalls.filter { call in
+                resultByCallID[call.id] != nil && seenCallIDs.insert(call.id).inserted
+            }
+
+            var sanitizedAssistant = message
+            sanitizedAssistant.toolCalls = validCalls.isEmpty ? nil : validCalls
+            if !validCalls.isEmpty || sanitizedAssistant.hasMeaningfulNonToolTranscriptContent {
+                sanitized.append(sanitizedAssistant)
+            }
+            for call in validCalls {
+                if let result = resultByCallID[call.id] {
+                    sanitized.append(result)
+                }
+            }
+
+            index = nextIndex
+        }
+
+        return sanitized
+    }
+}

--- a/Sources/Ayna/Models/AynaError.swift
+++ b/Sources/Ayna/Models/AynaError.swift
@@ -418,6 +418,35 @@ struct AnyCodable: Codable, Equatable, @unchecked Sendable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
 
+        if Mirror(reflecting: value).displayStyle == .class,
+           let number = value as? NSNumber
+        {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                try container.encode(number.boolValue)
+            } else if let decimalNumber = number as? NSDecimalNumber {
+                let decimal = decimalNumber.decimalValue
+                if decimal.isNaN {
+                    try container.encodeNil()
+                } else {
+                    try container.encode(decimal)
+                }
+            } else if CFNumberIsFloatType(number) {
+                let double = number.doubleValue
+                if double.isFinite {
+                    try container.encode(double)
+                } else {
+                    try container.encodeNil()
+                }
+            } else if let int = Int64(number.stringValue) {
+                try container.encode(int)
+            } else if let uint = UInt64(number.stringValue) {
+                try container.encode(uint)
+            } else {
+                try container.encodeNil()
+            }
+            return
+        }
+
         switch value {
         case let bool as Bool:
             try container.encode(bool)

--- a/Sources/Ayna/Models/AynaError.swift
+++ b/Sources/Ayna/Models/AynaError.swift
@@ -402,6 +402,19 @@ struct AnyCodable: Codable, Equatable, @unchecked Sendable {
             value = bool
         } else if let int = try? container.decode(Int.self) {
             value = int
+        } else if let uint = try? container.decode(UInt64.self) {
+            value = NSNumber(value: uint)
+        } else if let decimal = try? container.decode(Decimal.self) {
+            if let double = try? container.decode(Double.self),
+               Decimal(
+                   string: String(double),
+                   locale: Locale(identifier: "en_US_POSIX")
+               ) == decimal
+            {
+                value = double
+            } else {
+                value = NSDecimalNumber(decimal: decimal)
+            }
         } else if let double = try? container.decode(Double.self) {
             value = double
         } else if let string = try? container.decode(String.self) {
@@ -466,7 +479,19 @@ struct AnyCodable: Codable, Equatable, @unchecked Sendable {
     }
 
     static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
-        switch (lhs.value, rhs.value) {
+        let lhsBoolean = jsonBooleanValue(lhs.value)
+        let rhsBoolean = jsonBooleanValue(rhs.value)
+        if lhsBoolean != nil || rhsBoolean != nil {
+            return lhsBoolean == rhsBoolean
+        }
+
+        let lhsNumber = jsonNumberValue(lhs.value)
+        let rhsNumber = jsonNumberValue(rhs.value)
+        if lhsNumber != nil || rhsNumber != nil {
+            return lhsNumber == rhsNumber
+        }
+
+        return switch (lhs.value, rhs.value) {
         case let (lhs as Bool, rhs as Bool):
             lhs == rhs
         case let (lhs as Int, rhs as Int):
@@ -479,10 +504,51 @@ struct AnyCodable: Codable, Equatable, @unchecked Sendable {
             lhs == rhs
         case let (lhs as [String: AnyCodable], rhs as [String: AnyCodable]):
             lhs == rhs
+        case let (lhs as [Any], rhs as [Any]):
+            lhs.count == rhs.count && zip(lhs, rhs).allSatisfy {
+                AnyCodable($0) == AnyCodable($1)
+            }
+        case let (lhs as [String: Any], rhs as [String: Any]):
+            lhs.count == rhs.count && lhs.allSatisfy { key, value in
+                guard let rhsValue = rhs[key] else { return false }
+                return AnyCodable(value) == AnyCodable(rhsValue)
+            }
         case (is NSNull, is NSNull):
             true
         default:
             false
+        }
+    }
+
+    private static func jsonBooleanValue(_ value: Any) -> Bool? {
+        if Mirror(reflecting: value).displayStyle == .class,
+           let number = value as? NSNumber
+        {
+            guard CFGetTypeID(number) == CFBooleanGetTypeID() else { return nil }
+            return number.boolValue
+        }
+        return value as? Bool
+    }
+
+    private static func jsonNumberValue(_ value: Any) -> Decimal? {
+        if Mirror(reflecting: value).displayStyle == .class,
+           let number = value as? NSNumber
+        {
+            guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
+            let decimal = number.decimalValue
+            return decimal.isNaN ? nil : decimal
+        }
+
+        return switch value {
+        case let int as Int:
+            Decimal(int)
+        case let double as Double where double.isFinite:
+            Decimal(
+                string: String(double),
+                locale: Locale(identifier: "en_US_POSIX")
+            )
+        default:
+            nil
         }
     }
 }

--- a/Sources/Ayna/Models/Conversation.swift
+++ b/Sources/Ayna/Models/Conversation.swift
@@ -203,9 +203,8 @@ struct Conversation: Identifiable, Equatable, Sendable {
         in group: ResponseGroup,
         messagesByID: [UUID: Message]
     ) -> UUID? {
-        func eligibleMessageID(for entry: ResponseGroupEntry) -> UUID? {
-            guard entry.status == .selected || entry.status == .completed,
-                  let message = messagesByID[entry.id],
+        func meaningfulMessageID(for entry: ResponseGroupEntry) -> UUID? {
+            guard let message = messagesByID[entry.id],
                   message.responseGroupId == group.id,
                   message.role == .assistant,
                   message.hasMeaningfulHistoryContent
@@ -217,13 +216,14 @@ struct Conversation: Identifiable, Equatable, Sendable {
 
         if let selectedResponseID = group.selectedResponseId,
            let selectedEntry = group.responses.first(where: { $0.id == selectedResponseID }),
-           let selectedMessageID = eligibleMessageID(for: selectedEntry)
+           selectedEntry.status == .selected || selectedEntry.status == .completed,
+           let selectedMessageID = meaningfulMessageID(for: selectedEntry)
         {
             return selectedMessageID
         }
 
         for entry in group.responses where entry.status == .selected {
-            if let selectedMessageID = eligibleMessageID(for: entry) {
+            if let selectedMessageID = meaningfulMessageID(for: entry) {
                 return selectedMessageID
             }
         }
@@ -231,14 +231,35 @@ struct Conversation: Identifiable, Equatable, Sendable {
         for entry in group.responses
             where entry.modelName == model && (entry.status == .selected || entry.status == .completed)
         {
-            if let defaultModelMessageID = eligibleMessageID(for: entry) {
+            if let defaultModelMessageID = meaningfulMessageID(for: entry) {
                 return defaultModelMessageID
             }
         }
 
         for entry in group.responses where entry.status == .completed {
-            if let completedMessageID = eligibleMessageID(for: entry) {
+            if let completedMessageID = meaningfulMessageID(for: entry) {
                 return completedMessageID
+            }
+        }
+
+        if let selectedResponseID = group.selectedResponseId,
+           let selectedEntry = group.responses.first(where: {
+               $0.id == selectedResponseID && $0.status == .failed
+           }),
+           let selectedMessageID = meaningfulMessageID(for: selectedEntry)
+        {
+            return selectedMessageID
+        }
+
+        for entry in group.responses where entry.modelName == model && entry.status == .failed {
+            if let defaultModelMessageID = meaningfulMessageID(for: entry) {
+                return defaultModelMessageID
+            }
+        }
+
+        for entry in group.responses where entry.status == .failed {
+            if let failedMessageID = meaningfulMessageID(for: entry) {
+                return failedMessageID
             }
         }
 

--- a/Sources/Ayna/Models/Conversation.swift
+++ b/Sources/Ayna/Models/Conversation.swift
@@ -166,31 +166,83 @@ struct Conversation: Identifiable, Equatable, Sendable {
     // MARK: - Multi-Model Support
 
     /// Get the effective message history for API requests.
-    /// This filters out unselected responses from response groups to maintain linear context.
+    /// This linearizes each response group to one terminal, meaningful response.
     func getEffectiveHistory() -> [Message] {
-        var effectiveMessages: [Message] = []
+        var messagesByID: [UUID: Message] = [:]
+        for message in messages where messagesByID[message.id] == nil {
+            messagesByID[message.id] = message
+        }
 
-        for message in messages {
-            // If message is part of a response group
-            if let groupId = message.responseGroupId {
-                // Find the corresponding response group
-                if let group = responseGroups.first(where: { $0.id == groupId }) {
-                    // Only include if this is the selected response, or if no selection made yet
-                    if group.selectedResponseId == message.id || group.selectedResponseId == nil {
-                        effectiveMessages.append(message)
-                    }
-                    // Skip unselected responses
-                } else {
-                    // No group found, include the message anyway
-                    effectiveMessages.append(message)
-                }
-            } else {
-                // Regular message (not part of a response group)
-                effectiveMessages.append(message)
+        var groupsByID: [UUID: ResponseGroup] = [:]
+        var chosenMessageIDByGroupID: [UUID: UUID] = [:]
+        for group in responseGroups where groupsByID[group.id] == nil {
+            groupsByID[group.id] = group
+            if let messageID = effectiveResponseMessageID(in: group, messagesByID: messagesByID) {
+                chosenMessageIDByGroupID[group.id] = messageID
             }
         }
 
-        return effectiveMessages
+        return messages.filter { message in
+            guard message.role != .assistant || message.hasMeaningfulHistoryContent else {
+                return false
+            }
+
+            guard let groupID = message.responseGroupId else {
+                return message.isSelectedResponse != false
+            }
+
+            guard groupsByID[groupID] != nil else {
+                return message.isSelectedResponse != false
+            }
+
+            return chosenMessageIDByGroupID[groupID] == message.id
+        }
+    }
+
+    private func effectiveResponseMessageID(
+        in group: ResponseGroup,
+        messagesByID: [UUID: Message]
+    ) -> UUID? {
+        func eligibleMessageID(for entry: ResponseGroupEntry) -> UUID? {
+            guard entry.status == .selected || entry.status == .completed,
+                  let message = messagesByID[entry.id],
+                  message.responseGroupId == group.id,
+                  message.role == .assistant,
+                  message.hasMeaningfulHistoryContent
+            else {
+                return nil
+            }
+            return message.id
+        }
+
+        if let selectedResponseID = group.selectedResponseId,
+           let selectedEntry = group.responses.first(where: { $0.id == selectedResponseID }),
+           let selectedMessageID = eligibleMessageID(for: selectedEntry)
+        {
+            return selectedMessageID
+        }
+
+        for entry in group.responses where entry.status == .selected {
+            if let selectedMessageID = eligibleMessageID(for: entry) {
+                return selectedMessageID
+            }
+        }
+
+        for entry in group.responses
+            where entry.modelName == model && (entry.status == .selected || entry.status == .completed)
+        {
+            if let defaultModelMessageID = eligibleMessageID(for: entry) {
+                return defaultModelMessageID
+            }
+        }
+
+        for entry in group.responses where entry.status == .completed {
+            if let completedMessageID = eligibleMessageID(for: entry) {
+                return completedMessageID
+            }
+        }
+
+        return nil
     }
 
     /// Add a response group for multi-model responses
@@ -240,6 +292,48 @@ struct Conversation: Identifiable, Equatable, Sendable {
             responseGroups[index] = group
             updatedAt = Date()
         }
+    }
+}
+
+extension Message {
+    var hasMeaningfulNonToolTranscriptContent: Bool {
+        if !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        if let reasoning,
+           !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return true
+        }
+        if !(citations?.isEmpty ?? true) {
+            return true
+        }
+        if let imageData, !imageData.isEmpty {
+            return true
+        }
+        if let imagePath,
+           !imagePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return true
+        }
+        if attachments?.contains(where: { attachment in
+            if let data = attachment.data, !data.isEmpty {
+                return true
+            }
+            if let localPath = attachment.localPath,
+               !localPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                return true
+            }
+            return false
+        }) == true {
+            return true
+        }
+        return false
+    }
+
+    var hasMeaningfulHistoryContent: Bool {
+        hasMeaningfulNonToolTranscriptContent || !(toolCalls?.isEmpty ?? true)
     }
 }
 

--- a/Sources/Ayna/Models/Conversation.swift
+++ b/Sources/Ayna/Models/Conversation.swift
@@ -119,6 +119,10 @@ struct Conversation: Identifiable, Equatable, Sendable {
         case multiModelEnabled, activeModels, responseGroups
     }
 
+    private enum LegacyCodingKeys: String, CodingKey {
+        case systemPrompt
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
@@ -127,7 +131,18 @@ struct Conversation: Identifiable, Equatable, Sendable {
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         model = try container.decode(String.self, forKey: .model)
-        systemPromptMode = try container.decode(SystemPromptMode.self, forKey: .systemPromptMode)
+        if container.contains(.systemPromptMode) {
+            systemPromptMode = try container.decode(SystemPromptMode.self, forKey: .systemPromptMode)
+        } else {
+            let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
+            if let legacySystemPrompt = try legacyContainer.decodeIfPresent(String.self, forKey: .systemPrompt),
+               !legacySystemPrompt.isEmpty
+            {
+                systemPromptMode = .custom(legacySystemPrompt)
+            } else {
+                systemPromptMode = .inheritGlobal
+            }
+        }
         temperature = try container.decode(Double.self, forKey: .temperature)
         // Provide defaults for new multi-model fields (backward compatibility)
         multiModelEnabled = try container.decodeIfPresent(Bool.self, forKey: .multiModelEnabled) ?? false

--- a/Sources/Ayna/Models/Message.swift
+++ b/Sources/Ayna/Models/Message.swift
@@ -30,9 +30,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
     var content: String
     let timestamp: Date
     var isLiked: Bool
-    #if !os(watchOS)
         var toolCalls: [MCPToolCall]?
-    #endif
     var model: String? // Track which model generated this message
 
     // Multi-model response support
@@ -102,6 +100,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
             content: String,
             timestamp: Date = Date(),
             isLiked: Bool = false,
+            toolCalls: [MCPToolCall]? = nil,
             model: String? = nil,
             responseGroupId: UUID? = nil,
             isSelectedResponse: Bool? = nil,
@@ -119,6 +118,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
             self.content = content
             self.timestamp = timestamp
             self.isLiked = isLiked
+            self.toolCalls = toolCalls
             self.model = model
             self.responseGroupId = responseGroupId
             self.isSelectedResponse = isSelectedResponse
@@ -177,7 +177,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
 
     #if os(watchOS)
         private enum CodingKeys: String, CodingKey {
-            case id, role, content, timestamp, isLiked, model
+            case id, role, content, timestamp, isLiked, toolCalls, model
             case responseGroupId, isSelectedResponse
             case mediaType, imageData, imagePath, attachments, reasoning, citations
             case isEdited, editedAt
@@ -190,6 +190,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
             content = try container.decode(String.self, forKey: .content)
             timestamp = try container.decode(Date.self, forKey: .timestamp)
             isLiked = try container.decode(Bool.self, forKey: .isLiked)
+            toolCalls = try container.decodeIfPresent([MCPToolCall].self, forKey: .toolCalls)
             model = try container.decodeIfPresent(String.self, forKey: .model)
             // Multi-model fields (backward compatibility)
             responseGroupId = try container.decodeIfPresent(UUID.self, forKey: .responseGroupId)

--- a/Sources/Ayna/Models/WatchDataModels.swift
+++ b/Sources/Ayna/Models/WatchDataModels.swift
@@ -47,6 +47,8 @@ struct WatchMessage: Codable, Identifiable {
     var content: String
     var timestamp: Date
     var model: String?
+    var toolCalls: [MCPToolCall]?
+    var citations: [CitationReference]?
 
     init(from message: Message) {
         id = message.id
@@ -54,12 +56,14 @@ struct WatchMessage: Codable, Identifiable {
         content = message.content
         timestamp = message.timestamp
         model = message.model
+        toolCalls = message.toolCalls
+        citations = message.citations
     }
 
     func toMessage() -> Message {
         let messageRole: Message.Role
-        if let r = Message.Role(rawValue: role) {
-            messageRole = r
+        if let decodedRole = Message.Role(rawValue: role) {
+            messageRole = decodedRole
         } else {
             DiagnosticsLogger.log(.watchConnectivity, level: .default, message: "Invalid message role", metadata: ["role": role])
             messageRole = .assistant
@@ -70,7 +74,9 @@ struct WatchMessage: Codable, Identifiable {
             role: messageRole,
             content: content,
             timestamp: timestamp,
-            model: model
+            toolCalls: toolCalls,
+            model: model,
+            citations: citations
         )
     }
 }

--- a/Sources/Ayna/Models/WatchDataModels.swift
+++ b/Sources/Ayna/Models/WatchDataModels.swift
@@ -8,40 +8,416 @@
 
 import Foundation
 
-/// Lightweight conversation model for Watch sync (strips heavy data like images and attachments)
-struct WatchConversation: Codable, Identifiable {
+/// Compact phone-authoritative request settings for a conversation whose body is omitted.
+struct WatchConversationRequestConfiguration: Codable, Equatable, Identifiable, Sendable {
+    let id: UUID
+    var model: String
+    var temperature: Double
+    var resolvedSystemPrompt: String?
+
+    init(
+        id: UUID,
+        model: String,
+        temperature: Double,
+        resolvedSystemPrompt: String?
+    ) {
+        self.id = id
+        self.model = model
+        self.temperature = temperature
+        self.resolvedSystemPrompt = resolvedSystemPrompt?.nilIfEmpty
+    }
+
+    init(from conversation: Conversation, resolvedSystemPrompt: String?) {
+        self.init(
+            id: conversation.id,
+            model: conversation.model,
+            temperature: conversation.temperature,
+            resolvedSystemPrompt: resolvedSystemPrompt
+        )
+    }
+
+    func apply(to conversation: inout WatchConversation) {
+        guard conversation.id == id else { return }
+        conversation.model = model
+        conversation.temperature = temperature
+        conversation.resolvedSystemPrompt = resolvedSystemPrompt?.nilIfEmpty
+    }
+}
+
+/// Lightweight conversation model for Watch sync.
+///
+/// The model intentionally carries the resolved prompt and temperature needed to make
+/// requests on Watch, while omitting phone-only state such as prompt inheritance mode,
+/// pending auto-send prompts, attachments, and multi-model response bookkeeping.
+struct WatchConversation: Codable, Equatable, Identifiable, Sendable {
     let id: UUID
     var title: String
     var messages: [WatchMessage]
     var model: String
     var updatedAt: Date
     var createdAt: Date
+    var temperature: Double
+    var resolvedSystemPrompt: String?
+    var watchRevision: UInt64
 
-    init(from conversation: Conversation) {
+    init(
+        id: UUID,
+        title: String,
+        messages: [WatchMessage] = [],
+        model: String,
+        updatedAt: Date,
+        createdAt: Date,
+        temperature: Double = 0.7,
+        resolvedSystemPrompt: String? = nil,
+        watchRevision: UInt64 = 0
+    ) {
+        self.id = id
+        self.title = title
+        self.messages = messages
+        self.model = model
+        self.updatedAt = updatedAt
+        self.createdAt = createdAt
+        self.temperature = temperature
+        self.resolvedSystemPrompt = resolvedSystemPrompt
+        self.watchRevision = watchRevision
+    }
+
+    init(
+        from conversation: Conversation,
+        watchRevision: UInt64 = 0,
+        maximumMessages: Int = 20
+    ) {
+        self.init(
+            from: conversation,
+            resolvedSystemPrompt: Self.resolveSystemPrompt(for: conversation),
+            watchRevision: watchRevision,
+            maximumMessages: maximumMessages
+        )
+    }
+
+    init(
+        from conversation: Conversation,
+        resolvedSystemPrompt: String?,
+        watchRevision: UInt64 = 0,
+        maximumMessages: Int = 20
+    ) {
         id = conversation.id
         title = conversation.title
         model = conversation.model
         updatedAt = conversation.updatedAt
         createdAt = conversation.createdAt
-        // Only include recent messages and strip attachments
-        messages = conversation.messages.suffix(20).map { WatchMessage(from: $0) }
+        temperature = conversation.temperature
+        self.resolvedSystemPrompt = resolvedSystemPrompt?.nilIfEmpty
+        self.watchRevision = watchRevision
+
+        let history = conversation.getEffectiveHistory()
+        messages = history.suffix(max(0, maximumMessages)).map { WatchMessage(from: $0) }
     }
 
+    /// Converts the shared Watch state back into a new phone conversation.
+    /// Existing phone conversations should instead be updated through
+    /// ``PhoneWatchMutationReducer`` so phone-only state is preserved.
     func toConversation() -> Conversation {
         var conversation = Conversation(
             id: id,
             title: title,
             createdAt: createdAt,
-            model: model
+            model: model,
+            systemPromptMode: .inheritGlobal,
+            temperature: temperature
         )
         conversation.updatedAt = updatedAt
         conversation.messages = messages.map { $0.toMessage() }
         return conversation
     }
+
+    /// Request-ready effective history. The conversation's resolved prompt is prepended
+    /// as a stable synthetic system message and the remaining messages are already the
+    /// phone conversation's effective (selected-response) history.
+    var effectiveHistory: [Message] {
+        var history = messages.map { $0.toMessage() }
+        if let resolvedSystemPrompt = resolvedSystemPrompt?.nilIfEmpty {
+            history.insert(
+                Message(
+                    id: id,
+                    role: .system,
+                    content: resolvedSystemPrompt,
+                    timestamp: createdAt
+                ),
+                at: 0
+            )
+        }
+        return history
+    }
+
+    private static func resolveSystemPrompt(for conversation: Conversation) -> String? {
+        switch conversation.systemPromptMode {
+        case .inheritGlobal:
+            AppPreferences.globalSystemPrompt.nilIfEmpty
+        case let .custom(prompt):
+            prompt.nilIfEmpty
+        case .disabled:
+            nil
+        }
+    }
+
+    // MARK: - Backward-compatible Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case messages
+        case model
+        case updatedAt
+        case createdAt
+        case temperature
+        case resolvedSystemPrompt
+        case watchRevision
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        messages = try container.decode([WatchMessage].self, forKey: .messages)
+        model = try container.decode(String.self, forKey: .model)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        temperature = try container.decodeIfPresent(Double.self, forKey: .temperature) ?? 0.7
+        resolvedSystemPrompt = try container.decodeIfPresent(String.self, forKey: .resolvedSystemPrompt)?.nilIfEmpty
+        watchRevision = try container.decodeIfPresent(UInt64.self, forKey: .watchRevision) ?? 0
+    }
 }
 
-/// Lightweight message model for Watch sync (no images or attachments)
-struct WatchMessage: Codable, Identifiable {
+/// A revisioned phone-authoritative snapshot.
+///
+/// Conversation bodies, authoritative IDs, and compact request configurations are bounded
+/// independently. Body or page omission is not deletion; absence is authoritative only when
+/// the ID manifest is explicitly complete. Tombstones always remain authoritative.
+struct WatchSyncSnapshot: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 3
+
+    static func supportsSchemaVersion(_ schemaVersion: Int) -> Bool {
+        schemaVersion > 0 && schemaVersion <= currentSchemaVersion
+    }
+
+    var schemaVersion: Int
+    var sourceID: UUID
+    var revision: WatchSyncRevision
+    var paginationCursor: WatchSyncRevision
+    var conversations: [WatchConversation]
+    var authoritativeConversationIDs: [UUID]
+    var authoritativeConversationIDsAreComplete: Bool
+    var conversationConfigurations: [WatchConversationRequestConfiguration]
+    var conversationConfigurationsAreComplete: Bool
+    var acknowledgedPeerID: UUID?
+    var acknowledgedWatchRevisions: [UUID: WatchSyncRevision]
+    var tombstones: [WatchConversationTombstone]
+
+    var snapshotRevision: WatchSyncRevision {
+        get { revision }
+        set { revision = newValue }
+    }
+
+    init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        sourceID: UUID = WatchSyncIdentity.legacySourceID,
+        revision: WatchSyncRevision,
+        paginationCursor: WatchSyncRevision? = nil,
+        conversations: [WatchConversation],
+        authoritativeConversationIDs: [UUID],
+        authoritativeConversationIDsAreComplete: Bool = true,
+        conversationConfigurations: [WatchConversationRequestConfiguration] = [],
+        conversationConfigurationsAreComplete: Bool = false,
+        acknowledgedPeerID: UUID? = WatchSyncIdentity.legacyPeerID,
+        acknowledgedWatchRevisions: [UUID: WatchSyncRevision] = [:],
+        tombstones: [WatchConversationTombstone] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.sourceID = sourceID
+        self.revision = revision
+        self.paginationCursor = paginationCursor ?? Self.defaultPaginationCursor(for: revision)
+        self.conversations = WatchConversationCanonicalizer.watchConversations(conversations)
+        self.authoritativeConversationIDs = WatchConversationCanonicalizer.uniqueIDs(
+            authoritativeConversationIDs
+        )
+        self.authoritativeConversationIDsAreComplete = authoritativeConversationIDsAreComplete
+        self.conversationConfigurations = WatchConversationCanonicalizer.requestConfigurations(
+            conversationConfigurations
+        )
+        self.conversationConfigurationsAreComplete = conversationConfigurationsAreComplete
+        self.acknowledgedPeerID = acknowledgedPeerID
+        self.acknowledgedWatchRevisions = acknowledgedWatchRevisions
+        self.tombstones = tombstones.sorted(by: Self.tombstoneSort)
+    }
+
+    init(
+        snapshotRevision: WatchSyncRevision,
+        sourceID: UUID = WatchSyncIdentity.legacySourceID,
+        paginationCursor: WatchSyncRevision? = nil,
+        conversations: [WatchConversation],
+        authoritativeConversationIDs: [UUID],
+        authoritativeConversationIDsAreComplete: Bool = true,
+        conversationConfigurations: [WatchConversationRequestConfiguration] = [],
+        conversationConfigurationsAreComplete: Bool = false,
+        acknowledgedPeerID: UUID? = WatchSyncIdentity.legacyPeerID,
+        acknowledgedWatchRevisions: [UUID: WatchSyncRevision] = [:],
+        tombstoneRevisions: [UUID: WatchSyncRevision] = [:]
+    ) {
+        self.init(
+            sourceID: sourceID,
+            revision: snapshotRevision,
+            paginationCursor: paginationCursor,
+            conversations: conversations,
+            authoritativeConversationIDs: authoritativeConversationIDs,
+            authoritativeConversationIDsAreComplete: authoritativeConversationIDsAreComplete,
+            conversationConfigurations: conversationConfigurations,
+            conversationConfigurationsAreComplete: conversationConfigurationsAreComplete,
+            acknowledgedPeerID: acknowledgedPeerID,
+            acknowledgedWatchRevisions: acknowledgedWatchRevisions,
+            tombstones: tombstoneRevisions.map {
+                WatchConversationTombstone(conversationID: $0.key, revision: $0.value)
+            }
+        )
+    }
+
+    func acknowledgedRevision(for conversationID: UUID) -> WatchSyncRevision {
+        acknowledgedWatchRevisions[conversationID] ?? 0
+    }
+
+    func tombstoneRevision(for conversationID: UUID) -> WatchSyncRevision? {
+        tombstones
+            .filter { $0.conversationID == conversationID }
+            .map(\.revision)
+            .max()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case sourceID
+        case revision
+        case snapshotRevision
+        case paginationCursor
+        case conversations
+        case authoritativeConversationIDs
+        case authoritativeConversationIDsAreComplete
+        case conversationConfigurations
+        case conversationConfigurationsAreComplete
+        case acknowledgedPeerID
+        case acknowledgedWatchRevisions
+        case tombstones
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if container.contains(.schemaVersion) {
+            schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        } else {
+            schemaVersion = 1
+        }
+        sourceID = try container.decodeIfPresent(UUID.self, forKey: .sourceID)
+            ?? WatchSyncIdentity.legacySourceID
+        revision = try container.decodeIfPresent(WatchSyncRevision.self, forKey: .revision)
+            ?? container.decodeIfPresent(WatchSyncRevision.self, forKey: .snapshotRevision)
+            ?? 0
+        paginationCursor = try container.decodeIfPresent(
+            WatchSyncRevision.self,
+            forKey: .paginationCursor
+        ) ?? Self.defaultPaginationCursor(for: revision)
+        let decodedConversations = try container.decodeIfPresent(
+            [WatchConversation].self,
+            forKey: .conversations
+        ) ?? []
+        conversations = WatchConversationCanonicalizer.watchConversations(decodedConversations)
+        if container.contains(.authoritativeConversationIDs) {
+            authoritativeConversationIDs = try WatchConversationCanonicalizer.uniqueIDs(
+                container.decode([UUID].self, forKey: .authoritativeConversationIDs)
+            )
+        } else {
+            authoritativeConversationIDs = conversations.map(\.id)
+        }
+        authoritativeConversationIDsAreComplete = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .authoritativeConversationIDsAreComplete
+        ) ?? (schemaVersion <= 2)
+        let decodedConfigurations = try container.decodeIfPresent(
+            [WatchConversationRequestConfiguration].self,
+            forKey: .conversationConfigurations
+        ) ?? []
+        conversationConfigurations = WatchConversationCanonicalizer.requestConfigurations(
+            decodedConfigurations
+        )
+        conversationConfigurationsAreComplete = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .conversationConfigurationsAreComplete
+        ) ?? false
+        acknowledgedPeerID = try container.decodeIfPresent(UUID.self, forKey: .acknowledgedPeerID)
+            ?? WatchSyncIdentity.legacyPeerID
+        let encodedAcknowledgements = try container.decodeIfPresent(
+            [String: WatchSyncRevision].self,
+            forKey: .acknowledgedWatchRevisions
+        ) ?? [:]
+        acknowledgedWatchRevisions = WatchSyncRevisionMapCodec.decode(encodedAcknowledgements)
+        tombstones = try container.decodeIfPresent([WatchConversationTombstone].self, forKey: .tombstones) ?? []
+        tombstones.sort(by: Self.tombstoneSort)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(sourceID, forKey: .sourceID)
+        try container.encode(revision, forKey: .revision)
+        try container.encode(paginationCursor, forKey: .paginationCursor)
+        try container.encode(conversations, forKey: .conversations)
+        try container.encode(authoritativeConversationIDs, forKey: .authoritativeConversationIDs)
+        try container.encode(
+            authoritativeConversationIDsAreComplete,
+            forKey: .authoritativeConversationIDsAreComplete
+        )
+        try container.encode(conversationConfigurations, forKey: .conversationConfigurations)
+        try container.encode(
+            conversationConfigurationsAreComplete,
+            forKey: .conversationConfigurationsAreComplete
+        )
+        try container.encodeIfPresent(acknowledgedPeerID, forKey: .acknowledgedPeerID)
+        let encodedAcknowledgements = WatchSyncRevisionMapCodec.encode(acknowledgedWatchRevisions)
+        try container.encode(encodedAcknowledgements, forKey: .acknowledgedWatchRevisions)
+        try container.encode(tombstones.sorted(by: Self.tombstoneSort), forKey: .tombstones)
+    }
+
+    private static func defaultPaginationCursor(
+        for revision: WatchSyncRevision
+    ) -> WatchSyncRevision {
+        revision > 0 ? revision - 1 : 0
+    }
+
+    private static func tombstoneSort(
+        _ lhs: WatchConversationTombstone,
+        _ rhs: WatchConversationTombstone
+    ) -> Bool {
+        if lhs.conversationID != rhs.conversationID {
+            return lhs.conversationID.uuidString < rhs.conversationID.uuidString
+        }
+        return lhs.revision < rhs.revision
+    }
+}
+
+struct WatchSyncPayload: Equatable, Sendable {
+    let snapshot: WatchSyncSnapshot
+    let data: Data
+
+    var encodedSnapshot: Data {
+        data
+    }
+}
+
+struct WatchMutationPayload: Equatable, Sendable {
+    let mutation: WatchConversationMutation
+    let data: Data
+}
+
+/// Lightweight message model for Watch sync (no images or attachments).
+struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
     let id: UUID
     var role: String
     var content: String
@@ -49,6 +425,24 @@ struct WatchMessage: Codable, Identifiable {
     var model: String?
     var toolCalls: [MCPToolCall]?
     var citations: [CitationReference]?
+
+    init(
+        id: UUID,
+        role: String,
+        content: String,
+        timestamp: Date,
+        model: String? = nil,
+        toolCalls: [MCPToolCall]? = nil,
+        citations: [CitationReference]? = nil
+    ) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
+        self.model = model
+        self.toolCalls = toolCalls
+        self.citations = citations
+    }
 
     init(from message: Message) {
         id = message.id
@@ -65,7 +459,12 @@ struct WatchMessage: Codable, Identifiable {
         if let decodedRole = Message.Role(rawValue: role) {
             messageRole = decodedRole
         } else {
-            DiagnosticsLogger.log(.watchConnectivity, level: .default, message: "Invalid message role", metadata: ["role": role])
+            DiagnosticsLogger.log(
+                .watchConnectivity,
+                level: .default,
+                message: "Invalid message role",
+                metadata: ["role": role]
+            )
             messageRole = .assistant
         }
 
@@ -78,5 +477,11 @@ struct WatchMessage: Codable, Identifiable {
             model: model,
             citations: citations
         )
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -92,6 +92,27 @@ struct RequestFlightObserver: Sendable {
     static let none = RequestFlightObserver { _, _ in }
 }
 
+#if !os(watchOS)
+    /// Owner-specific cancellation token for one image transport request.
+    ///
+    /// Higher-level image operations retain these tokens so replacing a view or
+    /// cancelling one conversation cannot accidentally cancel another owner's work.
+    @MainActor
+    final class AIImageRequest {
+        fileprivate weak var service: AIService?
+        fileprivate let flightID: RequestFlightID
+
+        fileprivate init(service: AIService, flightID: RequestFlightID) {
+            self.service = service
+            self.flightID = flightID
+        }
+
+        func cancel() {
+            service?.cancelImageRequest(flightID)
+        }
+    }
+#endif
+
 private final class OrderedMainActorForwarder<Event: Sendable>: Sendable {
     private struct State: Sendable {
         var events: [Event] = []
@@ -199,6 +220,7 @@ class AIService: ObservableObject {
     private var multiModelStreamTasks: [String: RequestFlight<Task<Void, Never>>] = [:]
     #if !os(watchOS)
         private var appleIntelligenceTask: Task<Void, Never>?
+        private var imageRequests: [RequestFlightID: OpenAIImageService.RequestHandle] = [:]
     #endif
 
     /// Holds Anthropic providers during active requests to prevent deallocation.
@@ -335,6 +357,18 @@ class AIService: ObservableObject {
         case imageGeneration
     }
 
+    #if !os(watchOS)
+        private static func makeImageService(
+            urlSession: URLSession,
+            retryDelay: @escaping @Sendable (Int, Date?) async -> Void
+        ) -> OpenAIImageService {
+            OpenAIImageService(
+                urlSession: urlSession,
+                retryDelay: { attempt in await retryDelay(attempt, nil) }
+            )
+        }
+    #endif
+
     init(
         urlSession: URLSession? = nil,
         anthropicProviderFactory: @escaping @MainActor (URLSession) -> any AIProviderProtocol = {
@@ -354,7 +388,7 @@ class AIService: ObservableObject {
         if let session = urlSession {
             self.urlSession = session
             #if !os(watchOS)
-                imageService = OpenAIImageService(urlSession: session)
+                imageService = Self.makeImageService(urlSession: session, retryDelay: retryDelay)
             #endif
         } else {
             let config = URLSessionConfiguration.default
@@ -362,7 +396,7 @@ class AIService: ObservableObject {
             config.timeoutIntervalForResource = 300 // 5 minutes
             self.urlSession = URLSession(configuration: config)
             #if !os(watchOS)
-                imageService = OpenAIImageService(urlSession: self.urlSession)
+                imageService = Self.makeImageService(urlSession: self.urlSession, retryDelay: retryDelay)
             #endif
         }
 
@@ -811,7 +845,7 @@ class AIService: ObservableObject {
         return .chat
     }
 
-    func cancelCurrentRequest() {
+    func cancelCurrentRequest(includeImageRequests: Bool = true) {
         DiagnosticsLogger.log(
             .aiService,
             level: .info,
@@ -840,6 +874,13 @@ class AIService: ObservableObject {
         #if !os(watchOS)
             let appleTask = appleIntelligenceTask
             appleIntelligenceTask = nil
+            let imageRequestHandles: [OpenAIImageService.RequestHandle]
+            if includeImageRequests {
+                imageRequestHandles = Array(imageRequests.values)
+                imageRequests.removeAll()
+            } else {
+                imageRequestHandles = []
+            }
         #endif
 
         // Fence queued multi-model starts before active handles can release shared permits.
@@ -868,6 +909,7 @@ class AIService: ObservableObject {
         multiAnthropicProviders.forEach { $0.cancelRequest() }
         #if !os(watchOS)
             appleTask?.cancel()
+            imageRequestHandles.forEach { $0.cancel() }
         #endif
         DiagnosticsLogger.log(
             .aiService,
@@ -879,17 +921,18 @@ class AIService: ObservableObject {
     #if !os(watchOS)
         /// Generates an image from a text prompt.
         /// Delegates to OpenAIImageService for the actual network request.
+        @discardableResult
         func generateImage(
             prompt: String,
             model: String? = nil,
             onComplete: @escaping @Sendable (Data) -> Void,
             onError: @escaping @Sendable (Error) -> Void,
             attempt: Int = 0
-        ) {
+        ) -> AIImageRequest? {
             let requestModel = (model ?? selectedModel).trimmingCharacters(in: .whitespacesAndNewlines)
             guard !requestModel.isEmpty else {
                 onError(AIError.missingModel)
-                return
+                return nil
             }
 
             let effectiveProvider = modelProviders[requestModel] ?? provider
@@ -910,29 +953,54 @@ class AIService: ObservableObject {
                 outputCompression: outputCompression
             )
 
+            let flightID = RequestFlightID()
+            let requestHandle = OpenAIImageService.RequestHandle()
+            imageRequests[flightID] = requestHandle
+
             imageService.generateImage(
                 prompt: prompt,
                 requestConfig: requestConfig,
                 imageConfig: imageConfig,
-                onComplete: onComplete,
-                onError: onError,
+                requestHandle: requestHandle,
+                onComplete: { [weak self] data in
+                    Task { @MainActor [weak self] in
+                        guard let self,
+                              self.finishImageRequest(flightID, handle: requestHandle)
+                        else {
+                            return
+                        }
+                        onComplete(data)
+                    }
+                },
+                onError: { [weak self] error in
+                    Task { @MainActor [weak self] in
+                        guard let self,
+                              self.finishImageRequest(flightID, handle: requestHandle)
+                        else {
+                            return
+                        }
+                        onError(error)
+                    }
+                },
                 attempt: attempt
             )
+            return AIImageRequest(service: self, flightID: flightID)
         }
 
         /// Edits an image based on a prompt and source image.
         /// Delegates to OpenAIImageService for the actual network request.
+        @discardableResult
         func editImage(
             prompt: String,
             sourceImage: Data,
             model: String? = nil,
             onComplete: @escaping @Sendable (Data) -> Void,
             onError: @escaping @Sendable (Error) -> Void
-        ) {
+        ) -> AIImageRequest? {
             let requestModel = (model ?? selectedModel).trimmingCharacters(in: .whitespacesAndNewlines)
             guard !requestModel.isEmpty else {
                 onError(AIError.missingModel)
-                return
+                return nil
             }
 
             let effectiveProvider = modelProviders[requestModel] ?? provider
@@ -953,14 +1021,53 @@ class AIService: ObservableObject {
                 outputCompression: outputCompression
             )
 
+            let flightID = RequestFlightID()
+            let requestHandle = OpenAIImageService.RequestHandle()
+            imageRequests[flightID] = requestHandle
+
             imageService.editImage(
                 prompt: prompt,
                 sourceImage: sourceImage,
                 requestConfig: requestConfig,
                 imageConfig: imageConfig,
-                onComplete: onComplete,
-                onError: onError
+                requestHandle: requestHandle,
+                onComplete: { [weak self] data in
+                    Task { @MainActor [weak self] in
+                        guard let self,
+                              self.finishImageRequest(flightID, handle: requestHandle)
+                        else {
+                            return
+                        }
+                        onComplete(data)
+                    }
+                },
+                onError: { [weak self] error in
+                    Task { @MainActor [weak self] in
+                        guard let self,
+                              self.finishImageRequest(flightID, handle: requestHandle)
+                        else {
+                            return
+                        }
+                        onError(error)
+                    }
+                }
             )
+            return AIImageRequest(service: self, flightID: flightID)
+        }
+
+        fileprivate func cancelImageRequest(_ flightID: RequestFlightID) {
+            guard let requestHandle = imageRequests.removeValue(forKey: flightID) else { return }
+            requestHandle.cancel()
+        }
+
+        private func finishImageRequest(
+            _ flightID: RequestFlightID,
+            handle: OpenAIImageService.RequestHandle
+        ) -> Bool {
+            guard imageRequests[flightID] === handle else { return false }
+            imageRequests.removeValue(forKey: flightID)
+            handle.finish()
+            return true
         }
     #endif
 

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -289,8 +289,8 @@ private enum MultiModelBatchCallback: @unchecked Sendable {
 #endif
 
 struct AIServiceResponseSimulationCallbacks: Sendable {
-    let onChunk: @Sendable (String) -> Void
-    let onComplete: @Sendable () -> Void
+    let onChunk: @MainActor @Sendable (String) -> Void
+    let onComplete: @MainActor @Sendable () -> Void
 }
 
 typealias AIServiceResponseSimulator = @MainActor @Sendable (
@@ -2025,35 +2025,31 @@ class AIService: ObservableObject {
     ) -> AIServiceResponseSimulationCallbacks {
         AIServiceResponseSimulationCallbacks(
             onChunk: { [weak self] chunk in
-                MainActor.assumeIsolated {
-                    guard let self else { return }
-                    let ownsRequest = self.ownsSimulatedTextRequest(
-                        flightID,
-                        isMultiModelRequest: isMultiModelRequest,
-                        modelName: modelName
-                    )
-                    if isMultiModelRequest {
-                        self.requestFlightObserver.record(.multiModelCallback, ownsRequest)
-                    }
-                    guard ownsRequest else { return }
-                    onChunk(chunk)
+                guard let self else { return }
+                let ownsRequest = self.ownsSimulatedTextRequest(
+                    flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    modelName: modelName
+                )
+                if isMultiModelRequest {
+                    self.requestFlightObserver.record(.multiModelCallback, ownsRequest)
                 }
+                guard ownsRequest else { return }
+                onChunk(chunk)
             },
             onComplete: { [weak self] in
-                MainActor.assumeIsolated {
-                    guard let self else { return }
-                    let finishedRequest = self.finishSimulatedTextRequest(
-                        flightID,
-                        isMultiModelRequest: isMultiModelRequest,
-                        modelName: modelName,
-                        requestHandle: requestHandle
-                    )
-                    if isMultiModelRequest {
-                        self.requestFlightObserver.record(.multiModelCallback, finishedRequest)
-                    }
-                    guard finishedRequest else { return }
-                    onComplete()
+                guard let self else { return }
+                let finishedRequest = self.finishSimulatedTextRequest(
+                    flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    modelName: modelName,
+                    requestHandle: requestHandle
+                )
+                if isMultiModelRequest {
+                    self.requestFlightObserver.record(.multiModelCallback, finishedRequest)
                 }
+                guard finishedRequest else { return }
+                onComplete()
             }
         )
     }

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -36,6 +36,107 @@ enum APIEndpointType: String, CaseIterable, Codable {
     }
 }
 
+struct RequestFlightID: Hashable, Sendable {
+    private let rawValue = UUID()
+}
+
+struct RequestFlight<Handle> {
+    private var id: RequestFlightID?
+    private var handle: Handle?
+
+    var isActive: Bool {
+        id != nil
+    }
+
+    func owns(_ id: RequestFlightID) -> Bool {
+        self.id == id
+    }
+
+    @discardableResult
+    mutating func install(_ handle: Handle, id: RequestFlightID) -> Handle? {
+        let previous = self.handle
+        self.id = id
+        self.handle = handle
+        return previous
+    }
+
+    @discardableResult
+    mutating func clear(ifOwnedBy id: RequestFlightID) -> Bool {
+        guard owns(id) else { return false }
+        self.id = nil
+        handle = nil
+        return true
+    }
+
+    mutating func take() -> Handle? {
+        id = nil
+        defer { handle = nil }
+        return handle
+    }
+}
+
+enum RequestFlightCheckpoint: Sendable {
+    case streamCancellation
+    case streamRetry
+    case dataCallback
+    case dataRetry
+    case anthropicTerminal
+}
+
+struct RequestFlightObserver: Sendable {
+    let record: @Sendable (RequestFlightCheckpoint, Bool) -> Void
+
+    static let none = RequestFlightObserver { _, _ in }
+}
+
+private final class OrderedMainActorForwarder<Event: Sendable>: Sendable {
+    private struct State: Sendable {
+        var events: [Event] = []
+        var isDraining = false
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let receive: @MainActor @Sendable (Event) -> Void
+
+    init(receive: @escaping @MainActor @Sendable (Event) -> Void) {
+        self.receive = receive
+    }
+
+    func enqueue(_ event: Event) {
+        let shouldStart = state.withLock { state -> Bool in
+            state.events.append(event)
+            guard !state.isDraining else { return false }
+            state.isDraining = true
+            return true
+        }
+        guard shouldStart else { return }
+
+        Task { @MainActor [self] in
+            while let event = nextEvent() {
+                receive(event)
+            }
+        }
+    }
+
+    private func nextEvent() -> Event? {
+        state.withLock { state in
+            guard !state.events.isEmpty else {
+                state.isDraining = false
+                return nil
+            }
+            return state.events.removeFirst()
+        }
+    }
+}
+
+private enum AnthropicFlightCallback: @unchecked Sendable {
+    case chunk(String)
+    case complete
+    case error(Error)
+    case toolRequest(id: String, name: String, arguments: [String: Any])
+    case reasoning(String)
+}
+
 @MainActor
 class AIService: ObservableObject {
     static let shared = AIService()
@@ -59,17 +160,19 @@ class AIService: ObservableObject {
     }
 
     // Track current task for cancellation
-    private var currentTask: URLSessionDataTask?
-    private var currentStreamTask: Task<Void, Never>?
+    private var currentTask = RequestFlight<URLSessionDataTask>()
+    private var multiModelDataTasks: [String: RequestFlight<URLSessionDataTask>] = [:]
+    private var currentStreamTask = RequestFlight<Task<Void, Never>>()
     private var multiModelTask: Task<Void, Never>?
     /// Tracks individual stream tasks for each model in multi-model mode
-    private var multiModelStreamTasks: [String: Task<Void, Never>] = [:]
+    private var multiModelStreamTasks: [String: RequestFlight<Task<Void, Never>>] = [:]
     #if !os(watchOS)
         private var appleIntelligenceTask: Task<Void, Never>?
     #endif
 
-    /// Holds the Anthropic provider during streaming to prevent deallocation
-    private var currentAnthropicProvider: AnthropicProvider?
+    /// Holds Anthropic providers during active requests to prevent deallocation.
+    private var currentAnthropicProvider = RequestFlight<any AIProviderProtocol>()
+    private var multiModelAnthropicProviders: [String: RequestFlight<any AIProviderProtocol>] = [:]
 
     @Published var provider: AIProvider {
         didSet {
@@ -84,6 +187,9 @@ class AIService: ObservableObject {
 
     /// Custom URLSession with longer timeout for slow models
     private let urlSession: URLSession
+    private let anthropicProviderFactory: @MainActor (URLSession) -> any AIProviderProtocol
+    private let retryDelay: @Sendable (Int, Date?) async -> Void
+    private let requestFlightObserver: RequestFlightObserver
 
     // Image generation service
     #if !os(watchOS)
@@ -197,7 +303,20 @@ class AIService: ObservableObject {
         case imageGeneration
     }
 
-    init(urlSession: URLSession? = nil) {
+    init(
+        urlSession: URLSession? = nil,
+        anthropicProviderFactory: @escaping @MainActor (URLSession) -> any AIProviderProtocol = {
+            AnthropicProvider(urlSession: $0)
+        },
+        retryDelay: @escaping @Sendable (Int, Date?) async -> Void = { attempt, retryAfterDate in
+            await AIRetryPolicy.wait(for: attempt, retryAfterDate: retryAfterDate)
+        },
+        requestFlightObserver: RequestFlightObserver = .none
+    ) {
+        self.anthropicProviderFactory = anthropicProviderFactory
+        self.retryDelay = retryDelay
+        self.requestFlightObserver = requestFlightObserver
+
         if let session = urlSession {
             self.urlSession = session
             #if !os(watchOS)
@@ -617,14 +736,44 @@ class AIService: ObservableObject {
             level: .info,
             message: "Canceling current request"
         )
-        currentTask?.cancel()
-        currentTask = nil
-        currentStreamTask?.cancel()
-        currentStreamTask = nil
+
+        let dataTask = currentTask.take()
+        let multiDataTasks = multiModelDataTasks.compactMap { model, flight -> (String, URLSessionDataTask)? in
+            var flight = flight
+            return flight.take().map { (model, $0) }
+        }
+        multiModelDataTasks.removeAll()
+        let streamTask = currentStreamTask.take()
+        let multiStreamTasks = multiModelStreamTasks.compactMap { model, flight -> (String, Task<Void, Never>)? in
+            var flight = flight
+            return flight.take().map { (model, $0) }
+        }
+        multiModelStreamTasks.removeAll()
+        let anthropicProvider = currentAnthropicProvider.take()
+        let multiAnthropicProviders = multiModelAnthropicProviders.compactMap { _, flight -> (any AIProviderProtocol)? in
+            var flight = flight
+            return flight.take()
+        }
+        multiModelAnthropicProviders.removeAll()
+        #if !os(watchOS)
+            let appleTask = appleIntelligenceTask
+            appleIntelligenceTask = nil
+        #endif
+
+        dataTask?.cancel()
+        for (model, task) in multiDataTasks {
+            task.cancel()
+            DiagnosticsLogger.log(
+                .aiService,
+                level: .info,
+                message: "Cancelled multi-model data task",
+                metadata: ["model": model]
+            )
+        }
+        streamTask?.cancel()
         multiModelTask?.cancel()
         multiModelTask = nil
-        // Cancel all individual multi-model stream tasks
-        for (model, task) in multiModelStreamTasks {
+        for (model, task) in multiStreamTasks {
             task.cancel()
             DiagnosticsLogger.log(
                 .aiService,
@@ -633,13 +782,10 @@ class AIService: ObservableObject {
                 metadata: ["model": model]
             )
         }
-        multiModelStreamTasks.removeAll()
-        // Cancel Anthropic provider and clear reference to prevent memory leak
-        currentAnthropicProvider?.cancelRequest()
-        currentAnthropicProvider = nil
+        anthropicProvider?.cancelRequest()
+        multiAnthropicProviders.forEach { $0.cancelRequest() }
         #if !os(watchOS)
-            appleIntelligenceTask?.cancel()
-            appleIntelligenceTask = nil
+            appleTask?.cancel()
         #endif
         DiagnosticsLogger.log(
             .aiService,
@@ -881,6 +1027,7 @@ class AIService: ObservableObject {
                 stream: stream,
                 tools: tools,
                 conversationId: conversationId,
+                isMultiModelRequest: isMultiModelRequest,
                 callbacks: anthropicCallbacks
             )
             return
@@ -919,7 +1066,8 @@ class AIService: ObservableObject {
                 onComplete: onComplete,
                 onError: onError,
                 onToolCallRequested: onToolCallRequested,
-                onReasoning: onReasoning
+                onReasoning: onReasoning,
+                isMultiModelRequest: isMultiModelRequest
             )
             return
         }
@@ -1015,14 +1163,21 @@ class AIService: ObservableObject {
             streamResponse(request: request, callbacks: callbacks, isMultiModelRequest: isMultiModelRequest, modelName: requestModel)
         } else {
             nonStreamResponse(
-                request: request, onChunk: onChunk, onComplete: onComplete, onError: onError,
-                onToolCall: onToolCall, onReasoning: onReasoning
+                request: request,
+                modelName: requestModel,
+                isMultiModelRequest: isMultiModelRequest,
+                onChunk: onChunk,
+                onComplete: onComplete,
+                onError: onError,
+                onToolCall: onToolCall,
+                onReasoning: onReasoning
             )
         }
     }
 
     // MARK: - Multi-Model Parallel Requests
 
+    // swiftlint:disable function_body_length
     /// Sends a message to multiple models in parallel using TaskGroup.
     /// Each model streams independently, and tool calls are deferred until the user selects a response.
     ///
@@ -1062,10 +1217,24 @@ class AIService: ObservableObject {
 
         // Cancel any existing multi-model task and individual stream tasks
         multiModelTask?.cancel()
-        for (_, task) in multiModelStreamTasks {
-            task.cancel()
+        let previousDataTasks = multiModelDataTasks.compactMap { _, flight -> URLSessionDataTask? in
+            var flight = flight
+            return flight.take()
+        }
+        multiModelDataTasks.removeAll()
+        let previousStreamTasks = multiModelStreamTasks.compactMap { _, flight -> Task<Void, Never>? in
+            var flight = flight
+            return flight.take()
         }
         multiModelStreamTasks.removeAll()
+        let previousAnthropicProviders = multiModelAnthropicProviders.compactMap { _, flight -> (any AIProviderProtocol)? in
+            var flight = flight
+            return flight.take()
+        }
+        multiModelAnthropicProviders.removeAll()
+        previousDataTasks.forEach { $0.cancel() }
+        previousStreamTasks.forEach { $0.cancel() }
+        previousAnthropicProviders.forEach { $0.cancelRequest() }
 
         // Use a TaskGroup to send requests in parallel
         let task = Task {
@@ -1207,6 +1376,8 @@ class AIService: ObservableObject {
         multiModelTask = task
     }
 
+    // swiftlint:enable function_body_length
+
     private func simulateUITestResponse(
         messages: [Message],
         stream: Bool,
@@ -1248,9 +1419,70 @@ class AIService: ObservableObject {
         }
     }
 
+    private func ownsDataFlight(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String
+    ) -> Bool {
+        if isMultiModelRequest {
+            return multiModelDataTasks[modelName]?.owns(flightID) == true
+        }
+        return currentTask.owns(flightID)
+    }
+
+    @discardableResult
+    private func clearDataFlight(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String
+    ) -> Bool {
+        if isMultiModelRequest {
+            guard var flight = multiModelDataTasks[modelName],
+                  flight.clear(ifOwnedBy: flightID)
+            else {
+                return false
+            }
+            multiModelDataTasks.removeValue(forKey: modelName)
+            return true
+        }
+        return currentTask.clear(ifOwnedBy: flightID)
+    }
+
+    private func takeDataTask(
+        isMultiModelRequest: Bool,
+        modelName: String
+    ) -> URLSessionDataTask? {
+        if isMultiModelRequest {
+            var flight = multiModelDataTasks.removeValue(forKey: modelName)
+            return flight?.take()
+        }
+        return currentTask.take()
+    }
+
+    @discardableResult
+    private func installDataTask(
+        _ task: URLSessionDataTask,
+        flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String,
+        requiresExistingOwner: Bool
+    ) -> Bool {
+        if isMultiModelRequest {
+            var flight = multiModelDataTasks[modelName] ?? RequestFlight()
+            guard !requiresExistingOwner || flight.owns(flightID) else { return false }
+            flight.install(task, id: flightID)
+            multiModelDataTasks[modelName] = flight
+            return true
+        }
+
+        guard !requiresExistingOwner || currentTask.owns(flightID) else { return false }
+        currentTask.install(task, id: flightID)
+        return true
+    }
+
     // The Responses API flow handles multimodal payload assembly in one place for debugging clarity.
     // swiftlint:disable superfluous_disable_command
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func responsesAPIRequest(
         messages: [Message],
         model: String,
@@ -1260,8 +1492,29 @@ class AIService: ObservableObject {
         onError: @escaping @Sendable (Error) -> Void,
         onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)? = nil,
         onReasoning: (@Sendable (String) -> Void)? = nil,
-        attempt: Int = 0
+        isMultiModelRequest: Bool = false,
+        attempt: Int = 0,
+        existingFlightID: RequestFlightID? = nil
     ) {
+        let flightID = existingFlightID ?? RequestFlightID()
+        guard existingFlightID == nil || ownsDataFlight(
+            flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: model
+        ) else {
+            return
+        }
+
+        func reportSetupError(_ error: Error) {
+            if existingFlightID == nil || clearDataFlight(
+                flightID,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: model
+            ) {
+                onError(error)
+            }
+        }
+
         // Check if this model has a provider override
         let effectiveProvider = modelProviders[model] ?? provider
         let endpointInfo = customEndpoint(for: model)
@@ -1269,7 +1522,7 @@ class AIService: ObservableObject {
 
         // Apple Intelligence doesn't support the responses API
         if effectiveProvider == .appleIntelligence {
-            onError(AIError.apiError("Apple Intelligence doesn't support the Responses API endpoint"))
+            reportSetupError(AIError.apiError("Apple Intelligence doesn't support the Responses API endpoint"))
             return
         }
 
@@ -1279,12 +1532,12 @@ class AIService: ObservableObject {
         do {
             apiURL = try getResponsesAPIURL(deploymentName: model, provider: effectiveProvider)
         } catch {
-            onError(error)
+            reportSetupError(error)
             return
         }
 
         guard let url = URL(string: apiURL) else {
-            onError(AIError.invalidURL)
+            reportSetupError(AIError.invalidURL)
             return
         }
 
@@ -1322,21 +1575,46 @@ class AIService: ObservableObject {
                 isAzure: usesAzureEndpoint
             )
         else {
-            onError(AIError.invalidRequest)
+            reportSetupError(AIError.invalidRequest)
             return
+        }
+
+        if existingFlightID == nil {
+            let previousTask = takeDataTask(
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: model
+            )
+            previousTask?.cancel()
+        } else {
+            guard ownsDataFlight(
+                flightID,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: model
+            ) else {
+                return
+            }
         }
 
         let task = urlSession.dataTask(with: request) { [weak self] data, _, error in
             let selfRef = self
             Task { @MainActor in
                 guard let self = selfRef else { return }
-
-                // Clear the task reference
-                self.currentTask = nil
+                let ownsFlight = self.ownsDataFlight(
+                    flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    modelName: model
+                )
+                self.requestFlightObserver.record(.dataCallback, ownsFlight)
+                guard ownsFlight else { return }
 
                 if let error {
                     // Don't report error if it was cancelled
                     if (error as NSError).code == NSURLErrorCancelled {
+                        self.clearDataFlight(
+                            flightID,
+                            isMultiModelRequest: isMultiModelRequest,
+                            modelName: model
+                        )
                         return
                     }
 
@@ -1350,6 +1628,13 @@ class AIService: ObservableObject {
                         Task { @MainActor [weak self] in
                             guard let self else { return }
                             await self.delay(for: attempt)
+                            let ownsFlight = self.ownsDataFlight(
+                                flightID,
+                                isMultiModelRequest: isMultiModelRequest,
+                                modelName: model
+                            )
+                            self.requestFlightObserver.record(.dataRetry, ownsFlight)
+                            guard ownsFlight else { return }
                             self.responsesAPIRequest(
                                 messages: messages,
                                 model: model,
@@ -1359,17 +1644,33 @@ class AIService: ObservableObject {
                                 onError: onError,
                                 onToolCallRequested: onToolCallRequested,
                                 onReasoning: onReasoning,
-                                attempt: attempt + 1
+                                isMultiModelRequest: isMultiModelRequest,
+                                attempt: attempt + 1,
+                                existingFlightID: flightID
                             )
                         }
                         return
                     }
 
+                    guard self.clearDataFlight(
+                        flightID,
+                        isMultiModelRequest: isMultiModelRequest,
+                        modelName: model
+                    ) else {
+                        return
+                    }
                     onError(error)
                     return
                 }
 
                 guard let data else {
+                    guard self.clearDataFlight(
+                        flightID,
+                        isMultiModelRequest: isMultiModelRequest,
+                        modelName: model
+                    ) else {
+                        return
+                    }
                     onError(AIError.noData)
                     return
                 }
@@ -1380,6 +1681,13 @@ class AIService: ObservableObject {
                     if let errorDict = json?["error"] as? [String: Any],
                        let message = errorDict["message"] as? String
                     {
+                        guard self.clearDataFlight(
+                            flightID,
+                            isMultiModelRequest: isMultiModelRequest,
+                            modelName: model
+                        ) else {
+                            return
+                        }
                         onError(AIError.apiError(message))
                         return
                     }
@@ -1387,10 +1695,45 @@ class AIService: ObservableObject {
                     if let outputArray = json?["output"] as? [[String: Any]] {
                         let result = OpenAIRequestBuilder.deliverResponsesOutput(
                             outputArray,
-                            onChunk: onChunk,
-                            onReasoning: onReasoning,
-                            onToolCallRequested: onToolCallRequested
+                            onChunk: { chunk in
+                                guard self.ownsDataFlight(
+                                    flightID,
+                                    isMultiModelRequest: isMultiModelRequest,
+                                    modelName: model
+                                ) else {
+                                    return
+                                }
+                                onChunk(chunk)
+                            },
+                            onReasoning: { reasoning in
+                                guard self.ownsDataFlight(
+                                    flightID,
+                                    isMultiModelRequest: isMultiModelRequest,
+                                    modelName: model
+                                ) else {
+                                    return
+                                }
+                                onReasoning?(reasoning)
+                            },
+                            onToolCallRequested: { toolID, toolName, arguments in
+                                guard self.ownsDataFlight(
+                                    flightID,
+                                    isMultiModelRequest: isMultiModelRequest,
+                                    modelName: model
+                                ) else {
+                                    return
+                                }
+                                onToolCallRequested?(toolID, toolName, arguments)
+                            }
                         )
+
+                        guard self.ownsDataFlight(
+                            flightID,
+                            isMultiModelRequest: isMultiModelRequest,
+                            modelName: model
+                        ) else {
+                            return
+                        }
 
                         if result.hasToolCalls {
                             DiagnosticsLogger.log(
@@ -1402,15 +1745,37 @@ class AIService: ObservableObject {
                         }
                     }
 
+                    guard self.clearDataFlight(
+                        flightID,
+                        isMultiModelRequest: isMultiModelRequest,
+                        modelName: model
+                    ) else {
+                        return
+                    }
                     onComplete()
                 } catch {
+                    guard self.clearDataFlight(
+                        flightID,
+                        isMultiModelRequest: isMultiModelRequest,
+                        modelName: model
+                    ) else {
+                        return
+                    }
                     onError(error)
                 }
             }
         }
 
-        // Store and start the task
-        currentTask = task
+        guard installDataTask(
+            task,
+            flightID: flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: model,
+            requiresExistingOwner: existingFlightID != nil
+        ) else {
+            task.cancel()
+            return
+        }
         task.resume()
     }
 
@@ -1494,25 +1859,157 @@ class AIService: ObservableObject {
             lowercased.contains("ratelimit")
     }
 
+    private func ownsStreamFlight(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String?
+    ) -> Bool {
+        if isMultiModelRequest {
+            guard let modelName else { return false }
+            return multiModelStreamTasks[modelName]?.owns(flightID) == true
+        }
+        return currentStreamTask.owns(flightID)
+    }
+
+    @discardableResult
+    private func clearStreamFlight(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String?
+    ) -> Bool {
+        if isMultiModelRequest {
+            guard let modelName,
+                  var flight = multiModelStreamTasks[modelName],
+                  flight.clear(ifOwnedBy: flightID)
+            else {
+                return false
+            }
+            multiModelStreamTasks.removeValue(forKey: modelName)
+            return true
+        }
+        return currentStreamTask.clear(ifOwnedBy: flightID)
+    }
+
+    private func takeStreamTask(
+        isMultiModelRequest: Bool,
+        modelName: String?
+    ) -> Task<Void, Never>? {
+        if isMultiModelRequest {
+            guard let modelName else { return nil }
+            var flight = multiModelStreamTasks.removeValue(forKey: modelName)
+            return flight?.take()
+        }
+        return currentStreamTask.take()
+    }
+
+    @discardableResult
+    private func installStreamTask(
+        _ task: Task<Void, Never>,
+        flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String?,
+        requiresExistingOwner: Bool
+    ) -> Bool {
+        if isMultiModelRequest {
+            guard let modelName else { return false }
+            var flight = multiModelStreamTasks[modelName] ?? RequestFlight()
+            guard !requiresExistingOwner || flight.owns(flightID) else { return false }
+            flight.install(task, id: flightID)
+            multiModelStreamTasks[modelName] = flight
+            return true
+        }
+
+        guard !requiresExistingOwner || currentStreamTask.owns(flightID) else { return false }
+        currentStreamTask.install(task, id: flightID)
+        return true
+    }
+
+    @discardableResult
+    private func deliverStreamBuffers(
+        content: String,
+        reasoning: String,
+        callbacks: StreamCallbacks,
+        flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String?,
+        terminal: Bool
+    ) -> Bool {
+        guard ownsStreamFlight(
+            flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: modelName
+        ) else {
+            return false
+        }
+
+        if !content.isEmpty {
+            callbacks.onChunk(content)
+            guard ownsStreamFlight(
+                flightID,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: modelName
+            ) else {
+                return false
+            }
+        }
+
+        if !reasoning.isEmpty {
+            callbacks.onReasoning?(reasoning)
+            guard ownsStreamFlight(
+                flightID,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: modelName
+            ) else {
+                return false
+            }
+        }
+
+        if terminal {
+            guard clearStreamFlight(
+                flightID,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: modelName
+            ) else {
+                return false
+            }
+            callbacks.onComplete()
+        }
+        return true
+    }
+
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func streamResponse(
         request: URLRequest,
         callbacks: StreamCallbacks,
         attempt: Int = 0,
         isMultiModelRequest: Bool = false,
-        modelName: String? = nil
+        modelName: String? = nil,
+        existingFlightID: RequestFlightID? = nil
     ) {
         let session = urlSession
+        let flightID = existingFlightID ?? RequestFlightID()
 
-        // Cancel any existing stream task before starting a new one
-        // Skip cancellation for multi-model requests to allow parallel streaming
-        if currentStreamTask != nil, !isMultiModelRequest {
-            DiagnosticsLogger.log(
-                .aiService,
-                level: .info,
-                message: "⚠️ Cancelling existing stream task before starting new one"
+        if existingFlightID != nil {
+            guard ownsStreamFlight(
+                flightID,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: modelName
+            ) else {
+                return
+            }
+        } else {
+            let previousTask = takeStreamTask(
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: modelName
             )
-            currentStreamTask?.cancel()
+            if previousTask != nil, !isMultiModelRequest {
+                DiagnosticsLogger.log(
+                    .aiService,
+                    level: .info,
+                    message: "⚠️ Cancelling existing stream task before starting new one"
+                )
+            }
+            previousTask?.cancel()
         }
 
         DiagnosticsLogger.log(
@@ -1557,7 +2054,9 @@ class AIService: ObservableObject {
                             for try await byte in bytes {
                                 errorData.append(byte)
                                 // Limit error body size to prevent memory issues
-                                if errorData.count > 4096 { break }
+                                if errorData.count > 4096 {
+                                    break
+                                }
                             }
                         } catch {
                             // Ignore errors reading error body
@@ -1621,6 +2120,54 @@ class AIService: ObservableObject {
                     var currentToolCallBuffers: [Int: [String: Any]] = [:]
                     var toolCallIds: [Int: String] = [:]
 
+                    let guardedToolCall: (@Sendable (String, String, [String: Any]) async -> String)? = if let onToolCall = callbacks.onToolCall {
+                        { [weak self] toolCallID, toolName, arguments in
+                            guard let self else { return "" }
+                            let ownsFlight = await MainActor.run {
+                                self.ownsStreamFlight(
+                                    flightID,
+                                    isMultiModelRequest: isMultiModelRequest,
+                                    modelName: modelName
+                                )
+                            }
+                            guard ownsFlight, !Task.isCancelled else { return "" }
+
+                            let result = await onToolCall(toolCallID, toolName, arguments)
+                            let stillOwnsFlight = await MainActor.run {
+                                self.ownsStreamFlight(
+                                    flightID,
+                                    isMultiModelRequest: isMultiModelRequest,
+                                    modelName: modelName
+                                )
+                            }
+                            guard stillOwnsFlight, !Task.isCancelled else { return "" }
+                            return result
+                        }
+                    } else {
+                        nil
+                    }
+
+                    let guardedToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)? = if let onToolCallRequested = callbacks.onToolCallRequested {
+                        { [weak self] toolCallID, toolName, arguments in
+                            let arguments = UncheckedSendableWrapper(arguments)
+                            MainActor.assumeIsolated {
+                                guard let self,
+                                      !Task.isCancelled,
+                                      self.ownsStreamFlight(
+                                          flightID,
+                                          isMultiModelRequest: isMultiModelRequest,
+                                          modelName: modelName
+                                      )
+                                else {
+                                    return
+                                }
+                                onToolCallRequested(toolCallID, toolName, arguments.value)
+                            }
+                        }
+                    } else {
+                        nil
+                    }
+
                     // Batching buffers
                     var contentBuffer = ""
                     var reasoningBuffer = ""
@@ -1655,13 +2202,32 @@ class AIService: ObservableObject {
                         // Check if we have a newline (UTF-8: 0x0A)
                         if byte == 0x0A {
                             if let line = String(data: buffer, encoding: .utf8) {
+                                let ownsFlight = await MainActor.run {
+                                    self.ownsStreamFlight(
+                                        flightID,
+                                        isMultiModelRequest: isMultiModelRequest,
+                                        modelName: modelName
+                                    )
+                                }
+                                guard ownsFlight else { throw CancellationError() }
+
                                 let result = await OpenAIStreamParser.processStreamLine(
                                     line,
                                     toolCallBuffers: currentToolCallBuffers,
                                     toolCallIds: toolCallIds,
-                                    onToolCall: callbacks.onToolCall,
-                                    onToolCallRequested: callbacks.onToolCallRequested
+                                    onToolCall: guardedToolCall,
+                                    onToolCallRequested: guardedToolCallRequested
                                 )
+                                let ownsAfterParser = await MainActor.run {
+                                    self.ownsStreamFlight(
+                                        flightID,
+                                        isMultiModelRequest: isMultiModelRequest,
+                                        modelName: modelName
+                                    )
+                                }
+                                guard ownsAfterParser else { throw CancellationError() }
+                                try Task.checkCancellation()
+
                                 currentToolCallBuffers = result.toolCallBuffers
                                 toolCallIds = result.toolCallIds
 
@@ -1676,11 +2242,16 @@ class AIService: ObservableObject {
                                     // Flush remaining buffers
                                     let contentToSend = contentBuffer
                                     let reasoningToSend = reasoningBuffer
-                                    await MainActor.run {
-                                        if !contentToSend.isEmpty { callbacks.onChunk(contentToSend) }
-                                        if !reasoningToSend.isEmpty { callbacks.onReasoning?(reasoningToSend) }
-                                        self.currentStreamTask = nil
-                                        callbacks.onComplete()
+                                    _ = await MainActor.run {
+                                        self.deliverStreamBuffers(
+                                            content: contentToSend,
+                                            reasoning: reasoningToSend,
+                                            callbacks: callbacks,
+                                            flightID: flightID,
+                                            isMultiModelRequest: isMultiModelRequest,
+                                            modelName: modelName,
+                                            terminal: true
+                                        )
                                     }
                                     return
                                 }
@@ -1691,10 +2262,18 @@ class AIService: ObservableObject {
                                     if timeSinceLastUpdate > 0.05 || contentBuffer.count > 100 || reasoningBuffer.count > 100 {
                                         let contentToSend = contentBuffer
                                         let reasoningToSend = reasoningBuffer
-                                        await MainActor.run {
-                                            if !contentToSend.isEmpty { callbacks.onChunk(contentToSend) }
-                                            if !reasoningToSend.isEmpty { callbacks.onReasoning?(reasoningToSend) }
+                                        let delivered = await MainActor.run {
+                                            self.deliverStreamBuffers(
+                                                content: contentToSend,
+                                                reasoning: reasoningToSend,
+                                                callbacks: callbacks,
+                                                flightID: flightID,
+                                                isMultiModelRequest: isMultiModelRequest,
+                                                modelName: modelName,
+                                                terminal: false
+                                            )
                                         }
+                                        guard delivered else { return }
                                         contentBuffer = ""
                                         reasoningBuffer = ""
                                         lastUpdateTime = CFAbsoluteTimeGetCurrent()
@@ -1711,6 +2290,14 @@ class AIService: ObservableObject {
                     let receivedData = hasReceivedData
                     let bytesReceived = totalBytesReceived
                     await MainActor.run {
+                        guard self.ownsStreamFlight(
+                            flightID,
+                            isMultiModelRequest: isMultiModelRequest,
+                            modelName: modelName
+                        ) else {
+                            return
+                        }
+
                         DiagnosticsLogger.log(
                             .aiService,
                             level: .info,
@@ -1723,10 +2310,6 @@ class AIService: ObservableObject {
                             ]
                         )
 
-                        if !contentToSend.isEmpty { callbacks.onChunk(contentToSend) }
-                        if !reasoningToSend.isEmpty { callbacks.onReasoning?(reasoningToSend) }
-                        self.currentStreamTask = nil
-
                         // Log warning if no data was received but no error occurred
                         if !receivedData {
                             DiagnosticsLogger.log(
@@ -1737,7 +2320,15 @@ class AIService: ObservableObject {
                             )
                         }
 
-                        callbacks.onComplete()
+                        self.deliverStreamBuffers(
+                            content: contentToSend,
+                            reasoning: reasoningToSend,
+                            callbacks: callbacks,
+                            flightID: flightID,
+                            isMultiModelRequest: isMultiModelRequest,
+                            modelName: modelName,
+                            terminal: true
+                        )
                     }
                 } onCancel: {
                     DiagnosticsLogger.log(
@@ -1745,15 +2336,6 @@ class AIService: ObservableObject {
                         level: .info,
                         message: "Stream task cancellation handler triggered"
                     )
-                }
-            } catch is CancellationError {
-                await MainActor.run {
-                    DiagnosticsLogger.log(
-                        .aiService,
-                        level: .info,
-                        message: "Stream task cancelled via CancellationError"
-                    )
-                    self.currentStreamTask = nil
                 }
             } catch {
                 await handleStreamError(
@@ -1763,15 +2345,20 @@ class AIService: ObservableObject {
                     request: request,
                     callbacks: callbacks,
                     isMultiModelRequest: isMultiModelRequest,
-                    modelName: modelName
+                    modelName: modelName,
+                    flightID: flightID
                 )
             }
         }
-        // Store task reference - use dictionary for multi-model, single var otherwise
-        if isMultiModelRequest, let modelName {
-            multiModelStreamTasks[modelName] = task
-        } else {
-            currentStreamTask = task
+        guard installStreamTask(
+            task,
+            flightID: flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: modelName,
+            requiresExistingOwner: existingFlightID != nil
+        ) else {
+            task.cancel()
+            return
         }
     }
 
@@ -1863,6 +2450,17 @@ class AIService: ObservableObject {
         callbacks.onComplete()
     }
 
+    private nonisolated func isStreamCancellation(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+        if let urlError = error as? URLError {
+            return urlError.code == .cancelled
+        }
+        let error = error as NSError
+        return error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled
+    }
+
     private func handleStreamError(
         error: Error,
         attempt: Int,
@@ -1870,8 +2468,32 @@ class AIService: ObservableObject {
         request: URLRequest,
         callbacks: StreamCallbacks,
         isMultiModelRequest: Bool = false,
-        modelName: String? = nil
+        modelName: String? = nil,
+        flightID: RequestFlightID
     ) async {
+        if isStreamCancellation(error) {
+            DiagnosticsLogger.log(
+                .aiService,
+                level: .info,
+                message: "Stream task cancelled"
+            )
+            let cleared = clearStreamFlight(
+                flightID,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: modelName
+            )
+            requestFlightObserver.record(.streamCancellation, cleared)
+            return
+        }
+
+        guard ownsStreamFlight(
+            flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: modelName
+        ) else {
+            return
+        }
+
         if shouldRetry(error: error, attempt: attempt, hasReceivedData: hasReceivedData) {
             // Get retry-after date for GitHub Models rate limits
             let isGitHubModelsRequest = request.url?.host?.contains("models.github.ai") == true
@@ -1879,9 +2501,7 @@ class AIService: ObservableObject {
                 .map { $0.replacingOccurrences(of: "Bearer ", with: "") }
 
             let retryAfterDate: Date? = if isGitHubModelsRequest, let accessToken, !accessToken.isEmpty {
-                await MainActor.run {
-                    GitHubOAuthService.shared.retryAfterDate(forAccessToken: accessToken)
-                }
+                GitHubOAuthService.shared.retryAfterDate(forAccessToken: accessToken)
             } else {
                 nil
             }
@@ -1896,63 +2516,92 @@ class AIService: ObservableObject {
                 ]
             )
             await delay(for: attempt, retryAfterDate: retryAfterDate)
-            await MainActor.run {
-                streamResponse(
-                    request: request,
-                    callbacks: callbacks,
-                    attempt: attempt + 1,
-                    isMultiModelRequest: isMultiModelRequest,
-                    modelName: modelName
+            let ownsFlight = ownsStreamFlight(
+                flightID,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: modelName
+            )
+            requestFlightObserver.record(.streamRetry, ownsFlight)
+            guard ownsFlight else { return }
+            streamResponse(
+                request: request,
+                callbacks: callbacks,
+                attempt: attempt + 1,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: modelName,
+                existingFlightID: flightID
+            )
+            return
+        }
+
+        guard clearStreamFlight(
+            flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: modelName
+        ) else {
+            return
+        }
+
+        // Check if it's a timeout error and provide a better message
+        if let urlError = error as? URLError, urlError.code == .timedOut {
+            callbacks.onError(
+                AIError.apiError(
+                    "Request timed out. The model may be slow or overloaded. Please try again."
                 )
-            }
+            )
+        } else if let urlError = error as? URLError, urlError.code == .networkConnectionLost {
+            callbacks.onError(
+                AIError.apiError(
+                    "Network connection was lost. The server may have rejected the request."
+                )
+            )
         } else {
-            await MainActor.run {
-                // Clean up task reference appropriately
-                if isMultiModelRequest, let modelName {
-                    self.multiModelStreamTasks.removeValue(forKey: modelName)
-                } else {
-                    self.currentStreamTask = nil
-                }
-                // Check if it's a timeout error and provide a better message
-                if let urlError = error as? URLError, urlError.code == .timedOut {
-                    callbacks.onError(
-                        AIError.apiError(
-                            "Request timed out. The model may be slow or overloaded. Please try again."
-                        )
-                    )
-                } else if let urlError = error as? URLError, urlError.code == .networkConnectionLost {
-                    callbacks.onError(
-                        AIError.apiError(
-                            "Network connection was lost. The server may have rejected the request."
-                        )
-                    )
-                } else if (error as? CancellationError) != nil {
-                    // Task was cancelled, don't report as error
-                    DiagnosticsLogger.log(
-                        .aiService,
-                        level: .info,
-                        message: "Stream task cancelled via CancellationError"
-                    )
-                } else {
-                    callbacks.onError(error)
-                }
-            }
+            callbacks.onError(error)
         }
     }
 
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func nonStreamResponse(
         request: URLRequest,
+        modelName: String,
+        isMultiModelRequest: Bool,
         onChunk: @escaping @Sendable (String) -> Void,
         onComplete: @escaping @Sendable () -> Void,
         onError: @escaping @Sendable (Error) -> Void,
         onToolCall: (@Sendable (String, String, [String: Any]) async -> String)? = nil,
         onReasoning: (@Sendable (String) -> Void)? = nil,
-        attempt: Int = 0
+        attempt: Int = 0,
+        existingFlightID: RequestFlightID? = nil
     ) {
+        let flightID = existingFlightID ?? RequestFlightID()
+        if existingFlightID == nil {
+            let previousTask = takeDataTask(
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: modelName
+            )
+            previousTask?.cancel()
+        } else {
+            guard ownsDataFlight(
+                flightID,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: modelName
+            ) else {
+                return
+            }
+        }
+
         let task = urlSession.dataTask(with: request) { [weak self] data, _, error in
             let selfRef = self
             Task { @MainActor in
                 guard let self = selfRef else { return }
+                let ownsFlight = self.ownsDataFlight(
+                    flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    modelName: modelName
+                )
+                self.requestFlightObserver.record(.dataCallback, ownsFlight)
+                guard ownsFlight else { return }
+
                 if let error {
                     if self.shouldRetry(error: error, attempt: attempt) {
                         DiagnosticsLogger.log(
@@ -1964,16 +2613,33 @@ class AIService: ObservableObject {
                         Task { @MainActor [weak self] in
                             guard let self else { return }
                             await self.delay(for: attempt)
+                            let ownsFlight = self.ownsDataFlight(
+                                flightID,
+                                isMultiModelRequest: isMultiModelRequest,
+                                modelName: modelName
+                            )
+                            self.requestFlightObserver.record(.dataRetry, ownsFlight)
+                            guard ownsFlight else { return }
                             self.nonStreamResponse(
                                 request: request,
+                                modelName: modelName,
+                                isMultiModelRequest: isMultiModelRequest,
                                 onChunk: onChunk,
                                 onComplete: onComplete,
                                 onError: onError,
                                 onToolCall: onToolCall,
                                 onReasoning: onReasoning,
-                                attempt: attempt + 1
+                                attempt: attempt + 1,
+                                existingFlightID: flightID
                             )
                         }
+                        return
+                    }
+                    guard self.clearDataFlight(
+                        flightID,
+                        isMultiModelRequest: isMultiModelRequest,
+                        modelName: modelName
+                    ) else {
                         return
                     }
                     onError(error)
@@ -1981,6 +2647,13 @@ class AIService: ObservableObject {
                 }
 
                 guard let data else {
+                    guard self.clearDataFlight(
+                        flightID,
+                        isMultiModelRequest: isMultiModelRequest,
+                        modelName: modelName
+                    ) else {
+                        return
+                    }
                     onError(AIError.invalidResponse)
                     return
                 }
@@ -1991,6 +2664,13 @@ class AIService: ObservableObject {
                     if let errorDict = json?["error"] as? [String: Any],
                        let message = errorDict["message"] as? String
                     {
+                        guard self.clearDataFlight(
+                            flightID,
+                            isMultiModelRequest: isMultiModelRequest,
+                            modelName: modelName
+                        ) else {
+                            return
+                        }
                         onError(AIError.apiError(message))
                         return
                     }
@@ -2016,6 +2696,13 @@ class AIService: ObservableObject {
                         // Handle reasoning content if found
                         if let reasoning = foundReasoning, let onReasoning {
                             onReasoning(reasoning)
+                            guard self.ownsDataFlight(
+                                flightID,
+                                isMultiModelRequest: isMultiModelRequest,
+                                modelName: modelName
+                            ) else {
+                                return
+                            }
                         }
 
                         // Handle regular content
@@ -2027,14 +2714,28 @@ class AIService: ObservableObject {
                             )
 
                             for segment in textSegments where !segment.isEmpty {
+                                guard self.ownsDataFlight(
+                                    flightID,
+                                    isMultiModelRequest: isMultiModelRequest,
+                                    modelName: modelName
+                                ) else {
+                                    return
+                                }
                                 onChunk(segment)
                             }
                         }
 
-                        // Handle tool calls
+                        // Async tool execution intentionally remains outside request-flight ownership.
                         if let toolCalls = message["tool_calls"] as? [[String: Any]],
                            let onToolCall
                         {
+                            guard self.clearDataFlight(
+                                flightID,
+                                isMultiModelRequest: isMultiModelRequest,
+                                modelName: modelName
+                            ) else {
+                                return
+                            }
                             Task {
                                 for toolCall in toolCalls {
                                     if let id = toolCall["id"] as? String,
@@ -2058,17 +2759,47 @@ class AIService: ObservableObject {
                             return
                         }
 
+                        guard self.clearDataFlight(
+                            flightID,
+                            isMultiModelRequest: isMultiModelRequest,
+                            modelName: modelName
+                        ) else {
+                            return
+                        }
                         onComplete()
                     } else {
+                        guard self.clearDataFlight(
+                            flightID,
+                            isMultiModelRequest: isMultiModelRequest,
+                            modelName: modelName
+                        ) else {
+                            return
+                        }
                         onError(AIError.invalidResponse)
                     }
                 } catch {
+                    guard self.clearDataFlight(
+                        flightID,
+                        isMultiModelRequest: isMultiModelRequest,
+                        modelName: modelName
+                    ) else {
+                        return
+                    }
                     onError(error)
                 }
             }
         }
 
-        currentTask = task
+        guard installDataTask(
+            task,
+            flightID: flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: modelName,
+            requiresExistingOwner: existingFlightID != nil
+        ) else {
+            task.cancel()
+            return
+        }
         task.resume()
     }
 
@@ -2170,12 +2901,42 @@ class AIService: ObservableObject {
 
     // MARK: - Anthropic Provider Handler
 
+    private func ownsAnthropicFlight(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        model: String
+    ) -> Bool {
+        if isMultiModelRequest {
+            return multiModelAnthropicProviders[model]?.owns(flightID) == true
+        }
+        return currentAnthropicProvider.owns(flightID)
+    }
+
+    @discardableResult
+    private func clearAnthropicFlight(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        model: String
+    ) -> Bool {
+        if isMultiModelRequest {
+            guard var flight = multiModelAnthropicProviders[model],
+                  flight.clear(ifOwnedBy: flightID)
+            else {
+                return false
+            }
+            multiModelAnthropicProviders.removeValue(forKey: model)
+            return true
+        }
+        return currentAnthropicProvider.clear(ifOwnedBy: flightID)
+    }
+
     private func handleAnthropicRequest(
         messages: [Message],
         model: String,
         stream: Bool,
         tools: [[String: Any]]?,
         conversationId: UUID?,
+        isMultiModelRequest: Bool,
         callbacks: AIProviderStreamCallbacks
     ) {
         let modelAPIKey = getAPIKey(for: model)
@@ -2209,28 +2970,102 @@ class AIService: ObservableObject {
             conversationHistory: conversationHistory
         )
 
-        // Get provider and send request
-        // Store provider to prevent deallocation during streaming
-        let provider = AnthropicProvider(urlSession: urlSession)
-        currentAnthropicProvider = provider
+        // Install ownership before sending because a provider may fail synchronously.
+        let provider = anthropicProviderFactory(urlSession)
+        let flightID = RequestFlightID()
+        if isMultiModelRequest {
+            var previousFlight = multiModelAnthropicProviders.removeValue(forKey: model)
+            let previousProvider = previousFlight?.take()
+            previousProvider?.cancelRequest()
+            var flight = RequestFlight<any AIProviderProtocol>()
+            flight.install(provider, id: flightID)
+            multiModelAnthropicProviders[model] = flight
+        } else {
+            let previousProvider = currentAnthropicProvider.take()
+            previousProvider?.cancelRequest()
+            currentAnthropicProvider.install(provider, id: flightID)
+        }
 
-        // Wrap callbacks to clear provider reference on completion
-        let wrappedCallbacks = AIProviderStreamCallbacks(
-            onChunk: callbacks.onChunk,
-            onComplete: { [weak self] in
-                Task { @MainActor in
-                    self?.currentAnthropicProvider = nil
+        let forwarder = OrderedMainActorForwarder<AnthropicFlightCallback> { [weak self] event in
+            guard let self else { return }
+
+            switch event {
+            case let .chunk(chunk):
+                guard self.ownsAnthropicFlight(
+                    flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    model: model
+                ) else {
+                    return
+                }
+                callbacks.onChunk(chunk)
+
+            case .complete:
+                let ownsFlight = self.ownsAnthropicFlight(
+                    flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    model: model
+                )
+                self.requestFlightObserver.record(.anthropicTerminal, ownsFlight)
+                guard ownsFlight,
+                      self.clearAnthropicFlight(
+                          flightID,
+                          isMultiModelRequest: isMultiModelRequest,
+                          model: model
+                      )
+                else {
+                    return
                 }
                 callbacks.onComplete()
-            },
-            onError: { [weak self] error in
-                Task { @MainActor in
-                    self?.currentAnthropicProvider = nil
+
+            case let .error(error):
+                let ownsFlight = self.ownsAnthropicFlight(
+                    flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    model: model
+                )
+                self.requestFlightObserver.record(.anthropicTerminal, ownsFlight)
+                guard ownsFlight,
+                      self.clearAnthropicFlight(
+                          flightID,
+                          isMultiModelRequest: isMultiModelRequest,
+                          model: model
+                      )
+                else {
+                    return
                 }
                 callbacks.onError(error)
+
+            case let .toolRequest(toolID, toolName, arguments):
+                guard self.ownsAnthropicFlight(
+                    flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    model: model
+                ) else {
+                    return
+                }
+                callbacks.onToolCallRequested?(toolID, toolName, arguments)
+
+            case let .reasoning(reasoning):
+                guard self.ownsAnthropicFlight(
+                    flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    model: model
+                ) else {
+                    return
+                }
+                callbacks.onReasoning?(reasoning)
+            }
+        }
+
+        let wrappedCallbacks = AIProviderStreamCallbacks(
+            onChunk: { forwarder.enqueue(.chunk($0)) },
+            onComplete: { forwarder.enqueue(.complete) },
+            onError: { forwarder.enqueue(.error($0)) },
+            onToolCallRequested: { toolID, toolName, arguments in
+                forwarder.enqueue(.toolRequest(id: toolID, name: toolName, arguments: arguments))
             },
-            onToolCallRequested: callbacks.onToolCallRequested,
-            onReasoning: callbacks.onReasoning
+            onReasoning: { forwarder.enqueue(.reasoning($0)) }
         )
 
         provider.sendMessage(
@@ -2252,7 +3087,7 @@ class AIService: ObservableObject {
     }
 
     private func delay(for attempt: Int, retryAfterDate: Date? = nil) async {
-        await AIRetryPolicy.wait(for: attempt, retryAfterDate: retryAfterDate)
+        await retryDelay(attempt, retryAfterDate)
     }
 
     enum AIError: LocalizedError {

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -73,6 +73,11 @@ struct RequestFlight<Handle> {
         defer { handle = nil }
         return handle
     }
+
+    mutating func take(ifOwnedBy id: RequestFlightID) -> Handle? {
+        guard owns(id) else { return nil }
+        return take()
+    }
 }
 
 enum RequestFlightCheckpoint: Sendable {
@@ -90,6 +95,81 @@ struct RequestFlightObserver: Sendable {
     let record: @Sendable (RequestFlightCheckpoint, Bool) -> Void
 
     static let none = RequestFlightObserver { _, _ in }
+}
+
+/// Owner-specific cancellation token for one text request.
+///
+/// The token retains the logical request identity across transport retries so a
+/// stale owner can never cancel a newer request that reused the same service.
+@MainActor
+final class AITextRequest {
+    fileprivate weak var service: AIService?
+    fileprivate let flightID: RequestFlightID
+
+    fileprivate init(service: AIService, flightID: RequestFlightID) {
+        self.service = service
+        self.flightID = flightID
+    }
+
+    func cancel() {
+        service?.cancelTextRequest(flightID)
+    }
+}
+
+/// Owner-specific cancellation token for one multi-model text batch.
+///
+/// The batch and every child transport share one logical request identity so a
+/// stale token cannot cancel a replacement batch or an unrelated foreground request.
+@MainActor
+final class AITextBatchRequest {
+    fileprivate weak var service: AIService?
+    fileprivate let flightID: RequestFlightID
+
+    fileprivate init(service: AIService, flightID: RequestFlightID) {
+        self.service = service
+        self.flightID = flightID
+    }
+
+    func cancel() {
+        service?.cancelTextBatchRequest(flightID)
+    }
+}
+
+private final class SimulatedTextRequestHandle: @unchecked Sendable {
+    private struct State: Sendable {
+        var task: Task<Void, Never>?
+        var isTerminal = false
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    func install(_ task: Task<Void, Never>) {
+        let shouldCancel = state.withLock { state -> Bool in
+            guard !state.isTerminal else { return true }
+            state.task = task
+            return false
+        }
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func cancel() {
+        let task = state.withLock { state -> Task<Void, Never>? in
+            guard !state.isTerminal else { return nil }
+            state.isTerminal = true
+            defer { state.task = nil }
+            return state.task
+        }
+        task?.cancel()
+    }
+
+    func finish() {
+        state.withLock { state in
+            state.isTerminal = true
+            state.task = nil
+        }
+    }
 }
 
 #if !os(watchOS)
@@ -254,6 +334,10 @@ class AIService: ObservableObject {
     private var currentTask = RequestFlight<URLSessionDataTask>()
     private var multiModelDataTasks: [String: RequestFlight<URLSessionDataTask>] = [:]
     private var currentStreamTask = RequestFlight<Task<Void, Never>>()
+    private var currentNonStreamToolTask = RequestFlight<Task<Void, Never>>()
+    private var multiModelNonStreamToolTasks: [String: RequestFlight<Task<Void, Never>>] = [:]
+    private var currentSimulatedTextRequest = RequestFlight<SimulatedTextRequestHandle>()
+    private var multiModelSimulatedTextRequests: [String: RequestFlight<SimulatedTextRequestHandle>] = [:]
     private var multiModelTask = RequestFlight<Task<Void, Never>>()
     /// Tracks individual stream tasks for each model in multi-model mode
     private var multiModelStreamTasks: [String: RequestFlight<Task<Void, Never>>] = [:]
@@ -892,6 +976,92 @@ class AIService: ObservableObject {
         return .chat
     }
 
+    fileprivate func cancelTextRequest(_ flightID: RequestFlightID) {
+        let dataTask = currentTask.take(ifOwnedBy: flightID)
+        let streamTask = currentStreamTask.take(ifOwnedBy: flightID)
+        let nonStreamToolTask = currentNonStreamToolTask.take(ifOwnedBy: flightID)
+        let simulatedRequest = currentSimulatedTextRequest.take(ifOwnedBy: flightID)
+        let anthropicProvider = currentAnthropicProvider.take(ifOwnedBy: flightID)
+
+        let multiDataTaskModels = multiModelDataTasks.compactMap { model, flight in
+            flight.owns(flightID) ? model : nil
+        }
+        let multiDataTasks = multiDataTaskModels.compactMap { model -> URLSessionDataTask? in
+            var ownedFlight = multiModelDataTasks.removeValue(forKey: model)
+            return ownedFlight?.take(ifOwnedBy: flightID)
+        }
+        let multiStreamTaskModels = multiModelStreamTasks.compactMap { model, flight in
+            flight.owns(flightID) ? model : nil
+        }
+        let multiStreamTasks = multiStreamTaskModels.compactMap { model -> Task<Void, Never>? in
+            var ownedFlight = multiModelStreamTasks.removeValue(forKey: model)
+            return ownedFlight?.take(ifOwnedBy: flightID)
+        }
+        let multiNonStreamToolTaskModels = multiModelNonStreamToolTasks.compactMap { model, flight in
+            flight.owns(flightID) ? model : nil
+        }
+        let multiNonStreamToolTasks = multiNonStreamToolTaskModels.compactMap { model -> Task<Void, Never>? in
+            var ownedFlight = multiModelNonStreamToolTasks.removeValue(forKey: model)
+            return ownedFlight?.take(ifOwnedBy: flightID)
+        }
+        let multiSimulatedRequestModels = multiModelSimulatedTextRequests.compactMap { model, flight in
+            flight.owns(flightID) ? model : nil
+        }
+        let multiSimulatedRequests = multiSimulatedRequestModels.compactMap { model -> SimulatedTextRequestHandle? in
+            var ownedFlight = multiModelSimulatedTextRequests.removeValue(forKey: model)
+            return ownedFlight?.take(ifOwnedBy: flightID)
+        }
+        let multiAnthropicProviderModels = multiModelAnthropicProviders.compactMap { model, flight in
+            flight.owns(flightID) ? model : nil
+        }
+        let multiAnthropicProviders = multiAnthropicProviderModels.compactMap { model -> (any AIProviderProtocol)? in
+            var ownedFlight = multiModelAnthropicProviders.removeValue(forKey: model)
+            return ownedFlight?.take(ifOwnedBy: flightID)
+        }
+
+        #if !os(watchOS)
+            let appleTask = currentAppleIntelligenceTask.take(ifOwnedBy: flightID)
+            let multiAppleTaskModels = multiModelAppleIntelligenceTasks.compactMap { model, flight in
+                flight.owns(flightID) ? model : nil
+            }
+            let multiAppleTasks = multiAppleTaskModels.compactMap { model -> AppleIntelligenceRequestHandle? in
+                var ownedFlight = multiModelAppleIntelligenceTasks.removeValue(forKey: model)
+                return ownedFlight?.take(ifOwnedBy: flightID)
+            }
+        #endif
+
+        dataTask?.cancel()
+        multiDataTasks.forEach { $0.cancel() }
+        streamTask?.cancel()
+        multiStreamTasks.forEach { $0.cancel() }
+        nonStreamToolTask?.cancel()
+        multiNonStreamToolTasks.forEach { $0.cancel() }
+        simulatedRequest?.cancel()
+        multiSimulatedRequests.forEach { $0.cancel() }
+        anthropicProvider?.cancelRequest()
+        multiAnthropicProviders.forEach { $0.cancelRequest() }
+        #if !os(watchOS)
+            appleTask?.cancel()
+            multiAppleTasks.forEach { $0.cancel() }
+        #endif
+    }
+
+    fileprivate func cancelTextBatchRequest(_ flightID: RequestFlightID) {
+        guard let batchTask = multiModelTask.take(ifOwnedBy: flightID) else { return }
+
+        // Fence queued runners before cancelling children that may release shared permits.
+        batchTask.cancel()
+        cancelTextRequest(flightID)
+    }
+
+    private func cancelForegroundNonStreamToolRequest() {
+        guard currentNonStreamToolTask.isActive else { return }
+        let dataTask = currentTask.take()
+        let toolTask = currentNonStreamToolTask.take()
+        dataTask?.cancel()
+        toolTask?.cancel()
+    }
+
     func cancelCurrentRequest(includeImageRequests: Bool = true) {
         DiagnosticsLogger.log(
             .aiService,
@@ -907,6 +1077,18 @@ class AIService: ObservableObject {
         }
         multiModelDataTasks.removeAll()
         let streamTask = currentStreamTask.take()
+        let nonStreamToolTask = currentNonStreamToolTask.take()
+        let multiNonStreamToolTasks = multiModelNonStreamToolTasks.compactMap { _, flight -> Task<Void, Never>? in
+            var flight = flight
+            return flight.take()
+        }
+        multiModelNonStreamToolTasks.removeAll()
+        let simulatedRequest = currentSimulatedTextRequest.take()
+        let multiSimulatedRequests = multiModelSimulatedTextRequests.compactMap { _, flight -> SimulatedTextRequestHandle? in
+            var flight = flight
+            return flight.take()
+        }
+        multiModelSimulatedTextRequests.removeAll()
         let multiStreamTasks = multiModelStreamTasks.compactMap { model, flight -> (String, Task<Void, Never>)? in
             var flight = flight
             return flight.take().map { (model, $0) }
@@ -947,6 +1129,10 @@ class AIService: ObservableObject {
             )
         }
         streamTask?.cancel()
+        nonStreamToolTask?.cancel()
+        multiNonStreamToolTasks.forEach { $0.cancel() }
+        simulatedRequest?.cancel()
+        multiSimulatedRequests.forEach { $0.cancel() }
         for (model, task) in multiStreamTasks {
             task.cancel()
             DiagnosticsLogger.log(
@@ -1158,8 +1344,8 @@ class AIService: ObservableObject {
         return nil
     }
 
-    // swiftlint:disable:next function_body_length
-    func sendMessage(
+    @discardableResult
+    func sendMessage( // swiftlint:disable:this function_body_length
         messages: [Message],
         model: String? = nil,
         temperature: Double? = nil,
@@ -1173,9 +1359,16 @@ class AIService: ObservableObject {
         onToolCall: (@Sendable (String, String, [String: Any]) async -> String)? = nil,
         onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)? = nil,
         onReasoning: (@Sendable (String) -> Void)? = nil,
-        preparedAPIKey: String? = nil
-    ) {
+        preparedAPIKey: String? = nil,
+        requestFlightID: RequestFlightID? = nil
+    ) -> AITextRequest {
+        let flightID = requestFlightID ?? RequestFlightID()
+        let requestHandle = AITextRequest(service: self, flightID: flightID)
         let requestModel = (model ?? selectedModel).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !isMultiModelRequest {
+            cancelForegroundNonStreamToolRequest()
+        }
 
         DiagnosticsLogger.log(
             .aiService,
@@ -1191,11 +1384,23 @@ class AIService: ObservableObject {
         )
 
         if let responseSimulator {
+            let simulatedRequest = beginSimulatedTextRequest(
+                flightID: flightID,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: requestModel
+            )
             responseSimulator(
                 messages,
-                AIServiceResponseSimulationCallbacks(onChunk: onChunk, onComplete: onComplete)
+                ownedSimulationCallbacks(
+                    flightID: flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    modelName: requestModel,
+                    requestHandle: simulatedRequest,
+                    onChunk: onChunk,
+                    onComplete: onComplete
             )
-            return
+            )
+            return requestHandle
         }
 
         // Mock response for UI tests on macOS and iOS (UITestEnvironment not available on watchOS)
@@ -1204,10 +1409,13 @@ class AIService: ObservableObject {
                 simulateUITestResponse(
                     messages: messages,
                     stream: stream,
+                    flightID: flightID,
+                    isMultiModelRequest: isMultiModelRequest,
+                    modelName: requestModel,
                     onChunk: onChunk,
                     onComplete: onComplete
                 )
-                return
+                return requestHandle
             }
         #endif
 
@@ -1218,7 +1426,7 @@ class AIService: ObservableObject {
                 message: "❌ Model is empty"
             )
             onError(AIError.missingModel)
-            return
+            return requestHandle
         }
         let effectiveProvider = modelProviders[requestModel] ?? provider
         let endpointInfo = customEndpoint(for: requestModel)
@@ -1251,7 +1459,7 @@ class AIService: ObservableObject {
                         onChunk: onChunk,
                         onComplete: onComplete,
                         onError: onError
-                    ))
+                    ), flightID: flightID)
                 } else if #available(macOS 26.0, iOS 26.0, *) {
                     handleAppleIntelligenceRequest(AppleIntelligenceRequestContext(
                         service: AppleIntelligenceService.shared,
@@ -1264,17 +1472,17 @@ class AIService: ObservableObject {
                         onChunk: onChunk,
                         onComplete: onComplete,
                         onError: onError
-                    ))
+                    ), flightID: flightID)
                 } else {
                     onError(AIError.apiError("Apple Intelligence requires macOS 26.0 or iOS 26.0 or later"))
                 }
-                return
+                return requestHandle
             }
         #else
             // Apple Intelligence is not available on watchOS
             if effectiveProvider == .appleIntelligence {
                 onError(AIError.apiError("Apple Intelligence is not available on Apple Watch"))
-                return
+                return requestHandle
             }
         #endif
 
@@ -1294,9 +1502,10 @@ class AIService: ObservableObject {
                 tools: tools,
                 conversationId: conversationId,
                 isMultiModelRequest: isMultiModelRequest,
-                callbacks: anthropicCallbacks
+                callbacks: anthropicCallbacks,
+                flightID: flightID
             )
-            return
+            return requestHandle
         }
 
         // Validate provider settings
@@ -1304,7 +1513,7 @@ class AIService: ObservableObject {
             try validateProviderSettings(for: effectiveProvider, model: requestModel)
         } catch {
             onError(error)
-            return
+            return requestHandle
         }
 
         let modelAPIKey = preparedAPIKey ?? getAPIKey(for: requestModel)
@@ -1313,7 +1522,7 @@ class AIService: ObservableObject {
         if effectiveProvider == .githubModels {
             if let rateLimitError = checkGitHubModelsRateLimit(accessToken: modelAPIKey) {
                 onError(AIError.apiError(rateLimitError))
-                return
+                return requestHandle
             }
         }
 
@@ -1322,7 +1531,7 @@ class AIService: ObservableObject {
         if endpointType == .responses {
             if effectiveProvider == .githubModels {
                 onError(AIError.apiError("GitHub Models does not support the Responses API endpoint"))
-                return
+                return requestHandle
             }
             responsesAPIRequest(
                 messages: messages,
@@ -1333,9 +1542,10 @@ class AIService: ObservableObject {
                 onError: onError,
                 onToolCallRequested: onToolCallRequested,
                 onReasoning: onReasoning,
-                isMultiModelRequest: isMultiModelRequest
+                isMultiModelRequest: isMultiModelRequest,
+                initialFlightID: flightID
             )
-            return
+            return requestHandle
         }
 
         // Build API request
@@ -1344,7 +1554,7 @@ class AIService: ObservableObject {
             apiURL = try getAPIURL(deploymentName: requestModel, provider: effectiveProvider)
         } catch {
             onError(error)
-            return
+            return requestHandle
         }
 
         guard let url = URL(string: apiURL) else {
@@ -1355,7 +1565,7 @@ class AIService: ObservableObject {
                 metadata: ["url": apiURL]
             )
             onError(AIError.invalidURL)
-            return
+            return requestHandle
         }
 
         let needsAuth = effectiveProvider == .openai || effectiveProvider == .githubModels
@@ -1403,7 +1613,7 @@ class AIService: ObservableObject {
                 message: "❌ Failed to create request"
             )
             onError(AIError.invalidRequest)
-            return
+            return requestHandle
         }
 
         DiagnosticsLogger.log(
@@ -1426,7 +1636,13 @@ class AIService: ObservableObject {
                 onToolCallRequested: onToolCallRequested,
                 onReasoning: onReasoning
             )
-            streamResponse(request: request, callbacks: callbacks, isMultiModelRequest: isMultiModelRequest, modelName: requestModel)
+            streamResponse(
+                request: request,
+                callbacks: callbacks,
+                isMultiModelRequest: isMultiModelRequest,
+                modelName: requestModel,
+                initialFlightID: flightID
+            )
         } else {
             nonStreamResponse(
                 request: request,
@@ -1436,9 +1652,11 @@ class AIService: ObservableObject {
                 onComplete: onComplete,
                 onError: onError,
                 onToolCall: onToolCall,
-                onReasoning: onReasoning
+                onReasoning: onReasoning,
+                initialFlightID: flightID
             )
         }
+        return requestHandle
     }
 
     // MARK: - Multi-Model Parallel Requests
@@ -1457,6 +1675,7 @@ class AIService: ObservableObject {
     ///   - onError: Called with (modelName, error) when a model encounters an error
     ///   - onPendingToolCall: Called when a model requests a tool call (deferred until selection)
     ///   - onReasoning: Called with (modelName, reasoning) for reasoning content
+    @discardableResult
     func sendToMultipleModels(
         messages: [Message],
         models: [String],
@@ -1467,11 +1686,14 @@ class AIService: ObservableObject {
         onError: @escaping @Sendable (String, Error) -> Void,
         onPendingToolCall: (@Sendable (String, String, String, [String: Any]) -> Void)? = nil,
         onReasoning: (@Sendable (String, String) -> Void)? = nil
-    ) {
+    ) -> AITextBatchRequest {
+        let flightID = RequestFlightID()
+        let requestHandle = AITextBatchRequest(service: self, flightID: flightID)
+
         guard !models.isEmpty else {
             onError("", AIError.missingModel)
             onAllComplete()
-            return
+            return requestHandle
         }
 
         func rejectBatch(_ error: Error) {
@@ -1483,13 +1705,13 @@ class AIService: ObservableObject {
         let modelRequests = Array(zip(models, requestModels))
         guard !requestModels.contains(where: \.isEmpty) else {
             rejectBatch(AIError.missingModel)
-            return
+            return requestHandle
         }
 
         var uniqueModels: Set<String> = []
         if let duplicateModel = requestModels.first(where: { !uniqueModels.insert($0).inserted }) {
             rejectBatch(AIError.apiError("Duplicate model in multi-model request: \(duplicateModel)"))
-            return
+            return requestHandle
         }
 
         DiagnosticsLogger.log(
@@ -1510,6 +1732,16 @@ class AIService: ObservableObject {
             return flight.take()
         }
         multiModelStreamTasks.removeAll()
+        let previousNonStreamToolTasks = multiModelNonStreamToolTasks.compactMap { _, flight -> Task<Void, Never>? in
+            var flight = flight
+            return flight.take()
+        }
+        multiModelNonStreamToolTasks.removeAll()
+        let previousSimulatedRequests = multiModelSimulatedTextRequests.compactMap { _, flight -> SimulatedTextRequestHandle? in
+            var flight = flight
+            return flight.take()
+        }
+        multiModelSimulatedTextRequests.removeAll()
         let previousAnthropicProviders = multiModelAnthropicProviders.compactMap { _, flight -> (any AIProviderProtocol)? in
             var flight = flight
             return flight.take()
@@ -1527,12 +1759,13 @@ class AIService: ObservableObject {
         previousBatchTask?.cancel()
         previousDataTasks.forEach { $0.cancel() }
         previousStreamTasks.forEach { $0.cancel() }
+        previousNonStreamToolTasks.forEach { $0.cancel() }
+        previousSimulatedRequests.forEach { $0.cancel() }
         previousAnthropicProviders.forEach { $0.cancelRequest() }
         #if !os(watchOS)
             previousAppleTasks.forEach { $0.cancel() }
         #endif
 
-        let flightID = RequestFlightID()
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
 
@@ -1694,7 +1927,8 @@ class AIService: ObservableObject {
                                 onReasoning: { reasoning in
                                     callbackForwarder.enqueue(.reasoning(reasoning))
                                 },
-                                preparedAPIKey: preparedAPIKey
+                                preparedAPIKey: preparedAPIKey,
+                                requestFlightID: flightID
                             )
                         }
                     }
@@ -1720,16 +1954,132 @@ class AIService: ObservableObject {
             onAllComplete()
         }
         multiModelTask.install(task, id: flightID)?.cancel()
+        return requestHandle
     }
 
     // swiftlint:enable function_body_length cyclomatic_complexity
 
+    private func ownsSimulatedTextRequest(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String
+    ) -> Bool {
+        if isMultiModelRequest {
+            return multiModelSimulatedTextRequests[modelName]?.owns(flightID) == true
+        }
+        return currentSimulatedTextRequest.owns(flightID)
+    }
+
+    private func beginSimulatedTextRequest(
+        flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String
+    ) -> SimulatedTextRequestHandle {
+        let requestHandle = SimulatedTextRequestHandle()
+        let previousHandle: SimulatedTextRequestHandle?
+        if isMultiModelRequest {
+            var flight = multiModelSimulatedTextRequests[modelName] ?? RequestFlight()
+            previousHandle = flight.install(requestHandle, id: flightID)
+            multiModelSimulatedTextRequests[modelName] = flight
+        } else {
+            previousHandle = currentSimulatedTextRequest.install(requestHandle, id: flightID)
+        }
+        previousHandle?.cancel()
+        return requestHandle
+    }
+
+    @discardableResult
+    private func finishSimulatedTextRequest(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String,
+        requestHandle: SimulatedTextRequestHandle
+    ) -> Bool {
+        let ownedHandle: SimulatedTextRequestHandle?
+        if isMultiModelRequest {
+            guard var flight = multiModelSimulatedTextRequests[modelName],
+                  let handle = flight.take(ifOwnedBy: flightID)
+            else {
+                return false
+            }
+            multiModelSimulatedTextRequests.removeValue(forKey: modelName)
+            ownedHandle = handle
+        } else {
+            ownedHandle = currentSimulatedTextRequest.take(ifOwnedBy: flightID)
+        }
+        guard let ownedHandle, ownedHandle === requestHandle else {
+            ownedHandle?.cancel()
+            return false
+        }
+        requestHandle.finish()
+        return true
+    }
+
+    private func ownedSimulationCallbacks(
+        flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String,
+        requestHandle: SimulatedTextRequestHandle,
+        onChunk: @escaping @Sendable (String) -> Void,
+        onComplete: @escaping @Sendable () -> Void
+    ) -> AIServiceResponseSimulationCallbacks {
+        AIServiceResponseSimulationCallbacks(
+            onChunk: { [weak self] chunk in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    let ownsRequest = self.ownsSimulatedTextRequest(
+                        flightID,
+                        isMultiModelRequest: isMultiModelRequest,
+                        modelName: modelName
+                    )
+                    if isMultiModelRequest {
+                        self.requestFlightObserver.record(.multiModelCallback, ownsRequest)
+                    }
+                    guard ownsRequest else { return }
+                    onChunk(chunk)
+                }
+            },
+            onComplete: { [weak self] in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    let finishedRequest = self.finishSimulatedTextRequest(
+                        flightID,
+                        isMultiModelRequest: isMultiModelRequest,
+                        modelName: modelName,
+                        requestHandle: requestHandle
+                    )
+                    if isMultiModelRequest {
+                        self.requestFlightObserver.record(.multiModelCallback, finishedRequest)
+                    }
+                    guard finishedRequest else { return }
+                    onComplete()
+                }
+            }
+        )
+    }
+
     private func simulateUITestResponse(
         messages: [Message],
         stream: Bool,
+        flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String,
         onChunk: @escaping @Sendable (String) -> Void,
         onComplete: @escaping @Sendable () -> Void
     ) {
+        let requestHandle = beginSimulatedTextRequest(
+            flightID: flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: modelName
+        )
+        let callbacks = ownedSimulationCallbacks(
+            flightID: flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: modelName,
+            requestHandle: requestHandle,
+            onChunk: onChunk,
+            onComplete: onComplete
+        )
         let fallback = "Mock response"
         let userContent = messages.last(where: { $0.role == .user })?.content ?? fallback
 
@@ -1743,8 +2093,8 @@ class AIService: ObservableObject {
                 let content = String(userContent[range.upperBound ..< endRange.lowerBound])
                 // Return just the content as the title (or a shortened version)
                 let title = String(content.prefix(50))
-                onChunk(title)
-                onComplete()
+                callbacks.onChunk(title)
+                callbacks.onComplete()
                 return
             }
         }
@@ -1752,16 +2102,18 @@ class AIService: ObservableObject {
         let response = "UI Test Response: \(userContent)"
 
         if stream {
-            Task { @MainActor in
+            let task = Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(50))
-                onChunk(response)
-                onComplete()
+                callbacks.onChunk(response)
+                callbacks.onComplete()
             }
+            requestHandle.install(task)
         } else {
-            Task { @MainActor in
-                onChunk(response)
-                onComplete()
+            let task = Task { @MainActor in
+                callbacks.onChunk(response)
+                callbacks.onComplete()
             }
+            requestHandle.install(task)
         }
     }
 
@@ -1840,9 +2192,10 @@ class AIService: ObservableObject {
         onReasoning: (@Sendable (String) -> Void)? = nil,
         isMultiModelRequest: Bool = false,
         attempt: Int = 0,
+        initialFlightID: RequestFlightID? = nil,
         existingFlightID: RequestFlightID? = nil
     ) {
-        let flightID = existingFlightID ?? RequestFlightID()
+        let flightID = existingFlightID ?? initialFlightID ?? RequestFlightID()
         guard existingFlightID == nil || ownsDataFlight(
             flightID,
             isMultiModelRequest: isMultiModelRequest,
@@ -2330,10 +2683,11 @@ class AIService: ObservableObject {
         attempt: Int = 0,
         isMultiModelRequest: Bool = false,
         modelName: String? = nil,
+        initialFlightID: RequestFlightID? = nil,
         existingFlightID: RequestFlightID? = nil
     ) {
         let session = urlSession
-        let flightID = existingFlightID ?? RequestFlightID()
+        let flightID = existingFlightID ?? initialFlightID ?? RequestFlightID()
 
         if existingFlightID != nil {
             guard ownsStreamFlight(
@@ -2517,7 +2871,6 @@ class AIService: ObservableObject {
                     // Batching buffers
                     var contentBuffer = ""
                     var reasoningBuffer = ""
-                    var lastUpdateTime = CFAbsoluteTimeGetCurrent()
                     var totalBytesReceived = 0
 
                     // Maximum line length to prevent OOM from malformed streams without newlines
@@ -2602,10 +2955,11 @@ class AIService: ObservableObject {
                                     return
                                 }
 
-                                // Check if we should dispatch batch
+                                // Deliver each parsed SSE event before waiting for another byte.
+                                // Deferring a short tail until a later event can silently lose it
+                                // when Stop cancels a quiet stream between events. Platform views
+                                // perform their own render throttling where needed.
                                 if !contentBuffer.isEmpty || !reasoningBuffer.isEmpty {
-                                    let timeSinceLastUpdate = CFAbsoluteTimeGetCurrent() - lastUpdateTime
-                                    if timeSinceLastUpdate > 0.05 || contentBuffer.count > 100 || reasoningBuffer.count > 100 {
                                         let contentToSend = contentBuffer
                                         let reasoningToSend = reasoningBuffer
                                         let delivered = await MainActor.run {
@@ -2622,12 +2976,40 @@ class AIService: ObservableObject {
                                         guard delivered else { return }
                                         contentBuffer = ""
                                         reasoningBuffer = ""
-                                        lastUpdateTime = CFAbsoluteTimeGetCurrent()
-                                    }
                                 }
                             }
                             buffer.removeAll()
                         }
+                    }
+
+                    // Some providers close immediately after their final SSE `data:` record
+                    // without a trailing newline. Parse that residual record once before EOF
+                    // finalization instead of silently discarding it.
+                    if !buffer.isEmpty, let line = String(data: buffer, encoding: .utf8) {
+                        let ownsFlight = await MainActor.run {
+                            self.ownsStreamFlight(
+                                flightID,
+                                isMultiModelRequest: isMultiModelRequest,
+                                modelName: modelName
+                            )
+                        }
+                        guard ownsFlight else { throw CancellationError() }
+                        let result = await OpenAIStreamParser.processStreamLine(
+                            line,
+                            toolCallBuffers: currentToolCallBuffers,
+                            toolCallIds: toolCallIds,
+                            onToolCall: guardedToolCall,
+                            onToolCallRequested: guardedToolCallRequested
+                        )
+                        currentToolCallBuffers = result.toolCallBuffers
+                        toolCallIds = result.toolCallIds
+                        if let content = result.content {
+                            contentBuffer += content
+                        }
+                        if let reasoning = result.reasoning {
+                            reasoningBuffer += reasoning
+                        }
+                        buffer.removeAll()
                     }
 
                     // Flush any remaining content
@@ -2906,6 +3288,78 @@ class AIService: ObservableObject {
         }
     }
 
+    private func ownsNonStreamToolFlight(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String
+    ) -> Bool {
+        if isMultiModelRequest {
+            return multiModelNonStreamToolTasks[modelName]?.owns(flightID) == true
+        }
+        return currentNonStreamToolTask.owns(flightID)
+    }
+
+    private func ownsNonStreamToolExecution(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String
+    ) -> Bool {
+        ownsDataFlight(
+            flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: modelName
+        ) && ownsNonStreamToolFlight(
+            flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: modelName
+        )
+    }
+
+    @discardableResult
+    private func clearNonStreamToolFlight(
+        _ flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String
+    ) -> Bool {
+        if isMultiModelRequest {
+            guard var flight = multiModelNonStreamToolTasks[modelName],
+                  flight.clear(ifOwnedBy: flightID)
+            else {
+                return false
+            }
+            multiModelNonStreamToolTasks.removeValue(forKey: modelName)
+            return true
+        }
+        return currentNonStreamToolTask.clear(ifOwnedBy: flightID)
+    }
+
+    @discardableResult
+    private func installNonStreamToolTask(
+        _ task: Task<Void, Never>,
+        flightID: RequestFlightID,
+        isMultiModelRequest: Bool,
+        modelName: String
+    ) -> Bool {
+        guard ownsDataFlight(
+            flightID,
+            isMultiModelRequest: isMultiModelRequest,
+            modelName: modelName
+        ) else {
+            return false
+        }
+
+        if isMultiModelRequest {
+            var flight = multiModelNonStreamToolTasks[modelName] ?? RequestFlight()
+            let previousTask = flight.install(task, id: flightID)
+            multiModelNonStreamToolTasks[modelName] = flight
+            previousTask?.cancel()
+            return true
+        }
+
+        currentNonStreamToolTask.install(task, id: flightID)?.cancel()
+        return true
+    }
+
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func nonStreamResponse(
         request: URLRequest,
@@ -2917,9 +3371,10 @@ class AIService: ObservableObject {
         onToolCall: (@Sendable (String, String, [String: Any]) async -> String)? = nil,
         onReasoning: (@Sendable (String) -> Void)? = nil,
         attempt: Int = 0,
+        initialFlightID: RequestFlightID? = nil,
         existingFlightID: RequestFlightID? = nil
     ) {
-        let flightID = existingFlightID ?? RequestFlightID()
+        let flightID = existingFlightID ?? initialFlightID ?? RequestFlightID()
         if existingFlightID == nil {
             let previousTask = takeDataTask(
                 isMultiModelRequest: isMultiModelRequest,
@@ -3071,18 +3526,12 @@ class AIService: ObservableObject {
                             }
                         }
 
-                        // Async tool execution intentionally remains outside request-flight ownership.
                         if let toolCalls = message["tool_calls"] as? [[String: Any]],
                            let onToolCall
                         {
-                            guard self.clearDataFlight(
-                                flightID,
-                                isMultiModelRequest: isMultiModelRequest,
-                                modelName: modelName
-                            ) else {
-                                return
-                            }
-                            Task {
+                            let toolTask = Task { @MainActor [weak self] in
+                                guard let self else { return }
+
                                 for toolCall in toolCalls {
                                     if let id = toolCall["id"] as? String,
                                        let function = toolCall["function"] as? [String: Any],
@@ -3092,15 +3541,71 @@ class AIService: ObservableObject {
                                        let arguments = try? JSONSerialization.jsonObject(with: argsData)
                                        as? [String: Any]
                                     {
+                                        guard !Task.isCancelled,
+                                              self.ownsNonStreamToolExecution(
+                                                  flightID,
+                                                  isMultiModelRequest: isMultiModelRequest,
+                                                  modelName: modelName
+                                              )
+                                        else {
+                                            return
+                                        }
+
                                         let result = await onToolCall(id, name, arguments)
-                                        await MainActor.run {
+
+                                        guard !Task.isCancelled,
+                                              self.ownsNonStreamToolExecution(
+                                                  flightID,
+                                                  isMultiModelRequest: isMultiModelRequest,
+                                                  modelName: modelName
+                                              )
+                                        else {
+                                            return
+                                        }
+
                                             onChunk("\n\n[Tool: \(name)]\n\(result)\n")
+
+                                        guard self.ownsNonStreamToolExecution(
+                                            flightID,
+                                            isMultiModelRequest: isMultiModelRequest,
+                                            modelName: modelName
+                                        ) else {
+                                            return
                                         }
                                     }
                                 }
-                                await MainActor.run {
+
+                                guard !Task.isCancelled,
+                                      self.ownsNonStreamToolExecution(
+                                          flightID,
+                                          isMultiModelRequest: isMultiModelRequest,
+                                          modelName: modelName
+                                      ),
+                                      self.clearNonStreamToolFlight(
+                                          flightID,
+                                          isMultiModelRequest: isMultiModelRequest,
+                                          modelName: modelName
+                                      ),
+                                      self.clearDataFlight(
+                                          flightID,
+                                          isMultiModelRequest: isMultiModelRequest,
+                                          modelName: modelName
+                                      )
+                                else {
+                                    return
+                                }
+
                                     onComplete()
                                 }
+
+                            guard self.installNonStreamToolTask(
+                                toolTask,
+                                flightID: flightID,
+                                isMultiModelRequest: isMultiModelRequest,
+                                modelName: modelName
+                            ) else {
+                                toolTask.cancel()
+                                return
                             }
                             return
                         }
@@ -3553,7 +4058,10 @@ class AIService: ObservableObject {
             return serviceRequest
         }
 
-        private func handleAppleIntelligenceRequest(_ request: AppleIntelligenceRequestContext) {
+        private func handleAppleIntelligenceRequest(
+            _ request: AppleIntelligenceRequestContext,
+            flightID: RequestFlightID = RequestFlightID()
+        ) {
             guard request.service.isAvailable else {
                 request.onError(AIError.apiError(request.service.availabilityDescription()))
                 return
@@ -3569,7 +4077,6 @@ class AIService: ObservableObject {
             )
             let sessionID = appleSessionID(for: request)
             let requestTemperature = request.temperature ?? 0.7
-            let flightID = RequestFlightID()
             let task = Task { @MainActor [weak self] in
                 guard let self,
                       self.ownsAppleIntelligenceFlight(
@@ -3732,7 +4239,8 @@ class AIService: ObservableObject {
         tools: [[String: Any]]?,
         conversationId: UUID?,
         isMultiModelRequest: Bool,
-        callbacks: AIProviderStreamCallbacks
+        callbacks: AIProviderStreamCallbacks,
+        flightID: RequestFlightID = RequestFlightID()
     ) {
         let modelAPIKey = getAPIKey(for: model)
         let endpointInfo = customEndpoint(for: model)
@@ -3767,7 +4275,6 @@ class AIService: ObservableObject {
 
         // Install ownership before sending because a provider may fail synchronously.
         let provider = anthropicProviderFactory(urlSession)
-        let flightID = RequestFlightID()
         if isMultiModelRequest {
             var previousFlight = multiModelAnthropicProviders.removeValue(forKey: model)
             let previousProvider = previousFlight?.take()

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -81,6 +81,9 @@ enum RequestFlightCheckpoint: Sendable {
     case dataCallback
     case dataRetry
     case anthropicTerminal
+    case multiModelPermitQueued
+    case multiModelStart
+    case multiModelCallback
 }
 
 struct RequestFlightObserver: Sendable {
@@ -137,6 +140,34 @@ private enum AnthropicFlightCallback: @unchecked Sendable {
     case reasoning(String)
 }
 
+private enum MultiModelBatchCallback: @unchecked Sendable {
+    case chunk(String)
+    case complete
+    case error(Error)
+    case toolRequest(id: String, name: String, arguments: [String: Any])
+    case reasoning(String)
+}
+
+struct AIServiceResponseSimulationCallbacks: Sendable {
+    let onChunk: @Sendable (String) -> Void
+    let onComplete: @Sendable () -> Void
+}
+
+typealias AIServiceResponseSimulator = @MainActor @Sendable (
+    [Message],
+    AIServiceResponseSimulationCallbacks
+) -> Void
+
+private enum MultiModelCredentialSource: Sendable {
+    case githubOAuth
+    case storedModelKey(oauthTokenAtPreparation: String?)
+}
+
+private struct MultiModelPreparedCredential: Sendable {
+    let value: String
+    let source: MultiModelCredentialSource
+}
+
 @MainActor
 class AIService: ObservableObject {
     static let shared = AIService()
@@ -163,7 +194,7 @@ class AIService: ObservableObject {
     private var currentTask = RequestFlight<URLSessionDataTask>()
     private var multiModelDataTasks: [String: RequestFlight<URLSessionDataTask>] = [:]
     private var currentStreamTask = RequestFlight<Task<Void, Never>>()
-    private var multiModelTask: Task<Void, Never>?
+    private var multiModelTask = RequestFlight<Task<Void, Never>>()
     /// Tracks individual stream tasks for each model in multi-model mode
     private var multiModelStreamTasks: [String: RequestFlight<Task<Void, Never>>] = [:]
     #if !os(watchOS)
@@ -190,6 +221,7 @@ class AIService: ObservableObject {
     private let anthropicProviderFactory: @MainActor (URLSession) -> any AIProviderProtocol
     private let retryDelay: @Sendable (Int, Date?) async -> Void
     private let requestFlightObserver: RequestFlightObserver
+    private let responseSimulator: AIServiceResponseSimulator?
 
     // Image generation service
     #if !os(watchOS)
@@ -311,11 +343,13 @@ class AIService: ObservableObject {
         retryDelay: @escaping @Sendable (Int, Date?) async -> Void = { attempt, retryAfterDate in
             await AIRetryPolicy.wait(for: attempt, retryAfterDate: retryAfterDate)
         },
-        requestFlightObserver: RequestFlightObserver = .none
+        requestFlightObserver: RequestFlightObserver = .none,
+        responseSimulator: AIServiceResponseSimulator? = nil
     ) {
         self.anthropicProviderFactory = anthropicProviderFactory
         self.retryDelay = retryDelay
         self.requestFlightObserver = requestFlightObserver
+        self.responseSimulator = responseSimulator
 
         if let session = urlSession {
             self.urlSession = session
@@ -686,6 +720,53 @@ class AIService: ObservableObject {
         return modelAPIKeys[model] ?? ""
     }
 
+    private func prepareGitHubCredential(for model: String) async throws -> MultiModelPreparedCredential {
+        if GitHubOAuthService.shared.isAuthenticated {
+            do {
+                let accessToken = try await GitHubOAuthService.shared.getValidAccessToken()
+                guard !accessToken.isEmpty else {
+                    throw AynaError.missingAPIKey(provider: AIProvider.githubModels.displayName)
+                }
+                return MultiModelPreparedCredential(value: accessToken, source: .githubOAuth)
+            } catch {
+                if let storedKey = modelAPIKeys[model], !storedKey.isEmpty {
+                    return MultiModelPreparedCredential(
+                        value: storedKey,
+                        source: .storedModelKey(
+                            oauthTokenAtPreparation: GitHubOAuthService.shared.getAccessToken()
+                        )
+                    )
+                }
+                throw error
+            }
+        }
+
+        guard let storedKey = modelAPIKeys[model], !storedKey.isEmpty else {
+            throw AynaError.missingAPIKey(provider: AIProvider.githubModels.displayName)
+        }
+        return MultiModelPreparedCredential(
+            value: storedKey,
+            source: .storedModelKey(oauthTokenAtPreparation: nil)
+        )
+    }
+
+    private func isCurrentGitHubCredential(
+        _ credential: MultiModelPreparedCredential,
+        model: String
+    ) -> Bool {
+        switch credential.source {
+        case .githubOAuth:
+            return GitHubOAuthService.shared.isAuthenticated &&
+                GitHubOAuthService.shared.isCurrentAccessTokenValid(credential.value)
+        case let .storedModelKey(oauthTokenAtPreparation):
+            let currentOAuthToken = GitHubOAuthService.shared.isAuthenticated
+                ? GitHubOAuthService.shared.getAccessToken()
+                : nil
+            return modelAPIKeys[model] == credential.value &&
+                currentOAuthToken == oauthTokenAtPreparation
+        }
+    }
+
     private func getAPIURL(deploymentName: String? = nil, provider: AIProvider? = nil) throws -> String {
         let effectiveProvider = provider ?? self.provider
         let modelName = deploymentName ?? selectedModel
@@ -738,6 +819,7 @@ class AIService: ObservableObject {
         )
 
         let dataTask = currentTask.take()
+        let multiModelBatchTask = multiModelTask.take()
         let multiDataTasks = multiModelDataTasks.compactMap { model, flight -> (String, URLSessionDataTask)? in
             var flight = flight
             return flight.take().map { (model, $0) }
@@ -760,6 +842,8 @@ class AIService: ObservableObject {
             appleIntelligenceTask = nil
         #endif
 
+        // Fence queued multi-model starts before active handles can release shared permits.
+        multiModelBatchTask?.cancel()
         dataTask?.cancel()
         for (model, task) in multiDataTasks {
             task.cancel()
@@ -771,8 +855,6 @@ class AIService: ObservableObject {
             )
         }
         streamTask?.cancel()
-        multiModelTask?.cancel()
-        multiModelTask = nil
         for (model, task) in multiStreamTasks {
             task.cancel()
             DiagnosticsLogger.log(
@@ -931,7 +1013,8 @@ class AIService: ObservableObject {
         onError: @escaping @Sendable (Error) -> Void,
         onToolCall: (@Sendable (String, String, [String: Any]) async -> String)? = nil,
         onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)? = nil,
-        onReasoning: (@Sendable (String) -> Void)? = nil
+        onReasoning: (@Sendable (String) -> Void)? = nil,
+        preparedAPIKey: String? = nil
     ) {
         let requestModel = (model ?? selectedModel).trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -947,6 +1030,14 @@ class AIService: ObservableObject {
                 "toolCount": "\(tools?.count ?? 0)"
             ]
         )
+
+        if let responseSimulator {
+            responseSimulator(
+                messages,
+                AIServiceResponseSimulationCallbacks(onChunk: onChunk, onComplete: onComplete)
+            )
+            return
+        }
 
         // Mock response for UI tests on macOS and iOS (UITestEnvironment not available on watchOS)
         #if !os(watchOS)
@@ -1041,7 +1132,7 @@ class AIService: ObservableObject {
             return
         }
 
-        let modelAPIKey = getAPIKey(for: requestModel)
+        let modelAPIKey = preparedAPIKey ?? getAPIKey(for: requestModel)
 
         // Check GitHub Models rate limit before making request
         if effectiveProvider == .githubModels {
@@ -1177,7 +1268,7 @@ class AIService: ObservableObject {
 
     // MARK: - Multi-Model Parallel Requests
 
-    // swiftlint:disable function_body_length
+    // swiftlint:disable function_body_length cyclomatic_complexity
     /// Sends a message to multiple models in parallel using TaskGroup.
     /// Each model streams independently, and tool calls are deferred until the user selects a response.
     ///
@@ -1202,9 +1293,27 @@ class AIService: ObservableObject {
         onPendingToolCall: (@Sendable (String, String, String, [String: Any]) -> Void)? = nil,
         onReasoning: (@Sendable (String, String) -> Void)? = nil
     ) {
-        // Validate we have models to query
         guard !models.isEmpty else {
             onError("", AIError.missingModel)
+            onAllComplete()
+            return
+        }
+
+        func rejectBatch(_ error: Error) {
+            models.forEach { onError($0, error) }
+            onAllComplete()
+        }
+
+        let requestModels = models.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        let modelRequests = Array(zip(models, requestModels))
+        guard !requestModels.contains(where: \.isEmpty) else {
+            rejectBatch(AIError.missingModel)
+            return
+        }
+
+        var uniqueModels: Set<String> = []
+        if let duplicateModel = requestModels.first(where: { !uniqueModels.insert($0).inserted }) {
+            rejectBatch(AIError.apiError("Duplicate model in multi-model request: \(duplicateModel)"))
             return
         }
 
@@ -1212,11 +1321,10 @@ class AIService: ObservableObject {
             .aiService,
             level: .info,
             message: "🔀 Starting multi-model request",
-            metadata: ["models": models.joined(separator: ", ")]
+            metadata: ["models": requestModels.joined(separator: ", ")]
         )
 
-        // Cancel any existing multi-model task and individual stream tasks
-        multiModelTask?.cancel()
+        let previousBatchTask = multiModelTask.take()
         let previousDataTasks = multiModelDataTasks.compactMap { _, flight -> URLSessionDataTask? in
             var flight = flight
             return flight.take()
@@ -1232,19 +1340,30 @@ class AIService: ObservableObject {
             return flight.take()
         }
         multiModelAnthropicProviders.removeAll()
+
+        // Cancel the batch first so queued runners are fenced before active request handles release permits.
+        previousBatchTask?.cancel()
         previousDataTasks.forEach { $0.cancel() }
         previousStreamTasks.forEach { $0.cancel() }
         previousAnthropicProviders.forEach { $0.cancelRequest() }
+        // Apple Intelligence still uses one shared foreground task. Batch callbacks are ownership-gated here,
+        // but safely cancelling only a prior batch requires separate per-request Apple task ownership.
 
-        // Use a TaskGroup to send requests in parallel
-        let task = Task {
+        let flightID = RequestFlightID()
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+
             await withTaskGroup(of: Void.self) { group in
-                for model in models {
+                for (callbackModel, model) in modelRequests {
+                    guard !Task.isCancelled, self.multiModelTask.owns(flightID) else { return }
+                    let effectiveProvider = self.modelProviders[model] ?? self.provider
+                    let preparedEndpoint = self.modelEndpoints[model]
+                    let preparedEndpointType = self.modelEndpointTypes[model]
+                    let requestFlightObserver = self.requestFlightObserver
+
                     group.addTask { [weak self] in
                         guard let self else { return }
-
-                        // Check for cancellation before starting
-                        if Task.isCancelled {
+                        guard !Task.isCancelled else {
                             DiagnosticsLogger.log(
                                 .aiService,
                                 level: .info,
@@ -1254,105 +1373,152 @@ class AIService: ObservableObject {
                             return
                         }
 
-                        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                            Task { @MainActor in
-                                // Check for cancellation again on MainActor
-                                if Task.isCancelled {
-                                    continuation.resume()
-                                    return
+                        let preparedCredential: MultiModelPreparedCredential?
+                        if effectiveProvider == .githubModels {
+                            do {
+                                preparedCredential = try await self.prepareGitHubCredential(for: model)
+                            } catch {
+                                let message = error.localizedDescription
+                                await MainActor.run {
+                                    guard !Task.isCancelled, self.multiModelTask.owns(flightID) else { return }
+                                    onError(callbackModel, AIError.apiError(message))
                                 }
+                                return
+                            }
+                        } else {
+                            preparedCredential = nil
+                        }
+                        let preparedAPIKey = preparedCredential?.value
 
-                                // Concurrency gate for GitHub Models in multi-model mode.
-                                // GitHub Models rate limits are scoped per token/user, so we serialize per-token.
-                                let effectiveProvider = self.modelProviders[model] ?? self.provider
-                                let accessTokenForGate = (effectiveProvider == .githubModels)
-                                    ? self.getAPIKey(for: model)
-                                    : ""
+                        guard !Task.isCancelled else { return }
+                        let stillOwnsBatch = await MainActor.run {
+                            self.multiModelTask.owns(flightID)
+                        }
+                        guard stillOwnsBatch else { return }
 
-                                @MainActor
-                                func sendWithGate(_ gateRelease: OneShot?) {
-                                    self.sendMessage(
-                                        messages: messages,
-                                        model: model,
-                                        temperature: temperature,
-                                        stream: true,
-                                        tools: nil, // Tools disabled in multi-model mode - deferred
-                                        conversationId: nil,
-                                        isMultiModelRequest: true,
-                                        onChunk: { chunk in
-                                            onChunk(model, chunk)
-                                        },
-                                        onComplete: { [gateRelease] in
-                                            DiagnosticsLogger.log(
-                                                .aiService,
-                                                level: .info,
-                                                message: "✅ Model completed in multi-model request",
-                                                metadata: ["model": model]
-                                            )
-                                            gateRelease?.run()
-                                            onModelComplete(model)
-                                            continuation.resume()
-                                        },
-                                        onError: { [gateRelease] error in
-                                            DiagnosticsLogger.log(
-                                                .aiService,
-                                                level: .error,
-                                                message: "❌ Model failed in multi-model request",
-                                                metadata: ["model": model, "error": error.localizedDescription]
-                                            )
-                                            gateRelease?.run()
-                                            onError(model, error)
-                                            continuation.resume()
-                                        },
-                                        onToolCall: nil, // Deferred - not executed during multi-model
-                                        onToolCallRequested: { toolId, toolName, arguments in
-                                            // Report the tool call as pending (will execute after selection)
-                                            onPendingToolCall?(model, toolId, toolName, arguments)
-                                        },
-                                        onReasoning: { reasoning in
-                                            onReasoning?(model, reasoning)
-                                        }
+                        let gitHubPermit: MultiModelRequestRunner.GitHubPermit? = if let preparedAPIKey {
+                            MultiModelRequestRunner.GitHubPermit.shared(
+                                key: GitHubOAuthService.rateLimitKey(forAccessToken: preparedAPIKey),
+                                onQueued: {
+                                    requestFlightObserver.record(.multiModelPermitQueued, true)
+                                }
+                            )
+                        } else {
+                            nil
+                        }
+
+                        await MultiModelRequestRunner.run(gitHubPermit: gitHubPermit) { [weak self] completion in
+                            guard let self,
+                                  !Task.isCancelled,
+                                  self.multiModelTask.owns(flightID)
+                            else {
+                                completion()
+                                return
+                            }
+
+                            let callbackForwarder = OrderedMainActorForwarder<MultiModelBatchCallback> { [weak self] event in
+                                let ownsBatch = self?.multiModelTask.owns(flightID) == true
+                                requestFlightObserver.record(.multiModelCallback, ownsBatch)
+                                guard ownsBatch else { return }
+
+                                switch event {
+                                case let .chunk(chunk):
+                                    guard !completion.isFinished else { return }
+                                    onChunk(callbackModel, chunk)
+
+                                case .complete:
+                                    guard completion() else { return }
+                                    DiagnosticsLogger.log(
+                                        .aiService,
+                                        level: .info,
+                                        message: "✅ Model completed in multi-model request",
+                                        metadata: ["model": model]
                                     )
-                                }
+                                    onModelComplete(callbackModel)
 
-                                if effectiveProvider == .githubModels, !accessTokenForGate.isEmpty {
-                                    let gateKey = GitHubOAuthService.rateLimitKey(forAccessToken: accessTokenForGate)
-                                    do {
-                                        try await GitHubModelsRequestGate.shared.acquire(key: gateKey)
-                                    } catch {
-                                        continuation.resume()
-                                        return
-                                    }
+                                case let .error(error):
+                                    guard completion() else { return }
+                                    DiagnosticsLogger.log(
+                                        .aiService,
+                                        level: .error,
+                                        message: "❌ Model failed in multi-model request",
+                                        metadata: ["model": model, "error": error.localizedDescription]
+                                    )
+                                    onError(callbackModel, error)
 
-                                    let gateRelease = OneShot {
-                                        Task { await GitHubModelsRequestGate.shared.release(key: gateKey) }
-                                    }
+                                case let .toolRequest(toolID, toolName, arguments):
+                                    guard !completion.isFinished else { return }
+                                    onPendingToolCall?(callbackModel, toolID, toolName, arguments)
 
-                                    if Task.isCancelled {
-                                        gateRelease.run()
-                                        continuation.resume()
-                                        return
-                                    }
-
-                                    if let rateLimitError = self.checkGitHubModelsRateLimit(accessToken: accessTokenForGate) {
-                                        gateRelease.run()
-                                        onError(model, AIError.apiError(rateLimitError))
-                                        continuation.resume()
-                                        return
-                                    }
-
-                                    sendWithGate(gateRelease)
-                                } else {
-                                    sendWithGate(nil)
+                                case let .reasoning(reasoning):
+                                    guard !completion.isFinished else { return }
+                                    onReasoning?(callbackModel, reasoning)
                                 }
                             }
+
+                            let currentProvider = self.modelProviders[model] ?? self.provider
+                            let credentialIsCurrent = preparedCredential.map {
+                                self.isCurrentGitHubCredential($0, model: model)
+                            } ?? true
+                            guard currentProvider == effectiveProvider,
+                                  self.modelEndpoints[model] == preparedEndpoint,
+                                  self.modelEndpointTypes[model] == preparedEndpointType,
+                                  credentialIsCurrent
+                            else {
+                                callbackForwarder.enqueue(
+                                    .error(
+                                        AIError.apiError(
+                                            "Model configuration changed while the request was queued. Please retry."
+                                        )
+                                    )
+                                )
+                                return
+                            }
+
+                            requestFlightObserver.record(.multiModelStart, true)
+
+                            if effectiveProvider == .githubModels,
+                               let preparedAPIKey,
+                               let rateLimitError = self.checkGitHubModelsRateLimit(accessToken: preparedAPIKey)
+                            {
+                                callbackForwarder.enqueue(.error(AIError.apiError(rateLimitError)))
+                                return
+                            }
+
+                            self.sendMessage(
+                                messages: messages,
+                                model: model,
+                                temperature: temperature,
+                                stream: true,
+                                tools: nil, // Tools disabled in multi-model mode - deferred
+                                conversationId: nil,
+                                isMultiModelRequest: true,
+                                onChunk: { chunk in
+                                    callbackForwarder.enqueue(.chunk(chunk))
+                                },
+                                onComplete: {
+                                    callbackForwarder.enqueue(.complete)
+                                },
+                                onError: { error in
+                                    callbackForwarder.enqueue(.error(error))
+                                },
+                                onToolCall: nil, // Deferred - not executed during multi-model
+                                onToolCallRequested: { toolID, toolName, arguments in
+                                    callbackForwarder.enqueue(
+                                        .toolRequest(id: toolID, name: toolName, arguments: arguments)
+                                    )
+                                },
+                                onReasoning: { reasoning in
+                                    callbackForwarder.enqueue(.reasoning(reasoning))
+                                },
+                                preparedAPIKey: preparedAPIKey
+                            )
                         }
                     }
                 }
             }
 
-            // Check for cancellation before calling onAllComplete
-            if Task.isCancelled {
+            guard !Task.isCancelled else {
                 DiagnosticsLogger.log(
                     .aiService,
                     level: .info,
@@ -1361,22 +1527,19 @@ class AIService: ObservableObject {
                 return
             }
 
-            // All models completed
-            await MainActor.run {
-                self.multiModelTask = nil
-                self.multiModelStreamTasks.removeAll()
-                DiagnosticsLogger.log(
-                    .aiService,
-                    level: .info,
-                    message: "🏁 All models completed in multi-model request"
-                )
-                onAllComplete()
-            }
+            guard self.multiModelTask.clear(ifOwnedBy: flightID) else { return }
+            self.multiModelStreamTasks.removeAll()
+            DiagnosticsLogger.log(
+                .aiService,
+                level: .info,
+                message: "🏁 All models completed in multi-model request"
+            )
+            onAllComplete()
         }
-        multiModelTask = task
+        multiModelTask.install(task, id: flightID)?.cancel()
     }
 
-    // swiftlint:enable function_body_length
+    // swiftlint:enable function_body_length cyclomatic_complexity
 
     private func simulateUITestResponse(
         messages: [Message],

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -169,6 +169,45 @@ private enum MultiModelBatchCallback: @unchecked Sendable {
     case reasoning(String)
 }
 
+#if !os(watchOS)
+    @MainActor
+    private struct AppleIntelligenceRequestHandle {
+        let task: Task<Void, Never>
+        let service: any AppleIntelligenceServing
+        let sessionID: String
+
+        func cancel() {
+            task.cancel()
+            service.clearSession(conversationId: sessionID)
+        }
+    }
+
+    @MainActor
+    private struct AppleIntelligenceRequestContext {
+        let service: any AppleIntelligenceServing
+        let messages: [Message]
+        let modelName: String
+        let temperature: Double?
+        let stream: Bool
+        let conversationID: UUID?
+        let isMultiModelRequest: Bool
+        let onChunk: @Sendable (String) -> Void
+        let onComplete: @Sendable () -> Void
+        let onError: @Sendable (Error) -> Void
+    }
+
+    private struct AppleConversationContext {
+        let history: [AppleIntelligenceHistoryEntry]
+        let prompt: String
+        let requiresHistory: Bool
+    }
+
+    private struct AppleToolMatchPlan {
+        var assistantCallIDs: [UUID: [Int: String]] = [:]
+        var toolOutputIDs: [UUID: [Int: String]] = [:]
+    }
+#endif
+
 struct AIServiceResponseSimulationCallbacks: Sendable {
     let onChunk: @Sendable (String) -> Void
     let onComplete: @Sendable () -> Void
@@ -219,7 +258,8 @@ class AIService: ObservableObject {
     /// Tracks individual stream tasks for each model in multi-model mode
     private var multiModelStreamTasks: [String: RequestFlight<Task<Void, Never>>] = [:]
     #if !os(watchOS)
-        private var appleIntelligenceTask: Task<Void, Never>?
+        private var currentAppleIntelligenceTask = RequestFlight<AppleIntelligenceRequestHandle>()
+        private var multiModelAppleIntelligenceTasks: [String: RequestFlight<AppleIntelligenceRequestHandle>] = [:]
         private var imageRequests: [RequestFlightID: OpenAIImageService.RequestHandle] = [:]
     #endif
 
@@ -244,6 +284,9 @@ class AIService: ObservableObject {
     private let retryDelay: @Sendable (Int, Date?) async -> Void
     private let requestFlightObserver: RequestFlightObserver
     private let responseSimulator: AIServiceResponseSimulator?
+    #if !os(watchOS)
+        private let injectedAppleIntelligenceService: (any AppleIntelligenceServing)?
+    #endif
 
     // Image generation service
     #if !os(watchOS)
@@ -378,12 +421,16 @@ class AIService: ObservableObject {
             await AIRetryPolicy.wait(for: attempt, retryAfterDate: retryAfterDate)
         },
         requestFlightObserver: RequestFlightObserver = .none,
-        responseSimulator: AIServiceResponseSimulator? = nil
+        responseSimulator: AIServiceResponseSimulator? = nil,
+        appleIntelligenceService: (any AppleIntelligenceServing)? = nil
     ) {
         self.anthropicProviderFactory = anthropicProviderFactory
         self.retryDelay = retryDelay
         self.requestFlightObserver = requestFlightObserver
         self.responseSimulator = responseSimulator
+        #if !os(watchOS)
+            injectedAppleIntelligenceService = appleIntelligenceService
+        #endif
 
         if let session = urlSession {
             self.urlSession = session
@@ -872,8 +919,12 @@ class AIService: ObservableObject {
         }
         multiModelAnthropicProviders.removeAll()
         #if !os(watchOS)
-            let appleTask = appleIntelligenceTask
-            appleIntelligenceTask = nil
+            let appleTask = currentAppleIntelligenceTask.take()
+            let multiAppleTasks = multiModelAppleIntelligenceTasks.compactMap { _, flight -> AppleIntelligenceRequestHandle? in
+                var flight = flight
+                return flight.take()
+            }
+            multiModelAppleIntelligenceTasks.removeAll()
             let imageRequestHandles: [OpenAIImageService.RequestHandle]
             if includeImageRequests {
                 imageRequestHandles = Array(imageRequests.values)
@@ -909,6 +960,7 @@ class AIService: ObservableObject {
         multiAnthropicProviders.forEach { $0.cancelRequest() }
         #if !os(watchOS)
             appleTask?.cancel()
+            multiAppleTasks.forEach { $0.cancel() }
             imageRequestHandles.forEach { $0.cancel() }
         #endif
         DiagnosticsLogger.log(
@@ -1187,16 +1239,32 @@ class AIService: ObservableObject {
         // Handle Apple Intelligence separately
         #if !os(watchOS)
             if effectiveProvider == .appleIntelligence {
-                if #available(macOS 26.0, iOS 26.0, *) {
-                    handleAppleIntelligenceRequest(
+                if let service = injectedAppleIntelligenceService {
+                    handleAppleIntelligenceRequest(AppleIntelligenceRequestContext(
+                        service: service,
                         messages: messages,
+                        modelName: requestModel,
                         temperature: temperature,
                         stream: stream,
-                        conversationId: conversationId,
+                        conversationID: conversationId,
+                        isMultiModelRequest: isMultiModelRequest,
                         onChunk: onChunk,
                         onComplete: onComplete,
                         onError: onError
-                    )
+                    ))
+                } else if #available(macOS 26.0, iOS 26.0, *) {
+                    handleAppleIntelligenceRequest(AppleIntelligenceRequestContext(
+                        service: AppleIntelligenceService.shared,
+                        messages: messages,
+                        modelName: requestModel,
+                        temperature: temperature,
+                        stream: stream,
+                        conversationID: conversationId,
+                        isMultiModelRequest: isMultiModelRequest,
+                        onChunk: onChunk,
+                        onComplete: onComplete,
+                        onError: onError
+                    ))
                 } else {
                     onError(AIError.apiError("Apple Intelligence requires macOS 26.0 or iOS 26.0 or later"))
                 }
@@ -1447,14 +1515,22 @@ class AIService: ObservableObject {
             return flight.take()
         }
         multiModelAnthropicProviders.removeAll()
+        #if !os(watchOS)
+            let previousAppleTasks = multiModelAppleIntelligenceTasks.compactMap { _, flight -> AppleIntelligenceRequestHandle? in
+                var flight = flight
+                return flight.take()
+            }
+            multiModelAppleIntelligenceTasks.removeAll()
+        #endif
 
         // Cancel the batch first so queued runners are fenced before active request handles release permits.
         previousBatchTask?.cancel()
         previousDataTasks.forEach { $0.cancel() }
         previousStreamTasks.forEach { $0.cancel() }
         previousAnthropicProviders.forEach { $0.cancelRequest() }
-        // Apple Intelligence still uses one shared foreground task. Batch callbacks are ownership-gated here,
-        // but safely cancelling only a prior batch requires separate per-request Apple task ownership.
+        #if !os(watchOS)
+            previousAppleTasks.forEach { $0.cancel() }
+        #endif
 
         let flightID = RequestFlightID()
         let task = Task { @MainActor [weak self] in
@@ -3074,98 +3150,547 @@ class AIService: ObservableObject {
     }
 
     #if !os(watchOS)
-        @available(macOS 26.0, iOS 26.0, *)
-        private func handleAppleIntelligenceRequest(
+        private func ownsAppleIntelligenceFlight(
+            _ flightID: RequestFlightID,
+            isMultiModelRequest: Bool,
+            modelName: String
+        ) -> Bool {
+            if isMultiModelRequest {
+                return multiModelAppleIntelligenceTasks[modelName]?.owns(flightID) == true
+            }
+            return currentAppleIntelligenceTask.owns(flightID)
+        }
+
+        @discardableResult
+        private func clearAppleIntelligenceFlight(
+            _ flightID: RequestFlightID,
+            isMultiModelRequest: Bool,
+            modelName: String
+        ) -> Bool {
+            if isMultiModelRequest {
+                guard var flight = multiModelAppleIntelligenceTasks[modelName],
+                      flight.clear(ifOwnedBy: flightID)
+                else {
+                    return false
+                }
+                multiModelAppleIntelligenceTasks.removeValue(forKey: modelName)
+                return true
+            }
+            return currentAppleIntelligenceTask.clear(ifOwnedBy: flightID)
+        }
+
+        @discardableResult
+        private func finishAppleIntelligenceFlight(
+            _ flightID: RequestFlightID,
+            request: AppleIntelligenceRequestContext,
+            sessionID: String
+        ) -> Bool {
+            guard clearAppleIntelligenceFlight(
+                flightID,
+                isMultiModelRequest: request.isMultiModelRequest,
+                modelName: request.modelName
+            ) else {
+                return false
+            }
+            request.service.clearSession(conversationId: sessionID)
+            return true
+        }
+
+        private func installAppleIntelligenceHandle(
+            _ handle: AppleIntelligenceRequestHandle,
+            flightID: RequestFlightID,
+            isMultiModelRequest: Bool,
+            modelName: String
+        ) -> AppleIntelligenceRequestHandle? {
+            if isMultiModelRequest {
+                var flight = multiModelAppleIntelligenceTasks[modelName] ?? RequestFlight()
+                let previous = flight.install(handle, id: flightID)
+                multiModelAppleIntelligenceTasks[modelName] = flight
+                return previous
+            }
+            return currentAppleIntelligenceTask.install(handle, id: flightID)
+        }
+
+        private func appleSessionID(for request: AppleIntelligenceRequestContext) -> String {
+            let conversationScope = request.conversationID?.uuidString ?? "default"
+            let requestScope = UUID().uuidString
+            return request.isMultiModelRequest
+                ? "multi:\(conversationScope):\(request.modelName):\(requestScope)"
+                : "\(conversationScope):\(requestScope)"
+        }
+
+        private func appleSystemInstructions(
             messages: [Message],
-            temperature: Double?,
-            stream: Bool,
-            conversationId: UUID?,
-            onChunk: @escaping (String) -> Void,
-            onComplete: @escaping () -> Void,
-            onError: @escaping (Error) -> Void
-        ) {
-            let service = AppleIntelligenceService.shared
-
-            // Check availability
-            guard service.isAvailable else {
-                onError(AIError.apiError(service.availabilityDescription()))
-                return
-            }
-
-            // Extract system instructions (first system message if any)
-            let baseSystemInstructions =
-                messages.first(where: { $0.role == .system })?.content
-                    ?? "You are a helpful assistant."
-
-            // Inject memory context into system instructions
+            conversationID: UUID?
+        ) -> String {
+            var instructions = messages.first(where: { $0.role == .system })?.content
+                ?? "You are a helpful assistant."
             let memoryContext = MemoryContextProvider.shared.buildContext(
-                currentConversationId: conversationId
+                currentConversationId: conversationID
             )
-            var systemInstructions = baseSystemInstructions
-            if memoryContext.hasContent {
-                var memoryParts: [String] = []
-                if let sessionMetadata = memoryContext.sessionMetadata {
-                    memoryParts.append(sessionMetadata)
-                }
-                if let userMemory = memoryContext.userMemory {
-                    memoryParts.append(userMemory)
-                }
-                if let summaries = memoryContext.conversationSummaries {
-                    memoryParts.append(summaries)
-                }
-                if !memoryParts.isEmpty {
-                    systemInstructions += "\n\n" + memoryParts.joined(separator: "\n\n")
-                }
+            guard memoryContext.hasContent else { return instructions }
+
+            let memoryParts = [
+                memoryContext.sessionMetadata,
+                memoryContext.userMemory,
+                memoryContext.conversationSummaries,
+            ].compactMap(\.self)
+            if !memoryParts.isEmpty {
+                instructions += "\n\n" + memoryParts.joined(separator: "\n\n")
+            }
+            return instructions
+        }
+
+        private func appleToolMatchPlan(messages: [Message]) -> AppleToolMatchPlan {
+            struct PendingCall {
+                let messageID: UUID
+                let index: Int
+                let normalizedID: String
             }
 
-            // Get the last user message as the prompt
-            guard let lastUserMessage = messages.last(where: { $0.role == .user }) else {
-                onError(AIError.apiError("No user message found"))
+            var plan = AppleToolMatchPlan()
+            var pendingByOriginalID: [String: [PendingCall]] = [:]
+            var occurrenceByOriginalID: [String: Int] = [:]
+            let originalIDs = Set(messages.flatMap { ($0.toolCalls ?? []).map(\.id) })
+            var assignedIDs: Set<String> = []
+            for message in messages {
+                switch message.role {
+                case .assistant:
+                    for (index, call) in (message.toolCalls ?? []).enumerated() {
+                        let occurrence = occurrenceByOriginalID[call.id, default: 0]
+                        occurrenceByOriginalID[call.id] = occurrence + 1
+                        var normalizedID = call.id
+                        if occurrence > 0 || assignedIDs.contains(normalizedID) {
+                            var suffix = max(1, occurrence)
+                            repeat {
+                                normalizedID = "\(call.id)#\(suffix)"
+                                suffix += 1
+                            } while originalIDs.contains(normalizedID) || assignedIDs.contains(normalizedID)
+                        }
+                        assignedIDs.insert(normalizedID)
+                        pendingByOriginalID[call.id, default: []].append(PendingCall(
+                            messageID: message.id,
+                            index: index,
+                            normalizedID: normalizedID
+                        ))
+                    }
+                case .tool:
+                    for (index, call) in (message.toolCalls ?? []).enumerated() {
+                        guard var pending = pendingByOriginalID[call.id],
+                              let matched = pending.popLast()
+                        else {
+                            continue
+                        }
+                        pendingByOriginalID[call.id] = pending
+                        plan.assistantCallIDs[matched.messageID, default: [:]][matched.index] = matched.normalizedID
+                        plan.toolOutputIDs[message.id, default: [:]][index] = matched.normalizedID
+                    }
+                case .system, .user:
+                    break
+                }
+            }
+            return plan
+        }
+
+        private func appleHistoryEntries(
+            from message: Message,
+            matchPlan: AppleToolMatchPlan
+        ) -> [AppleIntelligenceHistoryEntry] {
+            let content = message.content
+            let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            switch message.role {
+            case .user:
+                guard !trimmedContent.isEmpty else { return [] }
+                return [AppleIntelligenceHistoryEntry(role: .user, content: content)]
+            case .assistant:
+                let toolCalls = (message.toolCalls ?? []).enumerated().compactMap { index, toolCall -> AppleIntelligenceToolCall? in
+                    guard let normalizedID = matchPlan.assistantCallIDs[message.id]?[index],
+                          let data = try? JSONEncoder().encode(toolCall.arguments),
+                          let argumentsJSON = String(data: data, encoding: .utf8)
+                    else {
+                        return nil
+                    }
+                    return AppleIntelligenceToolCall(
+                        id: normalizedID,
+                        name: toolCall.toolName,
+                        argumentsJSON: argumentsJSON
+                    )
+                }
+                guard !trimmedContent.isEmpty || !toolCalls.isEmpty else { return [] }
+                return [AppleIntelligenceHistoryEntry(
+                    role: .assistant,
+                    content: content,
+                    toolCalls: toolCalls
+                )]
+            case .tool:
+                return (message.toolCalls ?? []).enumerated().compactMap { index, toolCall in
+                    guard let normalizedID = matchPlan.toolOutputIDs[message.id]?[index] else { return nil }
+                    return AppleIntelligenceHistoryEntry(
+                        role: .tool,
+                        content: trimmedContent.isEmpty ? "(empty tool output)" : content,
+                        toolName: toolCall.toolName,
+                        toolCallID: normalizedID
+                    )
+                }
+            case .system:
+                return []
+            }
+        }
+
+        private func appleConversationContext(
+            messages: [Message]
+        ) -> AppleConversationContext? {
+            let messages = messages.filter { $0.isSelectedResponse != false }
+            guard let promptIndex = messages.lastIndex(where: { $0.role == .user }) else { return nil }
+            let matchPlan = appleToolMatchPlan(messages: messages)
+
+            let tailEntries = messages[messages.index(after: promptIndex)...].flatMap {
+                appleHistoryEntries(from: $0, matchPlan: matchPlan)
+            }
+            if !tailEntries.isEmpty {
+                let history = messages.flatMap {
+                    appleHistoryEntries(from: $0, matchPlan: matchPlan)
+                }
+                return AppleConversationContext(
+                    history: history,
+                    prompt: "Continue the conversation using the completed context above.",
+                    requiresHistory: true
+                )
+            }
+
+            let history = messages[..<promptIndex].flatMap {
+                appleHistoryEntries(from: $0, matchPlan: matchPlan)
+            }
+            return AppleConversationContext(
+                history: history,
+                prompt: messages[promptIndex].content,
+                requiresHistory: false
+            )
+        }
+
+        private func appleHistoryGroups(
+            _ history: [AppleIntelligenceHistoryEntry]
+        ) -> [[AppleIntelligenceHistoryEntry]] {
+            var groups: [[AppleIntelligenceHistoryEntry]] = []
+            for entry in history {
+                switch entry.role {
+                case .user:
+                    groups.append([entry])
+                case .assistant:
+                    if groups.last?.first?.role == .user {
+                        groups[groups.count - 1].append(entry)
+                    } else {
+                        groups.append([entry])
+                    }
+                case .tool:
+                    if let toolCallID = entry.toolCallID,
+                       groups.last?.contains(where: {
+                           $0.role == .assistant && $0.toolCalls.contains(where: { $0.id == toolCallID })
+                       }) == true
+                    {
+                        groups[groups.count - 1].append(entry)
+                    } else {
+                        groups.append([entry])
+                    }
+                }
+            }
+            return groups
+        }
+
+        private func estimatedAppleHistoryTokens(
+            _ entries: [AppleIntelligenceHistoryEntry]
+        ) -> Int {
+            AppleIntelligenceTranscriptBuilder.entries(from: entries).reduce(0) { total, entry in
+                total + 12 + estimatedAppleTokens(entry.content)
+            }
+        }
+
+        private func estimatedAppleTokens(_ text: String) -> Int {
+            let scalarCount = text.unicodeScalars.count
+            let asciiCount = text.unicodeScalars.lazy.filter(\.isASCII).count
+            let nonASCII = scalarCount - asciiCount
+            return ((asciiCount + 1) / 2) + nonASCII
+        }
+
+        private func compactAppleHistory(
+            _ history: [AppleIntelligenceHistoryEntry],
+            contextSize: Int,
+            systemInstructions: String,
+            prompt: String,
+            requireNewestGroup: Bool
+        ) -> [AppleIntelligenceHistoryEntry]? {
+            let responseReserve = max(64, min(1024, contextSize / 4))
+            let fixedCost = responseReserve + estimatedAppleTokens(systemInstructions) +
+                estimatedAppleTokens(prompt) + 32
+            guard fixedCost <= contextSize else { return nil }
+            var remaining = contextSize - fixedCost
+            var retainedGroups: [[AppleIntelligenceHistoryEntry]] = []
+            for group in appleHistoryGroups(history).reversed() {
+                let groupCost = estimatedAppleHistoryTokens(group)
+                guard groupCost <= remaining else {
+                    return requireNewestGroup && retainedGroups.isEmpty ? nil : retainedGroups.flatMap(\.self)
+                }
+                retainedGroups.insert(group, at: 0)
+                remaining -= groupCost
+            }
+            return retainedGroups.flatMap(\.self)
+        }
+
+        private func fallbackAppleServiceRequest(
+            request: AppleIntelligenceRequestContext,
+            conversationContext: AppleConversationContext,
+            sessionID: String,
+            systemInstructions: String,
+            temperature: Double
+        ) -> AppleIntelligenceRequest? {
+            guard let history = compactAppleHistory(
+                conversationContext.history,
+                contextSize: request.service.contextSize,
+                systemInstructions: systemInstructions,
+                prompt: conversationContext.prompt,
+                requireNewestGroup: conversationContext.requiresHistory
+            ) else {
+                return nil
+            }
+            return AppleIntelligenceRequest(
+                conversationID: sessionID,
+                prompt: conversationContext.prompt,
+                history: history,
+                systemInstructions: systemInstructions,
+                temperature: temperature
+            )
+        }
+
+        private func validatedAppleServiceRequest(
+            request: AppleIntelligenceRequestContext,
+            conversationContext: AppleConversationContext,
+            sessionID: String,
+            systemInstructions: String,
+            temperature: Double
+        ) async -> AppleIntelligenceRequest? {
+            var candidate = AppleIntelligenceRequest(
+                conversationID: sessionID,
+                prompt: conversationContext.prompt,
+                history: conversationContext.history,
+                systemInstructions: systemInstructions,
+                temperature: temperature
+            )
+            let maxInputTokens = max(0, request.service.contextSize - max(64, min(1024, request.service.contextSize / 4)))
+            if let initialCount = await request.service.tokenCount(for: candidate) {
+                guard initialCount > maxInputTokens else { return candidate }
+
+                var groups = appleHistoryGroups(candidate.history)
+                while !groups.isEmpty {
+                    if conversationContext.requiresHistory, groups.count == 1 {
+                        return nil
+                    }
+                    groups.removeFirst()
+                    candidate = AppleIntelligenceRequest(
+                        conversationID: sessionID,
+                        prompt: conversationContext.prompt,
+                        history: groups.flatMap(\.self),
+                        systemInstructions: systemInstructions,
+                        temperature: temperature
+                    )
+                    guard let tokenCount = await request.service.tokenCount(for: candidate) else {
+                        return fallbackAppleServiceRequest(
+                            request: request,
+                            conversationContext: conversationContext,
+                            sessionID: sessionID,
+                            systemInstructions: systemInstructions,
+                            temperature: temperature
+                        )
+                    }
+                    if tokenCount <= maxInputTokens {
+                        return candidate
+                    }
+                }
+                return nil
+            }
+
+            return fallbackAppleServiceRequest(
+                request: request,
+                conversationContext: conversationContext,
+                sessionID: sessionID,
+                systemInstructions: systemInstructions,
+                temperature: temperature
+            )
+        }
+
+        private func ownedAppleServiceRequest(
+            request: AppleIntelligenceRequestContext,
+            conversationContext: AppleConversationContext,
+            sessionID: String,
+            systemInstructions: String,
+            temperature: Double,
+            flightID: RequestFlightID
+        ) async -> AppleIntelligenceRequest? {
+            guard let serviceRequest = await validatedAppleServiceRequest(
+                request: request,
+                conversationContext: conversationContext,
+                sessionID: sessionID,
+                systemInstructions: systemInstructions,
+                temperature: temperature
+            ) else {
+                guard finishAppleIntelligenceFlight(
+                    flightID,
+                    request: request,
+                    sessionID: sessionID
+                ) else {
+                    return nil
+                }
+                request.onError(AIError.apiError("Apple Intelligence context is too large to continue safely"))
+                return nil
+            }
+            guard ownsAppleIntelligenceFlight(
+                flightID,
+                isMultiModelRequest: request.isMultiModelRequest,
+                modelName: request.modelName
+            ) else {
+                return nil
+            }
+            return serviceRequest
+        }
+
+        private func handleAppleIntelligenceRequest(_ request: AppleIntelligenceRequestContext) {
+            guard request.service.isAvailable else {
+                request.onError(AIError.apiError(request.service.availabilityDescription()))
+                return
+            }
+            guard let conversationContext = appleConversationContext(messages: request.messages) else {
+                request.onError(AIError.apiError("No user message found"))
                 return
             }
 
-            // Use the provided conversation ID or a default
-            let convId = conversationId?.uuidString ?? "default"
+            let systemInstructions = appleSystemInstructions(
+                messages: request.messages,
+                conversationID: request.conversationID
+            )
+            let sessionID = appleSessionID(for: request)
+            let requestTemperature = request.temperature ?? 0.7
+            let flightID = RequestFlightID()
+            let task = Task { @MainActor [weak self] in
+                guard let self,
+                      self.ownsAppleIntelligenceFlight(
+                          flightID,
+                          isMultiModelRequest: request.isMultiModelRequest,
+                          modelName: request.modelName
+                      )
+                else {
+                    return
+                }
+                guard let serviceRequest = await self.ownedAppleServiceRequest(
+                    request: request,
+                    conversationContext: conversationContext,
+                    sessionID: sessionID,
+                    systemInstructions: systemInstructions,
+                    temperature: requestTemperature,
+                    flightID: flightID
+                ) else {
+                    return
+                }
 
-            let requestTemp = temperature ?? 0.7
-
-            // Cancel any existing Apple Intelligence task
-            appleIntelligenceTask?.cancel()
-
-            let task = Task {
-                if stream {
-                    await service.streamResponse(
-                        conversationId: convId,
-                        prompt: lastUserMessage.content,
-                        systemInstructions: systemInstructions,
-                        temperature: requestTemp,
-                        onChunk: { chunk in
-                            onChunk(chunk)
+                if request.stream {
+                    await request.service.streamResponse(
+                        request: serviceRequest,
+                        onChunk: { [weak self] chunk in
+                            guard let self,
+                                  self.ownsAppleIntelligenceFlight(
+                                      flightID,
+                                      isMultiModelRequest: request.isMultiModelRequest,
+                                      modelName: request.modelName
+                                  )
+                            else {
+                                return
+                            }
+                            request.onChunk(chunk)
                         },
-                        onComplete: {
-                            onComplete()
+                        onComplete: { [weak self] in
+                            guard let self,
+                                  self.finishAppleIntelligenceFlight(
+                                      flightID,
+                                      request: request,
+                                      sessionID: sessionID
+                                  )
+                            else {
+                                return
+                            }
+                            request.onComplete()
                         },
-                        onError: { error in
-                            onError(error)
+                        onError: { [weak self] error in
+                            guard let self,
+                                  self.finishAppleIntelligenceFlight(
+                                      flightID,
+                                      request: request,
+                                      sessionID: sessionID
+                                  )
+                            else {
+                                return
+                            }
+                            request.onError(error)
                         }
                     )
                 } else {
-                    await service.generateResponse(
-                        conversationId: convId,
-                        prompt: lastUserMessage.content,
-                        systemInstructions: systemInstructions,
-                        temperature: requestTemp,
-                        onComplete: { response in
-                            onChunk(response)
-                            onComplete()
+                    await request.service.generateResponse(
+                        request: serviceRequest,
+                        onComplete: { [weak self] response in
+                            guard let self,
+                                  self.ownsAppleIntelligenceFlight(
+                                      flightID,
+                                      isMultiModelRequest: request.isMultiModelRequest,
+                                      modelName: request.modelName
+                                  )
+                            else {
+                                return
+                            }
+                            request.onChunk(response)
+                            guard self.finishAppleIntelligenceFlight(
+                                flightID,
+                                request: request,
+                                sessionID: sessionID
+                            ) else {
+                                return
+                            }
+                            request.onComplete()
                         },
-                        onError: { error in
-                            onError(error)
+                        onError: { [weak self] error in
+                            guard let self,
+                                  self.finishAppleIntelligenceFlight(
+                                      flightID,
+                                      request: request,
+                                      sessionID: sessionID
+                                  )
+                            else {
+                                return
+                            }
+                            request.onError(error)
                         }
                     )
                 }
+
+                guard !Task.isCancelled,
+                      self.finishAppleIntelligenceFlight(
+                          flightID,
+                          request: request,
+                          sessionID: sessionID
+                      )
+                else {
+                    return
+                }
+                request.onError(AIError.apiError("Apple Intelligence request ended without a terminal callback"))
             }
-            appleIntelligenceTask = task
+            let handle = AppleIntelligenceRequestHandle(
+                task: task,
+                service: request.service,
+                sessionID: sessionID
+            )
+            installAppleIntelligenceHandle(
+                handle,
+                flightID: flightID,
+                isMultiModelRequest: request.isMultiModelRequest,
+                modelName: request.modelName
+            )?.cancel()
         }
     #endif
 

--- a/Sources/Ayna/Services/AccessibilityService.swift
+++ b/Sources/Ayna/Services/AccessibilityService.swift
@@ -254,9 +254,15 @@
 
         // MARK: - Window Enumeration
 
+        /// Stable identity for an enumerated application window.
+        struct WindowIdentity: Hashable {
+            let processIdentifier: pid_t
+            let enumerationIndex: Int
+        }
+
         /// Information about a window
         struct WindowInfo: Identifiable, Hashable {
-            let id: CGWindowID
+            let id: WindowIdentity
             let title: String
             let appPID: pid_t
             let appName: String
@@ -392,11 +398,13 @@
                     continue
                 }
 
-                // Create a unique ID using index since we can't easily get CGWindowID from AXUIElement
-                let windowId = CGWindowID(app.processIdentifier * 100_000 + Int32(index))
+                let windowIdentity = WindowIdentity(
+                    processIdentifier: app.processIdentifier,
+                    enumerationIndex: index
+                )
 
                 let windowInfo = WindowInfo(
-                    id: windowId,
+                    id: windowIdentity,
                     title: title,
                     appPID: app.processIdentifier,
                     appName: app.localizedName ?? "Unknown",

--- a/Sources/Ayna/Services/AnthropicRequestBuilder.swift
+++ b/Sources/Ayna/Services/AnthropicRequestBuilder.swift
@@ -177,21 +177,20 @@ enum AnthropicRequestBuilder {
     static func extractSystemAndConvertMessages(
         _ messages: [Message]
     ) throws -> (systemPrompt: String?, messages: [[String: Any]]) {
+        let sanitizedMessages = ToolTranscriptSanitizer.sanitize(messages)
         var systemPrompt: String?
         var anthropicMessages: [[String: Any]] = []
         var imageCount = 0
 
-        #if !os(watchOS)
             // Build a set of valid tool_call_ids that have matching tool responses
             var toolResponseIds = Set<String>()
-            for message in messages {
+        for message in sanitizedMessages {
                 if message.role == .tool, let toolCallId = message.toolCalls?.first?.id {
                     toolResponseIds.insert(toolCallId)
                 }
             }
-        #endif
 
-        for (index, message) in messages.enumerated() {
+        for (index, message) in sanitizedMessages.enumerated() {
             // Extract system prompt (don't include in messages array)
             if message.role == .system {
                 if systemPrompt == nil {
@@ -203,7 +202,6 @@ enum AnthropicRequestBuilder {
                 continue
             }
 
-            #if !os(watchOS)
                 // Handle tool result messages - convert to Anthropic's tool_result format
                 if message.role == .tool {
                     guard let toolCallId = message.toolCalls?.first?.id else {
@@ -212,13 +210,16 @@ enum AnthropicRequestBuilder {
                     }
 
                     // Verify a preceding assistant message has matching tool_call
-                    if index == 0 { continue }
+                if index == 0 {
+                    continue
+                }
                     var foundAssistant = false
                     for prevIdx in stride(from: index - 1, through: 0, by: -1) {
-                        let prevMessage = messages[prevIdx]
+                    let prevMessage = sanitizedMessages[prevIdx]
                         if prevMessage.role == .assistant {
                             if let toolCalls = prevMessage.toolCalls,
-                               toolCalls.contains(where: { $0.id == toolCallId }) {
+                           toolCalls.contains(where: { $0.id == toolCallId })
+                        {
                                 foundAssistant = true
                             }
                             break
@@ -241,6 +242,13 @@ enum AnthropicRequestBuilder {
                     ])
                     continue
                 }
+
+            if message.role == .assistant,
+               message.toolCalls?.isEmpty ?? true,
+               message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                continue
+            }
 
                 // For assistant messages with tool_calls, filter to only those with matching tool responses
                 if message.role == .assistant, let toolCalls = message.toolCalls, !toolCalls.isEmpty {
@@ -275,12 +283,6 @@ enum AnthropicRequestBuilder {
                     }
                     // All tool calls have matching responses - fall through to normal conversion
                 }
-            #else
-                // Skip tool messages on watchOS (tools not supported)
-                if message.role == .tool {
-                    continue
-                }
-            #endif
 
             // Convert message
             let (converted, msgImageCount) = try convertMessage(message)
@@ -347,7 +349,6 @@ enum AnthropicRequestBuilder {
             payload["content"] = message.content
         }
 
-        #if !os(watchOS)
             // Handle assistant messages with tool calls
             if message.role == .assistant, let toolCalls = message.toolCalls, !toolCalls.isEmpty {
                 var contentArray: [[String: Any]] = []
@@ -377,7 +378,6 @@ enum AnthropicRequestBuilder {
 
                 payload["content"] = contentArray
             }
-        #endif
 
         return (payload, imageCount)
     }

--- a/Sources/Ayna/Services/AppleIntelligenceService.swift
+++ b/Sources/Ayna/Services/AppleIntelligenceService.swift
@@ -9,6 +9,132 @@ import Combine
 import Foundation
 import os.log
 
+struct AppleIntelligenceToolCall: Equatable, Sendable {
+    let id: String
+    let name: String
+    let argumentsJSON: String
+}
+
+struct AppleIntelligenceHistoryEntry: Equatable, Sendable {
+    enum Role: Equatable, Sendable {
+        case user
+        case assistant
+        case tool
+    }
+
+    let role: Role
+    let content: String
+    let toolName: String?
+    let toolCallID: String?
+    let toolCalls: [AppleIntelligenceToolCall]
+
+    init(
+        role: Role,
+        content: String,
+        toolName: String? = nil,
+        toolCallID: String? = nil,
+        toolCalls: [AppleIntelligenceToolCall] = []
+    ) {
+        self.role = role
+        self.content = content
+        self.toolName = toolName
+        self.toolCallID = toolCallID
+        self.toolCalls = toolCalls
+    }
+}
+
+struct AppleIntelligenceRequest: Sendable {
+    let conversationID: String
+    let prompt: String
+    let history: [AppleIntelligenceHistoryEntry]
+    let systemInstructions: String
+    let temperature: Double
+}
+
+struct AppleIntelligenceTranscriptEntry: Equatable, Sendable {
+    enum Role: Equatable, Sendable {
+        case user
+        case assistant
+    }
+
+    let role: Role
+    let content: String
+}
+
+enum AppleIntelligenceTranscriptBuilder {
+    static func entries(
+        from history: [AppleIntelligenceHistoryEntry]
+    ) -> [AppleIntelligenceTranscriptEntry] {
+        var toolOutputQueues = history.reduce(into: [String: [AppleIntelligenceHistoryEntry]]()) { outputs, entry in
+            if entry.role == .tool, let toolCallID = entry.toolCallID {
+                outputs[toolCallID, default: []].append(entry)
+            }
+        }
+        var transcript: [AppleIntelligenceTranscriptEntry] = []
+        for entry in history where entry.role != .tool {
+            switch entry.role {
+            case .user:
+                transcript.append(.init(role: .user, content: entry.content))
+            case .assistant:
+                var responseParts = entry.content.isEmpty ? [] : [entry.content]
+                for call in entry.toolCalls {
+                    guard var outputs = toolOutputQueues[call.id], !outputs.isEmpty else { continue }
+                    let output = outputs.removeFirst()
+                    toolOutputQueues[call.id] = outputs
+                    responseParts.append(
+                        "Tool interaction — \(call.name)\nArguments: \(call.argumentsJSON)\nResult: \(output.content)"
+                    )
+                }
+                if !responseParts.isEmpty {
+                    transcript.append(.init(role: .assistant, content: responseParts.joined(separator: "\n\n")))
+                }
+            case .tool:
+                break
+            }
+        }
+        return transcript
+    }
+}
+
+@MainActor
+protocol AppleIntelligenceServing: AnyObject {
+    var isAvailable: Bool { get }
+    var contextSize: Int { get }
+    func availabilityDescription() -> String
+    func clearSession(conversationId: String)
+    func tokenCount(for request: AppleIntelligenceRequest) async -> Int?
+    func streamResponse(
+        request: AppleIntelligenceRequest,
+        onChunk: @escaping @MainActor @Sendable (String) -> Void,
+        onComplete: @escaping @MainActor @Sendable () -> Void,
+        onError: @escaping @MainActor @Sendable (Error) -> Void
+    ) async
+    func generateResponse(
+        request: AppleIntelligenceRequest,
+        onComplete: @escaping @MainActor @Sendable (String) -> Void,
+        onError: @escaping @MainActor @Sendable (Error) -> Void
+    ) async
+}
+
+enum AppleIntelligenceRetryGate {
+    @MainActor
+    static func prepare(
+        clearSession: @MainActor () -> Void,
+        delay: @escaping @MainActor @Sendable () async throws -> Void = {
+            try await Task.sleep(for: .milliseconds(500))
+        }
+    ) async -> Bool {
+        guard !Task.isCancelled else { return false }
+        clearSession()
+        do {
+            try await delay()
+        } catch {
+            return false
+        }
+        return !Task.isCancelled
+    }
+}
+
 enum AppleIntelligenceError: LocalizedError {
     case deviceNotEligible
     case appleIntelligenceNotEnabled
@@ -40,7 +166,7 @@ enum AppleIntelligenceError: LocalizedError {
 
     @available(macOS 26.0, iOS 26.0, *)
     @MainActor
-    class AppleIntelligenceService: ObservableObject {
+    class AppleIntelligenceService: ObservableObject, AppleIntelligenceServing {
         static let shared = AppleIntelligenceService()
 
         @Published var model = SystemLanguageModel.default
@@ -64,6 +190,14 @@ enum AppleIntelligenceError: LocalizedError {
         /// Check if Apple Intelligence is available on this device
         var isAvailable: Bool {
             model.isAvailable
+        }
+
+        var contextSize: Int {
+            #if compiler(>=6.3)
+                model.contextSize
+            #else
+                4096
+            #endif
         }
 
         var availability: SystemLanguageModel.Availability {
@@ -90,10 +224,51 @@ enum AppleIntelligenceError: LocalizedError {
             }
         }
 
+        func tokenCount(for request: AppleIntelligenceRequest) async -> Int? {
+            #if compiler(>=6.3)
+                guard #available(macOS 26.4, iOS 26.4, *) else { return nil }
+                do {
+                    let historyTokens = try await model.tokenCount(for: transcriptEntries(
+                        systemInstructions: request.systemInstructions,
+                        history: request.history
+                    ))
+                    let promptTokens = try await model.tokenCount(for: request.prompt)
+                    return historyTokens + promptTokens
+                } catch {
+                    return nil
+                }
+            #else
+                return nil
+            #endif
+        }
+
+        private func transcriptEntries(
+            systemInstructions: String,
+            history: [AppleIntelligenceHistoryEntry]
+        ) -> [Transcript.Entry] {
+            var entries: [Transcript.Entry] = [
+                .instructions(Transcript.Instructions(
+                    segments: [.text(.init(content: systemInstructions))],
+                    toolDefinitions: []
+                )),
+            ]
+            for entry in AppleIntelligenceTranscriptBuilder.entries(from: history) {
+                let segment = Transcript.Segment.text(.init(content: entry.content))
+                switch entry.role {
+                case .user:
+                    entries.append(.prompt(.init(segments: [segment])))
+                case .assistant:
+                    entries.append(.response(.init(assetIDs: [], segments: [segment])))
+                }
+            }
+            return entries
+        }
+
         /// Get or create a session for a conversation
         private func getSession(
             conversationId: String,
-            systemInstructions: String
+            systemInstructions: String,
+            history: [AppleIntelligenceHistoryEntry]
         ) -> LanguageModelSession {
             sessionsLock.lock()
             defer { sessionsLock.unlock() }
@@ -102,7 +277,10 @@ enum AppleIntelligenceError: LocalizedError {
                 return existingSession
             }
 
-            let newSession = LanguageModelSession(instructions: systemInstructions)
+            let newSession = LanguageModelSession(transcript: Transcript(entries: transcriptEntries(
+                systemInstructions: systemInstructions,
+                history: history
+            )))
             sessions[conversationId] = newSession
             return newSession
         }
@@ -125,109 +303,111 @@ enum AppleIntelligenceError: LocalizedError {
 
         /// Stream response
         func streamResponse(
-            conversationId: String,
-            prompt: String,
-            systemInstructions: String = "You are a helpful assistant.",
-            temperature: Double = 0.7,
-            onChunk: @escaping (String) -> Void,
-            onComplete: @escaping () -> Void,
-            onError: @escaping (Error) -> Void
+            request: AppleIntelligenceRequest,
+            onChunk: @escaping @MainActor @Sendable (String) -> Void,
+            onComplete: @escaping @MainActor @Sendable () -> Void,
+            onError: @escaping @MainActor @Sendable (Error) -> Void
         ) async {
+            guard !Task.isCancelled else { return }
             // Check availability
             guard isAvailable else {
                 log(
                     "Apple Intelligence stream unavailable",
                     level: .error,
-                    metadata: ["conversationId": conversationId, "reason": availabilityDescription()]
+                    metadata: ["conversationId": request.conversationID, "reason": availabilityDescription()]
                 )
                 onError(getAvailabilityError())
                 return
             }
 
-            log("Starting Apple Intelligence stream", metadata: ["conversationId": conversationId])
+            log("Starting Apple Intelligence stream", metadata: ["conversationId": request.conversationID])
 
             let maxRetries = 2
 
             for attempt in 1 ... maxRetries {
+                guard !Task.isCancelled else { return }
                 // Get or create session
                 let session = getSession(
-                    conversationId: conversationId,
-                    systemInstructions: systemInstructions
+                    conversationId: request.conversationID,
+                    systemInstructions: request.systemInstructions,
+                    history: request.history
                 )
 
                 // Create generation options
-                let options = GenerationOptions(temperature: temperature)
+                let options = GenerationOptions(temperature: request.temperature)
 
                 do {
                     // Stream the response
-                    let stream = session.streamResponse(to: prompt, options: options)
+                    let stream = session.streamResponse(to: request.prompt, options: options)
 
                     var previousContent = ""
                     var hasReceivedContent = false
 
                     for try await snapshot in stream {
-                        await MainActor.run {
-                            // snapshot.content contains the full response so far, not just the delta
-                            // Calculate the new text by comparing with previous content
-                            let currentContent = snapshot.content
-                            if currentContent.hasPrefix(previousContent) {
-                                let delta = String(currentContent.dropFirst(previousContent.count))
-                                if !delta.isEmpty {
-                                    onChunk(delta)
-                                    hasReceivedContent = true
-                                }
-                            } else {
-                                // If content doesn't have expected prefix, send full content
-                                onChunk(currentContent)
+                        try Task.checkCancellation()
+                        // snapshot.content contains the full response so far, not just the delta
+                        // Calculate the new text by comparing with previous content
+                        let currentContent = snapshot.content
+                        if currentContent.hasPrefix(previousContent) {
+                            let delta = String(currentContent.dropFirst(previousContent.count))
+                            if !delta.isEmpty {
+                                onChunk(delta)
                                 hasReceivedContent = true
                             }
-                            previousContent = currentContent
+                        } else {
+                            // If content doesn't have expected prefix, send full content
+                            onChunk(currentContent)
+                            hasReceivedContent = true
                         }
+                        previousContent = currentContent
                     }
 
                     if hasReceivedContent {
-                        await MainActor.run {
-                            onComplete()
-                        }
-                        log("Completed Apple Intelligence stream", metadata: ["conversationId": conversationId])
+                        try Task.checkCancellation()
+                        onComplete()
+                        log("Completed Apple Intelligence stream", metadata: ["conversationId": request.conversationID])
                         return
                     } else {
                         if attempt < maxRetries {
                             log(
                                 "Apple Intelligence stream returned no content, retrying...",
                                 level: .default,
-                                metadata: ["conversationId": conversationId, "attempt": "\(attempt)"]
+                                metadata: ["conversationId": request.conversationID, "attempt": "\(attempt)"]
                             )
-                            clearSession(conversationId: conversationId)
-                            try? await Task.sleep(for: .milliseconds(500))
+                            guard await AppleIntelligenceRetryGate.prepare(clearSession: {
+                                self.clearSession(conversationId: request.conversationID)
+                            }) else {
+                                return
+                            }
                             continue
                         } else {
-                            await MainActor.run {
-                                onComplete()
-                            }
-                            log("Completed Apple Intelligence stream (empty)", metadata: ["conversationId": conversationId])
+                            try Task.checkCancellation()
+                            onComplete()
+                            log("Completed Apple Intelligence stream (empty)", metadata: ["conversationId": request.conversationID])
                             return
                         }
                     }
                 } catch is CancellationError {
-                    log("Apple Intelligence stream cancelled", metadata: ["conversationId": conversationId])
+                    log("Apple Intelligence stream cancelled", metadata: ["conversationId": request.conversationID])
                     return
                 } catch {
                     log(
                         "Apple Intelligence stream failed",
                         level: .error,
-                        metadata: ["conversationId": conversationId, "error": error.localizedDescription, "attempt": "\(attempt)"]
+                        metadata: ["conversationId": request.conversationID, "error": error.localizedDescription, "attempt": "\(attempt)"]
                     )
+                    guard !Task.isCancelled else { return }
 
                     if attempt < maxRetries {
-                        clearSession(conversationId: conversationId)
-                        try? await Task.sleep(for: .milliseconds(500))
+                        guard await AppleIntelligenceRetryGate.prepare(clearSession: {
+                            self.clearSession(conversationId: request.conversationID)
+                        }) else {
+                            return
+                        }
                         continue
                     }
 
-                    await MainActor.run {
-                        onError(AppleIntelligenceError.generationFailed(error.localizedDescription))
-                    }
+                    onError(AppleIntelligenceError.generationFailed(error.localizedDescription))
                     return
                 }
             }
@@ -235,54 +415,51 @@ enum AppleIntelligenceError: LocalizedError {
 
         /// Non-streaming response
         func generateResponse(
-            conversationId: String,
-            prompt: String,
-            systemInstructions: String = "You are a helpful assistant.",
-            temperature: Double = 0.7,
-            onComplete: @escaping (String) -> Void,
-            onError: @escaping (Error) -> Void
+            request: AppleIntelligenceRequest,
+            onComplete: @escaping @MainActor @Sendable (String) -> Void,
+            onError: @escaping @MainActor @Sendable (Error) -> Void
         ) async {
+            guard !Task.isCancelled else { return }
             // Check availability
             guard isAvailable else {
                 log(
                     "Apple Intelligence response unavailable",
                     level: .error,
-                    metadata: ["conversationId": conversationId, "reason": availabilityDescription()]
+                    metadata: ["conversationId": request.conversationID, "reason": availabilityDescription()]
                 )
                 onError(getAvailabilityError())
                 return
             }
 
-            log("Generating Apple Intelligence response", metadata: ["conversationId": conversationId])
+            log("Generating Apple Intelligence response", metadata: ["conversationId": request.conversationID])
 
             // Get or create session
             let session = getSession(
-                conversationId: conversationId,
-                systemInstructions: systemInstructions
+                conversationId: request.conversationID,
+                systemInstructions: request.systemInstructions,
+                history: request.history
             )
 
             // Create generation options
-            let options = GenerationOptions(temperature: temperature)
+            let options = GenerationOptions(temperature: request.temperature)
 
             do {
                 // Generate the response
-                let response = try await session.respond(to: prompt, options: options)
+                let response = try await session.respond(to: request.prompt, options: options)
 
-                await MainActor.run {
-                    onComplete(response.content)
-                }
-                log("Generated Apple Intelligence response", metadata: ["conversationId": conversationId])
+                try Task.checkCancellation()
+                onComplete(response.content)
+                log("Generated Apple Intelligence response", metadata: ["conversationId": request.conversationID])
             } catch is CancellationError {
-                log("Apple Intelligence generation cancelled", metadata: ["conversationId": conversationId])
+                log("Apple Intelligence generation cancelled", metadata: ["conversationId": request.conversationID])
             } catch {
+                guard !Task.isCancelled else { return }
                 log(
                     "Apple Intelligence generation failed",
                     level: .error,
-                    metadata: ["conversationId": conversationId, "error": error.localizedDescription]
+                    metadata: ["conversationId": request.conversationID, "error": error.localizedDescription]
                 )
-                await MainActor.run {
-                    onError(AppleIntelligenceError.generationFailed(error.localizedDescription))
-                }
+                onError(AppleIntelligenceError.generationFailed(error.localizedDescription))
             }
         }
 
@@ -311,15 +488,23 @@ enum AppleIntelligenceError: LocalizedError {
 
     @available(macOS 26.0, iOS 26.0, *)
     @MainActor
-    class AppleIntelligenceService: ObservableObject {
+    class AppleIntelligenceService: ObservableObject, AppleIntelligenceServing {
         static let shared = AppleIntelligenceService()
 
         var isAvailable: Bool {
             false
         }
 
+        var contextSize: Int {
+            0
+        }
+
         func availabilityDescription() -> String {
             "Apple Intelligence frameworks are not installed on this system"
+        }
+
+        func tokenCount(for _: AppleIntelligenceRequest) async -> Int? {
+            nil
         }
 
         func clearSession(conversationId _: String) {}
@@ -327,44 +512,34 @@ enum AppleIntelligenceError: LocalizedError {
         func clearAllSessions() {}
 
         func streamResponse(
-            conversationId: String,
-            prompt _: String,
-            systemInstructions _: String = "You are a helpful assistant.",
-            temperature _: Double = 0.7,
-            onChunk _: @escaping (String) -> Void,
-            onComplete _: @escaping () -> Void,
-            onError: @escaping (Error) -> Void
+            request: AppleIntelligenceRequest,
+            onChunk _: @escaping @MainActor @Sendable (String) -> Void,
+            onComplete _: @escaping @MainActor @Sendable () -> Void,
+            onError: @escaping @MainActor @Sendable (Error) -> Void
         ) async {
             DiagnosticsLogger.log(
                 .appleIntelligence,
                 level: .error,
                 message: "Apple Intelligence unavailable on this platform",
-                metadata: ["conversationId": conversationId]
+                metadata: ["conversationId": request.conversationID]
             )
 
-            await MainActor.run {
-                onError(getAvailabilityError())
-            }
+            onError(getAvailabilityError())
         }
 
         func generateResponse(
-            conversationId: String,
-            prompt _: String,
-            systemInstructions _: String = "You are a helpful assistant.",
-            temperature _: Double = 0.7,
-            onComplete _: @escaping (String) -> Void,
-            onError: @escaping (Error) -> Void
+            request: AppleIntelligenceRequest,
+            onComplete _: @escaping @MainActor @Sendable (String) -> Void,
+            onError: @escaping @MainActor @Sendable (Error) -> Void
         ) async {
             DiagnosticsLogger.log(
                 .appleIntelligence,
                 level: .error,
                 message: "Apple Intelligence unavailable on this platform",
-                metadata: ["conversationId": conversationId]
+                metadata: ["conversationId": request.conversationID]
             )
 
-            await MainActor.run {
-                onError(getAvailabilityError())
-            }
+            onError(getAvailabilityError())
         }
 
         private func getAvailabilityError() -> Error {

--- a/Sources/Ayna/Services/AppleIntelligenceService.swift
+++ b/Sources/Ayna/Services/AppleIntelligenceService.swift
@@ -35,7 +35,7 @@ enum AppleIntelligenceError: LocalizedError {
     }
 }
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && !os(watchOS)
     import FoundationModels
 
     @available(macOS 26.0, iOS 26.0, *)

--- a/Sources/Ayna/Services/BuiltinToolService.swift
+++ b/Sources/Ayna/Services/BuiltinToolService.swift
@@ -24,6 +24,8 @@ import os.log
 //
 // Uses dependency injection via SwiftUI Environment.
 #if os(macOS)
+    import Darwin
+
     /// Thread-safe accumulator for pipe data from Process stdout/stderr.
     private final class PipeAccumulator: @unchecked Sendable {
         private let lock = NSLock()
@@ -65,6 +67,99 @@ import os.log
         }
     }
 
+    /// Owns subprocess startup, completion, and TERM-to-KILL escalation as one atomic state.
+    private final class ProcessExecutionController: @unchecked Sendable {
+        private struct State {
+            var process: CommandSubprocess?
+            var isCancelled = false
+            var completionCommitted = false
+            var terminationRequested = false
+        }
+
+        private let lock = NSLock()
+        private var state = State()
+
+        func start(command: String, workingDirectory: URL?) throws -> CommandSubprocess? {
+            lock.lock()
+            guard !state.isCancelled else {
+                lock.unlock()
+                return nil
+            }
+            do {
+                // Keep installation and startup atomic with cancellation.
+                let process = try CommandSubprocess.start(
+                    command: command,
+                    workingDirectory: workingDirectory
+                )
+                state.process = process
+                lock.unlock()
+                return process
+            } catch {
+                state.process = nil
+                lock.unlock()
+                throw error
+            }
+        }
+
+        func cancel() {
+            requestTermination(markCancelled: true)
+        }
+
+        func timeout() {
+            requestTermination(markCancelled: false)
+        }
+
+        func finishIfNotCancelled() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !state.isCancelled, !state.completionCommitted else { return false }
+            state.completionCommitted = true
+            state.process = nil
+            return true
+        }
+
+        private func requestTermination(markCancelled: Bool) {
+            lock.lock()
+            guard !state.completionCommitted else {
+                lock.unlock()
+                return
+            }
+            if markCancelled {
+                state.isCancelled = true
+            }
+            guard !state.terminationRequested else {
+                lock.unlock()
+                return
+            }
+            state.terminationRequested = true
+            let process = state.process
+            lock.unlock()
+
+            guard let process, process.isRunning else { return }
+            process.terminate()
+
+            // `Process.terminate()` only sends SIGTERM. Commands may trap or ignore it,
+            // which would otherwise leave `waitUntilExit()` and the awaiting tool task
+            // suspended forever. Escalate to SIGKILL after a short grace period.
+            Task.detached { [weak self] in
+                try? await Task.sleep(for: .milliseconds(250))
+                guard let self, self.shouldForceKill(process) else { return }
+                process.forceKill()
+            }
+        }
+
+        private func shouldForceKill(_ process: CommandSubprocess) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !state.completionCommitted,
+                  state.process === process
+            else {
+                return false
+            }
+            return process.isRunning
+        }
+    }
+
     @Observable @MainActor
     final class BuiltinToolService {
         // MARK: - Properties
@@ -72,6 +167,8 @@ import os.log
         private let permissionService: PermissionService
         private let shellSandbox: ShellSandbox
         private let pathValidator: PathValidator
+        private let processStartGate: @Sendable () async -> Void
+        private let processCompletionGate: @Sendable () async -> Void
         let projectRoot: URL?
 
         /// Whether the service is enabled
@@ -106,12 +203,16 @@ import os.log
         init(
             permissionService: PermissionService,
             shellSandbox: ShellSandbox? = nil,
-            projectRoot: URL? = nil
+            projectRoot: URL? = nil,
+            processStartGate: @escaping @Sendable () async -> Void = {},
+            processCompletionGate: @escaping @Sendable () async -> Void = {}
         ) {
             self.permissionService = permissionService
             self.projectRoot = projectRoot
             self.pathValidator = PathValidator(projectRoot: projectRoot)
             self.shellSandbox = shellSandbox ?? ShellSandbox(projectRoot: projectRoot)
+            self.processStartGate = processStartGate
+            self.processCompletionGate = processCompletionGate
         }
 
         // MARK: - File Operations
@@ -141,6 +242,7 @@ import os.log
                     details: path,
                     conversationId: conversationId
                 )
+                try Task.checkCancellation()
                 if !approved {
                     throw ToolExecutionError.permissionDenied(tool: ToolName.readFile, reason: "User denied")
                 }
@@ -237,10 +339,10 @@ import os.log
                     details: path,
                     conversationId: conversationId
                 )
+                try Task.checkCancellation()
                 if !approved {
                     throw ToolExecutionError.permissionDenied(tool: ToolName.writeFile, reason: "User denied")
                 }
-                permissionService.recordSessionApproval(tool: ToolName.writeFile, details: path)
             }
 
             // Resolve path with symlink resolution to prevent TOCTOU attacks
@@ -279,6 +381,8 @@ import os.log
             } catch {
                 throw ToolExecutionError.fileNotWritable(path: path, underlying: "Cannot create directory: \(error.localizedDescription)")
             }
+
+            try Task.checkCancellation()
 
             // Write file
             do {
@@ -361,10 +465,10 @@ import os.log
                     diffPreview: diffPreview,
                     conversationId: conversationId
                 )
+                try Task.checkCancellation()
                 if !approved {
                     throw ToolExecutionError.permissionDenied(tool: ToolName.editFile, reason: "User denied")
                 }
-                permissionService.recordSessionApproval(tool: ToolName.editFile, details: path)
             }
 
             // Resolve path with symlink resolution to prevent TOCTOU attacks
@@ -387,6 +491,8 @@ import os.log
             case .allowed:
                 break
             }
+
+            try Task.checkCancellation()
 
             // Write updated content
             do {
@@ -422,6 +528,7 @@ import os.log
                     details: path,
                     conversationId: conversationId
                 )
+                try Task.checkCancellation()
                 if !approved {
                     throw ToolExecutionError.permissionDenied(tool: ToolName.listDirectory, reason: "User denied")
                 }
@@ -487,6 +594,7 @@ import os.log
                     details: "Pattern: \(pattern) in \(path)",
                     conversationId: conversationId
                 )
+                try Task.checkCancellation()
                 if !approved {
                     throw ToolExecutionError.permissionDenied(tool: ToolName.searchFiles, reason: "User denied")
                 }
@@ -523,7 +631,9 @@ import os.log
                 guard resourceValues?.isRegularFile == true else { continue }
 
                 let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
-                if let size = attrs?[.size] as? Int, size > maxReadSize { continue }
+                if let size = attrs?[.size] as? Int, size > maxReadSize {
+                    continue
+                }
 
                 // Read file
                 guard let data = try? Data(contentsOf: fileURL),
@@ -544,7 +654,9 @@ import os.log
                             matchEnd: match.range.location + match.range.length
                         ))
 
-                        if results.count >= maxSearchResults { break }
+                        if results.count >= maxSearchResults {
+                            break
+                        }
                     }
                 }
             }
@@ -600,14 +712,13 @@ import os.log
                     details: command,
                     conversationId: conversationId
                 )
+                try Task.checkCancellation()
                 if !approved {
                     throw ToolExecutionError.permissionDenied(tool: ToolName.runCommand, reason: "User denied")
                 }
-                // Only remember allowed commands
-                if validation == .allowed {
-                    permissionService.recordSessionApproval(tool: ToolName.runCommand, details: command)
-                }
             }
+
+            try Task.checkCancellation()
 
             // Execute command off the main thread to prevent UI freezes
             let startTime = Date()
@@ -645,58 +756,32 @@ import os.log
             timeoutSeconds: Int,
             startTime: Date
         ) async throws -> CommandResult {
-            // Use a class to share process reference with cancellation handler
-            final class ProcessHolder: @unchecked Sendable {
-                private var _process: Process?
-                private let lock = NSLock()
-
-                var process: Process? {
-                    get {
-                        lock.lock()
-                        defer { lock.unlock() }
-                        return _process
-                    }
-                    set {
-                        lock.lock()
-                        defer { lock.unlock() }
-                        _process = newValue
-                    }
-                }
-            }
-            let processHolder = ProcessHolder()
+            let processHolder = ProcessExecutionController()
+            let processStartGate = processStartGate
+            let processCompletionGate = processCompletionGate
 
             return try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { continuation in
                     Task.detached {
-                        let process = Process()
-                        processHolder.process = process
+                        await processStartGate()
 
-                        let stdoutPipe = Pipe()
-                        let stderrPipe = Pipe()
-
-                        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-                        process.arguments = ["-c", command]
-                        process.standardOutput = stdoutPipe
-                        process.standardError = stderrPipe
-
-                        if let workingDir {
-                            process.currentDirectoryURL = workingDir
+                        do {
+                            guard let process = try processHolder.start(
+                                command: command,
+                                workingDirectory: workingDir
+                            ) else {
+                                continuation.resume(throwing: CancellationError())
+                                return
                         }
 
-                        // Set up timeout task
                         let timeoutTask = Task {
                             do {
                                 try await Task.sleep(for: .seconds(timeoutSeconds))
-                                if process.isRunning {
-                                    process.terminate()
-                                }
+                                    processHolder.timeout()
                             } catch {
                                 // Cancelled - expected when process completes normally
                             }
                         }
-
-                        do {
-                            try process.run()
 
                             // Read both pipes concurrently to avoid deadlock (Apple TN2050).
                             // Sequential reads can deadlock if one pipe fills its buffer
@@ -705,50 +790,58 @@ import os.log
                             let stdoutAccumulator = PipeAccumulator(maxSize: self.maxOutputSize)
                             let stderrAccumulator = PipeAccumulator(maxSize: self.maxOutputSize)
 
-                            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                            process.standardOutput.readabilityHandler = { handle in
                                 let data = handle.availableData
                                 if data.isEmpty {
-                                    stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                                    process.standardOutput.readabilityHandler = nil
                                 } else {
                                     stdoutAccumulator.append(data)
                                 }
                             }
-                            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                            process.standardError.readabilityHandler = { handle in
                                 let data = handle.availableData
                                 if data.isEmpty {
-                                    stderrPipe.fileHandleForReading.readabilityHandler = nil
+                                    process.standardError.readabilityHandler = nil
                                 } else {
                                     stderrAccumulator.append(data)
                                 }
                             }
 
-                            process.waitUntilExit()
+                            let terminationStatus = process.waitUntilExit()
                             timeoutTask.cancel()
 
-                            // Clear handlers after exit
-                            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                            stderrPipe.fileHandleForReading.readabilityHandler = nil
-
-                            // Drain any remaining buffered data not captured by handlers
-                            let remainingStdout = stdoutPipe.fileHandleForReading.availableData
-                            let remainingStderr = stderrPipe.fileHandleForReading.availableData
-                            if !remainingStdout.isEmpty {
-                                stdoutAccumulator.append(remainingStdout)
+                            // Drain only bytes already buffered. A descendant retaining a write end
+                            // must never make post-exit cleanup block indefinitely.
+                            process.standardOutput.readabilityHandler = nil
+                            process.standardError.readabilityHandler = nil
+                            let remaining = process.drainAvailableOutput()
+                            if !remaining.stdout.isEmpty {
+                                stdoutAccumulator.append(remaining.stdout)
                             }
-                            if !remainingStderr.isEmpty {
-                                stderrAccumulator.append(remainingStderr)
+                            if !remaining.stderr.isEmpty {
+                                stderrAccumulator.append(remaining.stderr)
                             }
+                            process.closeOutput()
 
                             let duration = Date().timeIntervalSince(startTime)
 
                             var stdout = String(data: stdoutAccumulator.data, encoding: .utf8) ?? ""
                             var stderr = String(data: stderrAccumulator.data, encoding: .utf8) ?? ""
                             let truncationNote = "\n[Output truncated at \(self.maxOutputSize / 1024 / 1024)MB]"
-                            if stdoutAccumulator.truncated { stdout += truncationNote }
-                            if stderrAccumulator.truncated { stderr += truncationNote }
+                            if stdoutAccumulator.truncated {
+                                stdout += truncationNote
+                            }
+                            if stderrAccumulator.truncated {
+                                stderr += truncationNote
+                            }
 
+                            await processCompletionGate()
+                            guard processHolder.finishIfNotCancelled() else {
+                                continuation.resume(throwing: CancellationError())
+                                return
+                            }
                             let commandResult = CommandResult(
-                                exitCode: process.terminationStatus,
+                                exitCode: terminationStatus,
                                 stdout: stdout,
                                 stderr: stderr,
                                 duration: duration
@@ -756,19 +849,20 @@ import os.log
 
                             continuation.resume(returning: commandResult)
                         } catch {
+                            if processHolder.finishIfNotCancelled() {
                             continuation.resume(throwing: ToolExecutionError.commandFailed(
                                 command: command,
                                 exitCode: -1,
                                 stderr: error.localizedDescription
                             ))
+                            } else {
+                                continuation.resume(throwing: CancellationError())
                         }
                     }
                 }
-            } onCancel: {
-                // Terminate the process if the task is cancelled (e.g., user cancels stream)
-                if let process = processHolder.process, process.isRunning {
-                    process.terminate()
                 }
+            } onCancel: {
+                processHolder.cancel()
             }
         }
 

--- a/Sources/Ayna/Services/BuiltinToolService.swift
+++ b/Sources/Ayna/Services/BuiltinToolService.swift
@@ -77,7 +77,17 @@ import os.log
         }
 
         private let lock = NSLock()
+        private let processEscalationGate: @Sendable () async -> Void
+        private let subprocessSignal: CommandSubprocess.SignalProcess
         private var state = State()
+
+        init(
+            processEscalationGate: @escaping @Sendable () async -> Void,
+            subprocessSignal: @escaping CommandSubprocess.SignalProcess
+        ) {
+            self.processEscalationGate = processEscalationGate
+            self.subprocessSignal = subprocessSignal
+        }
 
         func start(command: String, workingDirectory: URL?) throws -> CommandSubprocess? {
             lock.lock()
@@ -89,7 +99,8 @@ import os.log
                 // Keep installation and startup atomic with cancellation.
                 let process = try CommandSubprocess.start(
                     command: command,
-                    workingDirectory: workingDirectory
+                    workingDirectory: workingDirectory,
+                    signalProcess: subprocessSignal
                 )
                 state.process = process
                 lock.unlock()
@@ -109,13 +120,21 @@ import os.log
             requestTermination(markCancelled: false)
         }
 
-        func finishIfNotCancelled() -> Bool {
+        func commitCompletion() -> Bool {
             lock.lock()
             defer { lock.unlock() }
-            guard !state.isCancelled, !state.completionCommitted else { return false }
+            guard !state.completionCommitted else { return false }
             state.completionCommitted = true
             state.process = nil
-            return true
+            return !state.isCancelled
+        }
+
+        func didReap(_ process: CommandSubprocess) {
+            lock.lock()
+            defer { lock.unlock() }
+            if state.process === process {
+                state.process = nil
+            }
         }
 
         private func requestTermination(markCancelled: Bool) {
@@ -141,8 +160,9 @@ import os.log
             // `Process.terminate()` only sends SIGTERM. Commands may trap or ignore it,
             // which would otherwise leave `waitUntilExit()` and the awaiting tool task
             // suspended forever. Escalate to SIGKILL after a short grace period.
+            let processEscalationGate = processEscalationGate
             Task.detached { [weak self] in
-                try? await Task.sleep(for: .milliseconds(250))
+                await processEscalationGate()
                 guard let self, self.shouldForceKill(process) else { return }
                 process.forceKill()
             }
@@ -169,6 +189,8 @@ import os.log
         private let pathValidator: PathValidator
         private let processStartGate: @Sendable () async -> Void
         private let processCompletionGate: @Sendable () async -> Void
+        private let processEscalationGate: @Sendable () async -> Void
+        private let subprocessSignal: CommandSubprocess.SignalProcess
         let projectRoot: URL?
 
         /// Whether the service is enabled
@@ -205,7 +227,11 @@ import os.log
             shellSandbox: ShellSandbox? = nil,
             projectRoot: URL? = nil,
             processStartGate: @escaping @Sendable () async -> Void = {},
-            processCompletionGate: @escaping @Sendable () async -> Void = {}
+            processCompletionGate: @escaping @Sendable () async -> Void = {},
+            processEscalationGate: @escaping @Sendable () async -> Void = {
+                try? await Task.sleep(for: .milliseconds(250))
+            },
+            subprocessSignal: @escaping CommandSubprocess.SignalProcess = { Darwin.kill($0, $1) }
         ) {
             self.permissionService = permissionService
             self.projectRoot = projectRoot
@@ -213,6 +239,8 @@ import os.log
             self.shellSandbox = shellSandbox ?? ShellSandbox(projectRoot: projectRoot)
             self.processStartGate = processStartGate
             self.processCompletionGate = processCompletionGate
+            self.processEscalationGate = processEscalationGate
+            self.subprocessSignal = subprocessSignal
         }
 
         // MARK: - File Operations
@@ -756,7 +784,10 @@ import os.log
             timeoutSeconds: Int,
             startTime: Date
         ) async throws -> CommandResult {
-            let processHolder = ProcessExecutionController()
+            let processHolder = ProcessExecutionController(
+                processEscalationGate: processEscalationGate,
+                subprocessSignal: subprocessSignal
+            )
             let processStartGate = processStartGate
             let processCompletionGate = processCompletionGate
 
@@ -772,16 +803,16 @@ import os.log
                             ) else {
                                 continuation.resume(throwing: CancellationError())
                                 return
-                        }
-
-                        let timeoutTask = Task {
-                            do {
-                                try await Task.sleep(for: .seconds(timeoutSeconds))
-                                    processHolder.timeout()
-                            } catch {
-                                // Cancelled - expected when process completes normally
                             }
-                        }
+
+                            let timeoutTask = Task {
+                                do {
+                                    try await Task.sleep(for: .seconds(timeoutSeconds))
+                                    processHolder.timeout()
+                                } catch {
+                                    // Cancelled - expected when process completes normally
+                                }
+                            }
 
                             // Read both pipes concurrently to avoid deadlock (Apple TN2050).
                             // Sequential reads can deadlock if one pipe fills its buffer
@@ -808,6 +839,7 @@ import os.log
                             }
 
                             let terminationStatus = process.waitUntilExit()
+                            processHolder.didReap(process)
                             timeoutTask.cancel()
 
                             // Drain only bytes already buffered. A descendant retaining a write end
@@ -836,7 +868,7 @@ import os.log
                             }
 
                             await processCompletionGate()
-                            guard processHolder.finishIfNotCancelled() else {
+                            guard processHolder.commitCompletion() else {
                                 continuation.resume(throwing: CancellationError())
                                 return
                             }
@@ -849,17 +881,17 @@ import os.log
 
                             continuation.resume(returning: commandResult)
                         } catch {
-                            if processHolder.finishIfNotCancelled() {
-                            continuation.resume(throwing: ToolExecutionError.commandFailed(
-                                command: command,
-                                exitCode: -1,
-                                stderr: error.localizedDescription
-                            ))
+                            if processHolder.commitCompletion() {
+                                continuation.resume(throwing: ToolExecutionError.commandFailed(
+                                    command: command,
+                                    exitCode: -1,
+                                    stderr: error.localizedDescription
+                                ))
                             } else {
                                 continuation.resume(throwing: CancellationError())
+                            }
                         }
                     }
-                }
                 }
             } onCancel: {
                 processHolder.cancel()

--- a/Sources/Ayna/Services/CommandSubprocess.swift
+++ b/Sources/Ayna/Services/CommandSubprocess.swift
@@ -1,0 +1,200 @@
+#if os(macOS)
+    import Darwin
+    import Foundation
+
+    /// A shell subprocess launched as the leader of its own process group.
+    ///
+    /// Group ownership lets cancellation and timeout terminate the shell and every descendant,
+    /// including background jobs that would otherwise retain stdout/stderr pipes indefinitely.
+    final class CommandSubprocess: @unchecked Sendable {
+        let processIdentifier: pid_t
+        let standardOutput: FileHandle
+        let standardError: FileHandle
+
+        private init(
+            processIdentifier: pid_t,
+            standardOutput: FileHandle,
+            standardError: FileHandle
+        ) {
+            self.processIdentifier = processIdentifier
+            self.standardOutput = standardOutput
+            self.standardError = standardError
+        }
+
+        static func start(command: String, workingDirectory: URL?) throws -> CommandSubprocess {
+            var stdoutDescriptors: [Int32] = [0, 0]
+            var stderrDescriptors: [Int32] = [0, 0]
+            guard pipe(&stdoutDescriptors) == 0 else {
+                throw posixError(errno)
+            }
+            guard pipe(&stderrDescriptors) == 0 else {
+                close(stdoutDescriptors[0])
+                close(stdoutDescriptors[1])
+                throw posixError(errno)
+            }
+
+            var fileActions: posix_spawn_file_actions_t?
+            var attributes: posix_spawnattr_t?
+            posix_spawn_file_actions_init(&fileActions)
+            posix_spawnattr_init(&attributes)
+            defer {
+                posix_spawn_file_actions_destroy(&fileActions)
+                posix_spawnattr_destroy(&attributes)
+            }
+
+            posix_spawn_file_actions_adddup2(&fileActions, stdoutDescriptors[1], STDOUT_FILENO)
+            posix_spawn_file_actions_adddup2(&fileActions, stderrDescriptors[1], STDERR_FILENO)
+            posix_spawn_file_actions_addclose(&fileActions, stdoutDescriptors[0])
+            posix_spawn_file_actions_addclose(&fileActions, stderrDescriptors[0])
+            posix_spawn_file_actions_addclose(&fileActions, stdoutDescriptors[1])
+            posix_spawn_file_actions_addclose(&fileActions, stderrDescriptors[1])
+
+            if let workingDirectory {
+                let result = workingDirectory.path.withCString {
+                    posix_spawn_file_actions_addchdir(&fileActions, $0)
+                }
+                guard result == 0 else {
+                    closePipeDescriptors(stdoutDescriptors, stderrDescriptors)
+                    throw posixError(result)
+                }
+            }
+
+            posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP))
+            posix_spawnattr_setpgroup(&attributes, 0)
+
+            let arguments = ["/bin/zsh", "-c", command]
+            var argumentPointers: [UnsafeMutablePointer<CChar>?] = arguments.map { strdup($0) }
+            argumentPointers.append(nil)
+            defer {
+                argumentPointers.dropLast().forEach { free($0) }
+            }
+
+            var processIdentifier: pid_t = 0
+            let spawnResult = "/bin/zsh".withCString { executable in
+                argumentPointers.withUnsafeMutableBufferPointer { buffer in
+                    posix_spawn(
+                        &processIdentifier,
+                        executable,
+                        &fileActions,
+                        &attributes,
+                        buffer.baseAddress,
+                        environ
+                    )
+                }
+            }
+
+            close(stdoutDescriptors[1])
+            close(stderrDescriptors[1])
+            guard spawnResult == 0 else {
+                close(stdoutDescriptors[0])
+                close(stderrDescriptors[0])
+                throw posixError(spawnResult)
+            }
+
+            return CommandSubprocess(
+                processIdentifier: processIdentifier,
+                standardOutput: FileHandle(fileDescriptor: stdoutDescriptors[0], closeOnDealloc: true),
+                standardError: FileHandle(fileDescriptor: stderrDescriptors[0], closeOnDealloc: true)
+            )
+        }
+
+        var isRunning: Bool {
+            if kill(processIdentifier, 0) == 0 {
+                return true
+            }
+            return errno != ESRCH
+        }
+
+        func terminate() {
+            signalProcessGroup(SIGTERM)
+        }
+
+        func forceKill() {
+            signalProcessGroup(SIGKILL)
+        }
+
+        /// Waits for the shell leader, then tears down any background descendants in its group.
+        func waitUntilExit() -> Int32 {
+            var status: Int32 = 0
+            while waitpid(processIdentifier, &status, 0) == -1, errno == EINTR {}
+
+            terminateRemainingProcessGroup()
+            return Self.exitCode(from: status)
+        }
+
+        func drainAvailableOutput() -> (stdout: Data, stderr: Data) {
+            (
+                Self.readAvailableData(from: standardOutput),
+                Self.readAvailableData(from: standardError)
+            )
+        }
+
+        func closeOutput() {
+            standardOutput.readabilityHandler = nil
+            standardError.readabilityHandler = nil
+            try? standardOutput.close()
+            try? standardError.close()
+        }
+
+        private func terminateRemainingProcessGroup() {
+            guard kill(-processIdentifier, 0) == 0 else { return }
+            _ = kill(-processIdentifier, SIGTERM)
+            usleep(50000)
+            if kill(-processIdentifier, 0) == 0 {
+                _ = kill(-processIdentifier, SIGKILL)
+            }
+        }
+
+        private func signalProcessGroup(_ signal: Int32) {
+            if kill(-processIdentifier, signal) == -1, errno == ESRCH {
+                _ = kill(processIdentifier, signal)
+            }
+        }
+
+        private static func readAvailableData(from handle: FileHandle) -> Data {
+            let descriptor = handle.fileDescriptor
+            let oldFlags = fcntl(descriptor, F_GETFL)
+            if oldFlags >= 0 {
+                _ = fcntl(descriptor, F_SETFL, oldFlags | O_NONBLOCK)
+            }
+            defer {
+                if oldFlags >= 0 {
+                    _ = fcntl(descriptor, F_SETFL, oldFlags)
+                }
+            }
+
+            var result = Data()
+            var buffer = [UInt8](repeating: 0, count: 8192)
+            while true {
+                let count = buffer.withUnsafeMutableBytes {
+                    Darwin.read(descriptor, $0.baseAddress, $0.count)
+                }
+                if count > 0 {
+                    result.append(buffer, count: count)
+                } else if count == -1, errno == EINTR {
+                    continue
+                } else {
+                    break
+                }
+            }
+            return result
+        }
+
+        private static func exitCode(from waitStatus: Int32) -> Int32 {
+            let signal = waitStatus & 0x7F
+            if signal == 0 {
+                return (waitStatus >> 8) & 0xFF
+            }
+            return signal
+        }
+
+        private static func closePipeDescriptors(_ stdout: [Int32], _ stderr: [Int32]) {
+            stdout.forEach { close($0) }
+            stderr.forEach { close($0) }
+        }
+
+        private static func posixError(_ code: Int32) -> NSError {
+            NSError(domain: NSPOSIXErrorDomain, code: Int(code))
+        }
+    }
+#endif

--- a/Sources/Ayna/Services/CommandSubprocess.swift
+++ b/Sources/Ayna/Services/CommandSubprocess.swift
@@ -7,21 +7,33 @@
     /// Group ownership lets cancellation and timeout terminate the shell and every descendant,
     /// including background jobs that would otherwise retain stdout/stderr pipes indefinitely.
     final class CommandSubprocess: @unchecked Sendable {
+        typealias SignalProcess = @Sendable (_ processIdentifier: pid_t, _ signal: Int32) -> Int32
+
         let processIdentifier: pid_t
         let standardOutput: FileHandle
         let standardError: FileHandle
 
+        private let signalLock = NSLock()
+        private let signalProcess: SignalProcess
+        private var ownsSignalTarget = true
+
         private init(
             processIdentifier: pid_t,
             standardOutput: FileHandle,
-            standardError: FileHandle
+            standardError: FileHandle,
+            signalProcess: @escaping SignalProcess
         ) {
             self.processIdentifier = processIdentifier
             self.standardOutput = standardOutput
             self.standardError = standardError
+            self.signalProcess = signalProcess
         }
 
-        static func start(command: String, workingDirectory: URL?) throws -> CommandSubprocess {
+        static func start(
+            command: String,
+            workingDirectory: URL?,
+            signalProcess: @escaping SignalProcess = { Darwin.kill($0, $1) }
+        ) throws -> CommandSubprocess {
             var stdoutDescriptors: [Int32] = [0, 0]
             var stderrDescriptors: [Int32] = [0, 0]
             guard pipe(&stdoutDescriptors) == 0 else {
@@ -94,15 +106,19 @@
             return CommandSubprocess(
                 processIdentifier: processIdentifier,
                 standardOutput: FileHandle(fileDescriptor: stdoutDescriptors[0], closeOnDealloc: true),
-                standardError: FileHandle(fileDescriptor: stderrDescriptors[0], closeOnDealloc: true)
+                standardError: FileHandle(fileDescriptor: stderrDescriptors[0], closeOnDealloc: true),
+                signalProcess: signalProcess
             )
         }
 
         var isRunning: Bool {
-            if kill(processIdentifier, 0) == 0 {
+            guard let probe = signalOwnedTarget(processIdentifier, 0) else {
+                return false
+            }
+            if probe.result == 0 {
                 return true
             }
-            return errno != ESRCH
+            return probe.errorCode != ESRCH
         }
 
         func terminate() {
@@ -115,10 +131,17 @@
 
         /// Waits for the shell leader, then tears down any background descendants in its group.
         func waitUntilExit() -> Int32 {
+            let exitObserved = waitForExitWithoutReaping()
+            if exitObserved {
+                // The zombie leader still reserves both its PID and process-group identifier,
+                // so descendant cleanup cannot target a reused process.
+                terminateRemainingProcessGroup()
+            }
+            revokeSignalAuthority()
+
             var status: Int32 = 0
             while waitpid(processIdentifier, &status, 0) == -1, errno == EINTR {}
 
-            terminateRemainingProcessGroup()
             return Self.exitCode(from: status)
         }
 
@@ -136,19 +159,54 @@
             try? standardError.close()
         }
 
+        private func waitForExitWithoutReaping() -> Bool {
+            var signalInformation = siginfo_t()
+            while waitid(
+                P_PID,
+                id_t(processIdentifier),
+                &signalInformation,
+                WEXITED | WNOWAIT
+            ) == -1 {
+                if errno == EINTR {
+                    continue
+                }
+                return false
+            }
+            return true
+        }
+
         private func terminateRemainingProcessGroup() {
-            guard kill(-processIdentifier, 0) == 0 else { return }
-            _ = kill(-processIdentifier, SIGTERM)
+            guard signalOwnedTarget(-processIdentifier, 0)?.result == 0 else { return }
+            _ = signalOwnedTarget(-processIdentifier, SIGTERM)
             usleep(50000)
-            if kill(-processIdentifier, 0) == 0 {
-                _ = kill(-processIdentifier, SIGKILL)
+            if signalOwnedTarget(-processIdentifier, 0)?.result == 0 {
+                _ = signalOwnedTarget(-processIdentifier, SIGKILL)
             }
         }
 
         private func signalProcessGroup(_ signal: Int32) {
-            if kill(-processIdentifier, signal) == -1, errno == ESRCH {
-                _ = kill(processIdentifier, signal)
+            guard let groupSignal = signalOwnedTarget(-processIdentifier, signal) else { return }
+            if groupSignal.result == -1, groupSignal.errorCode == ESRCH {
+                _ = signalOwnedTarget(processIdentifier, signal)
             }
+        }
+
+        private func signalOwnedTarget(
+            _ target: pid_t,
+            _ signal: Int32
+        ) -> (result: Int32, errorCode: Int32)? {
+            signalLock.lock()
+            defer { signalLock.unlock() }
+            guard ownsSignalTarget else { return nil }
+
+            let result = signalProcess(target, signal)
+            return (result, errno)
+        }
+
+        private func revokeSignalAuthority() {
+            signalLock.lock()
+            ownsSignalTarget = false
+            signalLock.unlock()
         }
 
         private static func readAvailableData(from handle: FileHandle) -> Data {

--- a/Sources/Ayna/Services/ConversationPersistenceCoordinator.swift
+++ b/Sources/Ayna/Services/ConversationPersistenceCoordinator.swift
@@ -405,17 +405,21 @@ final class ConversationPersistenceCoordinator {
         }
 
         ensureRewriteScheduled()
-        let pendingSaves = dirty.compactMap { id, intent -> (UUID, UInt64)? in
+        let pendingIntents = dirty.compactMap { id, intent -> (UUID, UInt64, DesiredState)? in
             guard proposedSaves[id] == nil,
-                  !intent.isScheduled, rewriteCoveredTokens[id] != intent.token,
-                  case .saved = intent.desired
+                  !intent.isScheduled, rewriteCoveredTokens[id] != intent.token
             else {
                 return nil
             }
-            return (id, intent.token)
+            return (id, intent.token, intent.desired)
         }
-        for (id, token) in pendingSaves {
-            activateSave(id: id, token: token)
+        for (id, token, desired) in pendingIntents {
+            switch desired {
+            case .saved:
+                activateSave(id: id, token: token)
+            case .deleted:
+                activateDelete(id: id, token: token)
+            }
         }
 
         let cutoff = nextTokenValue

--- a/Sources/Ayna/Services/ConversationPersistenceCoordinator.swift
+++ b/Sources/Ayna/Services/ConversationPersistenceCoordinator.swift
@@ -6,201 +6,593 @@
 //
 
 import Foundation
-import os.log
+import OSLog
 
-/// Notification posted when a conversation save fails (contains conversationId in userInfo)
-extension Notification.Name {
-    static let conversationSaveFailed = Notification.Name("conversationSaveFailed")
+protocol ConversationStoreAdapter: Sendable {
+    func loadConversations() async throws -> [Conversation]
+    func save(_ conversation: Conversation) async throws
+    func delete(_ conversationID: UUID) async throws
+    func clearConversations() async throws
 }
 
-/// Actor that coordinates conversation persistence to prevent race conditions.
-/// All save operations are serialized through this actor, with debouncing
-/// to coalesce rapid successive saves.
-actor ConversationPersistenceCoordinator {
-    private var pendingSaves: [UUID: Conversation] = [:]
-    private var activeSaveTasks: [UUID: Task<Void, Never>] = [:]
-    private let store: EncryptedConversationStore
+extension EncryptedConversationStore: ConversationStoreAdapter {
+    func clearConversations() async throws {
+        try await Task.detached(priority: .userInitiated) { [self] in
+            try clear()
+        }.value
+    }
+}
+
+enum ConversationSaveMode: Sendable { case coalesced, immediate }
+
+struct PersistenceReceipt<Value: Sendable>: Sendable {
+    fileprivate let task: Task<Value, Never>
+    fileprivate let reconcile: (@MainActor @Sendable (Value) -> Value)?
+
+    fileprivate init(
+        task: Task<Value, Never>,
+        reconcile: (@MainActor @Sendable (Value) -> Value)? = nil
+    ) {
+        self.task = task
+        self.reconcile = reconcile
+    }
+
+    @MainActor
+    var value: Value {
+        get async {
+            let settled = await task.value
+            return reconcile?(settled) ?? settled
+        }
+    }
+}
+
+enum ConversationLoadResult: Equatable, Sendable {
+    case loaded([Conversation]), failed(String), superseded
+}
+
+enum ConversationDeleteResult: Equatable, Sendable {
+    case deleted, failed(Conversation, String), superseded
+}
+
+enum ConversationClearResult: Equatable, Sendable {
+    case cleared, failed([Conversation], String), superseded
+}
+
+@MainActor
+final class ConversationPersistenceCoordinator {
+    private enum DesiredState { case saved(Conversation), deleted }
+
+    private struct DirtyIntent {
+        let token: UInt64
+        let root: UInt64
+        let desired: DesiredState
+        var isScheduled: Bool
+    }
+
+    private struct ClearLayer {
+        let token: UInt64
+        let changes: [UUID: DesiredState]
+    }
+
+    private let store: any ConversationStoreAdapter
     private let debounceDuration: Duration
 
+    private var snapshot: [UUID: Conversation] = [:]
+    private var storageSnapshot: [UUID: Conversation] = [:]
+    private var dirty: [UUID: DirtyIntent] = [:]
+    private var debounceTasks: [UUID: Task<Void, Never>] = [:]
+    private var outstandingByRoot: [UInt64: Int] = [:]
+
+    private var nextTokenValue: UInt64 = 0
+    private var latestLoadToken: UInt64 = 0
+    private var latestClearToken: UInt64 = 0
+    private var clearLayers: [ClearLayer] = []
+
+    private var rewriteToken: UInt64?
+    private var rewriteRoot: UInt64?
+    private var rewriteScheduledToken: UInt64?
+    private var rewriteCoveredTokens: [UUID: UInt64] = [:]
+    private var repairDeletedIDs: Set<UUID> = []
+
+    private var ioTail = Task { @MainActor in }
+
     init(
-        store: EncryptedConversationStore = .shared,
+        store: any ConversationStoreAdapter = EncryptedConversationStore.shared,
         debounceDuration: Duration = .milliseconds(200)
     ) {
         self.store = store
         self.debounceDuration = debounceDuration
     }
 
-    /// Enqueue a conversation for saving with debouncing.
-    /// Multiple rapid saves for the same conversation will be coalesced.
-    func enqueueSave(_ conversation: Conversation) {
-        // Store the latest version
-        pendingSaves[conversation.id] = conversation
+    @discardableResult
+    func apply(
+        _ conversation: Conversation,
+        mode: ConversationSaveMode = .coalesced
+    ) -> PersistenceReceipt<Void>? {
+        let token = nextToken()
+        let id = conversation.id
 
-        // Cancel any existing save task for this conversation
-        activeSaveTasks[conversation.id]?.cancel()
+        snapshot[id] = conversation
+        repairDeletedIDs.remove(id)
+        cancelDebounce(for: id)
+        dirty[id] = DirtyIntent(
+            token: token,
+            root: token,
+            desired: .saved(conversation),
+            isScheduled: false
+        )
 
-        // Create new debounced save task
-        activeSaveTasks[conversation.id] = Task { [weak self] in
-            guard let self else { return }
+        ensureRewriteScheduled()
+        if rewriteCoveredTokens[id] == token {
+            return mode == .immediate ? PersistenceReceipt(task: ioTail) : nil
+        }
+        if mode == .immediate || debounceDuration <= .zero {
+            return activateSave(id: id, token: token)
+        }
+        scheduleDebounce(id: id, token: token)
+        return nil
+    }
 
+    func load() -> PersistenceReceipt<ConversationLoadResult> {
+        let token = nextToken()
+        latestLoadToken = token
+        let store = store
+
+        let physical: PersistenceReceipt<ConversationLoadResult> = appendOperation(root: token) { [weak self] in
             do {
-                try await Task.sleep(for: debounceDuration)
+                let conversations = try await store.loadConversations()
+                guard let self else { return .superseded }
+                self.storageSnapshot = self.dictionary(from: conversations)
+                return self.finishLoad(conversations, token: token)
             } catch {
-                // Task was cancelled, which is expected when a newer save comes in
+                guard let self, self.latestLoadToken == token else { return .superseded }
+                self.log("❌ Failed to load conversations", level: .error, metadata: ["error": error.localizedDescription])
+                return .failed(error.localizedDescription)
+            }
+        }
+        return PersistenceReceipt(task: physical.task) { [weak self] result in
+            self?.reconcileLoad(result, token: token) ?? .superseded
+        }
+    }
+
+    func delete(_ conversation: Conversation) -> PersistenceReceipt<ConversationDeleteResult> {
+        let token = nextToken()
+        let id = conversation.id
+
+        snapshot.removeValue(forKey: id)
+        cancelDebounce(for: id)
+        dirty[id] = DirtyIntent(token: token, root: token, desired: .deleted, isScheduled: true)
+        ensureRewriteScheduled()
+
+        let store = store
+        let physical: PersistenceReceipt<ConversationDeleteResult> = appendOperation(root: token) { [weak self] in
+            do {
+                try await store.delete(id)
+                guard let self else { return .superseded }
+                self.storageSnapshot.removeValue(forKey: id)
+                self.repairDeletedIDs.remove(id)
+                return self.finishDelete(id: id, token: token, rollback: conversation, error: nil)
+            } catch {
+                guard let self else { return .superseded }
+                return self.finishDelete(
+                    id: id,
+                    token: token,
+                    rollback: conversation,
+                    error: error.localizedDescription
+                )
+            }
+        }
+        return PersistenceReceipt(task: physical.task) { [weak self] result in
+            self?.reconcileDelete(result, id: id, token: token) ?? .superseded
+        }
+    }
+
+    func clear(_ conversations: [Conversation]) -> PersistenceReceipt<ConversationClearResult> {
+        let ownedSnapshot = dictionary(from: conversations)
+        let priorDirty = dirty
+        let token = nextToken()
+        var changes = snapshot.mapValues { DesiredState.saved($0) }
+        for id in repairDeletedIDs {
+            changes[id] = .deleted
+        }
+        for (id, intent) in priorDirty {
+            changes[id] = intent.desired
+        }
+        for (id, conversation) in ownedSnapshot {
+            changes[id] = .saved(conversation)
+        }
+        clearLayers.append(ClearLayer(token: token, changes: changes))
+
+        latestClearToken = token
+        latestLoadToken = nextToken()
+        invalidateRewrite()
+        cancelAllDebounces()
+        dirty.removeAll()
+        snapshot.removeAll()
+
+        let store = store
+        let physical: PersistenceReceipt<ConversationClearResult> = appendOperation(root: token) { [weak self] in
+            do {
+                try await store.clearConversations()
+                guard let self else { return .superseded }
+                self.storageSnapshot.removeAll()
+                return self.finishClear(token: token, error: nil)
+            } catch {
+                guard let self else { return .superseded }
+                return self.finishClear(token: token, error: error.localizedDescription)
+            }
+        }
+        return PersistenceReceipt(task: physical.task) { [weak self] result in
+            self?.reconcileClear(result, token: token) ?? .superseded
+        }
+    }
+
+    func flush() -> PersistenceReceipt<Void> {
+        let pendingDebounces = debounceTasks
+        debounceTasks.removeAll()
+        for task in pendingDebounces.values {
+            task.cancel()
+        }
+
+        ensureRewriteScheduled()
+        let pendingSaves = dirty.compactMap { id, intent -> (UUID, UInt64)? in
+            guard !intent.isScheduled, rewriteCoveredTokens[id] != intent.token,
+                  case .saved = intent.desired
+            else {
+                return nil
+            }
+            return (id, intent.token)
+        }
+        for (id, token) in pendingSaves {
+            activateSave(id: id, token: token)
+        }
+
+        let cutoff = nextTokenValue
+        let task = Task { @MainActor [weak self] in
+            while let self, self.hasOutstanding(rootAtMost: cutoff) {
+                let tail = self.ioTail
+                await tail.value
+            }
+        }
+        return PersistenceReceipt(task: task)
+    }
+
+    private func scheduleDebounce(id: UUID, token: UInt64) {
+        let duration = debounceDuration
+        debounceTasks[id] = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: duration)
+            } catch {
                 return
             }
-
-            // Check if we were cancelled or if there's a newer version
-            guard !Task.isCancelled else { return }
-
-            await performSave()
+            self?.activateSave(id: id, token: token)
         }
     }
 
-    /// Save immediately without debouncing.
-    /// Cancels any pending debounced save for this conversation.
-    func saveImmediately(_ conversation: Conversation) async throws {
-        // Cancel any pending debounced save
-        activeSaveTasks[conversation.id]?.cancel()
-        activeSaveTasks.removeValue(forKey: conversation.id)
-        pendingSaves.removeValue(forKey: conversation.id)
-
-        // Save directly
-        try await store.save(conversation)
-
-        DiagnosticsLogger.log(
-            .conversationManager,
-            level: .debug,
-            message: "💾 Saved conversation immediately",
-            metadata: ["id": conversation.id.uuidString]
-        )
-    }
-
-    /// Delete a conversation.
-    func delete(_ conversationId: UUID) async throws {
-        // Cancel any pending save for this conversation
-        activeSaveTasks[conversationId]?.cancel()
-        activeSaveTasks.removeValue(forKey: conversationId)
-        pendingSaves.removeValue(forKey: conversationId)
-
-        // Delete from store
-        try await store.delete(conversationId)
-    }
-
-    /// Cancel all pending saves (useful for shutdown).
-    func cancelAllPendingSaves() {
-        for task in activeSaveTasks.values {
-            task.cancel()
+    @discardableResult
+    private func activateSave(id: UUID, token: UInt64) -> PersistenceReceipt<Void>? {
+        guard var intent = dirty[id], intent.token == token, !intent.isScheduled,
+              case let .saved(conversation) = intent.desired
+        else {
+            return nil
         }
-        activeSaveTasks.removeAll()
-        pendingSaves.removeAll()
-    }
 
-    /// Flush all pending saves immediately, bypassing the debounce timer.
-    /// Call this on app termination to prevent data loss.
-    func flushPendingSaves() async {
-        // Cancel debounce timers — we'll save directly
-        for task in activeSaveTasks.values {
-            task.cancel()
+        cancelDebounce(for: id)
+        intent.isScheduled = true
+        dirty[id] = intent
+
+        let store = store
+        return appendOperation(root: intent.root) { [weak self] in
+            do {
+                try await store.save(conversation)
+                self?.storageSnapshot[id] = conversation
+                self?.finishSave(id: id, token: token, error: nil)
+            } catch {
+                self?.finishSave(id: id, token: token, error: error.localizedDescription)
+            }
         }
-        activeSaveTasks.removeAll()
-
-        // Save all pending conversations
-        let conversationsToSave = pendingSaves
-        pendingSaves.removeAll()
-
-        await persistConversations(
-            conversationsToSave,
-            successMessage: "💾 Flushed pending conversation save on shutdown",
-            failureMessage: "❌ Failed to flush conversation on shutdown",
-            notifyOnFailure: false
-        )
     }
 
-    /// Returns the set of conversation IDs that currently have a pending save queued.
-    /// Used to implement "dirty-wins" reload reconciliation.
-    func pendingConversationIds() -> Set<UUID> {
-        Set(pendingSaves.keys)
-    }
-
-    // MARK: - Private
-
-    private func performSave() async {
-        // Get all pending saves and clear them atomically
-        let conversationsToSave = pendingSaves
-        pendingSaves.removeAll()
-
-        guard !Task.isCancelled else {
-            requeuePendingConversations(conversationsToSave)
+    private func finishSave(id: UUID, token: UInt64, error: String?) {
+        guard var intent = dirty[id], intent.token == token, case .saved = intent.desired else {
             return
         }
 
-        await persistConversations(
-            conversationsToSave,
-            successMessage: "💾 Saved conversation (debounced)",
-            failureMessage: "❌ Failed to save conversation",
-            notifyOnFailure: true
+        if let error {
+            intent.isScheduled = false
+            dirty[id] = intent
+            log("❌ Failed to save conversation", level: .error, metadata: ["id": id.uuidString, "error": error])
+        } else {
+            dirty.removeValue(forKey: id)
+            log("💾 Saved conversation", level: .debug, metadata: ["id": id.uuidString])
+        }
+    }
+
+    private func finishDelete(
+        id: UUID,
+        token: UInt64,
+        rollback: Conversation,
+        error: String?
+    ) -> ConversationDeleteResult {
+        guard let intent = dirty[id], intent.token == token, case .deleted = intent.desired else {
+            return .superseded
+        }
+
+        guard let error else {
+            dirty.removeValue(forKey: id)
+            log("🗑️ Deleted conversation", level: .debug, metadata: ["id": id.uuidString])
+            return .deleted
+        }
+
+        let restoreToken = nextToken()
+        snapshot[id] = rollback
+        repairDeletedIDs.remove(id)
+        dirty[id] = DirtyIntent(
+            token: restoreToken,
+            root: intent.root,
+            desired: .saved(rollback),
+            isScheduled: false
         )
+        ensureRewriteScheduled()
+        if rewriteCoveredTokens[id] != restoreToken {
+            activateSave(id: id, token: restoreToken)
+        }
 
-        // B32: activeSaveTasks entries are NOT removed here. enqueueSave is the sole
-        // writer to activeSaveTasks[id], ensuring a newer task is never accidentally
-        // removed after an await suspension in store.save().
+        log("❌ Failed to delete conversation; restored latest edit", level: .error, metadata: ["id": id.uuidString, "error": error])
+        return .failed(rollback, error)
     }
 
-    private func persistConversations(
-        _ conversationsToSave: [UUID: Conversation],
-        successMessage: String,
-        failureMessage: String,
-        notifyOnFailure: Bool
-    ) async {
-        guard !conversationsToSave.isEmpty else { return }
+    private func finishClear(token: UInt64, error: String?) -> ConversationClearResult {
+        guard let layerIndex = clearLayers.firstIndex(where: { $0.token == token }) else {
+            return .superseded
+        }
+        let isLatest = latestClearToken == token
 
-        let persistenceStore = store
-        await withTaskGroup(of: (UUID, Result<Void, Error>).self) { group in
-            for (id, conversation) in conversationsToSave {
-                group.addTask {
-                    do {
-                        try await persistenceStore.save(conversation)
-                        return (id, .success(()))
-                    } catch {
-                        return (id, .failure(error))
-                    }
-                }
+        guard let error else {
+            clearLayers.removeFirst(layerIndex + 1)
+            repairDeletedIDs.removeAll()
+            log("🧹 Cleared encrypted conversation store", level: .info)
+            return isLatest ? .cleared : .superseded
+        }
+        guard isLatest else { return .superseded }
+
+        var restored = storageSnapshot
+        for layer in clearLayers.prefix(layerIndex + 1) {
+            updateRepairDeletions(with: layer.changes)
+            apply(layer.changes, to: &restored)
+        }
+        let dirtyChanges = dirty.mapValues(\.desired)
+        updateRepairDeletions(with: dirtyChanges)
+        apply(dirtyChanges, to: &restored)
+        snapshot = restored
+        clearLayers.removeFirst(layerIndex + 1)
+
+        rewriteToken = nextToken()
+        rewriteRoot = token
+        ensureRewriteScheduled()
+
+        let ordered = orderedSnapshot()
+        log("⚠️ Clear failed; scheduled storage repair", level: .error, metadata: ["error": error, "count": "\(ordered.count)"])
+        return .failed(ordered, error)
+    }
+
+    private func finishLoad(_ conversations: [Conversation], token: UInt64) -> ConversationLoadResult {
+        guard latestLoadToken == token else { return .superseded }
+
+        if rewriteToken == nil {
+            var reconciled = dictionary(from: conversations)
+            applyDirty(to: &reconciled)
+            snapshot = reconciled
+        }
+
+        let ordered = orderedSnapshot()
+        log("✅ Loaded \(ordered.count) conversations", level: .info, metadata: ["count": "\(ordered.count)"])
+        return .loaded(ordered)
+    }
+
+    private func reconcileLoad(
+        _ result: ConversationLoadResult,
+        token: UInt64
+    ) -> ConversationLoadResult {
+        guard latestLoadToken == token else { return .superseded }
+        if case .loaded = result {
+            return .loaded(orderedSnapshot())
+        }
+        return result
+    }
+
+    private func reconcileClear(
+        _ result: ConversationClearResult,
+        token: UInt64
+    ) -> ConversationClearResult {
+        guard latestClearToken == token else { return .superseded }
+        if case let .failed(_, error) = result {
+            return .failed(orderedSnapshot(), error)
+        }
+        return result
+    }
+
+    private func reconcileDelete(
+        _ result: ConversationDeleteResult,
+        id: UUID,
+        token: UInt64
+    ) -> ConversationDeleteResult {
+        guard latestClearToken <= token else { return .superseded }
+        switch result {
+        case .deleted:
+            return snapshot[id] == nil ? .deleted : .superseded
+        case let .failed(_, error):
+            guard let current = snapshot[id] else { return .superseded }
+            return .failed(current, error)
+        case .superseded:
+            return .superseded
+        }
+    }
+
+    private func ensureRewriteScheduled() {
+        guard let token = rewriteToken, let root = rewriteRoot, rewriteScheduledToken == nil else { return }
+
+        let conversations = orderedSnapshot()
+        let coveredTokens = dirty.mapValues(\.token)
+        rewriteScheduledToken = token
+        rewriteCoveredTokens = coveredTokens
+        let store = store
+
+        _ = appendOperation(root: root) { [weak self] in
+            var firstError: String?
+
+            do {
+                try await store.clearConversations()
+            } catch {
+                firstError = error.localizedDescription
             }
 
-            for await (id, result) in group {
-                switch result {
-                case .success:
-                    DiagnosticsLogger.log(
-                        .conversationManager,
-                        level: .debug,
-                        message: successMessage,
-                        metadata: ["id": id.uuidString]
-                    )
-                case let .failure(error):
-                    DiagnosticsLogger.log(
-                        .conversationManager,
-                        level: .error,
-                        message: failureMessage,
-                        metadata: ["id": id.uuidString, "error": error.localizedDescription]
-                    )
+            for conversation in conversations {
+                do {
+                    try await store.save(conversation)
+                } catch where firstError == nil {
+                    firstError = error.localizedDescription
+                } catch {}
+            }
 
-                    guard notifyOnFailure else { continue }
-                    await MainActor.run {
-                        NotificationCenter.default.post(
-                            name: .conversationSaveFailed,
-                            object: nil,
-                            userInfo: ["conversationId": id]
-                        )
-                    }
+            self?.finishRewrite(
+                token: token,
+                conversations: conversations,
+                coveredTokens: coveredTokens,
+                error: firstError
+            )
+        }
+    }
+
+    private func finishRewrite(
+        token: UInt64,
+        conversations: [Conversation],
+        coveredTokens: [UUID: UInt64],
+        error: String?
+    ) {
+        guard rewriteToken == token else { return }
+
+        rewriteScheduledToken = nil
+        rewriteCoveredTokens.removeAll(keepingCapacity: true)
+
+        guard let error else {
+            rewriteToken = nil
+            rewriteRoot = nil
+            repairDeletedIDs.removeAll()
+            storageSnapshot = dictionary(from: conversations)
+            for (id, coveredToken) in coveredTokens {
+                guard let intent = dirty[id], intent.token == coveredToken,
+                      case .saved = intent.desired
+                else {
+                    continue
                 }
+                dirty.removeValue(forKey: id)
+                cancelDebounce(for: id)
+            }
+            log("✅ Repaired conversation storage after failed clear", level: .info)
+            return
+        }
+
+        log("❌ Failed to repair conversation storage", level: .error, metadata: ["error": error])
+    }
+
+    private func invalidateRewrite() {
+        rewriteToken = nil
+        rewriteRoot = nil
+        rewriteScheduledToken = nil
+        rewriteCoveredTokens.removeAll(keepingCapacity: true)
+    }
+
+    private func appendOperation<Output: Sendable>(
+        root: UInt64,
+        _ operation: @escaping @MainActor @Sendable () async -> Output
+    ) -> PersistenceReceipt<Output> {
+        outstandingByRoot[root, default: 0] += 1
+        let predecessor = ioTail
+        let task = Task { @MainActor in
+            await predecessor.value
+            let output = await operation()
+            self.finishOperation(root: root)
+            return output
+        }
+        ioTail = Task { @MainActor in
+            _ = await task.value
+        }
+        return PersistenceReceipt(task: task)
+    }
+
+    private func finishOperation(root: UInt64) {
+        guard let count = outstandingByRoot[root] else { return }
+        if count == 1 {
+            outstandingByRoot.removeValue(forKey: root)
+        } else {
+            outstandingByRoot[root] = count - 1
+        }
+    }
+
+    private func hasOutstanding(rootAtMost cutoff: UInt64) -> Bool {
+        outstandingByRoot.contains { $0.key <= cutoff && $0.value > 0 }
+    }
+
+    private func updateRepairDeletions(with changes: [UUID: DesiredState]) {
+        for (id, desired) in changes {
+            switch desired {
+            case .saved: repairDeletedIDs.remove(id)
+            case .deleted: repairDeletedIDs.insert(id)
             }
         }
     }
 
-    private func requeuePendingConversations(_ conversationsToSave: [UUID: Conversation]) {
-        for (id, conversation) in conversationsToSave where pendingSaves[id] == nil {
-            pendingSaves[id] = conversation
+    private func apply(
+        _ changes: [UUID: DesiredState],
+        to conversations: inout [UUID: Conversation]
+    ) {
+        for (id, desired) in changes {
+            switch desired {
+            case let .saved(conversation): conversations[id] = conversation
+            case .deleted: conversations.removeValue(forKey: id)
+            }
         }
+    }
+
+    private func applyDirty(to conversations: inout [UUID: Conversation]) {
+        apply(dirty.mapValues(\.desired), to: &conversations)
+    }
+
+    private func dictionary(from conversations: [Conversation]) -> [UUID: Conversation] {
+        Dictionary(conversations.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
+    }
+
+    private func orderedSnapshot() -> [Conversation] {
+        snapshot.values.sorted { lhs, rhs in
+            if lhs.updatedAt == rhs.updatedAt {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.updatedAt > rhs.updatedAt
+        }
+    }
+
+    private func cancelDebounce(for id: UUID) {
+        debounceTasks.removeValue(forKey: id)?.cancel()
+    }
+
+    private func cancelAllDebounces() {
+        for task in debounceTasks.values {
+            task.cancel()
+        }
+        debounceTasks.removeAll(keepingCapacity: true)
+    }
+
+    private func nextToken() -> UInt64 {
+        nextTokenValue &+= 1
+        return nextTokenValue
+    }
+
+    private func log(
+        _ message: String,
+        level: OSLogType = .default,
+        metadata: [String: String] = [:]
+    ) {
+        DiagnosticsLogger.log(.conversationManager, level: level, message: message, metadata: metadata)
     }
 }

--- a/Sources/Ayna/Services/ConversationPersistenceCoordinator.swift
+++ b/Sources/Ayna/Services/ConversationPersistenceCoordinator.swift
@@ -25,6 +25,12 @@ extension EncryptedConversationStore: ConversationStoreAdapter {
 
 enum ConversationSaveMode: Sendable { case coalesced, immediate }
 
+enum ConversationSaveResult: Equatable, Sendable {
+    case saved
+    case failed(String)
+    case superseded
+}
+
 struct PersistenceReceipt<Value: Sendable>: Sendable {
     fileprivate let task: Task<Value, Never>
     fileprivate let reconcile: (@MainActor @Sendable (Value) -> Value)?
@@ -46,27 +52,87 @@ struct PersistenceReceipt<Value: Sendable>: Sendable {
     }
 }
 
+/// Opaque identity for the repair responsibility created by a destructive operation.
+struct ConversationSnapshotRepairToken: Hashable, Sendable {
+    fileprivate enum Kind: Hashable, Sendable {
+        case delete(UUID)
+        case clear
+    }
+
+    fileprivate let operationToken: UInt64
+    fileprivate let kind: Kind
+
+    func isSuperseded(by newer: Self) -> Bool {
+        guard operationToken < newer.operationToken else { return false }
+        switch (kind, newer.kind) {
+        case (_, .clear):
+            return true
+        case let (.delete(id), .delete(newerID)):
+            return id == newerID
+        case (.clear, .delete):
+            return false
+        }
+    }
+}
+
+/// Whether the current repair responsibility is durable, retryable, or obsolete.
+enum ConversationSnapshotSettlementResult: Equatable, Sendable {
+    case settled
+    case failed
+    case superseded
+}
+
+/// A prompt operation receipt plus the token used to settle any compensating repair.
+struct DestructivePersistenceReceipt<Value: Sendable>: Sendable {
+    fileprivate let receipt: PersistenceReceipt<Value>
+    let repairToken: ConversationSnapshotRepairToken
+
+    @MainActor
+    var value: Value {
+        get async {
+            await receipt.value
+        }
+    }
+}
+
 enum ConversationLoadResult: Equatable, Sendable {
     case loaded([Conversation]), failed(String), superseded
 }
 
 enum ConversationDeleteResult: Equatable, Sendable {
-    case deleted, failed(Conversation, String), superseded
+    case deleted, failed(Conversation?, String), superseded
 }
 
 enum ConversationClearResult: Equatable, Sendable {
     case cleared, failed([Conversation], String), superseded
 }
 
+enum ConversationDurabilityResult: Equatable, Sendable {
+    case saved
+    case deleted
+    case failed
+}
+
 @MainActor
+// swiftlint:disable:next type_body_length
 final class ConversationPersistenceCoordinator {
-    private enum DesiredState { case saved(Conversation), deleted }
+    private enum DesiredState: Sendable { case saved(Conversation), deleted }
 
     private struct DirtyIntent {
         let token: UInt64
         let root: UInt64
+        let repairRoot: UInt64?
         let desired: DesiredState
+        let rollback: Conversation?
         var isScheduled: Bool
+    }
+
+    /// A proposal chain shares the durable state from before any uncommitted proposal wrote.
+    private struct ProposedSaveIntent {
+        let token: UInt64
+        let chainRoot: UInt64
+        var priorDurable: DesiredState?
+        let rollback: Conversation?
     }
 
     private struct ClearLayer {
@@ -74,17 +140,26 @@ final class ConversationPersistenceCoordinator {
         let changes: [UUID: DesiredState]
     }
 
+    private enum SnapshotRepairStatus {
+        case settled
+        case pending(isScheduled: Bool)
+        case superseded
+    }
+
     private let store: any ConversationStoreAdapter
     private let debounceDuration: Duration
+    private var durableSnapshotObserver: (@MainActor @Sendable () -> Void)?
 
     private var snapshot: [UUID: Conversation] = [:]
     private var storageSnapshot: [UUID: Conversation] = [:]
     private var dirty: [UUID: DirtyIntent] = [:]
+    private var proposedSaves: [UUID: ProposedSaveIntent] = [:]
     private var debounceTasks: [UUID: Task<Void, Never>] = [:]
     private var outstandingByRoot: [UInt64: Int] = [:]
 
     private var nextTokenValue: UInt64 = 0
     private var latestLoadToken: UInt64 = 0
+    private var latestRequestedLoadToken: UInt64 = 0
     private var latestClearToken: UInt64 = 0
     private var clearLayers: [ClearLayer] = []
 
@@ -104,46 +179,119 @@ final class ConversationPersistenceCoordinator {
         self.debounceDuration = debounceDuration
     }
 
+    func observeDurableSnapshotChanges(
+        _ observer: @escaping @MainActor @Sendable () -> Void
+    ) {
+        durableSnapshotObserver = observer
+    }
+
+    func durableConversations() -> [Conversation] {
+        ordered(storageSnapshot)
+    }
+
     @discardableResult
     func apply(
         _ conversation: Conversation,
         mode: ConversationSaveMode = .coalesced
-    ) -> PersistenceReceipt<Void>? {
+    ) -> PersistenceReceipt<ConversationSaveResult>? {
         let token = nextToken()
         let id = conversation.id
+        // A normal edit refines the current desired state; it does not discharge an
+        // inherited destructive repair responsibility.
+        let repairRoot = dirty[id]?.repairRoot
+        let root = repairRoot ?? token
 
+        proposedSaves.removeValue(forKey: id)
         snapshot[id] = conversation
         repairDeletedIDs.remove(id)
         cancelDebounce(for: id)
         dirty[id] = DirtyIntent(
             token: token,
-            root: token,
+            root: root,
+            repairRoot: repairRoot,
             desired: .saved(conversation),
+            rollback: nil,
             isScheduled: false
         )
 
-        ensureRewriteScheduled()
-        if rewriteCoveredTokens[id] == token {
-            return mode == .immediate ? PersistenceReceipt(task: ioTail) : nil
-        }
         if mode == .immediate || debounceDuration <= .zero {
             return activateSave(id: id, token: token)
+        }
+        ensureRewriteScheduled()
+        if rewriteCoveredTokens[id] == token {
+            return nil
         }
         scheduleDebounce(id: id, token: token)
         return nil
     }
 
+    func saveProposed(_ conversation: Conversation) -> PersistenceReceipt<ConversationSaveResult> {
+        let token = nextToken()
+        let id = conversation.id
+        let priorProposal = proposedSaves[id]
+
+        let rollback: Conversation? = if let rollback = priorProposal?.rollback {
+            rollback
+        } else if let intent = dirty[id], case .deleted = intent.desired {
+            intent.rollback
+        } else {
+            nil
+        }
+
+        cancelDebounce(for: id)
+        proposedSaves[id] = ProposedSaveIntent(
+            token: token,
+            chainRoot: priorProposal?.chainRoot ?? token,
+            priorDurable: priorProposal?.priorDurable,
+            rollback: rollback
+        )
+
+        let chainRoot = priorProposal?.chainRoot ?? token
+        let store = store
+        let physical: PersistenceReceipt<ConversationSaveResult> = appendOperation(root: token) { [weak self] in
+            self?.capturePriorDurableState(for: id, chainRoot: chainRoot)
+            do {
+                try await store.save(conversation)
+                guard let self else { return .superseded }
+                self.storageSnapshot[id] = conversation
+                self.recordDurableSnapshotChange()
+                return self.finishProposedSave(conversation, token: token, error: nil)
+            } catch {
+                guard let self else { return .superseded }
+                let description = error.localizedDescription
+                let compensationError = await self.compensateFailedProposedSave(id: id, token: token)
+                return self.finishProposedSave(
+                    conversation,
+                    token: token,
+                    error: description,
+                    compensationError: compensationError
+                )
+            }
+        }
+        return PersistenceReceipt(task: physical.task) { [weak self] result in
+            self?.reconcileProposedSave(result, conversation: conversation, token: token) ?? .superseded
+        }
+    }
+
     func load() -> PersistenceReceipt<ConversationLoadResult> {
         let token = nextToken()
         latestLoadToken = token
+        latestRequestedLoadToken = token
         let store = store
 
         let physical: PersistenceReceipt<ConversationLoadResult> = appendOperation(root: token) { [weak self] in
             do {
                 let conversations = try await store.loadConversations()
                 guard let self else { return .superseded }
-                self.storageSnapshot = self.dictionary(from: conversations)
-                return self.finishLoad(conversations, token: token)
+                let isLatestRequestedLoad = self.latestRequestedLoadToken == token
+                let result = self.finishLoad(conversations, token: token)
+                if isLatestRequestedLoad {
+                    self.storageSnapshot = self.dictionary(from: conversations)
+                    if case .loaded = result {
+                        self.recordDurableSnapshotChange()
+                    }
+                }
+                return result
             } catch {
                 guard let self, self.latestLoadToken == token else { return .superseded }
                 self.log("❌ Failed to load conversations", level: .error, metadata: ["error": error.localizedDescription])
@@ -155,39 +303,49 @@ final class ConversationPersistenceCoordinator {
         }
     }
 
-    func delete(_ conversation: Conversation) -> PersistenceReceipt<ConversationDeleteResult> {
-        let token = nextToken()
-        let id = conversation.id
-
-        snapshot.removeValue(forKey: id)
-        cancelDebounce(for: id)
-        dirty[id] = DirtyIntent(token: token, root: token, desired: .deleted, isScheduled: true)
-        ensureRewriteScheduled()
-
-        let store = store
-        let physical: PersistenceReceipt<ConversationDeleteResult> = appendOperation(root: token) { [weak self] in
-            do {
-                try await store.delete(id)
-                guard let self else { return .superseded }
-                self.storageSnapshot.removeValue(forKey: id)
-                self.repairDeletedIDs.remove(id)
-                return self.finishDelete(id: id, token: token, rollback: conversation, error: nil)
-            } catch {
-                guard let self else { return .superseded }
-                return self.finishDelete(
-                    id: id,
-                    token: token,
-                    rollback: conversation,
-                    error: error.localizedDescription
-                )
-            }
-        }
-        return PersistenceReceipt(task: physical.task) { [weak self] result in
-            self?.reconcileDelete(result, id: id, token: token) ?? .superseded
-        }
+    func delete(_ conversation: Conversation) -> DestructivePersistenceReceipt<ConversationDeleteResult> {
+        delete(id: conversation.id, rollback: conversation)
     }
 
-    func clear(_ conversations: [Conversation]) -> PersistenceReceipt<ConversationClearResult> {
+    func delete(id: UUID) -> DestructivePersistenceReceipt<ConversationDeleteResult> {
+        delete(id: id, rollback: nil)
+    }
+
+    private func delete(
+        id: UUID,
+        rollback: Conversation?
+    ) -> DestructivePersistenceReceipt<ConversationDeleteResult> {
+        let token = nextToken()
+
+        proposedSaves.removeValue(forKey: id)
+        snapshot.removeValue(forKey: id)
+        cancelDebounce(for: id)
+        dirty[id] = DirtyIntent(
+            token: token,
+            root: token,
+            repairRoot: token,
+            desired: .deleted,
+            rollback: rollback,
+            isScheduled: false
+        )
+        ensureRewriteScheduled()
+
+        let physical = activateDelete(id: id, token: token) ?? PersistenceReceipt(
+            task: Task { .superseded }
+        )
+        let receipt = PersistenceReceipt(task: physical.task) { [weak self] result in
+            self?.reconcileDelete(result, id: id, token: token) ?? .superseded
+        }
+        return DestructivePersistenceReceipt(
+            receipt: receipt,
+            repairToken: ConversationSnapshotRepairToken(
+                operationToken: token,
+                kind: .delete(id)
+            )
+        )
+    }
+
+    func clear(_ conversations: [Conversation]) -> DestructivePersistenceReceipt<ConversationClearResult> {
         let ownedSnapshot = dictionary(from: conversations)
         let priorDirty = dirty
         let token = nextToken()
@@ -201,6 +359,9 @@ final class ConversationPersistenceCoordinator {
         for (id, conversation) in ownedSnapshot {
             changes[id] = .saved(conversation)
         }
+        for id in proposedSaves.keys where changes[id] == nil {
+            changes[id] = .deleted
+        }
         clearLayers.append(ClearLayer(token: token, changes: changes))
 
         latestClearToken = token
@@ -208,6 +369,7 @@ final class ConversationPersistenceCoordinator {
         invalidateRewrite()
         cancelAllDebounces()
         dirty.removeAll()
+        proposedSaves.removeAll()
         snapshot.removeAll()
 
         let store = store
@@ -216,15 +378,23 @@ final class ConversationPersistenceCoordinator {
                 try await store.clearConversations()
                 guard let self else { return .superseded }
                 self.storageSnapshot.removeAll()
+                self.recordDurableSnapshotChange()
                 return self.finishClear(token: token, error: nil)
             } catch {
                 guard let self else { return .superseded }
                 return self.finishClear(token: token, error: error.localizedDescription)
             }
         }
-        return PersistenceReceipt(task: physical.task) { [weak self] result in
+        let receipt = PersistenceReceipt(task: physical.task) { [weak self] result in
             self?.reconcileClear(result, token: token) ?? .superseded
         }
+        return DestructivePersistenceReceipt(
+            receipt: receipt,
+            repairToken: ConversationSnapshotRepairToken(
+                operationToken: token,
+                kind: .clear
+            )
+        )
     }
 
     func flush() -> PersistenceReceipt<Void> {
@@ -236,7 +406,8 @@ final class ConversationPersistenceCoordinator {
 
         ensureRewriteScheduled()
         let pendingSaves = dirty.compactMap { id, intent -> (UUID, UInt64)? in
-            guard !intent.isScheduled, rewriteCoveredTokens[id] != intent.token,
+            guard proposedSaves[id] == nil,
+                  !intent.isScheduled, rewriteCoveredTokens[id] != intent.token,
                   case .saved = intent.desired
             else {
                 return nil
@@ -257,6 +428,137 @@ final class ConversationPersistenceCoordinator {
         return PersistenceReceipt(task: task)
     }
 
+    /// Waits for the repair attempt already associated with a destructive operation.
+    /// When `retryIfNeeded` is true, schedules at most one new attempt before waiting.
+    func settleCurrentSnapshot(
+        for repairToken: ConversationSnapshotRepairToken,
+        retryIfNeeded: Bool = false
+    ) async -> ConversationSnapshotSettlementResult {
+        var status = snapshotRepairStatus(for: repairToken)
+        switch status {
+        case .settled:
+            return .settled
+        case .superseded:
+            return .superseded
+        case let .pending(isScheduled):
+            if !isScheduled {
+                guard retryIfNeeded else { return .failed }
+                scheduleSnapshotRepair(for: repairToken)
+                status = snapshotRepairStatus(for: repairToken)
+                switch status {
+                case .settled:
+                    return .settled
+                case .superseded:
+                    return .superseded
+                case let .pending(isScheduled) where !isScheduled:
+                    return .failed
+                case .pending:
+                    break
+                }
+            }
+        }
+
+        let repairTail = ioTail
+        await repairTail.value
+
+        switch snapshotRepairStatus(for: repairToken) {
+        case .settled:
+            return .settled
+        case .superseded:
+            return .superseded
+        case .pending:
+            return .failed
+        }
+    }
+
+    func settleCurrentState(for id: UUID) async -> ConversationDurabilityResult {
+        let acceptedRootCutoff = nextTokenValue
+        var attemptedTokens: Set<UInt64> = []
+
+        while true {
+            var observedToken: UInt64?
+            if let intent = dirty[id] {
+                let token = intent.token
+                observedToken = token
+                if !intent.isScheduled {
+                    guard attemptedTokens.insert(token).inserted else {
+                        return .failed
+                    }
+                    switch intent.desired {
+                    case .saved:
+                        _ = activateSave(id: id, token: token)
+                    case .deleted:
+                        _ = activateDelete(id: id, token: token)
+                    }
+                }
+            }
+
+            let tail = ioTail
+            await tail.value
+
+            if hasOutstanding(rootAtMost: acceptedRootCutoff) {
+                continue
+            }
+
+            if let remaining = dirty[id] {
+                if remaining.token == observedToken,
+                   !remaining.isScheduled,
+                   attemptedTokens.contains(remaining.token)
+                {
+                    return .failed
+                }
+                continue
+            }
+
+            return storageSnapshot[id] == nil ? .deleted : .saved
+        }
+    }
+
+    private func snapshotRepairStatus(
+        for repairToken: ConversationSnapshotRepairToken
+    ) -> SnapshotRepairStatus {
+        if latestClearToken > repairToken.operationToken {
+            return .superseded
+        }
+
+        switch repairToken.kind {
+        case let .delete(id):
+            guard let intent = dirty[id] else {
+                return snapshot[id] == nil ? .superseded : .settled
+            }
+            guard intent.repairRoot == repairToken.operationToken else {
+                return .superseded
+            }
+            let isCoveredByRewrite = rewriteCoveredTokens[id] == intent.token
+            return .pending(isScheduled: intent.isScheduled || isCoveredByRewrite)
+        case .clear:
+            guard rewriteToken != nil, rewriteRoot == repairToken.operationToken else {
+                return .settled
+            }
+            return .pending(isScheduled: rewriteScheduledToken != nil)
+        }
+    }
+
+    private func scheduleSnapshotRepair(
+        for repairToken: ConversationSnapshotRepairToken
+    ) {
+        switch repairToken.kind {
+        case let .delete(id):
+            guard let intent = dirty[id], intent.repairRoot == repairToken.operationToken else { return }
+            switch intent.desired {
+            case .saved:
+                ensureRewriteScheduled()
+                if rewriteCoveredTokens[id] != intent.token {
+                    activateSave(id: id, token: intent.token)
+                }
+            case .deleted:
+                activateDelete(id: id, token: intent.token)
+            }
+        case .clear:
+            ensureRewriteScheduled()
+        }
+    }
+
     private func scheduleDebounce(id: UUID, token: UInt64) {
         let duration = debounceDuration
         debounceTasks[id] = Task { @MainActor [weak self] in
@@ -270,7 +572,45 @@ final class ConversationPersistenceCoordinator {
     }
 
     @discardableResult
-    private func activateSave(id: UUID, token: UInt64) -> PersistenceReceipt<Void>? {
+    private func activateDelete(
+        id: UUID,
+        token: UInt64
+    ) -> PersistenceReceipt<ConversationDeleteResult>? {
+        guard var intent = dirty[id], intent.token == token, !intent.isScheduled,
+              case .deleted = intent.desired
+        else {
+            return nil
+        }
+
+        intent.isScheduled = true
+        dirty[id] = intent
+        let rollback = intent.rollback
+        let store = store
+        return appendOperation(root: intent.root) { [weak self] in
+            do {
+                try await store.delete(id)
+                guard let self else { return .superseded }
+                self.storageSnapshot.removeValue(forKey: id)
+                self.repairDeletedIDs.remove(id)
+                self.recordDurableSnapshotChange()
+                return self.finishDelete(id: id, token: token, rollback: rollback, error: nil)
+            } catch {
+                guard let self else { return .superseded }
+                return self.finishDelete(
+                    id: id,
+                    token: token,
+                    rollback: rollback,
+                    error: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    @discardableResult
+    private func activateSave(
+        id: UUID,
+        token: UInt64
+    ) -> PersistenceReceipt<ConversationSaveResult>? {
         guard var intent = dirty[id], intent.token == token, !intent.isScheduled,
               case let .saved(conversation) = intent.desired
         else {
@@ -285,36 +625,253 @@ final class ConversationPersistenceCoordinator {
         return appendOperation(root: intent.root) { [weak self] in
             do {
                 try await store.save(conversation)
-                self?.storageSnapshot[id] = conversation
-                self?.finishSave(id: id, token: token, error: nil)
+                guard let self else { return .superseded }
+                self.storageSnapshot[id] = conversation
+                self.recordDurableSnapshotChange()
+                return self.finishSave(id: id, token: token, error: nil)
             } catch {
-                self?.finishSave(id: id, token: token, error: error.localizedDescription)
+                guard let self else { return .superseded }
+                let description = error.localizedDescription
+                return self.finishSave(id: id, token: token, error: description)
             }
         }
     }
 
-    private func finishSave(id: UUID, token: UInt64, error: String?) {
-        guard var intent = dirty[id], intent.token == token, case .saved = intent.desired else {
-            return
+    private func finishSave(
+        id: UUID,
+        token: UInt64,
+        error: String?
+    ) -> ConversationSaveResult {
+        guard proposedSaves[id].map({ $0.token <= token }) ?? true,
+              var intent = dirty[id], intent.token == token, case .saved = intent.desired
+        else {
+            return .superseded
         }
 
         if let error {
             intent.isScheduled = false
             dirty[id] = intent
             log("❌ Failed to save conversation", level: .error, metadata: ["id": id.uuidString, "error": error])
+            return .failed(error)
         } else {
             dirty.removeValue(forKey: id)
             log("💾 Saved conversation", level: .debug, metadata: ["id": id.uuidString])
+            return .saved
         }
+    }
+
+    private func finishProposedSave(
+        _ conversation: Conversation,
+        token: UInt64,
+        error: String?,
+        compensationError: String? = nil
+    ) -> ConversationSaveResult {
+        let id = conversation.id
+        guard let proposed = proposedSaves[id], proposed.token == token,
+              latestClearToken <= token
+        else {
+            return .superseded
+        }
+
+        // Physical success is not committed until the receipt reconciles. Retaining the
+        // intent lets a newer proposal inherit this chain's true pre-proposal durable state.
+        guard let error else {
+            return .saved
+        }
+
+        proposedSaves.removeValue(forKey: id)
+        let priorState = proposedPriorState(for: proposed)
+        restoreSupersededIntentAfterFailedProposedSave(
+            id: id,
+            token: token,
+            rollback: proposed.rollback
+        )
+        if dirty[id] == nil, let priorState {
+            apply(priorState, for: id, to: &snapshot)
+            if compensationError != nil {
+                retainFailedProposedCompensation(priorState, id: id, token: token)
+            }
+        }
+
+        var metadata = ["id": id.uuidString, "error": error]
+        if let compensationError {
+            metadata["compensationError"] = compensationError
+        }
+        log("❌ Failed to save proposed conversation", level: .error, metadata: metadata)
+        return .failed(error)
+    }
+
+    /// Capture after FIFO predecessors finish so an older accepted save can become the baseline.
+    private func capturePriorDurableState(for id: UUID, chainRoot: UInt64) {
+        guard var proposed = proposedSaves[id], proposed.chainRoot == chainRoot,
+              proposed.priorDurable == nil
+        else {
+            return
+        }
+
+        proposed.priorDurable = storageSnapshot[id].map(DesiredState.saved) ?? .deleted
+        proposedSaves[id] = proposed
+    }
+
+    /// Restore storage before the failed proposal receipt can let its caller decline the UI commit.
+    private func compensateFailedProposedSave(id: UUID, token: UInt64) async -> String? {
+        guard let proposed = proposedSaves[id], proposed.token == token,
+              latestClearToken <= token,
+              let priorState = proposedPriorState(for: proposed),
+              !storageSnapshotMatches(priorState, id: id)
+        else {
+            return nil
+        }
+
+        do {
+            switch priorState {
+            case let .saved(conversation):
+                try await store.save(conversation)
+            case .deleted:
+                try await store.delete(id)
+            }
+        } catch {
+            return error.localizedDescription
+        }
+
+        apply(priorState, for: id, to: &storageSnapshot)
+        recordDurableSnapshotChange()
+        log("↩️ Restored durable state after failed proposed save", level: .info, metadata: ["id": id.uuidString])
+        return nil
+    }
+
+    private func proposedPriorState(for proposed: ProposedSaveIntent) -> DesiredState? {
+        if let rollback = proposed.rollback {
+            return .saved(rollback)
+        }
+        return proposed.priorDurable
+    }
+
+    private func storageSnapshotMatches(_ desired: DesiredState, id: UUID) -> Bool {
+        switch desired {
+        case let .saved(conversation):
+            storageSnapshot[id] == conversation
+        case .deleted:
+            storageSnapshot[id] == nil
+        }
+    }
+
+    private func retainFailedProposedCompensation(
+        _ desired: DesiredState,
+        id: UUID,
+        token: UInt64
+    ) {
+        guard dirty[id] == nil else { return }
+
+        switch desired {
+        case .saved:
+            repairDeletedIDs.remove(id)
+        case .deleted:
+            repairDeletedIDs.insert(id)
+        }
+        dirty[id] = DirtyIntent(
+            token: token,
+            root: token,
+            repairRoot: nil,
+            desired: desired,
+            rollback: nil,
+            isScheduled: false
+        )
+
+        switch desired {
+        case .saved:
+            activateSave(id: id, token: token)
+        case .deleted:
+            activateDelete(id: id, token: token)
+        }
+    }
+
+    private func restoreSupersededIntentAfterFailedProposedSave(
+        id: UUID,
+        token: UInt64,
+        rollback: Conversation?
+    ) {
+        guard var intent = dirty[id], intent.token < token else { return }
+
+        switch intent.desired {
+        case let .saved(conversation):
+            snapshot[id] = conversation
+            repairDeletedIDs.remove(id)
+            if storageSnapshot[id] == conversation {
+                dirty.removeValue(forKey: id)
+            } else if !intent.isScheduled || outstandingByRoot[intent.root] == nil {
+                intent.isScheduled = false
+                dirty[id] = intent
+                activateSave(id: id, token: intent.token)
+            }
+        case .deleted:
+            if let rollback {
+                snapshot[id] = rollback
+                repairDeletedIDs.remove(id)
+                dirty[id] = DirtyIntent(
+                    token: intent.token,
+                    root: intent.root,
+                    repairRoot: intent.repairRoot ?? intent.root,
+                    desired: .saved(rollback),
+                    rollback: nil,
+                    isScheduled: false
+                )
+                if storageSnapshot[id] == rollback {
+                    dirty.removeValue(forKey: id)
+                } else {
+                    activateSave(id: id, token: intent.token)
+                }
+            } else {
+                snapshot.removeValue(forKey: id)
+                if !intent.isScheduled || outstandingByRoot[intent.root] == nil {
+                    intent.isScheduled = false
+                    dirty[id] = intent
+                    activateDelete(id: id, token: intent.token)
+                }
+            }
+        }
+    }
+
+    private func reconcileProposedSave(
+        _ result: ConversationSaveResult,
+        conversation: Conversation,
+        token: UInt64
+    ) -> ConversationSaveResult {
+        let id = conversation.id
+        guard latestClearToken <= token,
+              dirty[id].map({ $0.token <= token }) ?? true,
+              proposedSaves[id].map({ $0.token <= token }) ?? true
+        else {
+            return .superseded
+        }
+
+        guard case .saved = result else { return result }
+
+        if let proposed = proposedSaves[id] {
+            guard proposed.token == token else { return .superseded }
+            proposedSaves.removeValue(forKey: id)
+            if let intent = dirty[id], intent.token < token {
+                dirty.removeValue(forKey: id)
+            }
+            snapshot[id] = conversation
+            repairDeletedIDs.remove(id)
+            cancelDebounce(for: id)
+            log("💾 Saved proposed conversation", level: .debug, metadata: ["id": id.uuidString])
+            return .saved
+        }
+
+        return snapshot[id] == conversation ? .saved : .superseded
     }
 
     private func finishDelete(
         id: UUID,
         token: UInt64,
-        rollback: Conversation,
+        rollback: Conversation?,
         error: String?
     ) -> ConversationDeleteResult {
-        guard let intent = dirty[id], intent.token == token, case .deleted = intent.desired else {
+        guard proposedSaves[id].map({ $0.token <= token }) ?? true,
+              var intent = dirty[id], intent.token == token, case .deleted = intent.desired
+        else {
             return .superseded
         }
 
@@ -324,13 +881,27 @@ final class ConversationPersistenceCoordinator {
             return .deleted
         }
 
+        guard let rollback else {
+            intent.isScheduled = false
+            dirty[id] = intent
+            repairDeletedIDs.insert(id)
+            log(
+                "❌ Failed to delete conversation by ID; scheduled retry",
+                level: .error,
+                metadata: ["id": id.uuidString, "error": error]
+            )
+            return .failed(nil, error)
+        }
+
         let restoreToken = nextToken()
         snapshot[id] = rollback
         repairDeletedIDs.remove(id)
         dirty[id] = DirtyIntent(
             token: restoreToken,
             root: intent.root,
+            repairRoot: intent.repairRoot ?? intent.root,
             desired: .saved(rollback),
+            rollback: nil,
             isScheduled: false
         )
         ensureRewriteScheduled()
@@ -421,9 +992,17 @@ final class ConversationPersistenceCoordinator {
         switch result {
         case .deleted:
             return snapshot[id] == nil ? .deleted : .superseded
-        case let .failed(_, error):
-            guard let current = snapshot[id] else { return .superseded }
-            return .failed(current, error)
+        case let .failed(rollback, error):
+            if let current = snapshot[id] {
+                return .failed(current, error)
+            }
+            guard rollback == nil,
+                  let intent = dirty[id], intent.repairRoot == token,
+                  case .deleted = intent.desired
+            else {
+                return .superseded
+            }
+            return .failed(nil, error)
         case .superseded:
             return .superseded
         }
@@ -489,6 +1068,7 @@ final class ConversationPersistenceCoordinator {
                 dirty.removeValue(forKey: id)
                 cancelDebounce(for: id)
             }
+            recordDurableSnapshotChange()
             log("✅ Repaired conversation storage after failed clear", level: .info)
             return
         }
@@ -544,6 +1124,17 @@ final class ConversationPersistenceCoordinator {
     }
 
     private func apply(
+        _ desired: DesiredState,
+        for id: UUID,
+        to conversations: inout [UUID: Conversation]
+    ) {
+        switch desired {
+        case let .saved(conversation): conversations[id] = conversation
+        case .deleted: conversations.removeValue(forKey: id)
+        }
+    }
+
+    private func apply(
         _ changes: [UUID: DesiredState],
         to conversations: inout [UUID: Conversation]
     ) {
@@ -564,12 +1155,20 @@ final class ConversationPersistenceCoordinator {
     }
 
     private func orderedSnapshot() -> [Conversation] {
-        snapshot.values.sorted { lhs, rhs in
+        ordered(snapshot)
+    }
+
+    private func ordered(_ conversations: [UUID: Conversation]) -> [Conversation] {
+        conversations.values.sorted { lhs, rhs in
             if lhs.updatedAt == rhs.updatedAt {
                 return lhs.id.uuidString < rhs.id.uuidString
             }
             return lhs.updatedAt > rhs.updatedAt
         }
+    }
+
+    private func recordDurableSnapshotChange() {
+        durableSnapshotObserver?()
     }
 
     private func cancelDebounce(for id: UUID) {

--- a/Sources/Ayna/Services/DuckDuckGoSearchService.swift
+++ b/Sources/Ayna/Services/DuckDuckGoSearchService.swift
@@ -156,6 +156,9 @@ final class DuckDuckGoSearchService {
         } catch let error as DuckDuckGoSearchError {
             throw error
         } catch {
+            if Task.isCancelled {
+                throw CancellationError()
+            }
             log(.error, "❌ DuckDuckGo search failed", metadata: [
                 "error": error.localizedDescription,
             ])

--- a/Sources/Ayna/Services/EncryptedConversationStore.swift
+++ b/Sources/Ayna/Services/EncryptedConversationStore.swift
@@ -14,11 +14,14 @@ enum EncryptedStoreError: LocalizedError {
     /// The encryption key was previously created but is now missing (e.g., after device restore/migration)
     /// This indicates the key was deleted or corrupted, and existing encrypted data cannot be recovered
     case keyLost
+    case unreadableConversationFiles(count: Int)
 
     var errorDescription: String? {
         switch self {
         case .keyLost:
             "Encryption key was lost. Previously encrypted conversations cannot be recovered. Please contact support if you need assistance."
+        case let .unreadableConversationFiles(count):
+            "Failed to load \(count) encrypted conversation file(s)."
         }
     }
 }
@@ -160,7 +163,7 @@ final class EncryptedConversationStore: Sendable {
 
             let keyData = try keyCache.keyData()
 
-            return await withTaskGroup(of: Conversation?.self) { group in
+            let loadResult = await withTaskGroup(of: Conversation?.self) { group in
                 for url in encryptedFileURLs {
                     group.addTask {
                         do {
@@ -186,15 +189,18 @@ final class EncryptedConversationStore: Sendable {
                         failedCount += 1
                     }
                 }
-                if failedCount > 0 && conversations.isEmpty {
-                    DiagnosticsLogger.log(
-                        .encryptedStore, level: .error,
-                        message: "❌ All conversations failed to decrypt",
-                        metadata: ["failedCount": "\(failedCount)"]
-                    )
-                }
-                return conversations
+                return (conversations, failedCount)
             }
+
+            guard loadResult.1 == 0 else {
+                DiagnosticsLogger.log(
+                    .encryptedStore, level: .error,
+                    message: "❌ Refusing partial conversation load",
+                    metadata: ["failedCount": "\(loadResult.1)"]
+                )
+                throw EncryptedStoreError.unreadableConversationFiles(count: loadResult.1)
+            }
+            return loadResult.0
         }.value
     }
 
@@ -253,8 +259,7 @@ final class EncryptedConversationStore: Sendable {
         return try JSONDecoder().decode([Conversation].self, from: plaintext)
     }
 
-    private nonisolated static func load(from url: URL, keyData: Data) throws -> Conversation
-    {
+    private nonisolated static func load(from url: URL, keyData: Data) throws -> Conversation {
         let encryptedData = try Data(contentsOf: url)
         let box = try AES.GCM.SealedBox(combined: encryptedData)
         let key = SymmetricKey(data: keyData)

--- a/Sources/Ayna/Services/GitHubOAuthService.swift
+++ b/Sources/Ayna/Services/GitHubOAuthService.swift
@@ -102,29 +102,6 @@ struct GitHubRateLimitInfo {
 
 // MARK: - Concurrency Gate
 
-/// Runs an action at most once.
-final class OneShot: Sendable {
-    private let state = OSAllocatedUnfairLock(initialState: false)
-    private let action: @Sendable () -> Void
-
-    nonisolated init(_ action: @escaping @Sendable () -> Void) {
-        self.action = action
-    }
-
-    nonisolated func run() {
-        let shouldRun = state.withLock { didRun -> Bool in
-            if didRun {
-                return false
-            }
-            didRun = true
-            return true
-        }
-        if shouldRun {
-            action()
-        }
-    }
-}
-
 /// Serializes GitHub Models requests per token identity.
 ///
 /// Purpose: avoid parallel bursts in multi-model mode that trigger 429s.
@@ -134,7 +111,10 @@ actor GitHubModelsRequestGate {
     private var activeKeys: Set<String> = []
     private var waiters: [String: [(id: UUID, cont: CheckedContinuation<Void, any Error>)]] = [:]
 
-    func acquire(key: String) async throws {
+    func acquire(
+        key: String,
+        onQueued: @escaping @Sendable () -> Void = {}
+    ) async throws {
         try Task.checkCancellation()
 
         if !activeKeys.contains(key) {
@@ -143,6 +123,7 @@ actor GitHubModelsRequestGate {
         }
 
         let id = UUID()
+        onQueued()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { cont in
                 waiters[key, default: []].append((id: id, cont: cont))
@@ -340,6 +321,11 @@ class GitHubOAuthService: NSObject, ObservableObject {
             refreshTask = nil
             throw error
         }
+    }
+
+    func isCurrentAccessTokenValid(_ accessToken: String) -> Bool {
+        guard let tokenInfo = loadTokenInfo() else { return false }
+        return tokenInfo.accessToken == accessToken && !tokenInfo.isExpired
     }
 
     func signOut() {

--- a/Sources/Ayna/Services/MCPServerManager.swift
+++ b/Sources/Ayna/Services/MCPServerManager.swift
@@ -61,6 +61,7 @@ class MCPServerManager: ObservableObject {
     private let serviceFactory: (MCPServerConfig) -> MCPServicing
     private let retryDelayProvider: (Int) -> TimeInterval
     private let reconnectDelayProvider: () -> TimeInterval
+    private let reconnectSleeper: @MainActor @Sendable (TimeInterval) async throws -> Void
 
     @Published var serverConfigs: [MCPServerConfig] = []
     @Published var availableTools: [MCPTool] = []
@@ -86,11 +87,15 @@ class MCPServerManager: ObservableObject {
     init(
         serviceFactory: @escaping (MCPServerConfig) -> MCPServicing = { MCPService(serverConfig: $0) },
         retryDelayProvider: @escaping (Int) -> TimeInterval = { pow(2.0, Double($0 - 1)) },
-        reconnectDelayProvider: @escaping () -> TimeInterval = { 2 }
+        reconnectDelayProvider: @escaping () -> TimeInterval = { 2 },
+        reconnectSleeper: @escaping @MainActor @Sendable (TimeInterval) async throws -> Void = { delay in
+            try await Task.sleep(for: .seconds(delay))
+        }
     ) {
         self.serviceFactory = serviceFactory
         self.retryDelayProvider = retryDelayProvider
         self.reconnectDelayProvider = reconnectDelayProvider
+        self.reconnectSleeper = reconnectSleeper
         loadServerConfigs()
         initializeStatusEntries()
         MCPProcessTracker.shared.cleanupOrphanedProcesses()
@@ -535,7 +540,7 @@ class MCPServerManager: ObservableObject {
             guard let self else { return }
                 do {
             if delaySeconds > 0 {
-                        try await Task.sleep(for: .seconds(delaySeconds))
+                        try await reconnectSleeper(delaySeconds)
             }
                     try Task.checkCancellation()
                 } catch {

--- a/Sources/Ayna/Services/MCPServerManager.swift
+++ b/Sources/Ayna/Services/MCPServerManager.swift
@@ -10,6 +10,49 @@ import Combine
 import Foundation
 import os
 
+@MainActor
+private final class MCPServiceGenerationDelegate: MCPServiceDelegate {
+    weak var manager: MCPServerManager?
+    let serverName: String
+    let generation: UInt64
+
+    init(manager: MCPServerManager, serverName: String, generation: UInt64) {
+        self.manager = manager
+        self.serverName = serverName
+        self.generation = generation
+    }
+
+    func mcpService(_ service: MCPServicing, didTerminateWithError error: String?) {
+        manager?.handleServiceTermination(
+            service,
+            serverName: serverName,
+            generation: generation,
+            error: error
+        )
+    }
+}
+
+@MainActor
+private struct ManagedMCPService {
+    let configID: UUID
+    let generation: UInt64
+    let service: MCPServicing
+    let delegate: MCPServiceGenerationDelegate
+}
+
+private struct ManagedMCPTask: Sendable {
+    let operationID: UUID
+    let generation: UInt64
+    let task: Task<Void, Never>
+
+    init(operationID: UUID = UUID(), generation: UInt64, task: Task<Void, Never>) {
+        self.operationID = operationID
+        self.generation = generation
+        self.task = task
+    }
+}
+
+// swiftlint:disable type_body_length
 /// Manages multiple MCP server connections and tool discovery
 @MainActor
 class MCPServerManager: ObservableObject {
@@ -25,9 +68,14 @@ class MCPServerManager: ObservableObject {
     @Published var isDiscovering = false
     @Published private(set) var serverStatuses: [String: MCPServerStatus] = [:]
 
-    private var services: [String: MCPServicing] = [:] // serverName -> service
-    private var connectingServers: Set<String> = []
-    private var pendingReconnects: Set<String> = []
+        private var services: [String: ManagedMCPService] = [:]
+        private var serverGenerations: [String: UInt64] = [:]
+        private var connectionTasks: [String: ManagedMCPTask] = [:]
+        private var reconnectTasks: [String: ManagedMCPTask] = [:]
+        private var discoveryTasks: [String: ManagedMCPTask] = [:]
+        private var committedDiscoveryGenerations: [String: UInt64] = [:]
+        private var discoveryBatchTask: ManagedMCPTask?
+        private var discoveryBatchGeneration: UInt64 = 0
 
     // Optimization: Cache enabled tools and their OpenAI function format
     private var cachedEnabledTools: [MCPTool] = []
@@ -56,9 +104,7 @@ class MCPServerManager: ObservableObject {
         setStatus(for: config, state: config.enabled ? .idle : .disabled, clearExistingError: true)
 
         if config.enabled {
-            Task {
-                await connectToServer(config)
-            }
+                launchConnection(to: config)
         }
     }
 
@@ -89,20 +135,16 @@ class MCPServerManager: ObservableObject {
 
         // Handle connection state changes
         if wasEnabled, !config.enabled {
-            // Disconnect in the background
-            Task { @MainActor in
-                disconnectServer(config.name)
-            }
+                disconnectServer(previousConfig.name)
             setStatus(for: config, state: .disabled)
         } else if !wasEnabled, config.enabled {
-            setStatus(for: config, state: .idle, clearExistingError: true)
-            Task {
-                await connectToServer(config)
+                if previousConfig.name != config.name {
+                    disconnectServer(previousConfig.name)
             }
+                setStatus(for: config, state: .idle, clearExistingError: true)
+                launchConnection(to: config)
         } else if requiresRestart {
-            Task {
-                await restartServer(previousName: previousConfig.name, with: config)
-            }
+                restartServer(previousName: previousConfig.name, with: config)
         }
     }
 
@@ -186,82 +228,184 @@ class MCPServerManager: ObservableObject {
 
     // MARK: - Connection Management
 
-    func connectToServer(_ config: MCPServerConfig, autoDisableOnFailure: Bool = true) async {
+        func connectToServer(_ requestedConfig: MCPServerConfig, autoDisableOnFailure: Bool = true) async {
+            guard let config = currentConfig(matching: requestedConfig) else { return }
         guard config.enabled else {
             setStatus(for: config, state: .disabled)
             return
         }
 
-        if let existingService = services[config.name], existingService.isConnected {
-            let hasTools = !availableTools.filter { $0.serverName == config.name }.isEmpty
-
-            if !hasTools {
-                DiagnosticsLogger.log(
-                    .mcpServerManager,
-                    level: .info,
-                    message: "Server connected without tools; starting discovery",
-                    metadata: ["server": config.name]
+            if let managed = services[config.name], managed.service.isConnected {
+                if !availableTools.contains(where: { $0.serverName == config.name }),
+                   let operation = startDiscoveryOperation(
+                       serverName: config.name,
+                       generation: managed.generation,
+                       service: managed.service
                 )
-                await discoverTools(for: config.name)
+                {
+                    await awaitOperation(operation)
+                }
+                if isCurrentService(managed.service, serverName: config.name, generation: managed.generation) {
+                    setStatus(for: config, state: .connected, clearExistingError: true)
             }
-            setStatus(for: config, state: .connected)
             return
         }
 
-        setStatus(for: config, state: .connecting)
+            guard let operation = startConnectionOperation(
+                config: config,
+                autoDisableOnFailure: autoDisableOnFailure
+            ) else {
+                return
+            }
+            await awaitOperation(operation)
+        }
 
-        if connectingServers.contains(config.name) {
-            DiagnosticsLogger.log(
-                .mcpServerManager,
-                level: .debug,
-                message: "Connection attempt already in progress",
-                metadata: ["server": config.name]
+        private func launchConnection(to requestedConfig: MCPServerConfig, autoDisableOnFailure: Bool = true) {
+            guard let config = currentConfig(matching: requestedConfig), config.enabled else { return }
+
+            if let managed = services[config.name], managed.service.isConnected {
+                if !availableTools.contains(where: { $0.serverName == config.name }) {
+                    _ = startDiscoveryOperation(
+                        serverName: config.name,
+                        generation: managed.generation,
+                        service: managed.service
             )
+                }
             return
         }
+            _ = startConnectionOperation(config: config, autoDisableOnFailure: autoDisableOnFailure)
+        }
 
-        connectingServers.insert(config.name)
-        defer { connectingServers.remove(config.name) }
+        private func startConnectionOperation(
+            config: MCPServerConfig,
+            autoDisableOnFailure: Bool
+        ) -> ManagedMCPTask? {
+            if let existing = connectionTasks[config.name],
+               existing.generation == serverGenerations[config.name]
+            {
+                return existing
+            }
 
+            let generation = advanceGeneration(for: config.name)
+            cancelServerTasks(for: config.name)
+
+            if let previous = services.removeValue(forKey: config.name) {
+                previous.service.delegate = nil
+                previous.service.disconnect()
+            }
+            removeArtifacts(for: config.name)
+
+            let service = serviceFactory(config)
+            let delegate = MCPServiceGenerationDelegate(
+                manager: self,
+                serverName: config.name,
+                generation: generation
+            )
+            service.delegate = delegate
+            services[config.name] = ManagedMCPService(
+                configID: config.id,
+                generation: generation,
+                service: service,
+                delegate: delegate
+            )
+            setStatus(for: config, state: .connecting, clearExistingError: true)
+
+            let task = Task { @MainActor [weak self, service] in
+                guard let self else { return }
+                await self.runConnection(
+                    config: config,
+                    service: service,
+                    generation: generation,
+                    autoDisableOnFailure: autoDisableOnFailure
+                )
+                self.clearConnectionTask(serverName: config.name, generation: generation)
+            }
+            let operation = ManagedMCPTask(generation: generation, task: task)
+            connectionTasks[config.name] = operation
+            return operation
+        }
+
+        private func runConnection(
+            config: MCPServerConfig,
+            service: MCPServicing,
+            generation: UInt64,
+            autoDisableOnFailure: Bool
+        ) async {
         DiagnosticsLogger.log(
             .mcpServerManager,
             level: .info,
             message: "Attempting to connect to MCP server",
-            metadata: ["server": config.name]
+                metadata: ["server": config.name, "generation": "\(generation)"]
         )
-
-        if let existing = services[config.name] {
-            existing.delegate = nil
-            existing.disconnect()
-        }
-        let service = serviceFactory(config)
-        service.delegate = self
-        services[config.name] = service
 
         let maxAttempts = 3
         for attempt in 1 ... maxAttempts {
+                guard isCurrentService(service, serverName: config.name, generation: generation),
+                      !Task.isCancelled
+                else {
+                    service.disconnect()
+                    return
+                }
+
             do {
                 try await service.connect()
+                    try Task.checkCancellation()
+                    guard isCurrentService(service, serverName: config.name, generation: generation) else {
+                        service.disconnect()
+                        return
+                    }
+
                 DiagnosticsLogger.log(
                     .mcpServerManager,
                     level: .info,
                     message: "Connected to MCP server",
                     metadata: [
                         "server": config.name,
-                        "attempt": "#\(attempt)"
+                            "attempt": "#\(attempt)",
+                            "generation": "\(generation)"
                     ]
                 )
 
-                await discoverTools(for: config.name)
-                DiagnosticsLogger.log(
-                    .mcpServerManager,
-                    level: .info,
-                    message: "Tool discovery complete",
-                    metadata: ["server": config.name]
-                )
+                    guard let discovery = startDiscoveryOperation(
+                        serverName: config.name,
+                        generation: generation,
+                        service: service
+                    ) else {
+                        service.disconnect()
+                        return
+                    }
+                    await awaitOperation(discovery)
+                    try Task.checkCancellation()
+                    var lastAwaitedOperationID = discovery.operationID
+                    while committedDiscoveryGenerations[config.name] != generation,
+                          let replacement = discoveryTasks[config.name],
+                          replacement.generation == generation,
+                          replacement.operationID != lastAwaitedOperationID
+                    {
+                        lastAwaitedOperationID = replacement.operationID
+                        await awaitOperation(replacement)
+                        try Task.checkCancellation()
+                    }
+                    guard committedDiscoveryGenerations[config.name] == generation else {
+                        cancelConnectionGeneration(service: service, config: config, generation: generation)
+                        return
+                    }
+                    guard isCurrentService(service, serverName: config.name, generation: generation) else {
+                        service.disconnect()
+                        return
+                    }
+
                 setStatus(for: config, state: .connected, clearExistingError: true)
                 return
+                } catch is CancellationError {
+                    cancelConnectionGeneration(service: service, config: config, generation: generation)
+                    return
             } catch {
+                    guard isCurrentService(service, serverName: config.name, generation: generation) else {
+                        service.disconnect()
+                        return
+                    }
+
                 DiagnosticsLogger.log(
                     .mcpServerManager,
                     level: .error,
@@ -269,177 +413,189 @@ class MCPServerManager: ObservableObject {
                     metadata: [
                         "server": config.name,
                         "attempt": "#\(attempt)",
-                        "error": error.localizedDescription
+                            "error": error.localizedDescription,
+                            "generation": "\(generation)"
                     ]
                 )
-
                 service.disconnect()
 
                 if attempt < maxAttempts {
                     let delay = max(TimeInterval.zero, retryDelayProvider(attempt))
+                        if delay > 0 {
+                            do {
+                                try await Task.sleep(for: .seconds(delay))
+                            } catch {
+                                cancelConnectionGeneration(service: service, config: config, generation: generation)
+                                return
+                            }
+                        }
+                        continue
+                    }
+
+                    finishFailedConnection(
+                        service: service,
+                        config: config,
+                        generation: generation,
+                        error: error,
+                        autoDisableOnFailure: autoDisableOnFailure
+                    )
+                    return
+                }
+            }
+        }
+
+        private func cancelConnectionGeneration(
+            service: MCPServicing,
+            config: MCPServerConfig,
+            generation: UInt64
+        ) {
+            service.disconnect()
+            guard isCurrentService(service, serverName: config.name, generation: generation) else { return }
+
+            service.delegate = nil
+            services.removeValue(forKey: config.name)
+            cancelDiscoveryTask(for: config.name, generation: generation)
+            removeArtifacts(for: config.name)
+            if let latest = currentConfig(matching: config) {
+                setStatus(for: latest, state: latest.enabled ? .idle : .disabled)
+            }
                     DiagnosticsLogger.log(
                         .mcpServerManager,
                         level: .info,
-                        message: "Retrying connection",
-                        metadata: [
-                            "server": config.name,
-                            "delay": "\(delay)s"
-                        ]
+                message: "MCP server connection cancelled",
+                metadata: ["server": config.name, "generation": "\(generation)"]
                     )
-                    if delay > 0 {
-                        try? await Task.sleep(for: .seconds(delay))
-                    }
-                    continue
                 }
 
+        private func finishFailedConnection(
+            service: MCPServicing,
+            config: MCPServerConfig,
+            generation: UInt64,
+            error: Error,
+            autoDisableOnFailure: Bool
+        ) {
+            guard isCurrentService(service, serverName: config.name, generation: generation) else { return }
+
                 service.lastError = error.localizedDescription
+            service.delegate = nil
                 services.removeValue(forKey: config.name)
+            cancelDiscoveryTask(for: config.name, generation: generation)
+            removeArtifacts(for: config.name)
                 setStatus(for: config, state: .error(error.localizedDescription))
 
-                if autoDisableOnFailure,
-                   let index = serverConfigs.firstIndex(where: { $0.name == config.name })
-                {
+            guard autoDisableOnFailure,
+                  let index = serverConfigs.firstIndex(where: { $0.id == config.id })
+            else {
+                return
+            }
+
                     var updatedConfig = serverConfigs[index]
                     updatedConfig.enabled = false
                     serverConfigs[index] = updatedConfig
                     saveServerConfigs()
+            setStatus(for: updatedConfig, state: .disabled)
                     DiagnosticsLogger.log(
                         .mcpServerManager,
                         level: .error,
                         message: "Auto-disabled server due to repeated connection failures",
                         metadata: ["server": config.name]
                     )
-                    setStatus(for: updatedConfig, state: .disabled)
-                }
-
-                availableTools.removeAll { $0.serverName == config.name }
-                availableResources.removeAll { $0.serverName == config.name }
-                cachedEnabledTools = []
-                cachedOpenAIFunctions = []
-                refreshStatusToolCount(for: config.name)
-                break
-            }
-        }
     }
 
     private func shouldRestartServer(previousConfig: MCPServerConfig, updatedConfig: MCPServerConfig) -> Bool {
         guard previousConfig.enabled, updatedConfig.enabled else { return false }
-
-        let changedName = previousConfig.name != updatedConfig.name
-        let changedCommand = previousConfig.command != updatedConfig.command
-        let changedArgs = previousConfig.args != updatedConfig.args
-        let changedEnv = previousConfig.env != updatedConfig.env
-
-        return changedName || changedCommand || changedArgs || changedEnv
+            return previousConfig.name != updatedConfig.name
+                || previousConfig.command != updatedConfig.command
+                || previousConfig.args != updatedConfig.args
+                || previousConfig.env != updatedConfig.env
     }
 
-    private func restartServer(previousName: String?, with config: MCPServerConfig) async {
-        let nameToDisconnect = previousName ?? config.name
+        private func restartServer(previousName: String, with config: MCPServerConfig) {
         DiagnosticsLogger.log(
             .mcpServerManager,
             level: .info,
             message: "Restarting MCP server to apply config changes",
-            metadata: [
-                "server": config.name,
-                "previous": nameToDisconnect
-            ]
+                metadata: ["server": config.name, "previous": previousName]
         )
-
-        disconnectServer(nameToDisconnect)
+            disconnectServer(previousName)
         setStatus(for: config, state: .connecting, clearExistingError: true)
-        await connectToServer(config, autoDisableOnFailure: false)
+            launchConnection(to: config, autoDisableOnFailure: false)
     }
 
-    private func scheduleReconnect(for config: MCPServerConfig) {
-        guard !pendingReconnects.contains(config.name) else {
+        private func scheduleReconnect(for config: MCPServerConfig, generation: UInt64) {
+            guard serverGenerations[config.name] == generation,
+                  reconnectTasks[config.name] == nil
+            else {
             return
         }
 
-        pendingReconnects.insert(config.name)
         setStatus(for: config, state: .reconnecting)
         let delaySeconds = max(TimeInterval.zero, reconnectDelayProvider())
-        DiagnosticsLogger.log(
-            .mcpServerManager,
-            level: .info,
-            message: "Scheduling MCP reconnect",
-            metadata: [
-                "server": config.name,
-                "delay": "\(delaySeconds)s"
-            ]
-        )
-
-        Task { [weak self] in
+            let task = Task { @MainActor [weak self] in
             guard let self else { return }
+                do {
             if delaySeconds > 0 {
-                try? await Task.sleep(for: .seconds(delaySeconds))
+                        try await Task.sleep(for: .seconds(delaySeconds))
             }
-
-            await performScheduledReconnect(for: config.name)
+                    try Task.checkCancellation()
+                } catch {
+                    self.clearReconnectTask(serverName: config.name, generation: generation)
+                    return
+                }
+                self.performScheduledReconnect(serverName: config.name, generation: generation)
         }
+            reconnectTasks[config.name] = ManagedMCPTask(generation: generation, task: task)
     }
 
-    @MainActor
-    private func performScheduledReconnect(for serverName: String) async {
-        pendingReconnects.remove(serverName)
+        private func performScheduledReconnect(serverName: String, generation: UInt64) {
+            guard reconnectTasks[serverName]?.generation == generation else { return }
+            reconnectTasks.removeValue(forKey: serverName)
 
-        guard let latestConfig = serverConfigs.first(where: { $0.name == serverName }),
-              latestConfig.enabled
+            guard serverGenerations[serverName] == generation,
+                  let config = serverConfigs.first(where: { $0.name == serverName }),
+                  config.enabled
         else {
-            if let config = serverConfigs.first(where: { $0.name == serverName }) {
-                setStatus(for: config, state: .disabled)
-            }
             return
         }
-
-        setStatus(for: latestConfig, state: .connecting)
-        await connectToServer(latestConfig, autoDisableOnFailure: false)
+            launchConnection(to: config, autoDisableOnFailure: false)
     }
 
-    @MainActor
     func disconnectServer(_ serverName: String) {
-        services[serverName]?.disconnect()
-        services.removeValue(forKey: serverName)
-        pendingReconnects.remove(serverName)
+            _ = advanceGeneration(for: serverName)
+            cancelServerTasks(for: serverName)
 
-        // Remove tools from this server
-        availableTools.removeAll { $0.serverName == serverName }
-        availableResources.removeAll { $0.serverName == serverName }
-        refreshStatusToolCount(for: serverName)
+            if let managed = services.removeValue(forKey: serverName) {
+                managed.service.delegate = nil
+                managed.service.disconnect()
+            }
+            removeArtifacts(for: serverName)
 
         if let config = serverConfigs.first(where: { $0.name == serverName }) {
-            let newState: MCPServerStatus.State = config.enabled ? .idle : .disabled
-            setStatus(for: config, state: newState)
+                setStatus(for: config, state: config.enabled ? .idle : .disabled)
         }
     }
 
     func connectToAllEnabledServers() async {
         let enabledConfigs = serverConfigs.filter(\.enabled)
-        DiagnosticsLogger.log(
-            .mcpServerManager,
-            level: .info,
-            message: "Connecting to enabled MCP servers",
-            metadata: ["count": "\(enabledConfigs.count)", "servers": enabledConfigs.map(\.name).joined(separator: ",")]
-        )
-
-        await withTaskGroup(of: Void.self) { group in
             for config in enabledConfigs {
-                group.addTask {
-                    await self.connectToServer(config)
-                }
-            }
+                launchConnection(to: config)
         }
 
-        DiagnosticsLogger.log(
-            .mcpServerManager,
-            level: .info,
-            message: "All enabled servers connected",
-            metadata: ["tools": "\(availableTools.count)"]
-        )
+            let operations = enabledConfigs.compactMap { connectionTasks[$0.name] }
+            await awaitOperations(operations)
     }
 
-    @MainActor
     func disconnectAllServers() {
-        for serverName in services.keys {
+            discoveryBatchTask?.task.cancel()
+            discoveryBatchTask = nil
+            isDiscovering = false
+
+            let serverNames = Set(serverConfigs.map(\.name))
+                .union(services.keys)
+                .union(connectionTasks.keys)
+                .union(reconnectTasks.keys)
+                .union(discoveryTasks.keys)
+            for serverName in serverNames {
             disconnectServer(serverName)
         }
     }
@@ -447,78 +603,124 @@ class MCPServerManager: ObservableObject {
     // MARK: - Tool Discovery
 
     func discoverAllTools() async {
-        await MainActor.run {
+            discoveryBatchTask?.task.cancel()
+            discoveryBatchGeneration &+= 1
+            let generation = discoveryBatchGeneration
             isDiscovering = true
-        }
 
-        // Capture services snapshot to avoid concurrency issues
-        let servicesSnapshot = services
-
-        let results = await withTaskGroup(of: (String, [MCPTool], [MCPResource]).self) { group in
-            for (serverName, service) in servicesSnapshot where service.isConnected {
-                group.addTask {
-                    let tools = await (try? service.listTools()) ?? []
-                    let resources = await (try? service.listResources()) ?? []
-                    return (serverName, tools, resources)
+            let task = Task { @MainActor [weak self] in
+                guard let self else { return }
+                defer {
+                    if self.discoveryBatchTask?.generation == generation {
+                        self.discoveryBatchTask = nil
+                        self.isDiscovering = false
                 }
             }
+                guard !Task.isCancelled else { return }
 
-            var allTools: [MCPTool] = []
-            var allResources: [MCPResource] = []
-
-            for await (serverName, tools, resources) in group {
-                DiagnosticsLogger.log(
-                    .mcpServerManager,
-                    level: .info,
-                    message: "Discovered tools from server",
-                    metadata: ["server": serverName, "tools": "\(tools.count)"]
+                let snapshot = Array(self.services.map { ($0.key, $0.value) })
+                let operations = snapshot.compactMap { serverName, managed in
+                    self.startDiscoveryOperation(
+                        serverName: serverName,
+                        generation: managed.generation,
+                        service: managed.service,
+                        forceNew: true
                 )
-                allTools.append(contentsOf: tools)
-                allResources.append(contentsOf: resources)
             }
+                await self.awaitSharedOperations(operations)
 
-            return (allTools, allResources)
+                guard self.discoveryBatchTask?.generation == generation,
+                      !Task.isCancelled
+                else {
+                    return
         }
-
-        await MainActor.run {
-            self.availableTools = results.0
-            self.availableResources = results.1
-            self.isDiscovering = false
-            // Invalidate cache when tools change
-            self.cachedEnabledTools = []
-            self.cachedOpenAIFunctions = []
             self.refreshAllStatusToolCounts()
         }
+            let operation = ManagedMCPTask(generation: generation, task: task)
+            discoveryBatchTask = operation
+            await awaitOperation(operation)
     }
 
     func discoverTools(for serverName: String) async {
-        // Thread-safe access to services dictionary
-        let service = await MainActor.run {
-            services[serverName]
+            guard let managed = services[serverName], managed.service.isConnected,
+                  let operation = startDiscoveryOperation(
+                      serverName: serverName,
+                      generation: managed.generation,
+                      service: managed.service,
+                      forceNew: true
+                  )
+            else {
+                return
+            }
+            await awaitOperation(operation)
         }
 
-        guard let service, service.isConnected else {
-            DiagnosticsLogger.log(
-                .mcpServerManager,
-                level: .error,
-                message: "Cannot discover tools; service not connected",
-                metadata: ["server": serverName]
-            )
+        private func startDiscoveryOperation(
+            serverName: String,
+            generation: UInt64,
+            service: MCPServicing,
+            forceNew: Bool = false
+        ) -> ManagedMCPTask? {
+            guard isCurrentService(service, serverName: serverName, generation: generation),
+                  service.isConnected
+            else {
+                return nil
+            }
+            if let existing = discoveryTasks[serverName], existing.generation == generation, !forceNew {
+                if !existing.task.isCancelled {
+                    return existing
+                }
+                discoveryTasks.removeValue(forKey: serverName)
+            }
+            if forceNew,
+               let existing = discoveryTasks[serverName],
+               existing.generation == generation,
+               committedDiscoveryGenerations[serverName] == generation
+            {
+                existing.task.cancel()
+            }
+
+            committedDiscoveryGenerations.removeValue(forKey: serverName)
+            let operationID = UUID()
+            let task = Task { @MainActor [weak self, service] in
+                guard let self else { return }
+                await self.runDiscovery(
+                    serverName: serverName,
+                    generation: generation,
+                    operationID: operationID,
+                    service: service
+                )
+                self.clearDiscoveryTask(
+                    serverName: serverName,
+                    generation: generation,
+                    operationID: operationID
+                )
+            }
+            let operation = ManagedMCPTask(operationID: operationID, generation: generation, task: task)
+            discoveryTasks[serverName] = operation
+            return operation
+        }
+
+        private func runDiscovery(
+            serverName: String,
+            generation: UInt64,
+            operationID: UUID,
+            service: MCPServicing
+        ) async {
+            guard isCurrentService(service, serverName: serverName, generation: generation),
+                  service.isConnected
+            else {
             return
         }
 
-        // Discover tools and resources independently - don't let one failure block the other
         var tools: [MCPTool] = []
         var resources: [MCPResource] = []
 
         do {
             tools = try await service.listTools()
-            DiagnosticsLogger.log(
-                .mcpServerManager,
-                level: .info,
-                message: "Discovered tools",
-                metadata: ["server": serverName, "count": "\(tools.count)"]
-            )
+                try Task.checkCancellation()
+            } catch is CancellationError {
+                return
         } catch {
             DiagnosticsLogger.log(
                 .mcpServerManager,
@@ -527,15 +729,18 @@ class MCPServerManager: ObservableObject {
                 metadata: ["server": serverName, "error": error.localizedDescription]
             )
         }
+        guard isCurrentService(service, serverName: serverName, generation: generation),
+              discoveryTasks[serverName]?.operationID == operationID,
+              !Task.isCancelled
+            else {
+                return
+            }
 
         do {
             resources = try await service.listResources()
-            DiagnosticsLogger.log(
-                .mcpServerManager,
-                level: .info,
-                message: "Discovered resources",
-                metadata: ["server": serverName, "count": "\(resources.count)"]
-            )
+                try Task.checkCancellation()
+            } catch is CancellationError {
+                return
         } catch {
             DiagnosticsLogger.log(
                 .mcpServerManager,
@@ -544,21 +749,20 @@ class MCPServerManager: ObservableObject {
                 metadata: ["server": serverName, "error": error.localizedDescription]
             )
         }
-
-        await MainActor.run {
-            // Remove old tools/resources from this server
-            self.availableTools.removeAll { $0.serverName == serverName }
-            self.availableResources.removeAll { $0.serverName == serverName }
-
-            // Add newly discovered items
-            self.availableTools.append(contentsOf: tools)
-            self.availableResources.append(contentsOf: resources)
-
-            // Invalidate cache when tools change
-            self.cachedEnabledTools = []
-            self.cachedOpenAIFunctions = []
-            self.refreshStatusToolCount(for: serverName)
+            guard isCurrentService(service, serverName: serverName, generation: generation),
+                  discoveryTasks[serverName]?.operationID == operationID,
+                  !Task.isCancelled
+            else {
+                return
         }
+
+            availableTools.removeAll { $0.serverName == serverName }
+            availableResources.removeAll { $0.serverName == serverName }
+            availableTools.append(contentsOf: tools)
+            availableResources.append(contentsOf: resources)
+            committedDiscoveryGenerations[serverName] = generation
+            invalidateToolCache()
+            refreshStatusToolCount(for: serverName)
 
         DiagnosticsLogger.log(
             .mcpServerManager,
@@ -567,10 +771,137 @@ class MCPServerManager: ObservableObject {
             metadata: [
                 "server": serverName,
                 "tools": "\(tools.count)",
-                "resources": "\(resources.count)"
+                    "resources": "\(resources.count)",
+                    "generation": "\(generation)"
             ]
         )
     }
+
+        private func awaitOperation(_ operation: ManagedMCPTask) async {
+            await withTaskCancellationHandler {
+                await operation.task.value
+            } onCancel: {
+                operation.task.cancel()
+            }
+        }
+
+        private func awaitOperations(_ operations: [ManagedMCPTask]) async {
+            await withTaskCancellationHandler {
+                for operation in operations {
+                    await operation.task.value
+                }
+            } onCancel: {
+                for operation in operations {
+                    operation.task.cancel()
+                }
+            }
+        }
+
+        private func awaitSharedOperations(_ operations: [ManagedMCPTask]) async {
+            for operation in operations {
+                guard !Task.isCancelled else { return }
+                await operation.task.value
+            }
+        }
+
+        private func currentConfig(matching config: MCPServerConfig) -> MCPServerConfig? {
+            serverConfigs.first { $0.id == config.id && $0.name == config.name }
+        }
+
+        @discardableResult
+        private func advanceGeneration(for serverName: String) -> UInt64 {
+            let next = (serverGenerations[serverName] ?? 0) &+ 1
+            serverGenerations[serverName] = next
+            return next
+        }
+
+        private func isCurrentService(
+            _ service: MCPServicing,
+            serverName: String,
+            generation: UInt64
+        ) -> Bool {
+            guard let managed = services[serverName], managed.generation == generation else { return false }
+            return (managed.service as AnyObject) === (service as AnyObject)
+        }
+
+        private func cancelServerTasks(for serverName: String) {
+            connectionTasks.removeValue(forKey: serverName)?.task.cancel()
+            reconnectTasks.removeValue(forKey: serverName)?.task.cancel()
+            discoveryTasks.removeValue(forKey: serverName)?.task.cancel()
+            committedDiscoveryGenerations.removeValue(forKey: serverName)
+        }
+
+        private func cancelDiscoveryTask(for serverName: String, generation: UInt64) {
+            guard discoveryTasks[serverName]?.generation == generation else { return }
+            discoveryTasks.removeValue(forKey: serverName)?.task.cancel()
+        }
+
+        private func clearConnectionTask(serverName: String, generation: UInt64) {
+            guard connectionTasks[serverName]?.generation == generation else { return }
+            connectionTasks.removeValue(forKey: serverName)
+        }
+
+        private func clearReconnectTask(serverName: String, generation: UInt64) {
+            guard reconnectTasks[serverName]?.generation == generation else { return }
+            reconnectTasks.removeValue(forKey: serverName)
+        }
+
+        private func clearDiscoveryTask(
+            serverName: String,
+            generation: UInt64,
+            operationID: UUID
+        ) {
+            guard discoveryTasks[serverName]?.generation == generation,
+                  discoveryTasks[serverName]?.operationID == operationID
+            else { return }
+            discoveryTasks.removeValue(forKey: serverName)
+        }
+
+        private func removeArtifacts(for serverName: String) {
+            committedDiscoveryGenerations.removeValue(forKey: serverName)
+            availableTools.removeAll { $0.serverName == serverName }
+            availableResources.removeAll { $0.serverName == serverName }
+            invalidateToolCache()
+            refreshStatusToolCount(for: serverName)
+        }
+
+        private func invalidateToolCache() {
+            cachedEnabledTools = []
+            cachedOpenAIFunctions = []
+            toolLookup = [:]
+        }
+
+        fileprivate func handleServiceTermination(
+            _ service: MCPServicing,
+            serverName: String,
+            generation: UInt64,
+            error: String?
+        ) {
+            guard isCurrentService(service, serverName: serverName, generation: generation),
+                  let managed = services[serverName]
+            else {
+                DiagnosticsLogger.log(
+                    .mcpServerManager,
+                    level: .info,
+                    message: "Ignoring stale MCP service termination",
+                    metadata: ["server": serverName, "generation": "\(generation)"]
+                )
+                return
+            }
+
+            services.removeValue(forKey: serverName)
+            connectionTasks.removeValue(forKey: serverName)?.task.cancel()
+            cancelDiscoveryTask(for: serverName, generation: generation)
+            removeArtifacts(for: serverName)
+
+            guard let config = serverConfigs.first(where: { $0.id == managed.configID && $0.name == serverName }),
+                  config.enabled
+            else {
+                return
+            }
+            setStatus(for: config, state: .reconnecting, error: error)
+            scheduleReconnect(for: config, generation: generation)
+        }
 
     // MARK: - Tool Execution
 
@@ -590,11 +921,11 @@ class MCPServerManager: ObservableObject {
                 throw MCPManagerError.toolNotFound(name)
             }
 
-            guard let service = services[tool.serverName], service.isConnected else {
+                guard let managed = services[tool.serverName], managed.service.isConnected else {
                 throw MCPManagerError.toolNotFound(name)
             }
 
-            return ToolExecutionContext(service: service, arguments: sendableArguments)
+                return ToolExecutionContext(service: managed.service, arguments: sendableArguments)
         }
 
         do {
@@ -602,6 +933,8 @@ class MCPServerManager: ObservableObject {
                 let bridgedArguments = context.arguments.mapValues { $0.value }
                 return try await context.service.callTool(name: name, arguments: bridgedArguments)
             }
+            } catch is CancellationError {
+                throw CancellationError()
         } catch MCPServiceError.timeout {
             throw MCPManagerError.executionFailed(name, "Tool execution timed out after 30 seconds")
         } catch {
@@ -615,11 +948,11 @@ class MCPServerManager: ObservableObject {
         if case .connected? = serverStatuses[serverName]?.state {
             return true
         }
-        return services[serverName]?.isConnected ?? false
+            return services[serverName]?.service.isConnected ?? false
     }
 
     func getServerError(_ serverName: String) -> String? {
-        serverStatuses[serverName]?.lastError ?? services[serverName]?.lastError
+            serverStatuses[serverName]?.lastError ?? services[serverName]?.service.lastError
     }
 
     func getConnectedServerCount() -> Int {
@@ -685,39 +1018,6 @@ enum MCPManagerError: LocalizedError {
     }
 }
 
-// MARK: - MCPServiceDelegate
-
-extension MCPServerManager: MCPServiceDelegate {
-    func mcpService(_ service: MCPServicing, didTerminateWithError error: String?) {
-        let serverName = service.serverConfig.name
-        DiagnosticsLogger.log(
-            .mcpServerManager,
-            level: .error,
-            message: "MCP service disconnected",
-            metadata: [
-                "server": serverName,
-                "error": error ?? "unknown"
-            ]
-        )
-
-        services.removeValue(forKey: serverName)
-        availableTools.removeAll { $0.serverName == serverName }
-        availableResources.removeAll { $0.serverName == serverName }
-        cachedEnabledTools = []
-        cachedOpenAIFunctions = []
-
-        guard let config = serverConfigs.first(where: { $0.name == serverName }), config.enabled else {
-            if let config = serverConfigs.first(where: { $0.name == serverName }) {
-                setStatus(for: config, state: .disabled, error: error)
-            }
-            return
-        }
-
-        setStatus(for: config, state: .reconnecting, error: error)
-        scheduleReconnect(for: config)
-    }
-}
-
 // MARK: - Status Helpers
 
 private extension MCPServerManager {
@@ -779,4 +1079,5 @@ private extension MCPServerManager {
         }
     }
 }
+// swiftlint:enable type_body_length
 #endif

--- a/Sources/Ayna/Services/MCPServerManager.swift
+++ b/Sources/Ayna/Services/MCPServerManager.swift
@@ -44,11 +44,87 @@ private struct ManagedMCPTask: Sendable {
     let operationID: UUID
     let generation: UInt64
     let task: Task<Void, Never>
+    let completion: ManagedMCPTaskCompletion
 
-    init(operationID: UUID = UUID(), generation: UInt64, task: Task<Void, Never>) {
+    init(
+        operationID: UUID = UUID(),
+        generation: UInt64,
+        operation: @escaping @MainActor @Sendable () async -> Void
+    ) {
+        let completion = ManagedMCPTaskCompletion()
         self.operationID = operationID
         self.generation = generation
-        self.task = task
+        self.completion = completion
+        task = Task { @MainActor in
+            defer { completion.finish() }
+            await operation()
+        }
+    }
+}
+
+final class ManagedMCPTaskCompletion: Sendable {
+    private struct State {
+        var isFinished = false
+        var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
+        var cancelledWaiterIDs: Set<UUID> = []
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var pendingWaiterCount: Int {
+        state.withLock { $0.waiters.count }
+    }
+
+    func wait() async {
+        let waiterID = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                register(waiterID: waiterID, continuation: continuation)
+            }
+        } onCancel: {
+            cancel(waiterID: waiterID)
+        }
+    }
+
+    func finish() {
+        let continuations = state.withLock { state -> [CheckedContinuation<Void, Never>] in
+            guard !state.isFinished else { return [] }
+            state.isFinished = true
+            state.cancelledWaiterIDs.removeAll()
+            let continuations = Array(state.waiters.values)
+            state.waiters.removeAll()
+            return continuations
+        }
+        continuations.forEach { $0.resume() }
+    }
+
+    private func register(
+        waiterID: UUID,
+        continuation: CheckedContinuation<Void, Never>
+    ) {
+        let shouldResume = state.withLock { state in
+            if state.isFinished || state.cancelledWaiterIDs.remove(waiterID) != nil {
+                return true
+            }
+            state.waiters[waiterID] = continuation
+            return false
+        }
+        if shouldResume {
+            continuation.resume()
+        }
+    }
+
+    private func cancel(waiterID: UUID) {
+        let continuation = state.withLock { state -> CheckedContinuation<Void, Never>? in
+            if let continuation = state.waiters.removeValue(forKey: waiterID) {
+                return continuation
+            }
+            if !state.isFinished {
+                state.cancelledWaiterIDs.insert(waiterID)
+            }
+            return nil
+        }
+        continuation?.resume()
     }
 }
 
@@ -315,7 +391,7 @@ class MCPServerManager: ObservableObject {
             )
             setStatus(for: config, state: .connecting, clearExistingError: true)
 
-            let task = Task { @MainActor [weak self, service] in
+            let operation = ManagedMCPTask(generation: generation) { [weak self, service] in
                 guard let self else { return }
                 await self.runConnection(
                     config: config,
@@ -325,7 +401,6 @@ class MCPServerManager: ObservableObject {
                 )
                 self.clearConnectionTask(serverName: config.name, generation: generation)
             }
-            let operation = ManagedMCPTask(generation: generation, task: task)
             connectionTasks[config.name] = operation
             return operation
         }
@@ -536,7 +611,7 @@ class MCPServerManager: ObservableObject {
 
         setStatus(for: config, state: .reconnecting)
         let delaySeconds = max(TimeInterval.zero, reconnectDelayProvider())
-            let task = Task { @MainActor [weak self] in
+            reconnectTasks[config.name] = ManagedMCPTask(generation: generation) { [weak self] in
             guard let self else { return }
                 do {
             if delaySeconds > 0 {
@@ -549,7 +624,6 @@ class MCPServerManager: ObservableObject {
                 }
                 self.performScheduledReconnect(serverName: config.name, generation: generation)
         }
-            reconnectTasks[config.name] = ManagedMCPTask(generation: generation, task: task)
     }
 
         private func performScheduledReconnect(serverName: String, generation: UInt64) {
@@ -613,7 +687,7 @@ class MCPServerManager: ObservableObject {
             let generation = discoveryBatchGeneration
             isDiscovering = true
 
-            let task = Task { @MainActor [weak self] in
+            let operation = ManagedMCPTask(generation: generation) { [weak self] in
                 guard let self else { return }
                 defer {
                     if self.discoveryBatchTask?.generation == generation {
@@ -638,10 +712,9 @@ class MCPServerManager: ObservableObject {
                       !Task.isCancelled
                 else {
                     return
-        }
+            }
             self.refreshAllStatusToolCounts()
         }
-            let operation = ManagedMCPTask(generation: generation, task: task)
             discoveryBatchTask = operation
             await awaitOperation(operation)
     }
@@ -687,7 +760,10 @@ class MCPServerManager: ObservableObject {
 
             committedDiscoveryGenerations.removeValue(forKey: serverName)
             let operationID = UUID()
-            let task = Task { @MainActor [weak self, service] in
+            let operation = ManagedMCPTask(
+                operationID: operationID,
+                generation: generation
+            ) { [weak self, service] in
                 guard let self else { return }
                 await self.runDiscovery(
                     serverName: serverName,
@@ -701,7 +777,6 @@ class MCPServerManager: ObservableObject {
                     operationID: operationID
                 )
             }
-            let operation = ManagedMCPTask(operationID: operationID, generation: generation, task: task)
             discoveryTasks[serverName] = operation
             return operation
         }
@@ -783,29 +858,20 @@ class MCPServerManager: ObservableObject {
     }
 
         private func awaitOperation(_ operation: ManagedMCPTask) async {
-            await withTaskCancellationHandler {
-                await operation.task.value
-            } onCancel: {
-                operation.task.cancel()
-            }
+            await operation.completion.wait()
         }
 
         private func awaitOperations(_ operations: [ManagedMCPTask]) async {
-            await withTaskCancellationHandler {
-                for operation in operations {
-                    await operation.task.value
-                }
-            } onCancel: {
-                for operation in operations {
-                    operation.task.cancel()
-                }
+            for operation in operations {
+                guard !Task.isCancelled else { return }
+                await awaitOperation(operation)
             }
         }
 
         private func awaitSharedOperations(_ operations: [ManagedMCPTask]) async {
             for operation in operations {
                 guard !Task.isCancelled else { return }
-                await operation.task.value
+                await awaitOperation(operation)
             }
         }
 

--- a/Sources/Ayna/Services/MCPService.swift
+++ b/Sources/Ayna/Services/MCPService.swift
@@ -7,6 +7,7 @@
 
 #if os(macOS)
 import Combine
+import Darwin
 import Foundation
 import os
 
@@ -32,10 +33,46 @@ protocol MCPServiceDelegate: AnyObject {
     func mcpService(_ service: MCPServicing, didTerminateWithError error: String?)
 }
 
+private struct MCPRequestCompletionAction: Sendable {
+    enum Reason: Sendable {
+        case cancelled
+        case timedOut
+
+        var notificationReason: String {
+            switch self {
+            case .cancelled:
+                "Client cancelled request"
+            case .timedOut:
+                "Client request timed out"
+            }
+        }
+    }
+
+    let id: Int
+    let method: String
+    let transportID: UUID
+    let reason: Reason
+    let requiresTransportInvalidation: Bool
+}
+
 private final class PendingMCPRequestStore: @unchecked Sendable {
+    private enum WriteState {
+        case queued
+        case writing
+        case written
+    }
+
     private struct Entry {
+        let method: String
+        let transportID: UUID
         let continuation: CheckedContinuation<MCPResponse, Error>
-        let timeoutTask: Task<Void, Never>
+        var timeoutTask: Task<Void, Never>?
+        var writeState: WriteState
+    }
+
+    private struct CompletionOutcome {
+        let entry: Entry
+        let action: MCPRequestCompletionAction?
     }
 
     private let timeoutSeconds: TimeInterval
@@ -43,27 +80,85 @@ private final class PendingMCPRequestStore: @unchecked Sendable {
     private var entries: [Int: Entry] = [:]
 
     init(timeoutSeconds: TimeInterval) {
-        self.timeoutSeconds = timeoutSeconds
+        self.timeoutSeconds = max(0, timeoutSeconds)
     }
 
     var count: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return entries.count
+        lock.withLock { entries.count }
     }
 
-    func insert(id: Int, method: String, continuation: CheckedContinuation<MCPResponse, Error>) {
+    func insert(
+        id: Int,
+        method: String,
+        transportID: UUID,
+        continuation: CheckedContinuation<MCPResponse, Error>,
+        timeoutHandler: @escaping @Sendable (MCPRequestCompletionAction) -> Void
+    ) {
+        lock.withLock {
+            entries[id] = Entry(
+                method: method,
+                transportID: transportID,
+                continuation: continuation,
+                timeoutTask: nil,
+                writeState: .queued
+            )
+    }
+
         let timeoutSeconds = self.timeoutSeconds
         let timeoutTask = Task.detached { [weak self] in
-            guard let self else { return }
-            try? await Task.sleep(for: .seconds(timeoutSeconds))
-            guard !Task.isCancelled else { return }
-            self.timeoutRequest(id: id, method: method)
+            do {
+                try await Task.sleep(for: .seconds(timeoutSeconds))
+            } catch {
+                return
         }
 
-        lock.lock()
-        entries[id] = Entry(continuation: continuation, timeoutTask: timeoutTask)
-        lock.unlock()
+            guard let action = self?.timeoutRequest(id: id) else { return }
+            timeoutHandler(action)
+        }
+
+        let shouldCancelTimeout = lock.withLock { () -> Bool in
+            guard var entry = entries[id] else { return true }
+            entry.timeoutTask = timeoutTask
+            entries[id] = entry
+            return false
+        }
+        if shouldCancelTimeout {
+            timeoutTask.cancel()
+        }
+    }
+
+    func beginWrite(id: Int) -> Bool {
+        lock.withLock {
+            guard var entry = entries[id], entry.writeState == .queued else { return false }
+            entry.writeState = .writing
+            entries[id] = entry
+            return true
+        }
+    }
+
+    func finishWrite(id: Int) -> MCPRequestCompletionAction? {
+        lock.withLock {
+            if var entry = entries[id], entry.writeState == .writing {
+                entry.writeState = .written
+                entries[id] = entry
+            }
+            return nil
+        }
+    }
+
+    func failWrite(id: Int, error: Error) {
+        let continuation: CheckedContinuation<MCPResponse, Error>? = lock.withLock {
+            guard let entry = entries.removeValue(forKey: id) else { return nil }
+            entry.timeoutTask?.cancel()
+            return entry.continuation
+        }
+        continuation?.resume(throwing: error)
+    }
+
+    func cancel(id: Int) -> MCPRequestCompletionAction? {
+        guard let outcome = complete(id: id, reason: .cancelled) else { return nil }
+        outcome.entry.continuation.resume(throwing: CancellationError())
+        return outcome.action
     }
 
     @discardableResult
@@ -80,58 +175,255 @@ private final class PendingMCPRequestStore: @unchecked Sendable {
         return true
     }
 
+    func failAll(for transportID: UUID, error: Error) {
+        let continuations: [CheckedContinuation<MCPResponse, Error>] = lock.withLock {
+            let matchingIDs = entries.compactMap { id, entry in
+                entry.transportID == transportID ? id : nil
+            }
+            let matchingEntries = matchingIDs.compactMap { entries.removeValue(forKey: $0) }
+            matchingEntries.forEach { $0.timeoutTask?.cancel() }
+            return matchingEntries.map(\.continuation)
+        }
+        continuations.forEach { $0.resume(throwing: error) }
+    }
+
     func failAll(error: Error) {
         let continuations: [CheckedContinuation<MCPResponse, Error>] = lock.withLock {
             let allEntries = Array(entries.values)
             entries.removeAll()
-            allEntries.forEach { $0.timeoutTask.cancel() }
+            allEntries.forEach { $0.timeoutTask?.cancel() }
             return allEntries.map(\.continuation)
         }
-
         continuations.forEach { $0.resume(throwing: error) }
     }
 
-    private func timeoutRequest(id: Int, method: String) {
-        guard let entry = take(id: id) else { return }
+    private func timeoutRequest(id: Int) -> MCPRequestCompletionAction? {
+        guard let outcome = complete(id: id, reason: .timedOut) else { return nil }
 
         DiagnosticsLogger.log(
             .mcpService,
             level: .error,
             message: "MCP request timed out",
-            metadata: ["id": "\(id)", "method": method]
+            metadata: ["id": "\(id)", "method": outcome.entry.method]
         )
-        entry.continuation.resume(throwing: MCPServiceError.timeout)
+        outcome.entry.continuation.resume(throwing: MCPServiceError.timeout)
+        return outcome.action
+    }
+
+    private func complete(id: Int, reason: MCPRequestCompletionAction.Reason) -> CompletionOutcome? {
+        lock.withLock {
+            guard let entry = entries.removeValue(forKey: id) else { return nil }
+            entry.timeoutTask?.cancel()
+
+            switch entry.writeState {
+            case .queued:
+                return CompletionOutcome(entry: entry, action: nil)
+            case .writing:
+                return CompletionOutcome(
+                    entry: entry,
+                    action: MCPRequestCompletionAction(
+                        id: id,
+                        method: entry.method,
+                        transportID: entry.transportID,
+                        reason: reason,
+                        requiresTransportInvalidation: true
+                    )
+                )
+            case .written:
+                return CompletionOutcome(
+                    entry: entry,
+                    action: MCPRequestCompletionAction(
+                        id: id,
+                        method: entry.method,
+                        transportID: entry.transportID,
+                        reason: reason,
+                        requiresTransportInvalidation: false
+                    )
+                )
+            }
+        }
     }
 
     private func take(id: Int) -> Entry? {
         lock.withLock {
             guard let entry = entries.removeValue(forKey: id) else { return nil }
-            entry.timeoutTask.cancel()
+            entry.timeoutTask?.cancel()
             return entry
         }
     }
 }
 
 private extension NSLock {
-    func withLock<T>(_ body: () -> T) -> T {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
         lock()
         defer { unlock() }
-        return body()
+        return try body()
+    }
+}
+
+private final class MCPTransportLease: @unchecked Sendable {
+    let id: UUID
+
+    private let inputHandle: FileHandle
+    private let lock = NSLock()
+    private var isActive = true
+
+    init(id: UUID, inputHandle: FileHandle) {
+        self.id = id
+        self.inputHandle = inputHandle
+        // Closing a wedged transport from another task must make blocked writes fail with
+        // EPIPE rather than terminating the entire app with SIGPIPE.
+        _ = fcntl(inputHandle.fileDescriptor, F_SETNOSIGPIPE, 1)
+    }
+
+    func invalidate() {
+        lock.withLock { isActive = false }
+    }
+
+    func activeInputHandle() throws -> FileHandle {
+        try lock.withLock {
+            guard isActive else { throw MCPServiceError.notConnected }
+            return inputHandle
+        }
+    }
+}
+
+private final class MCPProcessLifecycle: @unchecked Sendable {
+    private struct State {
+        var isManualDisconnect = false
+        var isRegistered = false
+        var isFinalized = false
+    }
+
+    let id: UUID
+    let process: Process
+    let inputPipe: Pipe
+    let outputPipe: Pipe
+    let errorPipe: Pipe
+    let lease: MCPTransportLease
+    let trackingKey: String
+
+    private let registerProcess: @Sendable (String, pid_t) -> Void
+    private let unregisterProcess: @Sendable (String) -> Void
+    private let lock = NSLock()
+    private var state = State()
+
+    init(
+        id: UUID,
+        serverName: String,
+        process: Process,
+        inputPipe: Pipe,
+        outputPipe: Pipe,
+        errorPipe: Pipe,
+        registerProcess: @escaping @Sendable (String, pid_t) -> Void,
+        unregisterProcess: @escaping @Sendable (String) -> Void
+    ) {
+        self.id = id
+        self.process = process
+        self.inputPipe = inputPipe
+        self.outputPipe = outputPipe
+        self.errorPipe = errorPipe
+        lease = MCPTransportLease(id: id, inputHandle: inputPipe.fileHandleForWriting)
+        trackingKey = "\(serverName)#\(id.uuidString)"
+        self.registerProcess = registerProcess
+        self.unregisterProcess = unregisterProcess
+    }
+
+    func registerAfterLaunch() {
+        lock.lock()
+        guard !state.isFinalized, !state.isRegistered else {
+            lock.unlock()
+            return
+        }
+        registerProcess(trackingKey, process.processIdentifier)
+        state.isRegistered = true
+        lock.unlock()
+    }
+
+    func markManualDisconnect() {
+        lock.withLock { state.isManualDisconnect = true }
+    }
+
+    func stopReading() {
+        outputPipe.fileHandleForReading.readabilityHandler = nil
+        errorPipe.fileHandleForReading.readabilityHandler = nil
+    }
+
+    /// Returns whether this was a manual disconnect. Nil means another exit observer finalized it.
+    func finalize() -> Bool? {
+        let finalization: (manual: Bool, shouldUnregister: Bool)? = lock.withLock {
+            guard !state.isFinalized else { return nil }
+            state.isFinalized = true
+            return (state.isManualDisconnect, state.isRegistered)
+        }
+        guard let finalization else { return nil }
+
+        stopReading()
+        lease.invalidate()
+        if finalization.shouldUnregister {
+            unregisterProcess(trackingKey)
+        }
+        try? inputPipe.fileHandleForWriting.close()
+        try? outputPipe.fileHandleForReading.close()
+        try? errorPipe.fileHandleForReading.close()
+        return finalization.manual
+    }
+}
+
+private actor MCPOutboundWriter {
+    typealias MessageWriteHandler = @Sendable (FileHandle, Data) throws -> Void
+
+    private let writeHandler: MessageWriteHandler
+
+    init(writeHandler: @escaping MessageWriteHandler) {
+        self.writeHandler = writeHandler
+    }
+
+    func writeRequest(
+        id: Int,
+        method: String,
+        data: Data,
+        lifecycle: MCPProcessLifecycle,
+        store: PendingMCPRequestStore,
+        beforeWrite: (@Sendable (Int, String) -> Void)?,
+        completionHandler: @escaping @Sendable (MCPRequestCompletionAction) -> Void
+    ) {
+        beforeWrite?(id, method)
+        guard store.beginWrite(id: id) else { return }
+
+        do {
+            try write(data, lifecycle: lifecycle)
+            if let action = store.finishWrite(id: id) {
+                completionHandler(action)
+            }
+        } catch {
+            store.failWrite(id: id, error: error)
+        }
+    }
+
+    func writeNotification(_ data: Data, lifecycle: MCPProcessLifecycle) throws {
+        try write(data, lifecycle: lifecycle)
+    }
+
+    private func write(_ data: Data, lifecycle: MCPProcessLifecycle) throws {
+        let inputHandle = try lifecycle.lease.activeInputHandle()
+        try writeHandler(inputHandle, data)
     }
 }
 
 /// Service for communicating with MCP servers via stdio
 class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
-    private var process: Process?
-    private var standardInput: Pipe?
-    private var standardOutput: Pipe?
-    private var standardError: Pipe?
-
-    private var healthCheckTask: Task<Void, Never>?
-    private var isDisconnectingManually = false
+    private var activeLifecycle: MCPProcessLifecycle?
+    private var lifecycles: [UUID: MCPProcessLifecycle] = [:]
+    private var healthCheckTask: (transportID: UUID, task: Task<Void, Never>)?
 
     private var requestId = 0
     private let pendingRequests: PendingMCPRequestStore
+    private let requestWriteHook: (@Sendable (Int, String) -> Void)?
+    private let outboundWriter: MCPOutboundWriter
+    private let terminationGracePeriod: TimeInterval
+    private let processRegistrationHandler: @Sendable (String, pid_t) -> Void
+    private let processUnregistrationHandler: @Sendable (String) -> Void
 
     let serverConfig: MCPServerConfig
     @Published var isConnected = false
@@ -139,7 +431,6 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
     weak var delegate: MCPServiceDelegate?
 
     private var outputBuffer = ""
-
     private let stateLock = NSLock()
 
     @discardableResult
@@ -153,15 +444,40 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
         pendingRequests.count
     }
 
-    init(serverConfig: MCPServerConfig, requestTimeoutSeconds: TimeInterval = 30) {
+    init(
+        serverConfig: MCPServerConfig,
+        requestTimeoutSeconds: TimeInterval = 30,
+        requestWriteHook: (@Sendable (Int, String) -> Void)? = nil,
+        messageWriteHandler: @escaping @Sendable (FileHandle, Data) throws -> Void = { handle, data in
+            try handle.write(contentsOf: data)
+        },
+        terminationGracePeriod: TimeInterval = 0.5,
+        processRegistrationHandler: @escaping @Sendable (String, pid_t) -> Void = { trackingKey, pid in
+            MCPProcessTracker.shared.register(serverName: trackingKey, pid: pid)
+        },
+        processUnregistrationHandler: @escaping @Sendable (String) -> Void = { trackingKey in
+            MCPProcessTracker.shared.unregister(serverName: trackingKey)
+        }
+    ) {
         self.serverConfig = serverConfig
         pendingRequests = PendingMCPRequestStore(timeoutSeconds: requestTimeoutSeconds)
+        self.requestWriteHook = requestWriteHook
+        outboundWriter = MCPOutboundWriter(writeHandler: messageWriteHandler)
+        self.terminationGracePeriod = max(0, terminationGracePeriod)
+        self.processRegistrationHandler = processRegistrationHandler
+        self.processUnregistrationHandler = processUnregistrationHandler
     }
 
     deinit {
-        healthCheckTask?.cancel()
-        process?.terminate()
-        standardInput = nil
+        healthCheckTask?.task.cancel()
+        let remainingLifecycles = Array(lifecycles.values)
+        pendingRequests.failAll(error: MCPServiceError.notConnected)
+        for lifecycle in remainingLifecycles {
+            lifecycle.markManualDisconnect()
+            lifecycle.stopReading()
+            lifecycle.lease.invalidate()
+            Self.terminateProcess(lifecycle, gracePeriod: terminationGracePeriod)
+        }
     }
 
     // MARK: - Connection Management
@@ -170,14 +486,13 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
     /// can share the same cleanup/error propagation. Splitting it today would duplicate fragile state
     /// management, so we temporarily allow the longer body until the connection pipeline is refactored.
     func connect() async throws {
-        guard !isConnected else { return }
+        guard withLock({ activeLifecycle == nil }) else { return }
 
         let process = Process()
         let inputPipe = Pipe()
         let outputPipe = Pipe()
         let errorPipe = Pipe()
 
-        // Find the command executable with error handling
         DiagnosticsLogger.log(
             .mcpService,
             level: .info,
@@ -195,12 +510,8 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
             )
         } catch {
             let errorMsg = "Executable not found: \(serverConfig.command) - \(error.localizedDescription)"
-            DiagnosticsLogger.log(
-                .mcpService,
-                level: .error,
-                message: errorMsg
-            )
-            Task { @MainActor [weak self] in
+            DiagnosticsLogger.log(.mcpService, level: .error, message: errorMsg)
+            await MainActor.run { [weak self] in
                 self?.lastError = errorMsg
             }
             throw MCPServiceError.initializationFailed(errorMsg)
@@ -209,7 +520,6 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
         process.executableURL = URL(fileURLWithPath: commandPath)
         process.arguments = serverConfig.args
 
-        // Set up environment with proper PATH
         var environment = ProcessInfo.processInfo.environment
         let commonPaths = [
             "/opt/homebrew/bin",
@@ -219,154 +529,144 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
             "/opt/homebrew/opt/node/bin",
             NSHomeDirectory() + "/.nvm/versions/node/*/bin"
         ]
-        let existingPath = environment["PATH"] ?? ""
-        let newPath = (commonPaths + [existingPath]).joined(separator: ":")
-        environment["PATH"] = newPath
-
-        // Merge with user-provided environment
-        // Only merge if env is not empty to avoid potential type issues
-        if !serverConfig.env.isEmpty {
+        environment["PATH"] = (commonPaths + [environment["PATH"] ?? ""]).joined(separator: ":")
             for (key, value) in serverConfig.env {
                 environment[key] = value
             }
-        }
         process.environment = environment
         process.standardInput = inputPipe
         process.standardOutput = outputPipe
         process.standardError = errorPipe
 
-        withLock {
-            self.process = process
-            standardInput = inputPipe
-            standardOutput = outputPipe
-            standardError = errorPipe
+        let lifecycle = MCPProcessLifecycle(
+            id: UUID(),
+            serverName: serverConfig.name,
+            process: process,
+            inputPipe: inputPipe,
+            outputPipe: outputPipe,
+            errorPipe: errorPipe,
+            registerProcess: processRegistrationHandler,
+            unregisterProcess: processUnregistrationHandler
+        )
+        let installed = withLock { () -> Bool in
+            guard activeLifecycle == nil else { return false }
+            activeLifecycle = lifecycle
+            lifecycles[lifecycle.id] = lifecycle
+            outputBuffer = ""
+            return true
         }
-        process.terminationHandler = { [weak self] process in
-            guard let self else { return }
-            handleProcessTermination(exitCode: process.terminationStatus)
+        guard installed else { return }
+
+        process.terminationHandler = { [weak self, lifecycle] terminatedProcess in
+            let exitCode = terminatedProcess.terminationStatus
+            terminatedProcess.terminationHandler = nil
+            if let self {
+                self.processDidExit(lifecycle, exitCode: exitCode)
+            } else {
+                _ = lifecycle.finalize()
+        }
         }
 
-        // Set up output reading with error handling
         let serverName = serverConfig.name
         outputPipe.fileHandleForReading.readabilityHandler = { @Sendable [weak self] handle in
-            do {
                 let data = handle.availableData
-                guard !data.isEmpty else { return }
-
-                if let output = String(data: data, encoding: .utf8) {
-                    Task { @MainActor in
-                        self?.handleOutput(output)
-                    }
-                }
-            } catch {
-                DiagnosticsLogger.log(
-                    .mcpService,
-                    level: .error,
-                    message: "Error reading MCP output",
-                    metadata: ["server": serverName, "error": error.localizedDescription]
-                )
-            }
+            guard !data.isEmpty, let output = String(data: data, encoding: .utf8) else { return }
+            self?.handleOutput(output, transportID: lifecycle.id)
         }
 
-        // Set up error reading (stderr - may include info messages)
         errorPipe.fileHandleForReading.readabilityHandler = { @Sendable [weak self] handle in
-            do {
                 let data = handle.availableData
-                guard !data.isEmpty else { return }
+            guard !data.isEmpty, let output = String(data: data, encoding: .utf8) else { return }
 
-                if let output = String(data: data, encoding: .utf8) {
                     DiagnosticsLogger.log(
                         .mcpService,
                         level: .info,
                         message: "MCP server stderr",
                         metadata: ["server": serverName, "output": output]
                     )
-                    // Only treat it as an error if it contains error keywords
                     if output.lowercased().contains("error") || output.lowercased().contains("failed") {
-                        Task { @MainActor in
-                            self?.lastError = output
-                        }
-                    }
+                Task { @MainActor [weak self] in
+                    guard let self, self.isActiveTransport(lifecycle.id) else { return }
+                    self.lastError = output
                 }
-            } catch {
-                DiagnosticsLogger.log(
-                    .mcpService,
-                    level: .error,
-                    message: "Error reading stderr",
-                    metadata: ["server": serverName, "error": error.localizedDescription]
-                )
             }
         }
 
         do {
             try process.run()
-            MCPProcessTracker.shared.register(serverName: serverName, pid: process.processIdentifier)
-
-            // Initialize the MCP session
-            try await initialize()
+            lifecycle.registerAfterLaunch()
+            try await initialize(on: lifecycle)
+            guard isActiveTransport(lifecycle.id), !Task.isCancelled else {
+                disconnect(transportID: lifecycle.id)
+                throw CancellationError()
+            }
+        } catch is CancellationError {
+            disconnect(transportID: lifecycle.id)
+            throw CancellationError()
         } catch {
-            disconnect()
+            disconnect(transportID: lifecycle.id)
             let errorMsg = "Failed to start process: \(error.localizedDescription)"
-            DiagnosticsLogger.log(
-                .mcpService,
-                level: .error,
-                message: errorMsg
-            )
-            Task { @MainActor [weak self] in
-                self?.lastError = errorMsg
+            DiagnosticsLogger.log(.mcpService, level: .error, message: errorMsg)
+            await MainActor.run { [weak self] in
+                guard let self, !self.hasActiveReplacement(for: lifecycle.id) else { return }
+                self.lastError = errorMsg
             }
             throw MCPServiceError.initializationFailed(errorMsg)
         }
 
-        Task { @MainActor in
+        await MainActor.run { [weak self] in
+            guard let self, self.isActiveTransport(lifecycle.id) else { return }
             self.isConnected = true
             self.lastError = nil
         }
-
-        startHealthCheckTimer()
+        startHealthCheckTimer(for: lifecycle)
     }
 
     func disconnect() {
-        let alreadyDisconnecting = withLock {
-            if isDisconnectingManually { return true }
-            isDisconnectingManually = true
-            return false
-        }
-        guard !alreadyDisconnecting else { return }
-
-        stopHealthCheckTimer()
-
-        // Clean up handlers BEFORE terminating to stop processing
-        cleanupProcessResources()
-
-        // Capture process reference before clearing
-        let processToTerminate = withLock {
-            let processReference = process
-            process = nil
-            return processReference
+        _ = disconnect(transportID: nil)
         }
 
-        // Unregister from process tracker
-        MCPProcessTracker.shared.unregister(serverName: serverConfig.name)
+    @discardableResult
+    private func disconnect(transportID: UUID?) -> Bool {
+        let lifecycle: MCPProcessLifecycle? = withLock {
+            guard let current = activeLifecycle,
+                  transportID == nil || current.id == transportID
+            else {
+                return nil
+        }
 
-        // Terminate and wait for exit in background to avoid zombie processes
-        if let processToTerminate, processToTerminate.isRunning {
-            processToTerminate.terminate()
-            Task.detached {
-                processToTerminate.waitUntilExit()
+            current.markManualDisconnect()
+            current.lease.invalidate()
+            current.stopReading()
+            activeLifecycle = nil
+            outputBuffer = ""
+            if healthCheckTask?.transportID == current.id {
+                healthCheckTask?.task.cancel()
+                healthCheckTask = nil
+            }
+            return current
+        }
+        guard let lifecycle else { return false }
+
+        pendingRequests.failAll(for: lifecycle.id, error: MCPServiceError.notConnected)
+        Task { @MainActor [weak self] in
+            guard let self, !self.hasActiveReplacement(for: lifecycle.id) else { return }
+            self.isConnected = false
+        }
+
+        Self.terminateProcess(lifecycle, gracePeriod: terminationGracePeriod) { [weak self, lifecycle] exitCode in
+            if let self {
+                self.processDidExit(lifecycle, exitCode: exitCode)
+            } else {
+                _ = lifecycle.finalize()
             }
         }
-
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            isConnected = false
-            withLock { isDisconnectingManually = false }
-        }
+        return true
     }
 
     // MARK: - MCP Protocol Methods
 
-    private func initialize() async throws {
+    private func initialize(on lifecycle: MCPProcessLifecycle) async throws {
         let response = try await sendRequest(
             method: "initialize",
             params: [
@@ -379,15 +679,16 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
                     "name": "ayna",
                     "version": "1.0.0"
                 ] as [String: String])
-            ]
+            ],
+            lifecycle: lifecycle
         )
 
         guard response.error == nil else {
             throw MCPServiceError.initializationFailed(response.error?.message ?? "Unknown error")
         }
 
-        // Send initialized notification
-        try await sendNotification(method: "notifications/initialized")
+        // Send initialized notification on the same transport generation.
+        try await sendNotification(method: "notifications/initialized", lifecycle: lifecycle)
     }
 
     func listTools() async throws -> [MCPTool] {
@@ -472,67 +773,176 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
     // MARK: - Low-level JSON-RPC
 
     @MainActor
-    private func sendRequest(method: String, params: [String: AnyCodable]?) async throws -> MCPResponse {
+    private func sendRequest(
+        method: String,
+        params: [String: AnyCodable]?,
+        lifecycle suppliedLifecycle: MCPProcessLifecycle? = nil
+    ) async throws -> MCPResponse {
+        try Task.checkCancellation()
+        guard let lifecycle = suppliedLifecycle ?? withLock({ activeLifecycle }),
+              isActiveTransport(lifecycle.id)
+        else {
+            throw MCPServiceError.notConnected
+        }
+
         let id = withLock {
             requestId += 1
             return requestId
         }
-
-        return try await withCheckedThrowingContinuation { continuation in
-            pendingRequests.insert(id: id, method: method, continuation: continuation)
-
             let request = MCPRequest(id: id, method: method, params: params)
-
+        let requestData: Data
             do {
-                let data = try JSONEncoder().encode(request)
-                guard var jsonString = String(data: data, encoding: .utf8) else {
-                    pendingRequests.fail(id: id, error: MCPServiceError.encodingFailed)
+            var data = try JSONEncoder().encode(request)
+            data.append(0x0A)
+            requestData = data
+        } catch {
+            throw MCPServiceError.encodingFailed
+                }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                pendingRequests.insert(
+                    id: id,
+                    method: method,
+                    transportID: lifecycle.id,
+                    continuation: continuation,
+                    timeoutHandler: { [weak self] action in
+                        self?.handleRequestCompletion(action)
+                    }
+                )
+
+                guard !Task.isCancelled else {
+                    cancelRequest(id: id)
                     return
                 }
 
-                jsonString += "\n"
-
-                guard let inputHandle = withLock({ standardInput?.fileHandleForWriting }) else {
-                    pendingRequests.fail(id: id, error: MCPServiceError.notConnected)
-                    return
+                let writer = outboundWriter
+                let store = pendingRequests
+                let beforeWrite = requestWriteHook
+                Task.detached { [weak self, lifecycle] in
+                    await writer.writeRequest(
+                        id: id,
+                        method: method,
+                        data: requestData,
+                        lifecycle: lifecycle,
+                        store: store,
+                        beforeWrite: beforeWrite,
+                        completionHandler: { [weak self] action in
+                            self?.handleRequestCompletion(action)
                 }
+                    )
+            }
+        }
+        } onCancel: {
+            cancelRequest(id: id)
+        }
+    }
 
-                if let data = jsonString.data(using: .utf8) {
-                    inputHandle.write(data)
-                } else {
-                    pendingRequests.fail(id: id, error: MCPServiceError.encodingFailed)
-                }
+    private func cancelRequest(id: Int) {
+        if let action = pendingRequests.cancel(id: id) {
+            handleRequestCompletion(action)
+        }
+    }
+
+    private func handleRequestCompletion(_ action: MCPRequestCompletionAction) {
+        if action.requiresTransportInvalidation {
+            DiagnosticsLogger.log(
+                .mcpService,
+                level: .error,
+                message: "MCP request ended while its pipe write was blocked; disconnecting transport",
+                metadata: [
+                    "id": "\(action.id)",
+                    "method": action.method,
+                    "reason": action.reason.notificationReason,
+                    "server": serverConfig.name
+                ]
+            )
+            invalidateTransport(
+                action.transportID,
+                reason: "MCP transport write was interrupted: \(action.reason.notificationReason)"
+            )
+            return
+        }
+
+        if action.method == "initialize" {
+            DiagnosticsLogger.log(
+                .mcpService,
+                level: .info,
+                message: "Initialize request completed without a response; disconnecting transport",
+                metadata: [
+                    "id": "\(action.id)",
+                    "reason": action.reason.notificationReason,
+                    "server": serverConfig.name
+                ]
+            )
+            disconnect(transportID: action.transportID)
+            return
+        }
+
+        Task.detached { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.sendCancellationNotification(action)
             } catch {
-                pendingRequests.fail(id: id, error: error)
+                DiagnosticsLogger.log(
+                    .mcpService,
+                    level: .error,
+                    message: "Failed to send MCP cancellation notification; disconnecting",
+                    metadata: [
+                        "error": error.localizedDescription,
+                        "id": "\(action.id)",
+                        "server": self.serverConfig.name
+                    ]
+                )
+                self.disconnect(transportID: action.transportID)
             }
         }
     }
 
-    private func sendNotification(method: String, params: [String: AnyCodable]? = nil) async throws {
+    private func invalidateTransport(_ transportID: UUID, reason: String) {
+        guard disconnect(transportID: transportID) else { return }
+        Task { @MainActor [weak self] in
+            guard let self, !self.hasActiveReplacement(for: transportID) else { return }
+            self.lastError = reason
+            self.delegate?.mcpService(self, didTerminateWithError: reason)
+        }
+    }
+
+    /// MCP 2024-11-05 cancellation schema:
+    /// `notifications/cancelled` with params `{ "requestId": RequestId, "reason"?: string }`.
+    private func sendCancellationNotification(_ action: MCPRequestCompletionAction) async throws {
+        guard let lifecycle = withLock({ lifecycles[action.transportID] }) else {
+            throw MCPServiceError.notConnected
+        }
+        try await sendNotification(
+            method: "notifications/cancelled",
+            params: [
+                "requestId": AnyCodable(action.id),
+                "reason": AnyCodable(action.reason.notificationReason)
+            ],
+            lifecycle: lifecycle
+        )
+        }
+
+    private func sendNotification(
+        method: String,
+        params: [String: AnyCodable]? = nil,
+        lifecycle: MCPProcessLifecycle
+    ) async throws {
         let notification: [String: Any] = [
             "jsonrpc": "2.0",
             "method": method,
             "params": params?.mapValues { $0.value } ?? [:]
         ]
 
-        let data = try JSONSerialization.data(withJSONObject: notification)
-        guard var jsonString = String(data: data, encoding: .utf8) else {
-            throw MCPServiceError.encodingFailed
-        }
-
-        jsonString += "\n"
-
-        guard let inputHandle = withLock({ standardInput?.fileHandleForWriting }) else {
-            throw MCPServiceError.notConnected
-        }
-
-        if let data = jsonString.data(using: .utf8) {
-            inputHandle.write(data)
-        }
+        var data = try JSONSerialization.data(withJSONObject: notification)
+        data.append(0x0A)
+        try await outboundWriter.writeNotification(data, lifecycle: lifecycle)
     }
 
-    private func handleOutput(_ output: String) {
+    private func handleOutput(_ output: String, transportID: UUID) {
         let completedLines: [String] = withLock {
+            guard activeLifecycle?.id == transportID else { return [] }
             if outputBuffer.count + output.count > 1_048_576 {
                 DiagnosticsLogger.log(.mcpService, level: .error, message: "MCP output buffer exceeded 1MB limit, clearing")
                 outputBuffer = ""
@@ -582,8 +992,8 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
                     if !self.pendingRequests.resume(id: id, with: response) {
                         DiagnosticsLogger.log(
                             .mcpService,
-                            level: .error,
-                            message: "Received response for unknown request",
+                            level: .info,
+                            message: "Ignoring response for completed MCP request",
                             metadata: ["id": "\(id)"]
                         )
                     }
@@ -786,82 +1196,129 @@ class MCPService: ObservableObject, MCPServicing, @unchecked Sendable {
 
     // MARK: - Connection Monitoring
 
-    private func startHealthCheckTimer() {
-        stopHealthCheckTimer()
+    private func isActiveTransport(_ transportID: UUID) -> Bool {
+        withLock { activeLifecycle?.id == transportID }
+    }
 
-        let task = Task { [weak self] in
-            // Initial delay before first check
-            try? await Task.sleep(for: .seconds(5))
+    private func hasActiveReplacement(for transportID: UUID) -> Bool {
+        withLock {
+            guard let activeLifecycle else { return false }
+            return activeLifecycle.id != transportID
+        }
+    }
 
+    private func startHealthCheckTimer(for lifecycle: MCPProcessLifecycle) {
+        let task = Task { [weak self, lifecycle] in
+            do {
+                try await Task.sleep(for: .seconds(5))
             while !Task.isCancelled {
-                guard let self else { return }
-                let running = self.withLock { self.process?.isRunning ?? false }
-                if !running {
-                    let status = self.withLock { self.process?.terminationStatus }
-                    self.handleProcessTermination(exitCode: status)
+                    guard let self, self.isActiveTransport(lifecycle.id) else { return }
+                    if !lifecycle.process.isRunning {
+                        let exitCode = lifecycle.process.processIdentifier > 0
+                            ? lifecycle.process.terminationStatus
+                            : nil
+                        self.processDidExit(lifecycle, exitCode: exitCode)
                     return
                 }
-                try? await Task.sleep(for: .seconds(5))
+                    try await Task.sleep(for: .seconds(5))
             }
+            } catch {
+                // Cancellation is the expected shutdown path.
         }
-        withLock { healthCheckTask = task }
     }
 
-    private func stopHealthCheckTimer() {
         withLock {
-            healthCheckTask?.cancel()
-            healthCheckTask = nil
+            healthCheckTask?.task.cancel()
+            healthCheckTask = (lifecycle.id, task)
         }
     }
 
-    private func handleProcessTermination(exitCode: Int32?) {
-        stopHealthCheckTimer()
-        cleanupProcessResources()
-        withLock { process = nil }
-        let message: String? =
-            if let exitCode, exitCode != 0 {
+    private func processDidExit(_ lifecycle: MCPProcessLifecycle, exitCode: Int32?) {
+        guard let wasManualDisconnect = lifecycle.finalize() else { return }
+
+        let wasActive = withLock { () -> Bool in
+            lifecycles.removeValue(forKey: lifecycle.id)
+            guard activeLifecycle?.id == lifecycle.id else { return false }
+            activeLifecycle = nil
+            outputBuffer = ""
+            if healthCheckTask?.transportID == lifecycle.id {
+                healthCheckTask?.task.cancel()
+                healthCheckTask = nil
+            }
+            return true
+    }
+        pendingRequests.failAll(for: lifecycle.id, error: MCPServiceError.notConnected)
+        guard wasActive else { return }
+
+        Task { @MainActor [weak self] in
+            guard let self, !self.hasActiveReplacement(for: lifecycle.id) else { return }
+            self.isConnected = false
+            guard !wasManualDisconnect else { return }
+
+            let message = if let exitCode, exitCode != 0 {
                 "Exited with code \(exitCode)"
             } else {
-                nil
+                "MCP server process ended unexpectedly"
             }
-        handleUnexpectedDisconnect(reason: message)
-    }
-
-    private func handleUnexpectedDisconnect(reason: String?) {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            if withLock({ isDisconnectingManually }) {
-                withLock { isDisconnectingManually = false }
-                return
-            }
-
-            let message = reason ?? "MCP server process ended unexpectedly"
             DiagnosticsLogger.log(
                 .mcpService,
                 level: .error,
                 message: "Lost MCP connection",
                 metadata: [
-                    "server": serverConfig.name,
-                    "reason": message
+                    "server": self.serverConfig.name,
+                    "reason": message,
+                    "transport": lifecycle.id.uuidString
                 ]
             )
-            MCPProcessTracker.shared.unregister(serverName: serverConfig.name)
-            lastError = message
-            isConnected = false
-            delegate?.mcpService(self, didTerminateWithError: message)
+            self.lastError = message
+            self.delegate?.mcpService(self, didTerminateWithError: message)
         }
     }
 
-    private func cleanupProcessResources() {
-        withLock {
-            standardOutput?.fileHandleForReading.readabilityHandler = nil
-            standardError?.fileHandleForReading.readabilityHandler = nil
-            standardInput = nil
-            standardOutput = nil
-            standardError = nil
+    private static func terminateProcess(_ lifecycle: MCPProcessLifecycle, gracePeriod: TimeInterval) {
+        terminateProcess(lifecycle, gracePeriod: gracePeriod) { _ in
+            _ = lifecycle.finalize()
+        }
         }
 
-        pendingRequests.failAll(error: MCPServiceError.notConnected)
+    private static func terminateProcess(
+        _ lifecycle: MCPProcessLifecycle,
+        gracePeriod: TimeInterval,
+        completion: @escaping @Sendable (Int32?) -> Void
+    ) {
+        Task.detached {
+            let process = lifecycle.process
+            if process.isRunning {
+                process.terminate()
+                let clock = ContinuousClock()
+                let deadline = clock.now.advanced(by: .seconds(gracePeriod))
+                while process.isRunning, clock.now < deadline {
+                    try? await Task.sleep(for: .milliseconds(25))
+                }
+
+                if process.isRunning {
+                    DiagnosticsLogger.log(
+                        .mcpService,
+                        level: .info,
+                        message: "MCP process ignored SIGTERM; escalating to SIGKILL",
+                        metadata: [
+                            "pid": "\(process.processIdentifier)",
+                            "transport": lifecycle.id.uuidString
+                        ]
+                    )
+                    Darwin.kill(process.processIdentifier, SIGKILL)
+                }
+
+                if process.isRunning {
+                    process.waitUntilExit()
+                }
+            }
+
+            let exitCode = process.processIdentifier > 0 && !process.isRunning
+                ? process.terminationStatus
+                : nil
+            completion(exitCode)
+        }
     }
 }
 

--- a/Sources/Ayna/Services/MemoryContextProvider.swift
+++ b/Sources/Ayna/Services/MemoryContextProvider.swift
@@ -25,11 +25,11 @@ final class MemoryContextProvider {
     private(set) var isMemoryEnabled: Bool = false {
         didSet {
             AppPreferences.storage.set(isMemoryEnabled, forKey: "memoryEnabled")
-            if isMemoryEnabled, !memoryService.isLoaded {
+            if isMemoryEnabled {
+                scheduleMemoryLoadIfNeeded()
+            } else {
                 loadTask?.cancel()
-                loadTask = Task { [weak self] in
-                    await self?.loadAll()
-                }
+                loadTask = nil
             }
         }
     }
@@ -43,7 +43,14 @@ final class MemoryContextProvider {
 
     /// Sets whether memory is enabled
     func setMemoryEnabled(_ enabled: Bool) {
+        guard isMemoryEnabled != enabled else {
+            if enabled {
+                scheduleMemoryLoadIfNeeded()
+            }
+            return
+        }
         isMemoryEnabled = enabled
+        NotificationCenter.default.post(name: .watchSyncContextDidChange, object: nil)
     }
 
     /// Sets whether auto extraction is enabled
@@ -69,10 +76,32 @@ final class MemoryContextProvider {
         // Load stored values
         isMemoryEnabled = AppPreferences.storage.bool(forKey: "memoryEnabled")
         isAutoExtractionEnabled = AppPreferences.storage.bool(forKey: "memoryAutoExtraction")
+        scheduleMemoryLoadIfNeeded()
     }
 
     deinit {
         loadTask?.cancel()
+    }
+
+    nonisolated static func requiresAuthoritativeLoad(
+        isEnabled: Bool,
+        hasAuthoritativeFacts: Bool
+    ) -> Bool {
+        isEnabled && !hasAuthoritativeFacts
+    }
+
+    private func scheduleMemoryLoadIfNeeded() {
+        guard Self.requiresAuthoritativeLoad(
+            isEnabled: isMemoryEnabled,
+            hasAuthoritativeFacts: memoryService.hasAuthoritativeFacts
+        ), loadTask == nil else {
+            return
+        }
+        loadTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.loadAll()
+            self.loadTask = nil
+        }
     }
 
     /// Loads all memory data from storage.
@@ -232,9 +261,15 @@ struct MemoryContext: Sendable {
     /// Estimated token count for the memory context
     var estimatedTokens: Int {
         var tokens = 0
-        if let meta = sessionMetadata { tokens += meta.count / 4 }
-        if let memory = userMemory { tokens += memory.count / 4 }
-        if let summaries = conversationSummaries { tokens += summaries.count / 4 }
+        if let meta = sessionMetadata {
+            tokens += meta.count / 4
+        }
+        if let memory = userMemory {
+            tokens += memory.count / 4
+        }
+        if let summaries = conversationSummaries {
+            tokens += summaries.count / 4
+        }
         return tokens
     }
 }

--- a/Sources/Ayna/Services/MultiModelRequestRunner.swift
+++ b/Sources/Ayna/Services/MultiModelRequestRunner.swift
@@ -1,0 +1,210 @@
+import os
+
+/// Bridges one callback-driven multi-model request into structured concurrency.
+struct MultiModelRequestRunner: Sendable {
+    /// A GitHub Models gate acquisition paired with its explicit release.
+    struct GitHubPermit: Sendable {
+        private let acquireAction: @Sendable () async throws -> Void
+        private let releaseAction: @Sendable () async -> Void
+
+        init(
+            acquire: @escaping @Sendable () async throws -> Void,
+            release: @escaping @Sendable () async -> Void
+        ) {
+            acquireAction = acquire
+            releaseAction = release
+        }
+
+        static func shared(
+            key: String,
+            onQueued: @escaping @Sendable () -> Void = {}
+        ) -> GitHubPermit {
+            GitHubPermit(
+                acquire: {
+                    try await GitHubModelsRequestGate.shared.acquire(key: key, onQueued: onQueued)
+                },
+                release: {
+                    await GitHubModelsRequestGate.shared.release(key: key)
+                }
+            )
+        }
+
+        fileprivate func acquire() async throws {
+            try await acquireAction()
+        }
+
+        fileprivate func release() async {
+            await releaseAction()
+        }
+    }
+
+    private enum ContinuationPhase {
+        case pending
+        case preparing(CheckedContinuation<Void, Never>)
+        case invoking(CheckedContinuation<Void, Never>, terminalRequested: Bool)
+        case started(CheckedContinuation<Void, Never>)
+        case finished
+    }
+
+    private final class ContinuationState: Sendable {
+        private let phase = OSAllocatedUnfairLock(initialState: ContinuationPhase.pending)
+
+        func install(_ continuation: CheckedContinuation<Void, Never>) -> Bool {
+            let installed = phase.withLock { phase in
+                guard case .pending = phase else { return false }
+                phase = .preparing(continuation)
+                return true
+            }
+
+            if !installed {
+                continuation.resume()
+            }
+            return installed
+        }
+
+        func commitStart() -> Bool {
+            phase.withLock { phase in
+                guard case let .preparing(continuation) = phase else { return false }
+                phase = .invoking(continuation, terminalRequested: false)
+                return true
+            }
+        }
+
+        func startReturned() {
+            let continuation = phase.withLock { phase -> CheckedContinuation<Void, Never>? in
+                guard case let .invoking(continuation, terminalRequested) = phase else {
+                    return nil
+                }
+
+                if terminalRequested {
+                    phase = .finished
+                    return continuation
+                }
+
+                phase = .started(continuation)
+                return nil
+            }
+            continuation?.resume()
+        }
+
+        var isFinished: Bool {
+            phase.withLock { phase in
+                switch phase {
+                case let .invoking(_, terminalRequested):
+                    terminalRequested
+                case .finished:
+                    true
+                case .pending, .preparing, .started:
+                    false
+                }
+            }
+        }
+
+        @discardableResult
+        func finish() -> Bool {
+            let result = phase.withLock { phase -> (didFinish: Bool, continuation: CheckedContinuation<Void, Never>?) in
+                switch phase {
+                case .pending:
+                    phase = .finished
+                    return (true, nil)
+                case let .preparing(continuation):
+                    phase = .finished
+                    return (true, continuation)
+                case let .invoking(continuation, terminalRequested):
+                    guard !terminalRequested else { return (false, nil) }
+                    phase = .invoking(continuation, terminalRequested: true)
+                    return (true, nil)
+                case let .started(continuation):
+                    phase = .finished
+                    return (true, continuation)
+                case .finished:
+                    return (false, nil)
+                }
+            }
+            result.continuation?.resume()
+            return result.didFinish
+        }
+    }
+
+    /// Idempotent completion handle that may be called from any callback thread.
+    final class Completion: Sendable {
+        private let state = ContinuationState()
+
+        fileprivate init() {}
+
+        @discardableResult
+        func callAsFunction() -> Bool {
+            state.finish()
+        }
+
+        var isFinished: Bool {
+            state.isFinished
+        }
+
+        fileprivate func install(_ continuation: CheckedContinuation<Void, Never>) -> Bool {
+            state.install(continuation)
+        }
+
+        fileprivate func commitStart() -> Bool {
+            state.commitStart()
+        }
+
+        fileprivate func startReturned() {
+            state.startReturned()
+        }
+
+        fileprivate func cancel() {
+            state.finish()
+        }
+    }
+
+    /// Acquires an optional GitHub permit, synchronously commits `start` on the
+    /// main actor, then waits for either callback completion or cancellation.
+    @MainActor
+    static func run(
+        gitHubPermit: GitHubPermit? = nil,
+        start: @escaping @MainActor @Sendable (Completion) -> Void
+    ) async {
+        guard !Task.isCancelled else { return }
+
+        if let gitHubPermit {
+            do {
+                try await gitHubPermit.acquire()
+            } catch {
+                return
+            }
+
+            guard !Task.isCancelled else {
+                await gitHubPermit.release()
+                return
+            }
+
+            await waitForCompletion(start: start)
+            await gitHubPermit.release()
+            return
+        }
+
+        await waitForCompletion(start: start)
+    }
+
+    @MainActor
+    private static func waitForCompletion(
+        start: @escaping @MainActor @Sendable (Completion) -> Void
+    ) async {
+        let completion = Completion()
+
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard completion.install(continuation),
+                      completion.commitStart()
+                else {
+                    return
+                }
+                start(completion)
+                completion.startReturned()
+            }
+        } onCancel: {
+            completion.cancel()
+        }
+    }
+}

--- a/Sources/Ayna/Services/OpenAIImageService.swift
+++ b/Sources/Ayna/Services/OpenAIImageService.swift
@@ -11,6 +11,76 @@ import os
 /// Service responsible for image generation via OpenAI-compatible APIs.
 /// Handles both standard OpenAI and Azure OpenAI image endpoints.
 final class OpenAIImageService: @unchecked Sendable {
+    private struct RequestHandleState: Sendable {
+        var isActive = true
+        var cancellations: [@Sendable () -> Void] = []
+    }
+
+    private struct GenerationContext: Sendable {
+        let requestHandle: RequestHandle
+        let onComplete: @Sendable (Data) -> Void
+        let onError: @Sendable (Error) -> Void
+    }
+
+    /// Owns every transport and retry spawned by one logical image request.
+    ///
+    /// The handle is installed by `AIService` before the request starts so Stop can
+    /// synchronously fence callbacks, cancel an active URLSession task, and prevent
+    /// a retry or image download from starting after cancellation.
+    final class RequestHandle: @unchecked Sendable {
+        private let state = OSAllocatedUnfairLock(initialState: RequestHandleState())
+
+        var isActive: Bool {
+            state.withLock { $0.isActive }
+        }
+
+        func resume(_ task: URLSessionTask) {
+            let shouldResume = state.withLock { state -> Bool in
+                guard state.isActive else { return false }
+                state.cancellations.append { task.cancel() }
+                return true
+            }
+
+            if shouldResume {
+                task.resume()
+            } else {
+                task.cancel()
+            }
+        }
+
+        func run(_ operation: @escaping @Sendable () async -> Void) {
+            let task = Task {
+                guard !Task.isCancelled else { return }
+                await operation()
+            }
+            let shouldContinue = state.withLock { state -> Bool in
+                guard state.isActive else { return false }
+                state.cancellations.append { task.cancel() }
+                return true
+            }
+            if !shouldContinue {
+                task.cancel()
+            }
+        }
+
+        func finish() {
+            state.withLock { state in
+                state.isActive = false
+                state.cancellations.removeAll()
+            }
+        }
+
+        func cancel() {
+            let cancellations = state.withLock { state -> [@Sendable () -> Void] in
+                guard state.isActive else { return [] }
+                state.isActive = false
+                defer { state.cancellations.removeAll() }
+                return state.cancellations
+            }
+            cancellations.forEach { $0() }
+        }
+    }
+
     // MARK: - Configuration
 
     struct ImageConfig {
@@ -38,10 +108,17 @@ final class OpenAIImageService: @unchecked Sendable {
     // MARK: - Properties
 
     private let urlSession: URLSession
+    private let retryDelay: @Sendable (Int) async -> Void
 
     // MARK: - Initialization
 
-    init(urlSession: URLSession? = nil) {
+    init(
+        urlSession: URLSession? = nil,
+        retryDelay: @escaping @Sendable (Int) async -> Void = { attempt in
+            await AIRetryPolicy.wait(for: attempt)
+        }
+    ) {
+        self.retryDelay = retryDelay
         if let session = urlSession {
             self.urlSession = session
         } else {
@@ -66,6 +143,7 @@ final class OpenAIImageService: @unchecked Sendable {
         prompt: String,
         requestConfig: RequestConfig,
         imageConfig: ImageConfig = .default,
+        requestHandle: RequestHandle,
         onComplete: @escaping @Sendable (Data) -> Void,
         onError: @escaping @Sendable (Error) -> Void,
         attempt: Int = 0
@@ -143,28 +221,24 @@ final class OpenAIImageService: @unchecked Sendable {
         }
 
         // Execute request
-        executeRequest(
-            request,
-            prompt: prompt,
-            requestConfig: requestConfig,
-            imageConfig: imageConfig,
+        let context = GenerationContext(
+            requestHandle: requestHandle,
             onComplete: onComplete,
-            onError: onError,
-            attempt: attempt
+            onError: onError
         )
+        executeRequest(request, context: context, attempt: attempt)
     }
 
     // MARK: - Private Methods
 
     private func executeRequest(
         _ request: URLRequest,
-        prompt: String,
-        requestConfig: RequestConfig,
-        imageConfig: ImageConfig,
-        onComplete: @escaping @Sendable (Data) -> Void,
-        onError: @escaping @Sendable (Error) -> Void,
+        context: GenerationContext,
         attempt: Int
     ) {
+        let requestHandle = context.requestHandle
+        guard requestHandle.isActive else { return }
+
         let circuitKey = NetworkCircuitBreaker.key(for: request.url, label: "openai.image")
         let circuitGate = NetworkCircuitBreaker.shouldAllowRequest(key: circuitKey)
         if !circuitGate.allowed {
@@ -172,32 +246,33 @@ final class OpenAIImageService: @unchecked Sendable {
             let message = seconds > 0
                 ? "Image generation temporarily unavailable. Please try again in \(seconds)s."
                 : "Image generation temporarily unavailable. Please try again shortly."
-            Task { @MainActor in
-                onError(AynaError.apiError(message: message))
+            requestHandle.run { @MainActor in
+                guard requestHandle.isActive else { return }
+                context.onError(AynaError.apiError(message: message))
             }
             return
         }
 
-        urlSession.dataTask(with: request) { [weak self] data, response, error in
+        let task = urlSession.dataTask(with: request) { [weak self] data, response, error in
+            guard requestHandle.isActive else { return }
+
             if let error {
                 if NetworkCircuitBreaker.shouldRecordFailure(error: error) {
                     NetworkCircuitBreaker.recordFailure(key: circuitKey)
                 }
                 self?.handleError(
                     error,
-                    prompt: prompt,
-                    requestConfig: requestConfig,
-                    imageConfig: imageConfig,
-                    onComplete: onComplete,
-                    onError: onError,
+                    request: request,
+                    context: context,
                     attempt: attempt
                 )
                 return
             }
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                Task { @MainActor in
-                    onError(AynaError.invalidResponse(detail: nil))
+                requestHandle.run { @MainActor in
+                    guard requestHandle.isActive else { return }
+                    context.onError(AynaError.invalidResponse(detail: nil))
                 }
                 return
             }
@@ -208,8 +283,9 @@ final class OpenAIImageService: @unchecked Sendable {
                     level: .error,
                     message: "No data received from image generation"
                 )
-                Task { @MainActor in
-                    onError(AynaError.invalidResponse(detail: "No data received"))
+                requestHandle.run { @MainActor in
+                    guard requestHandle.isActive else { return }
+                    context.onError(AynaError.invalidResponse(detail: "No data received"))
                 }
                 return
             }
@@ -229,28 +305,30 @@ final class OpenAIImageService: @unchecked Sendable {
                     return "HTTP \(httpResponse.statusCode)"
                 }()
 
-                Task { @MainActor in
-                    onError(AynaError.apiError(message: message))
+                requestHandle.run { @MainActor in
+                    guard requestHandle.isActive else { return }
+                    context.onError(AynaError.apiError(message: message))
                 }
                 return
             }
 
             NetworkCircuitBreaker.recordSuccess(key: circuitKey)
 
-            self?.parseResponse(data, onComplete: onComplete, onError: onError)
-        }.resume()
+            self?.parseResponse(data, context: context)
+        }
+        requestHandle.resume(task)
     }
 
     private func handleError(
         _ error: Error,
-        prompt: String,
-        requestConfig: RequestConfig,
-        imageConfig: ImageConfig,
-        onComplete: @escaping @Sendable (Data) -> Void,
-        onError: @escaping @Sendable (Error) -> Void,
+        request: URLRequest,
+        context: GenerationContext,
         attempt: Int
     ) {
-        Task { @MainActor [weak self] in
+        let requestHandle = context.requestHandle
+        let retryDelay = retryDelay
+        requestHandle.run { @MainActor [weak self] in
+            guard requestHandle.isActive else { return }
             if AIRetryPolicy.shouldRetry(error: error, attempt: attempt) {
                 DiagnosticsLogger.log(
                     .aiService,
@@ -258,30 +336,26 @@ final class OpenAIImageService: @unchecked Sendable {
                     message: "⚠️ Retrying image generation (attempt \(attempt + 1))",
                     metadata: ["error": error.localizedDescription]
                 )
-                await AIRetryPolicy.wait(for: attempt)
-                self?.generateImage(
-                    prompt: prompt,
-                    requestConfig: requestConfig,
-                    imageConfig: imageConfig,
-                    onComplete: onComplete,
-                    onError: onError,
-                    attempt: attempt + 1
-                )
+                await retryDelay(attempt)
+                guard requestHandle.isActive, !Task.isCancelled else { return }
+                self?.executeRequest(request, context: context, attempt: attempt + 1)
                 return
             }
-            onError(error)
+            context.onError(error)
         }
     }
 
     private func parseResponse(
         _ data: Data,
-        onComplete: @escaping @Sendable (Data) -> Void,
-        onError: @escaping @Sendable (Error) -> Void
+        context: GenerationContext
     ) {
+        let requestHandle = context.requestHandle
+        guard requestHandle.isActive else { return }
         do {
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                Task { @MainActor in
-                    onError(AynaError.invalidResponse(detail: nil))
+                requestHandle.run { @MainActor in
+                    guard requestHandle.isActive else { return }
+                    context.onError(AynaError.invalidResponse(detail: nil))
                 }
                 return
             }
@@ -297,63 +371,157 @@ final class OpenAIImageService: @unchecked Sendable {
                     message: "API error in image generation",
                     metadata: ["code": code, "message": message]
                 )
-                Task { @MainActor in
+                requestHandle.run { @MainActor in
+                    guard requestHandle.isActive else { return }
                     if code == "contentFilter" {
-                        onError(AynaError.contentFiltered(reason: message))
+                        context.onError(AynaError.contentFiltered(reason: message))
                     } else {
-                        onError(AynaError.apiError(message: message))
+                        context.onError(AynaError.apiError(message: message))
                     }
                 }
                 return
             }
 
-            // Parse successful response
             guard let dataArray = json["data"] as? [[String: Any]],
                   let firstItem = dataArray.first
             else {
-                Task { @MainActor in
-                    onError(AynaError.invalidResponse(detail: nil))
+                requestHandle.run { @MainActor in
+                    guard requestHandle.isActive else { return }
+                    context.onError(AynaError.invalidResponse(detail: nil))
                 }
                 return
             }
 
-            // Try b64_json first (preferred)
             if let b64String = firstItem["b64_json"] as? String,
                let imageData = Data(base64Encoded: b64String)
             {
-                Task { @MainActor in
-                    onComplete(imageData)
+                requestHandle.run { @MainActor in
+                    guard requestHandle.isActive else { return }
+                    context.onComplete(imageData)
                 }
                 return
             }
 
-            // Fall back to URL download
             if let urlString = firstItem["url"] as? String,
                let url = URL(string: urlString)
             {
-                Task {
-                    do {
-                        let (imageData, _) = try await self.urlSession.data(from: url)
-                        await MainActor.run {
-                            onComplete(imageData)
-                        }
-                    } catch {
-                        await MainActor.run {
-                            onError(error)
-                        }
-                    }
-                }
+                downloadImage(from: url, context: context)
                 return
             }
 
-            Task { @MainActor in
-                onError(AynaError.invalidResponse(detail: nil))
+            requestHandle.run { @MainActor in
+                guard requestHandle.isActive else { return }
+                context.onError(AynaError.invalidResponse(detail: nil))
             }
         } catch {
-            Task { @MainActor in
-                onError(error)
+            requestHandle.run { @MainActor in
+                guard requestHandle.isActive else { return }
+                context.onError(error)
             }
         }
+    }
+
+    private func downloadImage(
+        from url: URL,
+        context: GenerationContext,
+        attempt: Int = 0
+    ) {
+        let requestHandle = context.requestHandle
+        requestHandle.run { [weak self] in
+            guard let self, requestHandle.isActive else { return }
+            do {
+                let (imageData, response) = try await self.urlSession.data(from: url)
+                guard requestHandle.isActive, !Task.isCancelled else { return }
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    self.handleDownloadError(
+                        AynaError.invalidResponse(detail: "Image download returned no HTTP response"),
+                        url: url,
+                        context: context,
+                        attempt: attempt
+                    )
+                    return
+                }
+                guard (200 ... 299).contains(httpResponse.statusCode) else {
+                    self.handleDownloadError(
+                        AynaError.httpError(statusCode: httpResponse.statusCode, message: nil),
+                        url: url,
+                        context: context,
+                        attempt: attempt
+                    )
+                    return
+                }
+                guard !imageData.isEmpty else {
+                    self.handleDownloadError(
+                        AynaError.invalidResponse(detail: "Image download returned empty data"),
+                        url: url,
+                        context: context,
+                        attempt: attempt
+                    )
+                    return
+                }
+                guard Self.isSupportedImageData(imageData) else {
+                    self.handleDownloadError(
+                        AynaError.invalidResponse(detail: "Image download returned unsupported data"),
+                        url: url,
+                        context: context,
+                        attempt: attempt
+                    )
+                    return
+                }
+                await MainActor.run {
+                    guard requestHandle.isActive else { return }
+                    context.onComplete(imageData)
+                }
+            } catch let error as CancellationError {
+                guard requestHandle.isActive else { return }
+                self.handleDownloadError(error, url: url, context: context, attempt: attempt)
+            } catch let error as URLError where error.code == .cancelled {
+                guard requestHandle.isActive else { return }
+                self.handleDownloadError(error, url: url, context: context, attempt: attempt)
+            } catch {
+                self.handleDownloadError(error, url: url, context: context, attempt: attempt)
+            }
+        }
+    }
+
+    private func handleDownloadError(
+        _ error: Error,
+        url: URL,
+        context: GenerationContext,
+        attempt: Int
+    ) {
+        let requestHandle = context.requestHandle
+        let retryDelay = retryDelay
+        requestHandle.run { @MainActor [weak self] in
+            guard requestHandle.isActive else { return }
+            if AIRetryPolicy.shouldRetry(error: error, attempt: attempt) {
+                await retryDelay(attempt)
+                guard requestHandle.isActive, !Task.isCancelled else { return }
+                self?.downloadImage(from: url, context: context, attempt: attempt + 1)
+                return
+            }
+            context.onError(error)
+        }
+    }
+
+    private static func isSupportedImageData(_ data: Data) -> Bool {
+        let bytes = [UInt8](data.prefix(12))
+        if bytes.count >= 3, bytes[0] == 0xFF, bytes[1] == 0xD8, bytes[2] == 0xFF {
+            return true
+        }
+        if bytes.count >= 4,
+           bytes[0] == 0x89, bytes[1] == 0x50, bytes[2] == 0x4E, bytes[3] == 0x47
+        {
+            return true
+        }
+        if bytes.count >= 4,
+           bytes[0] == 0x47, bytes[1] == 0x49, bytes[2] == 0x46, bytes[3] == 0x38
+        {
+            return true
+        }
+        return bytes.count >= 12 &&
+            bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x46 &&
+            bytes[8] == 0x57 && bytes[9] == 0x45 && bytes[10] == 0x42 && bytes[11] == 0x50
     }
 
     // MARK: - Image Editing
@@ -372,6 +540,7 @@ final class OpenAIImageService: @unchecked Sendable {
         sourceImage: Data,
         requestConfig: RequestConfig,
         imageConfig: ImageConfig = .default,
+        requestHandle: RequestHandle,
         onComplete: @escaping @Sendable (Data) -> Void,
         onError: @escaping @Sendable (Error) -> Void
     ) {
@@ -464,15 +633,24 @@ final class OpenAIImageService: @unchecked Sendable {
         request.httpBody = body
 
         // Execute request
-        executeEditRequest(request, onComplete: onComplete, onError: onError)
+        executeEditRequest(
+            request,
+            requestHandle: requestHandle,
+            onComplete: onComplete,
+            onError: onError
+        )
     }
 
     private func executeEditRequest(
         _ request: URLRequest,
+        requestHandle: RequestHandle,
         onComplete: @escaping @Sendable (Data) -> Void,
         onError: @escaping @Sendable (Error) -> Void,
         attempt: Int = 0
     ) {
+        guard requestHandle.isActive else { return }
+        let retryDelay = retryDelay
+
         let circuitKey = NetworkCircuitBreaker.key(for: request.url, label: "openai.image.edit")
         let circuitGate = NetworkCircuitBreaker.shouldAllowRequest(key: circuitKey)
         if !circuitGate.allowed {
@@ -480,24 +658,35 @@ final class OpenAIImageService: @unchecked Sendable {
             let message = seconds > 0
                 ? "Image editing temporarily unavailable. Please try again in \(seconds)s."
                 : "Image editing temporarily unavailable. Please try again shortly."
-            Task { @MainActor in
+            requestHandle.run { @MainActor in
+                guard requestHandle.isActive else { return }
                 onError(AynaError.apiError(message: message))
             }
             return
         }
 
-        urlSession.dataTask(with: request) { [weak self] data, response, error in
+        let task = urlSession.dataTask(with: request) { [weak self] data, response, error in
+            guard requestHandle.isActive else { return }
+
             if let error {
                 if NetworkCircuitBreaker.shouldRecordFailure(error: error) {
                     NetworkCircuitBreaker.recordFailure(key: circuitKey)
                 }
                 if AIRetryPolicy.shouldRetry(error: error, attempt: attempt) {
-                    Task { @MainActor [weak self] in
-                        await AIRetryPolicy.wait(for: attempt)
-                        self?.executeEditRequest(request, onComplete: onComplete, onError: onError, attempt: attempt + 1)
+                    requestHandle.run { @MainActor [weak self] in
+                        await retryDelay(attempt)
+                        guard requestHandle.isActive, !Task.isCancelled else { return }
+                        self?.executeEditRequest(
+                            request,
+                            requestHandle: requestHandle,
+                            onComplete: onComplete,
+                            onError: onError,
+                            attempt: attempt + 1
+                        )
                     }
                 } else {
-                    Task { @MainActor in
+                    requestHandle.run { @MainActor in
+                        guard requestHandle.isActive else { return }
                         onError(error)
                     }
                 }
@@ -505,7 +694,8 @@ final class OpenAIImageService: @unchecked Sendable {
             }
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                Task { @MainActor in
+                requestHandle.run { @MainActor in
+                    guard requestHandle.isActive else { return }
                     onError(AynaError.invalidResponse(detail: nil))
                 }
                 return
@@ -517,7 +707,8 @@ final class OpenAIImageService: @unchecked Sendable {
                     level: .error,
                     message: "No data received from image editing"
                 )
-                Task { @MainActor in
+                requestHandle.run { @MainActor in
+                    guard requestHandle.isActive else { return }
                     onError(AynaError.invalidResponse(detail: "No data received"))
                 }
                 return
@@ -538,7 +729,8 @@ final class OpenAIImageService: @unchecked Sendable {
                     return "HTTP \(httpResponse.statusCode)"
                 }()
 
-                Task { @MainActor in
+                requestHandle.run { @MainActor in
+                    guard requestHandle.isActive else { return }
                     onError(AynaError.apiError(message: message))
                 }
                 return
@@ -546,8 +738,14 @@ final class OpenAIImageService: @unchecked Sendable {
 
             NetworkCircuitBreaker.recordSuccess(key: circuitKey)
 
-            self?.parseResponse(data, onComplete: onComplete, onError: onError)
-        }.resume()
+            let context = GenerationContext(
+                requestHandle: requestHandle,
+                onComplete: onComplete,
+                onError: onError
+            )
+            self?.parseResponse(data, context: context)
+        }
+        requestHandle.resume(task)
     }
 }
 

--- a/Sources/Ayna/Services/OpenAIRequestBuilder.swift
+++ b/Sources/Ayna/Services/OpenAIRequestBuilder.swift
@@ -181,7 +181,8 @@ enum OpenAIRequestBuilder {
                             let prevMessage = messages[prevIdx]
                             if prevMessage.role == .assistant {
                                 if let toolCalls = prevMessage.toolCalls,
-                                   toolCalls.contains(where: { $0.id == toolCallId }) {
+                                   toolCalls.contains(where: { $0.id == toolCallId })
+                                {
                                     foundAssistant = true
                                 }
                                 break
@@ -274,7 +275,7 @@ enum OpenAIRequestBuilder {
     /// - Messages are wrapped in `type: "message"` objects
     /// - Content types are `input_text`/`output_text` instead of just `text`
     /// - Images use `input_image` type
-    /// - System messages are skipped
+    /// - System messages are skipped here and promoted to top-level `instructions` by `buildResponsesBody`
     /// - Tool results use `function_call_output` type (not "tool" role)
     /// - Assistant tool calls use `function_call` type in output
     ///
@@ -444,6 +445,14 @@ enum OpenAIRequestBuilder {
             "reasoning": ["summary": "auto"],
             "text": ["verbosity": "medium"]
         ]
+
+        let instructions = messages
+            .filter { $0.role == .system && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .map(\.content)
+            .joined(separator: "\n\n")
+        if !instructions.isEmpty {
+            body["instructions"] = instructions
+        }
 
         // Add tools if provided (convert from Chat Completions format to Responses format)
         if let tools, !tools.isEmpty {

--- a/Sources/Ayna/Services/OpenAIRequestBuilder.swift
+++ b/Sources/Ayna/Services/OpenAIRequestBuilder.swift
@@ -34,7 +34,6 @@ enum OpenAIRequestBuilder {
     static func buildMessagePayload(from message: Message) -> [String: Any] {
         var payload: [String: Any] = ["role": message.role.rawValue]
 
-        #if !os(watchOS)
             // Handle tool role messages (tool results)
             if message.role == .tool {
                 payload["content"] = message.content
@@ -89,7 +88,6 @@ enum OpenAIRequestBuilder {
                 }
                 return payload
             }
-        #endif
 
         // Check if message has attachments (multimodal content)
         if let attachments = message.attachments, !attachments.isEmpty {
@@ -139,11 +137,12 @@ enum OpenAIRequestBuilder {
         stream: Bool,
         tools: [[String: Any]]? = nil
     ) -> [String: Any] {
-        #if !os(watchOS)
+        let sanitizedMessages = ToolTranscriptSanitizer.sanitize(messages)
+
             // Build a set of valid tool_call_ids that have matching tool responses
             // First, collect all tool messages and their tool_call_ids
             var toolResponseIds = Set<String>()
-            for message in messages {
+        for message in sanitizedMessages {
                 if message.role == .tool, let toolCallId = message.toolCalls?.first?.id {
                     toolResponseIds.insert(toolCallId)
                 }
@@ -154,7 +153,7 @@ enum OpenAIRequestBuilder {
             // 2. For assistant messages with tool_calls, only keep tool_calls that have matching responses
             // 3. For tool messages, only keep if preceding assistant has the matching tool_call
             var filteredMessages: [Message] = []
-            for (index, message) in messages.enumerated() {
+        for (index, message) in sanitizedMessages.enumerated() {
                 if message.role == .tool {
                     // Get the tool_call_id from this tool message
                     guard let toolCallId = message.toolCalls?.first?.id else {
@@ -178,7 +177,7 @@ enum OpenAIRequestBuilder {
                     } else {
                         var foundAssistant = false
                         for prevIdx in stride(from: index - 1, through: 0, by: -1) {
-                            let prevMessage = messages[prevIdx]
+                        let prevMessage = sanitizedMessages[prevIdx]
                             if prevMessage.role == .assistant {
                                 if let toolCalls = prevMessage.toolCalls,
                                    toolCalls.contains(where: { $0.id == toolCallId })
@@ -246,11 +245,13 @@ enum OpenAIRequestBuilder {
                 }
             }
 
-            let messagePayloads: [[String: Any]] = filteredMessages.map { buildMessagePayload(from: $0) }
-        #else
-            // watchOS: No tool support, just pass messages through
-            let messagePayloads: [[String: Any]] = messages.map { buildMessagePayload(from: $0) }
-        #endif
+        let messagePayloads = filteredMessages
+            .filter { message in
+                message.role != .assistant ||
+                    !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                    !(message.toolCalls?.isEmpty ?? true)
+            }
+            .map { buildMessagePayload(from: $0) }
 
         var body: [String: Any] = [
             "messages": messagePayloads,
@@ -282,78 +283,95 @@ enum OpenAIRequestBuilder {
     /// - Parameter messages: Messages to convert
     /// - Returns: Array of input items for the Responses API
     static func buildResponsesInput(from messages: [Message]) -> [[String: Any]] {
+        let sanitizedMessages = ToolTranscriptSanitizer.sanitize(messages)
         var inputArray: [[String: Any]] = []
+        var messageIndex = 0
 
-        for message in messages {
-            // Skip system messages - Responses API handles them differently
+        while messageIndex < sanitizedMessages.count {
+            let message = sanitizedMessages[messageIndex]
+
             if message.role == .system {
+                messageIndex += 1
                 continue
             }
 
-            #if !os(watchOS)
-                // Handle tool result messages - convert to function_call_output
+            // Orphan tool outputs are never emitted independently. A valid tool
+            // round is handled with its preceding assistant call below.
                 if message.role == .tool {
-                    if let toolCalls = message.toolCalls, let firstToolCall = toolCalls.first {
-                        let outputItem: [String: Any] = [
-                            "type": "function_call_output",
-                            "call_id": firstToolCall.id,
-                            "output": message.content
-                        ]
-                        inputArray.append(outputItem)
-                    }
+                messageIndex += 1
                     continue
                 }
 
-                // Handle assistant messages with tool calls
                 if message.role == .assistant, let toolCalls = message.toolCalls, !toolCalls.isEmpty {
-                    // First add any text content as a message
                     if !message.content.isEmpty {
-                        let messageItem: [String: Any] = [
+                    inputArray.append([
                             "type": "message",
                             "role": "assistant",
                             "content": [
                                 ["type": "output_text", "text": message.content]
                             ]
-                        ]
-                        inputArray.append(messageItem)
+                    ])
+                }
+
+                // Tool outputs belong to this round only while they are contiguous
+                // and immediately follow the assistant call.
+                var resultByCallID: [String: Message] = [:]
+                var nextIndex = messageIndex + 1
+                while nextIndex < sanitizedMessages.count, sanitizedMessages[nextIndex].role == .tool {
+                    let resultMessage = sanitizedMessages[nextIndex]
+                    if let callID = resultMessage.toolCalls?.first?.id,
+                       resultByCallID[callID] == nil
+                    {
+                        resultByCallID[callID] = resultMessage
+                    }
+                    nextIndex += 1
                     }
 
-                    // Then add each tool call as a function_call item
-                    for toolCall in toolCalls {
-                        // Convert AnyCodable arguments to JSON string
+                var validCalls: [MCPToolCall] = []
+                var seenCallIDs: Set<String> = []
+                for toolCall in toolCalls
+                    where resultByCallID[toolCall.id] != nil && seenCallIDs.insert(toolCall.id).inserted
+                {
                         var argumentsDict: [String: Any] = [:]
                         for (key, anyCodable) in toolCall.arguments {
                             argumentsDict[key] = anyCodable.value
                         }
-
-                        let argumentsString: String = if let argsData = try? JSONSerialization.data(withJSONObject: argumentsDict),
-                                                         let argsStr = String(data: argsData, encoding: .utf8)
-                        {
-                            argsStr
+                    let argumentsString: String = if let data = try? JSONSerialization.data(
+                        withJSONObject: argumentsDict
+                    ), let string = String(data: data, encoding: .utf8) {
+                        string
                         } else {
                             "{}"
                         }
-
-                        let functionCallItem: [String: Any] = [
+                    inputArray.append([
                             "type": "function_call",
                             "call_id": toolCall.id,
                             "name": toolCall.toolName,
                             "arguments": argumentsString
-                        ]
-                        inputArray.append(functionCallItem)
+                    ])
+                    validCalls.append(toolCall)
+                }
+
+                for toolCall in validCalls {
+                    guard let resultMessage = resultByCallID[toolCall.id] else { continue }
+                    inputArray.append([
+                        "type": "function_call_output",
+                        "call_id": toolCall.id,
+                        "output": resultMessage.content
+                    ])
                     }
+
+                messageIndex = nextIndex
                     continue
                 }
-            #endif
 
             var messageItem: [String: Any] = [
                 "type": "message",
                 "role": message.role.rawValue
             ]
-
             var contentArray: [[String: Any]] = []
 
-            if !message.content.isEmpty {
+            if !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 let contentType = message.role == .user ? "input_text" : "output_text"
                 contentArray.append([
                     "type": contentType,
@@ -361,21 +379,25 @@ enum OpenAIRequestBuilder {
                 ])
             }
 
-            // Add image attachments for user messages
             if let attachments = message.attachments, !attachments.isEmpty, message.role == .user {
                 for attachment in attachments where attachment.mimeType.starts(with: "image/") {
                     if let data = attachment.content {
-                        let base64Data = data.base64EncodedString()
                         contentArray.append([
                             "type": "input_image",
-                            "image_url": "data:\(attachment.mimeType);base64,\(base64Data)",
+                            "image_url": "data:\(attachment.mimeType);base64,\(data.base64EncodedString())"
                         ])
                     }
                 }
             }
 
+            guard !contentArray.isEmpty else {
+                messageIndex += 1
+                continue
+            }
+
             messageItem["content"] = contentArray
             inputArray.append(messageItem)
+            messageIndex += 1
         }
 
         return inputArray

--- a/Sources/Ayna/Services/PermissionService.swift
+++ b/Sources/Ayna/Services/PermissionService.swift
@@ -82,6 +82,29 @@ struct PendingApproval: Identifiable, Sendable, Equatable {
     }
 }
 
+private final class CancelledApprovalRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var ids: Set<UUID> = []
+
+    func mark(_ id: UUID) {
+        lock.lock()
+        ids.insert(id)
+        lock.unlock()
+    }
+
+    func contains(_ id: UUID) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return ids.contains(id)
+    }
+
+    func clear(_ id: UUID) {
+        lock.lock()
+        ids.remove(id)
+        lock.unlock()
+    }
+}
+
 // MARK: - Permission Service
 
 /// Manages approval workflow for dangerous operations.
@@ -104,12 +127,15 @@ final class PermissionService {
     /// Session approvals - tools that have been approved for this session
     /// Key format: "toolName:path" or "toolName:command"
     private var sessionApprovals: Set<String> = []
+    private var committedSessionApprovalKeys: Set<String> = []
+    private var pendingSessionApprovalOwners: [UUID: String] = [:]
 
     /// Whether to persist approvals across sessions
     var persistApprovalsAcrossSessions: Bool = false
 
     /// Continuations for async approval flow
     private var approvalContinuations: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private nonisolated let cancelledApprovals = CancelledApprovalRegistry()
 
     /// Timeout tasks for auto-deny
     private var timeoutTasks: [UUID: Task<Void, Never>] = [:]
@@ -251,6 +277,7 @@ final class PermissionService {
     func recordSessionApproval(tool: String, details: String) {
         let key = approvalKey(tool: tool, details: details)
         sessionApprovals.insert(key)
+        committedSessionApprovalKeys.insert(key)
 
         log(.info, "Session approval recorded", metadata: ["tool": tool, "key": key])
     }
@@ -304,28 +331,43 @@ final class PermissionService {
             conversationId: conversationId
         )
 
-        // Wait for approval - store continuation BEFORE adding to pending list
-        // and starting timeout to prevent race conditions where deny() could be
-        // called before the continuation is stored
-        return await withCheckedContinuation { continuation in
+        // Store the continuation before exposing the request so approval, denial,
+        // timeout, and task cancellation all race through the same exact ID.
+        let approved = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
             approvalContinuations[approval.id] = continuation
             pendingApprovals.append(approval)
+
+                // Cancellation can win before the continuation is installed.
+                // Recheck after insertion so this request is never orphaned.
+                guard !Task.isCancelled else {
+                    deny(approval.id)
+                    return
+                }
+
             log(.info, "Approval requested", metadata: [
                 "tool": toolName,
                 "id": approval.id.uuidString
             ])
 
-            // Post notification for UI updates
             NotificationCenter.default.post(name: .pendingApprovalsChanged, object: nil, userInfo: [
                 "conversationId": conversationId,
                 "count": pendingApprovals.count
             ])
-
-            // Show system notification for user attention
             showSystemNotification(for: approval)
-
             startTimeoutTask(for: approval.id)
         }
+        } onCancel: { [weak self] in
+            self?.cancelledApprovals.mark(approval.id)
+            Task { @MainActor in
+                self?.handleCancelledApproval(approval)
+            }
+        }
+        let accepted = approved && !Task.isCancelled
+        if accepted {
+            commitSessionApproval(for: approval.id)
+        }
+        return accepted
     }
 
     /// Approves a pending request.
@@ -334,6 +376,10 @@ final class PermissionService {
     ///   - approvalId: The ID of the pending approval
     ///   - rememberForSession: Whether to remember this approval for the session
     func approve(_ approvalId: UUID, rememberForSession: Bool = false) {
+        guard !cancelledApprovals.contains(approvalId) else {
+            deny(approvalId)
+            return
+        }
         guard let index = pendingApprovals.firstIndex(where: { $0.id == approvalId }) else {
             return
         }
@@ -342,7 +388,8 @@ final class PermissionService {
 
         // Record session approval if requested
         if rememberForSession {
-            recordSessionApproval(tool: approval.toolName, details: approval.details)
+            let key = approvalKey(tool: approval.toolName, details: approval.details)
+            pendingSessionApprovalOwners[approvalId] = key
         }
 
         // Remove from pending
@@ -359,6 +406,7 @@ final class PermissionService {
         if let continuation = approvalContinuations.removeValue(forKey: approvalId) {
             continuation.resume(returning: true)
         }
+        cancelledApprovals.clear(approvalId)
 
         log(.info, "Approval granted", metadata: [
             "tool": approval.toolName,
@@ -377,6 +425,7 @@ final class PermissionService {
     /// - Parameter approvalId: The ID of the pending approval
     func deny(_ approvalId: UUID) {
         guard let index = pendingApprovals.firstIndex(where: { $0.id == approvalId }) else {
+            cancelledApprovals.clear(approvalId)
             return
         }
 
@@ -396,6 +445,8 @@ final class PermissionService {
         if let continuation = approvalContinuations.removeValue(forKey: approvalId) {
             continuation.resume(returning: false)
         }
+        pendingSessionApprovalOwners.removeValue(forKey: approvalId)
+        cancelledApprovals.clear(approvalId)
 
         log(.info, "Approval denied", metadata: [
             "tool": approval.toolName,
@@ -447,6 +498,8 @@ final class PermissionService {
     /// Clears all session approvals.
     func clearSessionApprovals() {
         sessionApprovals.removeAll()
+        committedSessionApprovalKeys.removeAll()
+        pendingSessionApprovalOwners.removeAll()
         log(.info, "Session approvals cleared")
     }
 
@@ -473,6 +526,23 @@ final class PermissionService {
         }
     }
 
+    private func handleCancelledApproval(_ approval: PendingApproval) {
+        if let key = pendingSessionApprovalOwners.removeValue(forKey: approval.id),
+           !committedSessionApprovalKeys.contains(key),
+           !pendingSessionApprovalOwners.values.contains(key)
+        {
+            sessionApprovals.remove(key)
+        }
+        deny(approval.id)
+        cancelledApprovals.clear(approval.id)
+    }
+
+    private func commitSessionApproval(for approvalID: UUID) {
+        guard let key = pendingSessionApprovalOwners.removeValue(forKey: approvalID) else { return }
+        sessionApprovals.insert(key)
+        committedSessionApprovalKeys.insert(key)
+    }
+
     // MARK: - Private Helpers
 
     private func approvalKey(tool: String, details: String) -> String {
@@ -484,7 +554,7 @@ final class PermissionService {
         timeoutTasks[approvalId] = Task { [weak self] in
             do {
                 try await Task.sleep(for: .seconds(timeout))
-                await self?.deny(approvalId)
+                self?.deny(approvalId)
             } catch {
                 // Task was cancelled, which is expected
             }

--- a/Sources/Ayna/Services/TavilyService.swift
+++ b/Sources/Ayna/Services/TavilyService.swift
@@ -181,6 +181,9 @@ final class TavilyService: ObservableObject {
         } catch let error as TavilyError {
             throw error
         } catch {
+            if Task.isCancelled {
+                throw CancellationError()
+            }
             log(.error, "❌ Network error during web search", metadata: ["error": error.localizedDescription])
             if NetworkCircuitBreaker.shouldRecordFailure(error: error) {
                 NetworkCircuitBreaker.recordFailure(key: circuitKey)

--- a/Sources/Ayna/Services/TavilyService.swift
+++ b/Sources/Ayna/Services/TavilyService.swift
@@ -13,6 +13,8 @@ import os.log
 /// Service for managing Tavily Web Search API integration
 @MainActor
 final class TavilyService: ObservableObject {
+    typealias DataLoader = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
     static let shared = TavilyService()
 
     // MARK: - Constants
@@ -53,14 +55,20 @@ final class TavilyService: ObservableObject {
     // MARK: - Private Properties
 
     private let keychain: KeychainStoring
-    private let urlSession: URLSession
+    private let dataLoader: DataLoader
 
     // MARK: - Initialization
 
-    init(keychain: KeychainStoring? = nil, urlSession: URLSession = .shared) {
+    convenience init(keychain: KeychainStoring? = nil, urlSession: URLSession = .shared) {
+        self.init(keychain: keychain) { request in
+            try await urlSession.data(for: request)
+        }
+    }
+
+    init(keychain: KeychainStoring? = nil, dataLoader: @escaping DataLoader) {
         let effectiveKeychain = keychain ?? KeychainStorage.standard
         self.keychain = effectiveKeychain
-        self.urlSession = urlSession
+        self.dataLoader = dataLoader
 
         // Load saved API key
         apiKey = (try? effectiveKeychain.string(for: Constants.keychainAPIKey)) ?? ""
@@ -127,7 +135,7 @@ final class TavilyService: ObservableObject {
         urlRequest.httpBody = try encoder.encode(request)
 
         do {
-            let (data, response) = try await urlSession.data(for: urlRequest)
+            let (data, response) = try await dataLoader(urlRequest)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw TavilyError.invalidResponse

--- a/Sources/Ayna/Services/UserMemoryService.swift
+++ b/Sources/Ayna/Services/UserMemoryService.swift
@@ -8,19 +8,47 @@
 import Foundation
 import os.log
 
+protocol UserMemoryStoreAdapter: Sendable {
+    func loadMemory() async throws -> UserMemoryStore
+    func saveMemory(_ store: UserMemoryStore) async throws
+    func clearMemory() async throws
+}
+
+extension EncryptedMemoryStore: UserMemoryStoreAdapter {}
+
 /// Service for managing user memory facts.
 /// Provides CRUD operations and formatting for context injection.
 @MainActor
 @Observable
 final class UserMemoryService {
+    private enum InitialLoadMutation {
+        case upsert(UserMemoryFact)
+        case delete(UUID)
+        case clear
+    }
+
     static let shared = UserMemoryService()
 
     private(set) var facts: [UserMemoryFact] = []
     private(set) var isLoaded = false
+    /// True only when `facts` exactly matches a successfully persisted generation.
+    private(set) var hasAuthoritativeFacts = false
 
-    private let store: EncryptedMemoryStore
+    private let store: any UserMemoryStoreAdapter
+    private let notificationCenter: NotificationCenter
+    private let saveDebounceDuration: Duration
     private nonisolated(unsafe) var saveTask: Task<Void, Never>?
-    private let saveDebounceDuration: Duration = .milliseconds(500)
+    /// Storage writes wait for this task so initial disk state cannot be overwritten before it is reconciled.
+    private nonisolated(unsafe) var initialLoadTask: Task<Void, Never>?
+    /// Serializes physical writes so an older snapshot cannot finish after a newer one.
+    private nonisolated(unsafe) var persistenceTask: Task<Void, Never>?
+    private var factsGeneration: UInt64 = 0
+    private var durableGeneration: UInt64?
+    /// Prevents a load retry from replacing optimistic local or synced facts with stale disk state.
+    private var hasInMemoryAuthority = false
+    private var initialLoadID: UUID?
+    private var initialLoadMutations: [InitialLoadMutation] = []
+    private var initialLoadWasSuperseded = false
 
     /// Maximum number of facts to store
     static let maxFacts = 100
@@ -28,44 +56,66 @@ final class UserMemoryService {
     /// Token budget for memory context (approximate)
     static let defaultTokenBudget = 1000
 
-    init(store: EncryptedMemoryStore = .shared) {
+    init(
+        store: any UserMemoryStoreAdapter = EncryptedMemoryStore.shared,
+        saveDebounceDuration: Duration = .milliseconds(500),
+        notificationCenter: NotificationCenter = .default
+    ) {
         self.store = store
+        self.saveDebounceDuration = saveDebounceDuration
+        self.notificationCenter = notificationCenter
     }
 
     deinit {
         saveTask?.cancel()
+        initialLoadTask?.cancel()
+        persistenceTask?.cancel()
     }
 
     // MARK: - Loading
 
     /// Loads facts from encrypted storage.
     func loadFacts() async {
-        do {
-            let memoryStore = try await store.loadMemory()
-            facts = memoryStore.facts
-            isLoaded = true
-
-            DiagnosticsLogger.log(
-                .conversationManager,
-                level: .info,
-                message: "✅ Loaded user memory",
-                metadata: ["factCount": "\(facts.count)"]
-            )
-        } catch {
-            DiagnosticsLogger.log(
-                .conversationManager,
-                level: .error,
-                message: "❌ Failed to load user memory",
-                metadata: ["error": error.localizedDescription]
-            )
-            facts = []
-            isLoaded = true
+        if let initialLoadTask {
+            await initialLoadTask.value
+            return
         }
+
+        if hasInMemoryAuthority {
+            if !hasAuthoritativeFacts {
+                await saveImmediately()
+            }
+            return
+        }
+
+        let loadID = UUID()
+        let store = store
+        initialLoadID = loadID
+        initialLoadMutations = []
+        initialLoadWasSuperseded = false
+
+        let operation = Task { @MainActor [weak self] in
+            do {
+                let memoryStore = try await store.loadMemory()
+                self?.finishInitialLoad(memoryStore, loadID: loadID)
+            } catch {
+                DiagnosticsLogger.log(
+                    .conversationManager,
+                    level: .error,
+                    message: "❌ Failed to load user memory",
+                    metadata: ["error": error.localizedDescription]
+                )
+                self?.finishInitialLoadFailure(loadID: loadID)
+            }
+        }
+        initialLoadTask = operation
+        await operation.value
     }
 
     /// Loads facts received from iOS sync (watchOS only).
     /// Replaces local facts with synced facts and persists to disk.
     func loadFactsFromSync(_ syncedFacts: [UserMemoryFact]) {
+        supersedeInitialLoad()
         facts = Array(syncedFacts.prefix(Self.maxFacts))
         isLoaded = true
         scheduleSave() // Persist to disk for offline access
@@ -92,19 +142,9 @@ final class UserMemoryService {
         )
 
         facts.insert(fact, at: 0)
+        Self.enforceFactLimit(&facts)
 
-        // Enforce max limit
-        if facts.count > Self.maxFacts {
-            // Remove oldest inactive facts first, then oldest active
-            let inactiveFacts = facts.filter { !$0.isActive }
-            if !inactiveFacts.isEmpty, let oldest = inactiveFacts.last {
-                facts.removeAll { $0.id == oldest.id }
-            } else {
-                facts.removeLast()
-            }
-        }
-
-        scheduleSave()
+        scheduleSave(initialLoadMutation: .upsert(fact))
 
         DiagnosticsLogger.log(
             .conversationManager,
@@ -122,13 +162,13 @@ final class UserMemoryService {
 
         facts[index].content = content
         facts[index].updatedAt = Date()
-        scheduleSave()
+        scheduleSave(initialLoadMutation: .upsert(facts[index]))
     }
 
     /// Deletes a fact (hard delete).
     func deleteFact(_ id: UUID) {
         facts.removeAll { $0.id == id }
-        scheduleSave()
+        scheduleSave(initialLoadMutation: .delete(id))
 
         DiagnosticsLogger.log(
             .conversationManager,
@@ -143,30 +183,24 @@ final class UserMemoryService {
 
         facts[index].isActive = active
         facts[index].updatedAt = Date()
-        scheduleSave()
+        scheduleSave(initialLoadMutation: .upsert(facts[index]))
     }
 
     /// Clears all facts.
     func clearAllFacts() async {
-        await saveTask?.value
-        facts.removeAll()
         saveTask?.cancel()
+        saveTask = nil
+        facts.removeAll()
+        let generation = recordFactsChange(initialLoadMutation: .clear)
+        await waitForInitialLoad()
 
-        do {
-            try await store.clearMemory()
-            DiagnosticsLogger.log(
-                .conversationManager,
-                level: .info,
-                message: "🧹 Cleared all memory facts"
-            )
-        } catch {
-            DiagnosticsLogger.log(
-                .conversationManager,
-                level: .error,
-                message: "❌ Failed to clear memory store",
-                metadata: ["error": error.localizedDescription]
-            )
+        guard factsGeneration == generation, facts.isEmpty else {
+            await saveImmediately()
+            return
         }
+
+        let operation = enqueueClear(generation: generation)
+        await operation.value
     }
 
     // MARK: - Query
@@ -283,41 +317,234 @@ final class UserMemoryService {
 
     // MARK: - Persistence
 
-    private func scheduleSave() {
+    private func scheduleSave(initialLoadMutation: InitialLoadMutation? = nil) {
+        recordFactsChange(initialLoadMutation: initialLoadMutation)
+        let debounceDuration = saveDebounceDuration
         saveTask?.cancel()
-        saveTask = Task { [weak self] in
+        saveTask = Task { @MainActor [weak self] in
             do {
-                try await Task.sleep(for: self?.saveDebounceDuration ?? .milliseconds(500))
+                try await Task.sleep(for: debounceDuration)
             } catch {
                 return // Cancelled
             }
 
-            await self?.saveNow()
+            guard let self else { return }
+            await self.waitForInitialLoad()
+            guard !Task.isCancelled else { return }
+
+            let operation = self.enqueueSave(self.facts, generation: self.factsGeneration)
+            await operation.value
         }
     }
 
-    private func saveNow() async {
+    @discardableResult
+    private func recordFactsChange(initialLoadMutation: InitialLoadMutation? = nil) -> UInt64 {
+        factsGeneration &+= 1
+        hasInMemoryAuthority = true
+        hasAuthoritativeFacts = false
+
+        if let initialLoadMutation,
+           initialLoadID != nil,
+           !initialLoadWasSuperseded
+        {
+            initialLoadMutations.append(initialLoadMutation)
+        }
+
+        return factsGeneration
+    }
+
+    private func waitForInitialLoad() async {
+        let operation = initialLoadTask
+        await operation?.value
+    }
+
+    private func finishInitialLoad(
+        _ memoryStore: UserMemoryStore,
+        loadID: UUID
+    ) {
+        guard initialLoadID == loadID else { return }
+
+        let mutations = initialLoadMutations
+        let wasSuperseded = initialLoadWasSuperseded
+        resetInitialLoad(loadID: loadID)
+        guard !wasSuperseded else { return }
+
+        isLoaded = true
+        hasInMemoryAuthority = true
+
+        if mutations.isEmpty {
+            facts = memoryStore.facts
+            durableGeneration = factsGeneration
+            hasAuthoritativeFacts = true
+            publishDurableFacts()
+        } else {
+            facts = Self.applying(mutations, to: memoryStore.facts)
+            hasAuthoritativeFacts = false
+        }
+
+        DiagnosticsLogger.log(
+            .conversationManager,
+            level: .info,
+            message: "✅ Loaded user memory",
+            metadata: ["factCount": "\(facts.count)"]
+        )
+    }
+
+    private func finishInitialLoadFailure(loadID: UUID) {
+        guard initialLoadID == loadID else { return }
+
+        let hadLocalMutations = !initialLoadMutations.isEmpty
+        let wasSuperseded = initialLoadWasSuperseded
+        resetInitialLoad(loadID: loadID)
+        guard !wasSuperseded else { return }
+
+        if !hadLocalMutations {
+            facts = []
+            hasInMemoryAuthority = false
+        }
+        isLoaded = true
+        hasAuthoritativeFacts = false
+    }
+
+    private func supersedeInitialLoad() {
+        guard initialLoadID != nil else { return }
+        initialLoadWasSuperseded = true
+        initialLoadMutations.removeAll()
+    }
+
+    private func resetInitialLoad(loadID: UUID) {
+        guard initialLoadID == loadID else { return }
+        initialLoadID = nil
+        initialLoadMutations.removeAll()
+        initialLoadWasSuperseded = false
+        initialLoadTask = nil
+    }
+
+    private static func applying(
+        _ mutations: [InitialLoadMutation],
+        to storedFacts: [UserMemoryFact]
+    ) -> [UserMemoryFact] {
+        var mergedFacts = storedFacts
+
+        for mutation in mutations {
+            switch mutation {
+            case let .upsert(fact):
+                if let index = mergedFacts.firstIndex(where: { $0.id == fact.id }) {
+                    mergedFacts[index] = fact
+                } else {
+                    mergedFacts.insert(fact, at: 0)
+                }
+                enforceFactLimit(&mergedFacts)
+
+            case let .delete(id):
+                mergedFacts.removeAll { $0.id == id }
+
+            case .clear:
+                mergedFacts.removeAll()
+            }
+        }
+
+        return mergedFacts
+    }
+
+    private static func enforceFactLimit(_ facts: inout [UserMemoryFact]) {
+        guard facts.count > maxFacts else { return }
+
+        if let oldestInactiveIndex = facts.lastIndex(where: { !$0.isActive }) {
+            facts.remove(at: oldestInactiveIndex)
+        } else {
+            facts.removeLast()
+        }
+    }
+
+    @discardableResult
+    private func enqueueSave(
+        _ factsSnapshot: [UserMemoryFact],
+        generation: UInt64
+    ) -> Task<Void, Never> {
         let memoryStore = UserMemoryStore(
-            facts: facts,
+            facts: factsSnapshot,
             lastUpdated: Date(),
             version: UserMemoryStore.currentVersion
         )
+        let previousOperation = persistenceTask
+        let store = store
 
-        do {
-            try await store.saveMemory(memoryStore)
-        } catch {
-            DiagnosticsLogger.log(
-                .conversationManager,
-                level: .error,
-                message: "❌ Failed to save user memory",
-                metadata: ["error": error.localizedDescription]
-            )
+        let operation = Task { @MainActor [weak self] in
+            await previousOperation?.value
+
+            do {
+                try await store.saveMemory(memoryStore)
+                self?.finishPersistence(
+                    factsSnapshot: factsSnapshot,
+                    generation: generation
+                )
+            } catch {
+                DiagnosticsLogger.log(
+                    .conversationManager,
+                    level: .error,
+                    message: "❌ Failed to save user memory",
+                    metadata: ["error": error.localizedDescription]
+                )
+            }
         }
+        persistenceTask = operation
+        return operation
+    }
+
+    @discardableResult
+    private func enqueueClear(generation: UInt64) -> Task<Void, Never> {
+        let previousOperation = persistenceTask
+        let store = store
+
+        let operation = Task { @MainActor [weak self] in
+            await previousOperation?.value
+
+            do {
+                try await store.clearMemory()
+                self?.finishPersistence(factsSnapshot: [], generation: generation)
+                DiagnosticsLogger.log(
+                    .conversationManager,
+                    level: .info,
+                    message: "🧹 Cleared all memory facts"
+                )
+            } catch {
+                DiagnosticsLogger.log(
+                    .conversationManager,
+                    level: .error,
+                    message: "❌ Failed to clear memory store",
+                    metadata: ["error": error.localizedDescription]
+                )
+            }
+        }
+        persistenceTask = operation
+        return operation
+    }
+
+    private func finishPersistence(
+        factsSnapshot: [UserMemoryFact],
+        generation: UInt64
+    ) {
+        guard factsGeneration == generation, facts == factsSnapshot else { return }
+
+        hasInMemoryAuthority = true
+        guard durableGeneration != generation || !hasAuthoritativeFacts else { return }
+
+        durableGeneration = generation
+        hasAuthoritativeFacts = true
+        publishDurableFacts()
+    }
+
+    private func publishDurableFacts() {
+        notificationCenter.post(name: .watchSyncContextDidChange, object: nil)
     }
 
     /// Forces an immediate save (e.g., before app termination).
     func saveImmediately() async {
         saveTask?.cancel()
-        await saveNow()
+        saveTask = nil
+        await waitForInitialLoad()
+        let operation = enqueueSave(facts, generation: factsGeneration)
+        await operation.value
     }
 }

--- a/Sources/Ayna/Services/UserMemoryService.swift
+++ b/Sources/Ayna/Services/UserMemoryService.swift
@@ -46,6 +46,8 @@ final class UserMemoryService {
     private var durableGeneration: UInt64?
     /// Prevents a load retry from replacing optimistic local or synced facts with stale disk state.
     private var hasInMemoryAuthority = false
+    /// True after stored facts were loaded successfully or intentionally replaced in full.
+    private var hasReconciledStoredFacts = false
     private var initialLoadID: UUID?
     private var initialLoadMutations: [InitialLoadMutation] = []
     private var initialLoadWasSuperseded = false
@@ -81,7 +83,7 @@ final class UserMemoryService {
             return
         }
 
-        if hasInMemoryAuthority {
+        if isLoaded, hasInMemoryAuthority, hasReconciledStoredFacts {
             if !hasAuthoritativeFacts {
                 await saveImmediately()
             }
@@ -91,7 +93,6 @@ final class UserMemoryService {
         let loadID = UUID()
         let store = store
         initialLoadID = loadID
-        initialLoadMutations = []
         initialLoadWasSuperseded = false
 
         let operation = Task { @MainActor [weak self] in
@@ -118,6 +119,7 @@ final class UserMemoryService {
         supersedeInitialLoad()
         facts = Array(syncedFacts.prefix(Self.maxFacts))
         isLoaded = true
+        hasReconciledStoredFacts = true
         scheduleSave() // Persist to disk for offline access
 
         DiagnosticsLogger.log(
@@ -190,14 +192,11 @@ final class UserMemoryService {
     func clearAllFacts() async {
         saveTask?.cancel()
         saveTask = nil
+        supersedeInitialLoad()
         facts.removeAll()
-        let generation = recordFactsChange(initialLoadMutation: .clear)
-        await waitForInitialLoad()
-
-        guard factsGeneration == generation, facts.isEmpty else {
-            await saveImmediately()
-            return
-        }
+        isLoaded = true
+        hasReconciledStoredFacts = true
+        let generation = recordFactsChange()
 
         let operation = enqueueClear(generation: generation)
         await operation.value
@@ -329,7 +328,7 @@ final class UserMemoryService {
             }
 
             guard let self else { return }
-            await self.waitForInitialLoad()
+            guard await self.waitForInitialLoad() else { return }
             guard !Task.isCancelled else { return }
 
             let operation = self.enqueueSave(self.facts, generation: self.factsGeneration)
@@ -344,7 +343,7 @@ final class UserMemoryService {
         hasAuthoritativeFacts = false
 
         if let initialLoadMutation,
-           initialLoadID != nil,
+           initialLoadID != nil || !hasReconciledStoredFacts,
            !initialLoadWasSuperseded
         {
             initialLoadMutations.append(initialLoadMutation)
@@ -353,9 +352,16 @@ final class UserMemoryService {
         return factsGeneration
     }
 
-    private func waitForInitialLoad() async {
-        let operation = initialLoadTask
-        await operation?.value
+    private func waitForInitialLoad() async -> Bool {
+        if hasReconciledStoredFacts {
+            return true
+        }
+        if let initialLoadTask {
+            await initialLoadTask.value
+        } else {
+            await loadFacts()
+        }
+        return hasReconciledStoredFacts
     }
 
     private func finishInitialLoad(
@@ -371,6 +377,7 @@ final class UserMemoryService {
 
         isLoaded = true
         hasInMemoryAuthority = true
+        hasReconciledStoredFacts = true
 
         if mutations.isEmpty {
             facts = memoryStore.facts
@@ -395,7 +402,10 @@ final class UserMemoryService {
 
         let hadLocalMutations = !initialLoadMutations.isEmpty
         let wasSuperseded = initialLoadWasSuperseded
-        resetInitialLoad(loadID: loadID)
+        resetInitialLoad(
+            loadID: loadID,
+            preserveMutations: hadLocalMutations && !wasSuperseded
+        )
         guard !wasSuperseded else { return }
 
         if !hadLocalMutations {
@@ -407,15 +417,21 @@ final class UserMemoryService {
     }
 
     private func supersedeInitialLoad() {
-        guard initialLoadID != nil else { return }
-        initialLoadWasSuperseded = true
+        if initialLoadID != nil {
+            initialLoadWasSuperseded = true
+        }
         initialLoadMutations.removeAll()
     }
 
-    private func resetInitialLoad(loadID: UUID) {
+    private func resetInitialLoad(
+        loadID: UUID,
+        preserveMutations: Bool = false
+    ) {
         guard initialLoadID == loadID else { return }
         initialLoadID = nil
-        initialLoadMutations.removeAll()
+        if !preserveMutations {
+            initialLoadMutations.removeAll()
+        }
         initialLoadWasSuperseded = false
         initialLoadTask = nil
     }
@@ -502,6 +518,9 @@ final class UserMemoryService {
 
             do {
                 try await store.clearMemory()
+                self?.hasReconciledStoredFacts = true
+                self?.isLoaded = true
+                self?.initialLoadMutations.removeAll()
                 self?.finishPersistence(factsSnapshot: [], generation: generation)
                 DiagnosticsLogger.log(
                     .conversationManager,
@@ -543,7 +562,7 @@ final class UserMemoryService {
     func saveImmediately() async {
         saveTask?.cancel()
         saveTask = nil
-        await waitForInitialLoad()
+        guard await waitForInitialLoad() else { return }
         let operation = enqueueSave(facts, generation: factsGeneration)
         await operation.value
     }

--- a/Sources/Ayna/Services/WatchConnectivityLifecycleSupport.swift
+++ b/Sources/Ayna/Services/WatchConnectivityLifecycleSupport.swift
@@ -1,0 +1,549 @@
+//
+//  WatchConnectivityLifecycleSupport.swift
+//  Ayna
+//
+//  FIFO callback and legacy-operation lifecycle helpers.
+//
+
+import Foundation
+
+struct WatchSessionActivationToken: Equatable, Sendable {
+    fileprivate let generation: UInt64
+}
+
+final class WatchSessionActivationFence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var generation: UInt64 = 0
+
+    func beginActivation() -> WatchSessionActivationToken {
+        lock.lock()
+        defer { lock.unlock() }
+        generation &+= 1
+        if generation == 0 {
+            generation = 1
+        }
+        return WatchSessionActivationToken(generation: generation)
+    }
+
+    func isCurrent(_ activation: WatchSessionActivationToken) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return generation == activation.generation
+    }
+}
+
+#if os(iOS) || os(watchOS)
+    import WatchConnectivity
+#endif
+
+#if os(iOS)
+    final class WatchSessionDelegateProxy: NSObject, WCSessionDelegate, @unchecked Sendable {
+        private weak var owner: WatchConnectivityService?
+        let activation: WatchSessionActivationToken
+
+        init(
+            owner: WatchConnectivityService,
+            activation: WatchSessionActivationToken
+        ) {
+            self.owner = owner
+            self.activation = activation
+        }
+
+        func session(
+            _ session: WCSession,
+            activationDidCompleteWith activationState: WCSessionActivationState,
+            error: Error?
+        ) {
+            owner?.handleSessionActivation(
+                session,
+                activation: activation,
+                state: activationState,
+                error: error
+            )
+        }
+
+        func sessionDidBecomeInactive(_ session: WCSession) {
+            owner?.handleSessionDidBecomeInactive(session, activation: activation)
+        }
+
+        func sessionDidDeactivate(_ session: WCSession) {
+            owner?.handleSessionDidDeactivate(session, activation: activation)
+        }
+
+        func sessionWatchStateDidChange(_ session: WCSession) {
+            owner?.handleSessionWatchStateDidChange(session, activation: activation)
+        }
+
+        func sessionReachabilityDidChange(_ session: WCSession) {
+            owner?.handleSessionReachabilityDidChange(session, activation: activation)
+        }
+
+        func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+            owner?.handleSession(
+                session,
+                activation: activation,
+                didReceiveMessage: message
+            )
+        }
+
+        func session(
+            _ session: WCSession,
+            didReceiveMessage message: [String: Any],
+            replyHandler: @escaping ([String: Any]) -> Void
+        ) {
+            owner?.handleSession(
+                session,
+                activation: activation,
+                didReceiveMessage: message,
+                replyHandler: replyHandler
+            )
+        }
+
+        func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
+            owner?.handleSession(
+                session,
+                activation: activation,
+                didReceiveUserInfo: userInfo
+            )
+        }
+
+        func session(_ session: WCSession, didReceive file: WCSessionFile) {
+            owner?.handleSession(session, activation: activation, didReceive: file)
+        }
+    }
+#elseif os(watchOS)
+    final class WatchSessionDelegateProxy: NSObject, WCSessionDelegate, @unchecked Sendable {
+        private weak var owner: WatchConnectivityService?
+        let activation: WatchSessionActivationToken
+
+        init(
+            owner: WatchConnectivityService,
+            activation: WatchSessionActivationToken
+        ) {
+            self.owner = owner
+            self.activation = activation
+        }
+
+        func session(
+            _ session: WCSession,
+            activationDidCompleteWith activationState: WCSessionActivationState,
+            error: Error?
+        ) {
+            owner?.handleSessionActivation(
+                session,
+                activation: activation,
+                state: activationState,
+                error: error
+            )
+        }
+
+        func sessionReachabilityDidChange(_ session: WCSession) {
+            owner?.handleSessionReachabilityDidChange(session, activation: activation)
+        }
+
+        func session(
+            _ session: WCSession,
+            didReceiveApplicationContext applicationContext: [String: Any]
+        ) {
+            owner?.handleSession(
+                session,
+                activation: activation,
+                didReceiveApplicationContext: applicationContext
+            )
+        }
+
+        func session(
+            _ session: WCSession,
+            didFinish userInfoTransfer: WCSessionUserInfoTransfer,
+            error: Error?
+        ) {
+            owner?.handleSession(
+                session,
+                activation: activation,
+                didFinish: userInfoTransfer,
+                error: error
+            )
+        }
+
+        func session(
+            _ session: WCSession,
+            didFinish fileTransfer: WCSessionFileTransfer,
+            error: Error?
+        ) {
+            owner?.handleSession(
+                session,
+                activation: activation,
+                didFinish: fileTransfer,
+                error: error
+            )
+        }
+    }
+#endif
+
+final class WatchSessionEventQueue: @unchecked Sendable {
+    private struct Event: Sendable {
+        let operation: @MainActor @Sendable () async -> Void
+    }
+
+    private let lock = NSLock()
+    private var events: [Event] = []
+    private var nextIndex = 0
+    private var drainScheduled = false
+
+    func enqueue(_ operation: @escaping @MainActor @Sendable () async -> Void) {
+        lock.lock()
+        events.append(Event(operation: operation))
+        let shouldSchedule = !drainScheduled
+        drainScheduled = true
+        lock.unlock()
+
+        guard shouldSchedule else { return }
+        Task { @MainActor [weak self] in
+            await self?.drain()
+        }
+    }
+
+    @MainActor
+    private func drain() async {
+        while let event = dequeue() {
+            await event.operation()
+        }
+    }
+
+    private func dequeue() -> Event? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard events.indices.contains(nextIndex) else {
+            events.removeAll(keepingCapacity: true)
+            nextIndex = 0
+            drainScheduled = false
+            return nil
+        }
+        let event = events[nextIndex]
+        nextIndex += 1
+        return event
+    }
+}
+
+enum WatchLegacyIngressRouting {
+    static func shouldDefer(
+        isAuthoritative: Bool,
+        pendingDestructiveOperationCount: Int
+    ) -> Bool {
+        !isAuthoritative || pendingDestructiveOperationCount > 0
+    }
+}
+
+@MainActor
+final class WatchLegacyIngressDeferralQueue {
+    private struct DeferredOperation {
+        let waitUntilReady: @MainActor @Sendable () async -> Bool
+        let operation: @MainActor @Sendable () async -> Void
+    }
+
+    private var operations: [DeferredOperation] = []
+    private var drainTask: Task<Void, Never>?
+
+    func retain(
+        untilReady waitUntilReady: @escaping @MainActor @Sendable () async -> Bool,
+        operation: @escaping @MainActor @Sendable () async -> Void
+    ) {
+        operations.append(DeferredOperation(
+            waitUntilReady: waitUntilReady,
+            operation: operation
+        ))
+        scheduleDrain()
+    }
+
+    private func scheduleDrain() {
+        guard drainTask == nil, !operations.isEmpty else { return }
+        drainTask = Task { @MainActor [weak self] in
+            await self?.drain()
+        }
+    }
+
+    private func drain() async {
+        while !Task.isCancelled, let deferred = operations.first {
+            guard await deferred.waitUntilReady(), !Task.isCancelled else {
+                drainTask = nil
+                return
+            }
+            operations.removeFirst()
+            await deferred.operation()
+        }
+        drainTask = nil
+    }
+}
+
+enum WatchStandaloneHandshakeDisposition: Equatable, Sendable {
+    case requestFreshCycle
+    case preservePendingFreshCycle
+    case retireWithoutRequest
+}
+
+struct WatchPageCycleHandshakeTracker: Sendable {
+    private struct StandaloneIdentity: Equatable, Sendable {
+        let sourceID: UUID
+        let revision: WatchSyncRevision
+    }
+
+    private var lastStandaloneIdentity: StandaloneIdentity?
+
+    mutating func disposition(
+        sourceID: UUID,
+        snapshotRevision: WatchSyncRevision,
+        pendingRequest: WatchSyncRequestIdentity?
+    ) -> WatchStandaloneHandshakeDisposition {
+        let identity = StandaloneIdentity(
+            sourceID: sourceID,
+            revision: snapshotRevision
+        )
+        guard lastStandaloneIdentity == identity else {
+            lastStandaloneIdentity = identity
+            return .requestFreshCycle
+        }
+        return pendingRequest == .freshCycle
+            ? .preservePendingFreshCycle
+            : .retireWithoutRequest
+    }
+
+    mutating func pageCycleReceived() {
+        lastStandaloneIdentity = nil
+    }
+
+    mutating func reset() {
+        lastStandaloneIdentity = nil
+    }
+}
+
+enum WatchPageCycleRetryBackoff {
+    static func seconds(forAttempt attempt: Int) -> TimeInterval {
+        let boundedAttempt = min(max(0, attempt), 4)
+        return min(60, 5 * pow(2, Double(boundedAttempt)))
+    }
+}
+
+@MainActor
+final class WatchPageCycleRequestRetryController {
+    typealias Sleep = @MainActor @Sendable (TimeInterval) async throws -> Void
+
+    private let sleep: Sleep
+    private var retryTask: Task<Void, Never>?
+    private(set) var pendingRequest: WatchSyncRequestIdentity?
+
+    init(
+        sleep: @escaping Sleep = { delay in
+            try await Task.sleep(for: .seconds(delay))
+        }
+    ) {
+        self.sleep = sleep
+    }
+
+    func retain(
+        _ request: WatchSyncRequestIdentity?,
+        resend: @escaping @MainActor @Sendable (WatchSyncRequestIdentity) -> Void
+    ) {
+        guard request != pendingRequest else { return }
+        retryTask?.cancel()
+        retryTask = nil
+        pendingRequest = request
+        guard let request else { return }
+
+        retryTask = Task { @MainActor [weak self] in
+            var attempt = 0
+            while let self,
+                  self.pendingRequest == request,
+                  !Task.isCancelled
+            {
+                let delay = WatchPageCycleRetryBackoff.seconds(forAttempt: attempt)
+                do {
+                    try await self.sleep(delay)
+                } catch {
+                    return
+                }
+                guard self.pendingRequest == request, !Task.isCancelled else { return }
+                resend(request)
+                attempt += 1
+            }
+        }
+    }
+
+    func cancel() {
+        retryTask?.cancel()
+        retryTask = nil
+        pendingRequest = nil
+    }
+}
+
+struct WatchLegacyMutationMetadata {
+    let peerID: UUID?
+    let revision: WatchSyncRevision?
+
+    init(message: [String: Any]) {
+        peerID = (message[WatchMessageKeys.peerId] as? String).flatMap(UUID.init(uuidString:))
+        revision = WatchSyncValueDecoder.revision(message[WatchMessageKeys.mutationRevision])
+    }
+
+    func isFromActivePeer(_ activePeerID: UUID?) -> Bool {
+        guard let peerID else { return true }
+        return peerID == activePeerID
+    }
+
+    func isCovered(
+        conversationID: UUID,
+        activePeerID: UUID?,
+        acknowledgements: [UUID: WatchSyncRevision]
+    ) -> Bool {
+        guard let peerID, peerID == activePeerID, let revision else { return false }
+        return acknowledgements[conversationID, default: 0] >= revision
+    }
+}
+
+enum WatchLegacyCreateIngressAction: Equatable, Sendable {
+    case ignore
+    case create
+    case repairPlaceholder
+}
+
+enum WatchLegacyCreateIngressResolver {
+    static func action(
+        metadata: WatchLegacyMutationMetadata,
+        conversationID: UUID,
+        activePeerID: UUID?,
+        acknowledgements: [UUID: WatchSyncRevision],
+        conversationExists: Bool,
+        isTrackedPlaceholder: Bool
+    ) -> WatchLegacyCreateIngressAction {
+        if metadata.isCovered(
+            conversationID: conversationID,
+            activePeerID: activePeerID,
+            acknowledgements: acknowledgements
+        ) {
+            return .ignore
+        }
+        guard metadata.isFromActivePeer(activePeerID) else {
+            return .ignore
+        }
+        guard conversationExists else { return .create }
+        return isTrackedPlaceholder ? .repairPlaceholder : .ignore
+    }
+}
+
+struct WatchLegacySendResult {
+    let userInfos: [[String: Any]]
+    let componentIDs: Set<String>
+    let awaitingEchoComponentIDs: Set<String>
+    let fullyRepresented: Bool
+
+    var requiresEchoRetry: Bool {
+        !awaitingEchoComponentIDs.isEmpty
+    }
+
+    init(
+        userInfos: [[String: Any]],
+        awaitingEchoComponentIDs: Set<String> = [],
+        fullyRepresented: Bool
+    ) {
+        self.userInfos = userInfos
+        componentIDs = Set(userInfos.compactMap {
+            $0[WatchMessageKeys.legacyComponentId] as? String
+        })
+        self.awaitingEchoComponentIDs = awaitingEchoComponentIDs
+        self.fullyRepresented = fullyRepresented
+    }
+}
+
+@MainActor
+final class WatchLegacyAcknowledgementRetryTracker {
+    struct PendingAcknowledgement: Equatable, Sendable {
+        let operationID: UUID
+        let conversationID: UUID
+        let revision: WatchSyncRevision
+    }
+
+    private var pendingByOperationID: [UUID: PendingAcknowledgement] = [:]
+
+    func retain(_ mutation: WatchConversationMutation) {
+        pendingByOperationID[mutation.operationID] = PendingAcknowledgement(
+            operationID: mutation.operationID,
+            conversationID: mutation.conversationID,
+            revision: mutation.revision
+        )
+    }
+
+    func contains(operationID: UUID) -> Bool {
+        pendingByOperationID[operationID] != nil
+    }
+
+    func retry(
+        _ acknowledge: @MainActor (UUID, WatchSyncRevision) -> Bool
+    ) -> [PendingAcknowledgement] {
+        let pending = pendingByOperationID.values.sorted {
+            if $0.revision != $1.revision {
+                return $0.revision < $1.revision
+            }
+            return $0.operationID.uuidString < $1.operationID.uuidString
+        }
+        var acknowledged: [PendingAcknowledgement] = []
+        for acknowledgement in pending where acknowledge(
+            acknowledgement.conversationID,
+            acknowledgement.revision
+        ) {
+            pendingByOperationID.removeValue(forKey: acknowledgement.operationID)
+            acknowledged.append(acknowledgement)
+        }
+        return acknowledged
+    }
+
+    func cancel(operationID: UUID) {
+        pendingByOperationID.removeValue(forKey: operationID)
+    }
+
+    func reset() {
+        pendingByOperationID.removeAll()
+    }
+}
+
+@MainActor
+final class WatchLegacyOperationTracker {
+    private struct PendingOperation {
+        let conversationID: UUID
+        let revision: WatchSyncRevision
+        var remainingComponentIDs: Set<String>
+        let fullyRepresented: Bool
+    }
+
+    private var operations: [UUID: PendingOperation] = [:]
+
+    func begin(_ mutation: WatchConversationMutation, result: WatchLegacySendResult) {
+        operations[mutation.operationID] = PendingOperation(
+            conversationID: mutation.conversationID,
+            revision: mutation.revision,
+            remainingComponentIDs: result.componentIDs,
+            fullyRepresented: result.fullyRepresented
+        )
+    }
+
+    func completion(
+        operationID: UUID,
+        componentID: String
+    ) -> (conversationID: UUID, revision: WatchSyncRevision)? {
+        guard var operation = operations[operationID] else { return nil }
+        operation.remainingComponentIDs.remove(componentID)
+        guard operation.remainingComponentIDs.isEmpty else {
+            operations[operationID] = operation
+            return nil
+        }
+        operations.removeValue(forKey: operationID)
+        guard operation.fullyRepresented else { return nil }
+        return (operation.conversationID, operation.revision)
+    }
+
+    func cancel(operationID: UUID) {
+        operations.removeValue(forKey: operationID)
+    }
+
+    func reset() {
+        operations.removeAll()
+    }
+}

--- a/Sources/Ayna/Services/WatchConnectivityService.swift
+++ b/Sources/Ayna/Services/WatchConnectivityService.swift
@@ -1854,15 +1854,16 @@
                     do {
                         let snapshot = try JSONDecoder().decode(WatchSyncSnapshot.self, from: data)
                         if WatchSyncSnapshot.supportsSchemaVersion(snapshot.schemaVersion) {
-                            peerSyncMode = .revisioned
-                            legacyDeliveryTracker.reset()
-                            legacyAcknowledgementRetryTracker.reset()
-                            legacyOperationTracker.reset()
-                            _ = conversationStore?.clearLegacyDeliveryCoverage()
                             let pageMetadata = (context[WatchContextKeys.syncPageCycle] as? Data)
                                 .flatMap {
                                     try? JSONDecoder().decode(WatchSyncPageCycleMetadata.self, from: $0)
                                 }
+                            guard prepareRevisionedSnapshotApplication(
+                                snapshot,
+                                pageMetadata: pageMetadata
+                            ) else {
+                                return .ignore
+                            }
                             let pendingBefore = Set(
                                 conversationStore?.pendingMutationsForSync.map(\.operationID) ?? []
                             )
@@ -1989,6 +1990,37 @@
                     metadataIsComplete: WatchModelMetadataCompleteness
                         .legacyContextIsComplete(in: context)
                 )
+            }
+
+            private func prepareRevisionedSnapshotApplication(
+                _ snapshot: WatchSyncSnapshot,
+                pageMetadata: WatchSyncPageCycleMetadata?
+            ) -> Bool {
+                guard conversationStore?.clearLegacyDeliveryCoverage() == true else {
+                    if let pageMetadata, pageMetadata.isValid(for: snapshot) {
+                        let pageUpdate = pageCycleCoordinator.receive(
+                            pageMetadata,
+                            after: .persistenceFailed
+                        )
+                        retainSyncRequest(pageUpdate.pendingRequest.map {
+                            WatchSyncRequestIdentity.pageCycle($0)
+                        })
+                    }
+                    requestSync()
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .error,
+                        message: "⌚ Revisioned snapshot deferred because legacy delivery reset was not durable",
+                        metadata: ["snapshotRevision": "\(snapshot.revision)"]
+                    )
+                    return false
+                }
+
+                peerSyncMode = .revisioned
+                legacyDeliveryTracker.reset()
+                legacyAcknowledgementRetryTracker.reset()
+                legacyOperationTracker.reset()
+                return true
             }
 
             private func reconcileLegacyDeliveryEchoes(_ echoedConversations: [WatchConversation]) {

--- a/Sources/Ayna/Services/WatchConnectivityService.swift
+++ b/Sources/Ayna/Services/WatchConnectivityService.swift
@@ -1,1012 +1,2331 @@
-//
-//  WatchConnectivityService.swift
-//  ayna
-//
-//  Created on 11/29/25.
-//
-
+// swiftlint:disable file_length
 #if os(iOS) || os(watchOS)
+    import Combine
+    import Foundation
+    import os
+    import WatchConnectivity
 
-import Combine
-import Foundation
-import os
-import WatchConnectivity
+    #if os(iOS)
+        @MainActor
+        // swiftlint:disable:next type_body_length
+        final class WatchConnectivityService: NSObject, ObservableObject {
+            static let shared = WatchConnectivityService()
+            @Published private(set) var isWatchAppInstalled = false
+            @Published private(set) var isReachable = false
+            @Published private(set) var lastSyncDate: Date?
 
-// Note: WatchConversation and WatchMessage are defined in Core/Models/WatchDataModels.swift
-// to be shared across all platforms (macOS, iOS, watchOS).
+            private nonisolated let activationFence = WatchSessionActivationFence()
+            private nonisolated let callbackIdentityFence = WatchSessionCallbackIdentityFence()
+            private let mutationProcessingQueue = WatchMutationProcessingQueue()
+            private let recentAcknowledgements = WatchRecentAcknowledgementTracker()
+            private nonisolated let sessionEventQueue = WatchSessionEventQueue()
+            private let legacyIngressDeferralQueue = WatchLegacyIngressDeferralQueue()
+            private var session: WCSession?
+            private var sessionDelegate: WatchSessionDelegateProxy?
+            private var conversationManager: ConversationManager?
+            private var cancellables = Set<AnyCancellable>()
+            private var snapshotRevision: WatchSyncRevision = 0
+            private var sourceID = UUID()
+            private var activeWatchPeerID: UUID?
+            private var activeWatchCapability = WatchPeerCapabilityState()
+            private var acknowledgedWatchRevisions: [UUID: WatchSyncRevision] = [:]
+            private var acknowledgedWatchRevisionsByPeer: [UUID: [UUID: WatchSyncRevision]] = [:]
+            private var tombstoneRevisions: [UUID: WatchSyncRevision] = [:]
+            private var modelRemovalTracker = WatchModelRemovalTracker()
+            private struct PublishedApplicationContext {
+                let values: [String: Any]
+                let pageCycleMetadata: WatchSyncPageCycleMetadata?
+                let modelMetadataPageIsLossless: Bool
+                let modelRemovalTracker: WatchModelRemovalTracker
+            }
 
-/// Keys for WatchConnectivity context
-private enum WatchContextKeys {
-    static let conversations = "conversations"
-    static let selectedModel = "selectedModel"
-    static let availableModels = "availableModels"
-    static let customModels = "customModels"
-    static let defaultProvider = "defaultProvider"
-    static let modelProviders = "modelProviders"
-    static let modelEndpoints = "modelEndpoints"
-    static let modelEndpointTypes = "modelEndpointTypes"
-    static let modelUsesGitHubOAuth = "modelUsesGitHubOAuth"
-    static let modelAPIKeys = "modelAPIKeys"
-    static let githubAccessToken = "githubAccessToken"
-    static let tavilyAPIKey = "tavilyAPIKey"
-    static let tavilyEnabled = "tavilyEnabled"
-    static let webFetchEnabled = "webFetchEnabled"
-    static let memoryEnabled = "memoryEnabled"
-    static let memoryFacts = "memoryFacts"
-    static let lastSyncDate = "lastSyncDate"
-}
+            private struct ApplicationContextOptions {
+                let modelLimit: Int?
+                let modelMetadataCycleIsAuthoritative: Bool?
+                let maximumDefaultSystemPromptCharacters: Int
+                let modelRemovalPublication: WatchModelRemovalPublication
+                let modelMetadataEpoch: UUID
+            }
 
-/// Keys for WatchConnectivity messages
-private enum WatchMessageKeys {
-    static let type = "type"
-    static let conversation = "conversation"
-    static let newMessage = "newMessage"
-    static let conversationId = "conversationId"
-    static let title = "title"
+            private var knownConversationIDs: Set<UUID> = []
+            private var legacyPlaceholderConversationIDs: Set<UUID> = []
+            private var hasPersistedManifest = false
+            private var pageCycleCoordinator = WatchPhonePageCycleCoordinator()
 
-    // Message types
-    static let typeNewMessage = "newMessage"
-    static let typeNewConversation = "newConversation"
-    static let typeRequestSync = "requestSync"
-    static let typeSyncResponse = "syncResponse"
-    static let typeTitleUpdate = "titleUpdate"
-}
+            override private init() {
+                super.init()
+                loadSyncMetadata()
+                setupSession()
+            }
 
-// MARK: - iOS Side (Companion App)
+            private func setupSession() {
+                guard WCSession.isSupported() else {
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .info,
+                        message: "WatchConnectivity not supported on this device"
+                    )
+                    return
+                }
 
-#if os(iOS)
+                activateSession(WCSession.default)
 
-    /// WatchConnectivity service for the iOS companion app
-    /// Manages syncing conversations to Apple Watch and receiving new messages from Watch
-    @MainActor
-    final class WatchConnectivityService: NSObject, ObservableObject {
-        static let shared = WatchConnectivityService()
-
-        @Published private(set) var isWatchAppInstalled = false
-        @Published private(set) var isReachable = false
-        @Published private(set) var lastSyncDate: Date?
-
-        private var session: WCSession?
-        private var conversationManager: ConversationManager?
-        private var cancellables = Set<AnyCancellable>()
-
-        override private init() {
-            super.init()
-            setupSession()
-        }
-
-        private func setupSession() {
-            guard WCSession.isSupported() else {
                 DiagnosticsLogger.log(
                     .watchConnectivity,
                     level: .info,
-                    message: "WatchConnectivity not supported on this device"
+                    message: "📱 iOS WatchConnectivity session activating"
                 )
-                return
             }
 
-            session = WCSession.default
-            session?.delegate = self
-            session?.activate()
+            private func activateSession(_ targetSession: WCSession) {
+                let activation = activationFence.beginActivation()
+                callbackIdentityFence.activate(
+                    sessionID: ObjectIdentifier(targetSession),
+                    activation: activation
+                )
+                let delegate = WatchSessionDelegateProxy(
+                    owner: self,
+                    activation: activation
+                )
+                session = targetSession
+                sessionDelegate = delegate
+                targetSession.delegate = delegate
+                targetSession.activate()
+            }
 
-            DiagnosticsLogger.log(
-                .watchConnectivity,
-                level: .info,
-                message: "📱 iOS WatchConnectivity session activating"
-            )
-        }
-
-        /// Configure with ConversationManager to observe changes
-        func configure(with conversationManager: ConversationManager) {
-            self.conversationManager = conversationManager
-
-            // Observe conversation changes (skip empty lists to avoid resetting Watch)
-            conversationManager.$conversations
-                .debounce(for: .seconds(1), scheduler: RunLoop.main)
-                .filter { !$0.isEmpty } // Don't sync empty lists
-                .sink { [weak self] conversations in
+            func configure(with conversationManager: ConversationManager) {
+                self.conversationManager = conversationManager
+                cancellables = WatchConversationSyncObserver.observe(
+                    conversationManager: conversationManager
+                ) { [weak self] conversations in
                     self?.syncConversationsToWatch(conversations)
                 }
-                .store(in: &cancellables)
-        }
-
-        /// Sync conversations to Watch via application context
-        func syncConversationsToWatch(_ conversations: [Conversation]) {
-            guard let session, session.isPaired, session.isWatchAppInstalled else {
-                return
             }
 
-            // Only sync the 10 most recent conversations
-            let recentConversations = Array(conversations.prefix(10))
-            let watchConversations = recentConversations.map { WatchConversation(from: $0) }
+            func syncConversationsToWatch(_ conversations: [Conversation]) {
+                let pageCycle: WatchSyncPageCycleRequest?
+                if activeWatchCapability.supportsCurrentSchema {
+                    let cycleID = UUID()
+                    let cursor = pageCycleCoordinator.beginCycle(id: cycleID)
+                    pageCycle = WatchSyncPageCycleRequest(cycleID: cycleID, cursor: cursor)
+                } else {
+                    pageCycleCoordinator.reset()
+                    pageCycle = nil
+                }
+                publishConversationsToWatch(conversations, pageCycle: pageCycle)
+            }
 
-            do {
+            private func publishConversationsToWatch(
+                _ conversations: [Conversation],
+                pageCycle: WatchSyncPageCycleRequest?
+            ) {
+                guard conversationManager?.isConversationStateAuthoritative == true else {
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .debug,
+                        message: "Deferring Watch snapshot until phone conversation load succeeds"
+                    )
+                    return
+                }
+                let durableConversations = conversationManager?.durableConversationsForSync() ?? conversations
+                guard WatchPhonePublicationBarrier.prepare(
+                    pendingOperationCount: {
+                        self.conversationManager?.pendingDestructivePersistenceOperations ?? 0
+                    },
+                    reconcile: { [weak self] in
+                        self?.reconcilePhoneManifest(durableConversations)
+                    }
+                ) else {
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .debug,
+                        message: "Deferring Watch snapshot until destructive persistence settles"
+                    )
+                    return
+                }
+
+                guard let session, session.isPaired, session.isWatchAppInstalled else {
+                    return
+                }
+
+                do {
+                    let nextRevision = incrementSnapshotRevision()
+                    let state = PhoneWatchSyncState(
+                        peerID: activeWatchPeerID,
+                        conversations: durableConversations,
+                        acknowledgedWatchRevisions: acknowledgedWatchRevisions,
+                        tombstoneRevisions: tombstoneRevisions
+                    )
+                    let memoryFacts = try memoryFactsPayloadForSync()
+                    guard let publication = try boundedApplicationContext(
+                        state: state,
+                        snapshotRevision: nextRevision,
+                        memoryFacts: memoryFacts,
+                        pageCycle: pageCycle
+                    ) else {
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .error,
+                            message: "❌ Watch application context exceeds the safe byte budget"
+                        )
+                        return
+                    }
+                    let syncDate = Date()
+                    var contextWithDate = publication.values
+                    contextWithDate[WatchContextKeys.lastSyncDate] = syncDate.timeIntervalSince1970
+                    try session.updateApplicationContext(contextWithDate)
+                    modelRemovalTracker = publication.modelRemovalTracker
+                    persistSyncMetadata()
+                    if let metadata = publication.pageCycleMetadata {
+                        pageCycleCoordinator.recordPublished(
+                            metadata,
+                            modelMetadataPageIsLossless: publication.modelMetadataPageIsLossless
+                        )
+                    }
+                    lastSyncDate = syncDate
+                    let snapshotData = publication.values[WatchContextKeys.syncSnapshot] as? Data ?? Data()
+                    let publishedSnapshot = try? JSONDecoder().decode(WatchSyncSnapshot.self, from: snapshotData)
+
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .info,
+                        message: "📱→⌚ Published revisioned Watch snapshot",
+                        metadata: [
+                            "revision": "\(nextRevision)",
+                            "pageCycle": publication.pageCycleMetadata?.cycleID.uuidString ?? "none",
+                            "pageIndex": "\(publication.pageCycleMetadata?.cursor.pageIndex ?? -1)",
+                            "manifestCount": "\(publishedSnapshot?.authoritativeConversationIDs.count ?? 0)",
+                            "bodyCount": "\(publishedSnapshot?.conversations.count ?? 0)",
+                            "snapshotBytes": "\(snapshotData.count)",
+                            "contextBytes": "\(WatchApplicationContextSizer.size(contextWithDate))"
+                        ]
+                    )
+                } catch {
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .error,
+                        message: "❌ Failed to sync to Watch",
+                        metadata: ["error": error.localizedDescription]
+                    )
+                }
+            }
+
+            private func memoryFactsPayloadForSync() throws -> WatchMemoryFactsPayload {
                 let encoder = JSONEncoder()
-                let data = try encoder.encode(watchConversations)
+                let emptyFacts = try encoder.encode([UserMemoryFact]())
+                guard MemoryContextProvider.shared.isMemoryEnabled else {
+                    return WatchMemoryFactsPayload(
+                        data: emptyFacts,
+                        preservesAcrossFallbacks: true
+                    )
+                }
 
-                // Warn if payload is large (WCSession limit is ~65KB for applicationContext)
-                if data.count > 50000 {
+                guard UserMemoryService.shared.hasAuthoritativeFacts else {
+                    return WatchMemoryFactsPayload(
+                        data: nil,
+                        preservesAcrossFallbacks: false
+                    )
+                }
+
+                let facts = UserMemoryService.shared.activeFacts()
+                let encoded = try encoder.encode(facts)
+                guard encoded.count < 15000 else {
                     DiagnosticsLogger.log(
                         .watchConnectivity,
                         level: .default,
-                        message: "⚠️ Watch sync payload large",
-                        metadata: ["bytes": "\(data.count)"]
+                        message: "⚠️ Memory facts exceed Watch sync headroom; omitting non-authoritative facts",
+                        metadata: ["bytes": "\(encoded.count)", "factCount": "\(facts.count)"]
+                    )
+                    return WatchMemoryFactsPayload(
+                        data: nil,
+                        preservesAcrossFallbacks: false
                     )
                 }
+                return WatchMemoryFactsPayload(
+                    data: encoded,
+                    preservesAcrossFallbacks: facts.isEmpty
+                )
+            }
 
-                // Get all model configuration for Watch
-                let availableModels = AIService.shared.usableModels
+            private func boundedApplicationContext(
+                state: PhoneWatchSyncState,
+                snapshotRevision: WatchSyncRevision,
+                memoryFacts: WatchMemoryFactsPayload,
+                pageCycle: WatchSyncPageCycleRequest?
+            ) throws -> PublishedApplicationContext? {
+                let encoder = JSONEncoder()
+                let attempts = WatchApplicationContextAttempt.fallbacks(memoryFacts: memoryFacts)
+                var candidateRemovalTracker = modelRemovalTracker
+                let modelRemovalPublication = candidateRemovalTracker.publication(
+                    inventory: currentModelMetadataInventory()
+                )
+
+                for attempt in attempts {
+                    var configuration = WatchSyncPayloadConfiguration.default
+                    configuration.byteBudget = attempt.snapshotBytes
+                    if let modelLimit = attempt.modelLimit {
+                        configuration.maximumConversations = min(
+                            configuration.maximumConversations,
+                            modelLimit
+                        )
+                    }
+
+                    let snapshotData: Data
+                    let pageCycleMetadata: WatchSyncPageCycleMetadata?
+                    if let pageCycle {
+                        guard let payload = try? WatchSyncPayloadBuilder.buildPageCycle(
+                            state: state,
+                            sourceID: sourceID,
+                            snapshotRevision: snapshotRevision,
+                            cycleID: pageCycle.cycleID,
+                            cursor: pageCycle.cursor,
+                            prioritizedAcknowledgementIDs: recentAcknowledgements.ids,
+                            configuration: configuration,
+                            resolvedSystemPrompt: { [weak conversationManager] conversation in
+                                conversationManager?.effectiveSystemPrompt(for: conversation)
+                            }
+                        ) else {
+                            continue
+                        }
+                        snapshotData = payload.data
+                        pageCycleMetadata = pageCycleCoordinator.metadataForPublication(
+                            payload.metadata,
+                            modelMetadataPageIsLossless: attempt.modelLimit == nil
+                        )
+                    } else {
+                        guard let payload = try? WatchSyncPayloadBuilder.build(
+                            state: state,
+                            sourceID: sourceID,
+                            snapshotRevision: snapshotRevision,
+                            prioritizedAcknowledgementIDs: recentAcknowledgements.ids,
+                            configuration: configuration,
+                            resolvedSystemPrompt: { [weak conversationManager] conversation in
+                                conversationManager?.effectiveSystemPrompt(for: conversation)
+                            }
+                        ) else {
+                            continue
+                        }
+                        snapshotData = payload.data
+                        pageCycleMetadata = nil
+                    }
+
+                    let pageCycleData = try pageCycleMetadata.map { try encoder.encode($0) }
+                    let context = applicationContext(
+                        snapshotData: snapshotData,
+                        pageCycleData: pageCycleData,
+                        factsData: attempt.facts,
+                        authoritativeState: state,
+                        options: ApplicationContextOptions(
+                            modelLimit: attempt.modelLimit,
+                            modelMetadataCycleIsAuthoritative: pageCycleMetadata?
+                                .modelMetadataCycleIsAuthoritative,
+                            maximumDefaultSystemPromptCharacters: attempt.maximumDefaultSystemPromptCharacters,
+                            modelRemovalPublication: modelRemovalPublication,
+                            modelMetadataEpoch: candidateRemovalTracker.epoch
+                        )
+                    )
+                    if WatchApplicationContextSizer.isWithinSafeLimit(context) {
+                        return PublishedApplicationContext(
+                            values: context,
+                            pageCycleMetadata: pageCycleMetadata,
+                            modelMetadataPageIsLossless: attempt.modelLimit == nil,
+                            modelRemovalTracker: candidateRemovalTracker
+                        )
+                    }
+                }
+                return nil
+            }
+
+            private func currentModelMetadataInventory() -> WatchModelMetadataInventory {
+                let modelIDs = WatchModelSyncSelection.models(
+                    selectedModel: AIService.shared.selectedModel,
+                    availableModels: AIService.shared.usableModels + AIService.shared.customModels,
+                    referencedModels: [],
+                    limit: nil
+                )
+                let configured = Set(modelIDs)
+                let providers = AIService.shared.modelProviders
+                    .filter { configured.contains($0.key) }
+                    .mapValues(\.rawValue)
+                let endpoints = AIService.shared.modelEndpoints.filter {
+                    configured.contains($0.key) && !$0.value.isEmpty
+                }
+                let endpointTypes = AIService.shared.modelEndpointTypes
+                    .filter { configured.contains($0.key) }
+                    .mapValues(\.rawValue)
+                let gitHubOAuth = AIService.shared.modelUsesGitHubOAuth.filter {
+                    configured.contains($0.key)
+                }
+                let apiKeys = AIService.shared.modelAPIKeys.filter {
+                    configured.contains($0.key) && !$0.value.isEmpty
+                }
+                return WatchModelMetadataInventory(
+                    modelIDs: modelIDs,
+                    providerModelIDs: providers.keys.sorted(),
+                    endpointModelIDs: endpoints.keys.sorted(),
+                    endpointTypeModelIDs: endpointTypes.keys.sorted(),
+                    gitHubOAuthModelIDs: gitHubOAuth.keys.sorted(),
+                    apiKeyModelIDs: apiKeys.keys.sorted(),
+                    valueDigests: WatchModelMetadataValueDigests.hashing(
+                        providers: providers,
+                        endpoints: endpoints,
+                        endpointTypes: endpointTypes,
+                        gitHubOAuth: gitHubOAuth,
+                        apiKeys: apiKeys
+                    )
+                )
+            }
+
+            private func applicationContext(
+                snapshotData: Data,
+                pageCycleData: Data?,
+                factsData: Data?,
+                authoritativeState: PhoneWatchSyncState,
+                options: ApplicationContextOptions
+            ) -> [String: Any] {
                 let selectedModel = AIService.shared.selectedModel
-                let customModels = AIService.shared.customModels
-                let defaultProvider = AIService.shared.provider.rawValue
-                let modelProviders = AIService.shared.modelProviders.mapValues { $0.rawValue }
-                let modelEndpoints = AIService.shared.modelEndpoints
-                let modelEndpointTypes = AIService.shared.modelEndpointTypes.mapValues { $0.rawValue }
-                let modelUsesGitHubOAuth = AIService.shared.modelUsesGitHubOAuth
-
-                // SECURITY: API keys are persisted in WCSession applicationContext on watch.
-                // Consider migrating to sendMessage + Keychain.
-                let modelAPIKeys = AIService.shared.modelAPIKeys
-
-                // GitHub OAuth token for GitHub Models
-                let githubAccessToken = GitHubOAuthService.shared.getAccessToken() ?? ""
-
-                // Tavily web search settings
-                let tavilyAPIKey = TavilyService.shared.apiKey
-                let tavilyEnabled = TavilyService.shared.isEnabled
+                let snapshot = try? JSONDecoder().decode(WatchSyncSnapshot.self, from: snapshotData)
+                let modelPublication = if let snapshot {
+                    WatchModelSyncSelection.publication(
+                        selectedModel: selectedModel,
+                        availableModels: AIService.shared.usableModels,
+                        authoritativeState: authoritativeState,
+                        snapshot: snapshot,
+                        limit: options.modelLimit
+                    )
+                } else {
+                    WatchModelSyncSelection.publication(
+                        selectedModel: selectedModel,
+                        availableModels: AIService.shared.usableModels,
+                        referencedModels: [],
+                        limit: options.modelLimit
+                    )
+                }
+                let metadataModelSet = modelPublication.metadataModelIDs
+                let modelMetadataComplete = options.modelMetadataCycleIsAuthoritative ?? snapshot.map {
+                    WatchModelMetadataCompleteness.isCompletePublication(
+                        snapshot: $0,
+                        modelLimit: options.modelLimit
+                    )
+                } ?? false
 
                 var context: [String: Any] = [
-                    WatchContextKeys.conversations: data,
+                    WatchContextKeys.syncSnapshot: snapshotData,
                     WatchContextKeys.selectedModel: selectedModel,
-                    WatchContextKeys.availableModels: availableModels,
-                    WatchContextKeys.customModels: customModels,
-                    WatchContextKeys.defaultProvider: defaultProvider,
-                    WatchContextKeys.modelProviders: modelProviders,
-                    WatchContextKeys.modelEndpoints: modelEndpoints,
-                    WatchContextKeys.modelEndpointTypes: modelEndpointTypes,
-                    WatchContextKeys.modelUsesGitHubOAuth: modelUsesGitHubOAuth,
-                    WatchContextKeys.lastSyncDate: Date().timeIntervalSince1970
+                    WatchContextKeys.availableModels: modelPublication.availableModels,
+                    WatchContextKeys.customModels: AIService.shared.customModels.filter { metadataModelSet.contains($0) },
+                    WatchContextKeys.defaultProvider: AIService.shared.provider.rawValue,
+                    WatchContextKeys.modelProviders: modelPublication.metadataValues(
+                        from: AIService.shared.modelProviders
+                    )
+                    .mapValues(\.rawValue),
+                    WatchContextKeys.modelEndpoints: modelPublication.metadataValues(
+                        from: AIService.shared.modelEndpoints
+                    ),
+                    WatchContextKeys.modelEndpointTypes: modelPublication.metadataValues(
+                        from: AIService.shared.modelEndpointTypes
+                    )
+                    .mapValues(\.rawValue),
+                    WatchContextKeys.modelUsesGitHubOAuth: modelPublication.metadataValues(
+                        from: AIService.shared.modelUsesGitHubOAuth
+                    ),
+                    WatchContextKeys.modelAPIKeys: modelPublication.metadataValues(
+                        from: AIService.shared.modelAPIKeys
+                    ),
+                    WatchContextKeys.removedModelDigests: options.modelRemovalPublication.removedModelDigests,
+                    WatchContextKeys.removedModelProviderDigests: options.modelRemovalPublication.removedProviderDigests,
+                    WatchContextKeys.removedModelEndpointDigests: options.modelRemovalPublication.removedEndpointDigests,
+                    WatchContextKeys.removedModelEndpointTypeDigests: options.modelRemovalPublication.removedEndpointTypeDigests,
+                    WatchContextKeys.removedModelGitHubOAuthDigests: options.modelRemovalPublication.removedGitHubOAuthDigests,
+                    WatchContextKeys.removedModelAPIKeyDigests: options.modelRemovalPublication.removedAPIKeyDigests,
+                    WatchContextKeys.modelMetadataEpoch: options.modelMetadataEpoch.uuidString,
+                    WatchContextKeys.modelMetadataComplete: modelMetadataComplete,
+                    WatchContextKeys.githubAccessToken: GitHubOAuthService.shared.getAccessToken() ?? "",
+                    WatchContextKeys.tavilyAPIKey: TavilyService.shared.apiKey,
+                    WatchContextKeys.tavilyEnabled: TavilyService.shared.isEnabled,
+                    WatchContextKeys.webFetchEnabled: WebFetchService.shared.isEnabled,
+                    WatchContextKeys.memoryEnabled: MemoryContextProvider.shared.isMemoryEnabled
                 ]
-
-                // Only send API keys/tokens if they exist (don't overwrite with empty)
-                if !modelAPIKeys.isEmpty {
-                    context[WatchContextKeys.modelAPIKeys] = modelAPIKeys
+                if let defaultSystemPrompt = WatchPayloadStringLimiter.losslessRepresentation(
+                    AppPreferences.globalSystemPrompt,
+                    maximumCharacters: options.maximumDefaultSystemPromptCharacters
+                ) {
+                    context[WatchContextKeys.defaultSystemPrompt] = defaultSystemPrompt
                 }
-                if !githubAccessToken.isEmpty {
-                    context[WatchContextKeys.githubAccessToken] = githubAccessToken
+                if let factsData {
+                    context[WatchContextKeys.memoryFacts] = factsData
+                }
+                if let pageCycleData {
+                    context[WatchContextKeys.syncPageCycle] = pageCycleData
+                }
+                if !activeWatchCapability.supportsCurrentSchema,
+                   let snapshot,
+                   let legacyConversations = try? JSONEncoder().encode(snapshot.conversations)
+                {
+                    context[WatchContextKeys.conversations] = legacyConversations
+                }
+                return context
+            }
+
+            private func handleMutation(
+                _ mutation: WatchConversationMutation,
+                schemaVersion: Any?
+            ) async -> [String: Any]? {
+                switch WatchMutationIngressValidator.validate(
+                    schemaVersion: schemaVersion,
+                    fields: mutation.fields
+                ) {
+                case .accepted:
+                    break
+                case let .rejected(rejection):
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .error,
+                        message: "Rejecting unsupported Watch mutation ingress",
+                        metadata: [
+                            "operationId": mutation.operationID.uuidString,
+                            "conversationId": mutation.conversationID.uuidString,
+                            "reason": String(describing: rejection)
+                        ]
+                    )
+                    return WatchMutationReply.unsupported(for: mutation).message
                 }
 
-                // Tavily settings (always send to keep watch in sync)
-                context[WatchContextKeys.tavilyAPIKey] = tavilyAPIKey
-                context[WatchContextKeys.tavilyEnabled] = tavilyEnabled
+                let reply: WatchMutationReply? = await mutationProcessingQueue.enqueue { [weak self] in
+                    guard let self else { return nil }
+                    return await self.applyMutation(mutation)
+                }
+                return reply?.message
+            }
 
-                // Web fetch settings (always enabled on iOS, sync to watch)
-                context[WatchContextKeys.webFetchEnabled] = WebFetchService.shared.isEnabled
+            private func applyMutation(_ mutation: WatchConversationMutation) async -> WatchMutationReply? {
+                guard let conversationManager else { return nil }
 
-                // Memory settings (sync facts if enabled)
-                let memoryEnabled = MemoryContextProvider.shared.isMemoryEnabled
-                context[WatchContextKeys.memoryEnabled] = memoryEnabled
-                if memoryEnabled {
-                    let facts = UserMemoryService.shared.activeFacts()
-                    if !facts.isEmpty, let factsData = try? JSONEncoder().encode(facts) {
-                        // Only include facts if we have room (leave headroom for other context)
-                        if factsData.count < 15000 {
-                            context[WatchContextKeys.memoryFacts] = factsData
+                activateWatchPeer(mutation.peerID)
+                activeWatchCapability.apply(.receivedMutation)
+                guard conversationManager.isConversationStateAuthoritative else {
+                    return .retry(for: mutation)
+                }
+                guard conversationManager.pendingDestructivePersistenceOperations == 0 else {
+                    return .retry(for: mutation)
+                }
+
+                let state = PhoneWatchSyncState(
+                    peerID: activeWatchPeerID,
+                    conversations: conversationManager.conversations,
+                    acknowledgedWatchRevisions: acknowledgedWatchRevisions,
+                    tombstoneRevisions: tombstoneRevisions
+                )
+                let reduction = PhoneWatchMutationReducer.reduce(
+                    state,
+                    mutation: mutation,
+                    tombstoneRevision: mutation.fields.contains(.delete) ? nextSnapshotRevision() : nil
+                )
+
+                let persisted: Bool
+                switch reduction.disposition {
+                case .applied:
+                    guard let reduced = reduction.state.conversations.first(where: { $0.id == mutation.conversationID }) else {
+                        return nil
+                    }
+                    switch await conversationManager.persistProposedConversation(reduced).value {
+                    case .saved:
+                        conversationManager.commitPersistedConversation(reduced)
+                        persisted = true
+                    case .failed, .superseded:
+                        persisted = false
+                    }
+
+                case .deleted:
+                    let deletion = if let existing = conversationManager.conversations.first(where: {
+                        $0.id == mutation.conversationID
+                    }) {
+                        conversationManager.persistProposedDeletion(existing)
+                    } else {
+                        conversationManager.persistProposedDeletion(conversationID: mutation.conversationID)
+                    }
+                    switch await deletion.value {
+                    case .deleted:
+                        conversationManager.commitPersistedDeletion(mutation.conversationID)
+                        persisted = true
+                    case .failed, .superseded:
+                        persisted = false
+                    }
+
+                case .rejectedStale, .rejectedDeletedTombstone, .rejectedMissingCreate:
+                    persisted = true
+                }
+
+                guard persisted else {
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .error,
+                        message: "Watch mutation persistence failed; retaining durable Watch outbox entry",
+                        metadata: [
+                            "conversationId": mutation.conversationID.uuidString,
+                            "operationId": mutation.operationID.uuidString,
+                            "revision": "\(mutation.revision)"
+                        ]
+                    )
+                    return .retry(for: mutation)
+                }
+
+                legacyPlaceholderConversationIDs.remove(mutation.conversationID)
+                WatchMutationMetadataMerger.merge(
+                    reduction: reduction,
+                    conversationID: mutation.conversationID,
+                    acknowledgements: &acknowledgedWatchRevisions,
+                    tombstones: &tombstoneRevisions
+                )
+                recentAcknowledgements.record(mutation.conversationID)
+                reconcilePhoneManifest(conversationManager.conversations)
+
+                let acknowledgedRevision = acknowledgedWatchRevisions[mutation.conversationID] ?? mutation.revision
+                syncConversationsToWatch(conversationManager.conversations)
+
+                return .acknowledged(mutation, revision: acknowledgedRevision)
+            }
+
+            private func processLegacyPayload(
+                _ apply: @escaping @MainActor @Sendable (ConversationManager) async -> Void
+            ) async {
+                guard let conversationManager else { return }
+                guard !WatchLegacyIngressRouting.shouldDefer(
+                    isAuthoritative: conversationManager.isConversationStateAuthoritative,
+                    pendingDestructiveOperationCount: conversationManager.pendingDestructivePersistenceOperations
+                ) else {
+                    legacyIngressDeferralQueue.retain(
+                        untilReady: { [weak self] in
+                            guard let conversationManager = self?.conversationManager else { return false }
+                            return await conversationManager.waitUntilConversationStateIsAuthoritative()
+                        },
+                        operation: { [weak self] in
+                            guard let self, let conversationManager = self.conversationManager else { return }
+                            await self.performLegacyPayload(apply, with: conversationManager)
+                        }
+                    )
+                    return
+                }
+                await performLegacyPayload(apply, with: conversationManager)
+            }
+
+            private func performLegacyPayload(
+                _ apply: @escaping @MainActor @Sendable (ConversationManager) async -> Void,
+                with conversationManager: ConversationManager
+            ) async {
+                await WatchLegacyPersistenceBarrier.perform(
+                    pendingOperationCount: {
+                        conversationManager.pendingDestructivePersistenceOperations
+                    },
+                    changes: conversationManager.$pendingDestructivePersistenceOperations,
+                    reconcile: { [weak self] in
+                        self?.reconcilePhoneManifest(conversationManager.conversations)
+                    },
+                    apply: {
+                        await apply(conversationManager)
+                    }
+                )
+            }
+
+            private func persistLegacyConversation(
+                _ conversation: Conversation,
+                with conversationManager: ConversationManager
+            ) async -> Bool {
+                switch await conversationManager.persistProposedConversation(conversation).value {
+                case .saved:
+                    conversationManager.commitPersistedConversation(conversation)
+                    return true
+                case let .failed(error):
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .error,
+                        message: "Legacy Watch mutation persistence failed",
+                        metadata: [
+                            "conversationId": conversation.id.uuidString,
+                            "error": error
+                        ]
+                    )
+                    return false
+                case .superseded:
+                    return false
+                }
+            }
+
+            private func handleLegacyMessage(
+                from watchMessage: WatchMessage,
+                conversationID: UUID,
+                metadata: WatchLegacyMutationMetadata
+            ) async {
+                await processLegacyPayload { [weak self] conversationManager in
+                    guard let self,
+                          metadata.isFromActivePeer(self.activeWatchPeerID)
+                    else {
+                        return
+                    }
+                    guard !metadata.isCovered(
+                        conversationID: conversationID,
+                        activePeerID: self.activeWatchPeerID,
+                        acknowledgements: self.acknowledgedWatchRevisions
+                    ) else {
+                        return
+                    }
+                    guard self.tombstoneRevisions[conversationID] == nil else {
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .info,
+                            message: "Ignoring legacy Watch message for deleted conversation",
+                            metadata: ["conversationId": conversationID.uuidString]
+                        )
+                        return
+                    }
+                    let converted = watchMessage.toMessage()
+
+                    let proposed: Conversation
+                    let createdPlaceholder: Bool
+                    if var conversation = conversationManager.conversations.first(where: { $0.id == conversationID }) {
+                        createdPlaceholder = false
+                        if let index = conversation.messages.firstIndex(where: { $0.id == converted.id }) {
+                            guard conversation.messages[index] != converted else { return }
+                            conversation.messages[index] = converted
                         } else {
+                            conversation.messages.append(converted)
+                        }
+                        conversation.updatedAt = max(conversation.updatedAt, converted.timestamp)
+                        proposed = conversation
+                    } else {
+                        createdPlaceholder = true
+                        proposed = Conversation(
+                            id: conversationID,
+                            title: "Watch Chat",
+                            messages: [converted],
+                            createdAt: converted.timestamp,
+                            updatedAt: converted.timestamp,
+                            model: AIService.shared.selectedModel
+                        )
+                    }
+                    guard await self.persistLegacyConversation(proposed, with: conversationManager) else { return }
+                    if createdPlaceholder,
+                       self.legacyPlaceholderConversationIDs.insert(conversationID).inserted
+                    {
+                        self.persistSyncMetadata()
+                    }
+                    self.syncConversationsToWatch(conversationManager.conversations)
+                }
+            }
+
+            private func handleLegacyConversation(
+                _ watchConversation: WatchConversation,
+                metadata: WatchLegacyMutationMetadata
+            ) async {
+                await processLegacyPayload { [weak self] conversationManager in
+                    guard let self,
+                          self.tombstoneRevisions[watchConversation.id] == nil
+                    else {
+                        return
+                    }
+
+                    let existing = conversationManager.conversations.first {
+                        $0.id == watchConversation.id
+                    }
+                    let action = WatchLegacyCreateIngressResolver.action(
+                        metadata: metadata,
+                        conversationID: watchConversation.id,
+                        activePeerID: self.activeWatchPeerID,
+                        acknowledgements: self.acknowledgedWatchRevisions,
+                        conversationExists: existing != nil,
+                        isTrackedPlaceholder: self.legacyPlaceholderConversationIDs.contains(
+                            watchConversation.id
+                        )
+                    )
+                    guard action != .ignore else {
+                        if metadata.isCovered(
+                            conversationID: watchConversation.id,
+                            activePeerID: self.activeWatchPeerID,
+                            acknowledgements: self.acknowledgedWatchRevisions
+                        ), self.legacyPlaceholderConversationIDs.remove(watchConversation.id) != nil {
+                            self.persistSyncMetadata()
+                        }
+                        return
+                    }
+                    let conversation = WatchLegacyConversationMerger.mergeCreate(
+                        watchConversation,
+                        into: action == .repairPlaceholder ? existing : nil
+                    )
+                    guard await self.persistLegacyConversation(conversation, with: conversationManager) else { return }
+                    if self.legacyPlaceholderConversationIDs.remove(watchConversation.id) != nil {
+                        self.persistSyncMetadata()
+                    }
+                    self.syncConversationsToWatch(conversationManager.conversations)
+                }
+            }
+
+            private func handleLegacyTitleUpdate(
+                conversationID: UUID,
+                newTitle: String,
+                metadata: WatchLegacyMutationMetadata
+            ) async {
+                await processLegacyPayload { [weak self] conversationManager in
+                    guard let self,
+                          metadata.isFromActivePeer(self.activeWatchPeerID),
+                          !metadata.isCovered(
+                              conversationID: conversationID,
+                              activePeerID: self.activeWatchPeerID,
+                              acknowledgements: self.acknowledgedWatchRevisions
+                          ),
+                          self.tombstoneRevisions[conversationID] == nil,
+                          let conversation = conversationManager.conversations.first(where: { $0.id == conversationID }),
+                          conversation.title != newTitle
+                    else {
+                        return
+                    }
+
+                    var updated = conversation
+                    updated.title = newTitle
+                    updated.updatedAt = Date()
+                    guard await self.persistLegacyConversation(updated, with: conversationManager) else { return }
+                    self.syncConversationsToWatch(conversationManager.conversations)
+                }
+            }
+
+            private func handleReceivedMessage(_ message: [String: Any]) async -> [String: Any]? {
+                guard let type = message[WatchMessageKeys.type] as? String else { return nil }
+
+                switch type {
+                case WatchMessageKeys.typeMutation, "conversationMutation":
+                    guard let data = message[WatchMessageKeys.mutation] as? Data else {
+                        return unsupportedMutationReply(for: message)
+                    }
+                    do {
+                        let mutation = try JSONDecoder().decode(
+                            WatchConversationMutation.self,
+                            from: data
+                        )
+                        let schemaVersion = message[WatchMessageKeys.schemaVersion]
+                            ?? (type == "conversationMutation" ? NSNumber(value: 1) : nil)
+                        return await handleMutation(
+                            mutation,
+                            schemaVersion: schemaVersion
+                        )
+                    } catch {
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .error,
+                            message: "❌ Failed to decode Watch mutation",
+                            metadata: ["error": error.localizedDescription]
+                        )
+                        return unsupportedMutationReply(for: message)
+                    }
+
+                case WatchMessageKeys.typeNewMessage:
+                    guard let data = message[WatchMessageKeys.newMessage] as? Data,
+                          let idString = message[WatchMessageKeys.conversationId] as? String,
+                          let id = UUID(uuidString: idString),
+                          let watchMessage = try? JSONDecoder().decode(WatchMessage.self, from: data)
+                    else {
+                        return nil
+                    }
+                    await handleLegacyMessage(
+                        from: watchMessage,
+                        conversationID: id,
+                        metadata: WatchLegacyMutationMetadata(message: message)
+                    )
+
+                case WatchMessageKeys.typeNewConversation:
+                    guard let data = message[WatchMessageKeys.conversation] as? Data,
+                          let conversation = try? JSONDecoder().decode(WatchConversation.self, from: data)
+                    else {
+                        return nil
+                    }
+                    await handleLegacyConversation(
+                        conversation,
+                        metadata: WatchLegacyMutationMetadata(message: message)
+                    )
+
+                case WatchMessageKeys.typeRequestSync:
+                    let advertisedMaximumSchema = WatchSyncCapability.advertisedMaximumSchemaVersion(
+                        message[WatchMessageKeys.schemaVersion]
+                    )
+                    if let peerIDString = message[WatchMessageKeys.peerId] as? String,
+                       let peerID = UUID(uuidString: peerIDString)
+                    {
+                        await mutationProcessingQueue.enqueue { [weak self] in
+                            guard let self else { return }
+                            self.activateWatchPeer(peerID)
+                            self.activeWatchCapability.apply(.advertisedMaximumSchema(advertisedMaximumSchema))
+                        }
+                    } else {
+                        await mutationProcessingQueue.enqueue { [weak self] in
+                            self?.activeWatchCapability.apply(.advertisedMaximumSchema(advertisedMaximumSchema))
+                        }
+                    }
+                    if let conversations = conversationManager?.conversations {
+                        let requestedPage = (message[WatchMessageKeys.pageCycleRequest] as? Data)
+                            .flatMap {
+                                try? JSONDecoder().decode(WatchSyncPageCycleRequest.self, from: $0)
+                            }
+                        if let requestedPage,
+                           requestedPage.cursor.isValid,
+                           let publication = pageCycleCoordinator.publicationRequest(for: requestedPage)
+                        {
+                            publishConversationsToWatch(conversations, pageCycle: publication)
+                        } else {
+                            syncConversationsToWatch(conversations)
+                        }
+                    }
+
+                case WatchMessageKeys.typeTitleUpdate:
+                    guard let idString = message[WatchMessageKeys.conversationId] as? String,
+                          let id = UUID(uuidString: idString),
+                          let title = message[WatchMessageKeys.title] as? String
+                    else {
+                        return nil
+                    }
+                    await handleLegacyTitleUpdate(
+                        conversationID: id,
+                        newTitle: title,
+                        metadata: WatchLegacyMutationMetadata(message: message)
+                    )
+
+                default:
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .info,
+                        message: "📱 Unknown message type from Watch",
+                        metadata: ["type": type]
+                    )
+                }
+                return nil
+            }
+
+            private func unsupportedMutationReply(
+                for message: [String: Any]
+            ) -> [String: Any] {
+                var reply: [String: Any] = [
+                    WatchMessageKeys.type: WatchMessageKeys.typeMutationAck,
+                    WatchMessageKeys.status: "unsupported"
+                ]
+                for key in [WatchMessageKeys.operationId, WatchMessageKeys.conversationId] {
+                    if let value = message[key] as? String {
+                        reply[key] = value
+                    }
+                }
+                return reply
+            }
+
+            private func reconcilePhoneManifest(_ conversations: [Conversation]) {
+                let currentIDs = Set(conversations.map(\.id))
+                if hasPersistedManifest {
+                    let deletionRevision = nextSnapshotRevision()
+                    for id in knownConversationIDs.subtracting(currentIDs) {
+                        tombstoneRevisions[id] = max(
+                            tombstoneRevisions[id] ?? 0,
+                            acknowledgedWatchRevisions[id] ?? 0,
+                            deletionRevision
+                        )
+                    }
+                }
+                for id in currentIDs {
+                    tombstoneRevisions.removeValue(forKey: id)
+                }
+                knownConversationIDs = currentIDs
+                legacyPlaceholderConversationIDs.formIntersection(currentIDs)
+                hasPersistedManifest = true
+                pruneSyncMetadata(currentConversationIDs: currentIDs)
+                persistSyncMetadata()
+            }
+
+            private func pruneSyncMetadata(currentConversationIDs: Set<UUID>) {
+                let retainedIDs = currentConversationIDs
+                var retainedAcknowledgements = acknowledgedWatchRevisions.filter {
+                    retainedIDs.contains($0.key)
+                }
+                if retainedAcknowledgements.count < 128 {
+                    for entry in acknowledgedWatchRevisions
+                        .filter({ !retainedIDs.contains($0.key) })
+                        .sorted(by: { $0.value > $1.value })
+                        .prefix(128 - retainedAcknowledgements.count)
+                    {
+                        retainedAcknowledgements[entry.key] = entry.value
+                    }
+                }
+                acknowledgedWatchRevisions = retainedAcknowledgements
+            }
+
+            private func nextSnapshotRevision() -> WatchSyncRevision {
+                let next = snapshotRevision &+ 1
+                return next == 0 ? 1 : next
+            }
+
+            private func incrementSnapshotRevision() -> WatchSyncRevision {
+                if snapshotRevision == .max {
+                    sourceID = UUID()
+                    snapshotRevision = 1
+                } else {
+                    snapshotRevision = nextSnapshotRevision()
+                }
+                persistSyncMetadata()
+                return snapshotRevision
+            }
+
+            private func loadSyncMetadata() {
+                let defaults = UserDefaults.standard
+                let sourceMetadata = WatchSyncSourceMetadata.resolve(
+                    persistedSourceID: defaults.string(forKey: WatchSyncPersistenceKeys.sourceID),
+                    persistedSnapshotRevision: defaults.object(
+                        forKey: WatchSyncPersistenceKeys.snapshotRevision
+                    ),
+                    replacementSourceID: UUID()
+                )
+                sourceID = sourceMetadata.sourceID
+                snapshotRevision = sourceMetadata.snapshotRevision
+                activeWatchPeerID = defaults.string(forKey: WatchSyncPersistenceKeys.activeWatchPeerID)
+                    .flatMap(UUID.init(uuidString:))
+                acknowledgedWatchRevisionsByPeer = WatchSyncMetadataCodec.decodePeerRevisionMaps(
+                    defaults.data(forKey: WatchSyncPersistenceKeys.acknowledgedWatchRevisionsByPeer)
+                )
+                let legacyAcknowledgements = WatchSyncMetadataCodec.decodeRevisionMap(
+                    defaults.data(forKey: WatchSyncPersistenceKeys.acknowledgedWatchRevisions)
+                )
+                if let activeWatchPeerID {
+                    acknowledgedWatchRevisions = acknowledgedWatchRevisionsByPeer[activeWatchPeerID]
+                        ?? legacyAcknowledgements
+                } else {
+                    acknowledgedWatchRevisions = legacyAcknowledgements
+                }
+                tombstoneRevisions = WatchSyncMetadataCodec.decodeRevisionMap(
+                    defaults.data(forKey: WatchSyncPersistenceKeys.tombstoneRevisions)
+                )
+                if let trackerData = defaults.data(forKey: WatchSyncPersistenceKeys.modelRemovalTracker),
+                   let decodedTracker = try? JSONDecoder().decode(
+                       WatchModelRemovalTracker.self,
+                       from: trackerData
+                   )
+                {
+                    modelRemovalTracker = decodedTracker
+                }
+                if let encodedIDs = defaults.array(forKey: WatchSyncPersistenceKeys.authoritativeConversationIDs) as? [String] {
+                    knownConversationIDs = Set(encodedIDs.compactMap(UUID.init(uuidString:)))
+                    hasPersistedManifest = true
+                }
+                if let placeholderIDs = defaults.array(
+                    forKey: WatchSyncPersistenceKeys.legacyPlaceholderConversationIDs
+                ) as? [String] {
+                    legacyPlaceholderConversationIDs = Set(
+                        placeholderIDs.compactMap(UUID.init(uuidString:))
+                    )
+                }
+            }
+
+            private func persistSyncMetadata() {
+                let defaults = UserDefaults.standard
+                if let activeWatchPeerID {
+                    acknowledgedWatchRevisionsByPeer[activeWatchPeerID] = acknowledgedWatchRevisions
+                }
+                defaults.set(sourceID.uuidString, forKey: WatchSyncPersistenceKeys.sourceID)
+                defaults.set(NSNumber(value: snapshotRevision), forKey: WatchSyncPersistenceKeys.snapshotRevision)
+                defaults.set(WatchSyncMetadataCodec.encodeRevisionMap(acknowledgedWatchRevisions), forKey: WatchSyncPersistenceKeys.acknowledgedWatchRevisions)
+                defaults.set(
+                    WatchSyncMetadataCodec.encodePeerRevisionMaps(acknowledgedWatchRevisionsByPeer),
+                    forKey: WatchSyncPersistenceKeys.acknowledgedWatchRevisionsByPeer
+                )
+                defaults.set(activeWatchPeerID?.uuidString, forKey: WatchSyncPersistenceKeys.activeWatchPeerID)
+                defaults.set(WatchSyncMetadataCodec.encodeRevisionMap(tombstoneRevisions), forKey: WatchSyncPersistenceKeys.tombstoneRevisions)
+                defaults.set(
+                    try? JSONEncoder().encode(modelRemovalTracker),
+                    forKey: WatchSyncPersistenceKeys.modelRemovalTracker
+                )
+                defaults.set(
+                    knownConversationIDs.map(\.uuidString).sorted(),
+                    forKey: WatchSyncPersistenceKeys.authoritativeConversationIDs
+                )
+                defaults.set(
+                    legacyPlaceholderConversationIDs.map(\.uuidString).sorted(),
+                    forKey: WatchSyncPersistenceKeys.legacyPlaceholderConversationIDs
+                )
+            }
+
+            private func activateWatchPeer(_ peerID: UUID) {
+                guard activeWatchPeerID != peerID else { return }
+                if let activeWatchPeerID {
+                    acknowledgedWatchRevisionsByPeer[activeWatchPeerID] = acknowledgedWatchRevisions
+                }
+                activeWatchPeerID = peerID
+                acknowledgedWatchRevisions = acknowledgedWatchRevisionsByPeer[peerID] ?? [:]
+                activeWatchCapability.apply(.reset)
+                pageCycleCoordinator.reset()
+                persistSyncMetadata()
+            }
+
+            private func isCurrentCallback(
+                sessionID: ObjectIdentifier,
+                activation: WatchSessionActivationToken
+            ) -> Bool {
+                guard activationFence.isCurrent(activation),
+                      callbackIdentityFence.isCurrent(
+                          sessionID: sessionID,
+                          activation: activation
+                      ),
+                      let session
+                else {
+                    return false
+                }
+                return ObjectIdentifier(session) == sessionID
+            }
+        }
+
+        extension WatchConnectivityService {
+            nonisolated func handleSessionActivation(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken,
+                state activationState: WCSessionActivationState,
+                error: Error?
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let installed = session.isWatchAppInstalled
+                let reachable = session.isReachable
+                let errorDescription = error?.localizedDescription
+                Task { @MainActor in
+                    guard isCurrentCallback(sessionID: sessionID, activation: activation) else { return }
+                    if let errorDescription {
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .error,
+                            message: "❌ iOS session activation failed",
+                            metadata: ["error": errorDescription]
+                        )
+                        return
+                    }
+                    isWatchAppInstalled = installed
+                    isReachable = reachable
+                    if installed, let conversations = conversationManager?.conversations {
+                        syncConversationsToWatch(conversations)
+                    }
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .info,
+                        message: "📱 iOS session activated",
+                        metadata: ["state": "\(activationState.rawValue)", "reachable": "\(reachable)"]
+                    )
+                }
+            }
+
+            nonisolated func handleSessionDidBecomeInactive(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                sessionEventQueue.enqueue { [weak self] in
+                    guard let self,
+                          self.isCurrentCallback(sessionID: sessionID, activation: activation)
+                    else {
+                        return
+                    }
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .info,
+                        message: "📱 iOS session became inactive"
+                    )
+                }
+            }
+
+            nonisolated func handleSessionDidDeactivate(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                sessionEventQueue.enqueue { [weak self] in
+                    guard let self,
+                          self.isCurrentCallback(sessionID: sessionID, activation: activation)
+                    else {
+                        return
+                    }
+                    self.activeWatchCapability.apply(.reset)
+                    self.pageCycleCoordinator.reset()
+                    guard let currentSession = self.session else { return }
+                    self.activateSession(currentSession)
+                }
+            }
+
+            nonisolated func handleSessionWatchStateDidChange(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let installed = session.isWatchAppInstalled
+                let reachable = session.isReachable
+                Task { @MainActor in
+                    guard isCurrentCallback(sessionID: sessionID, activation: activation) else { return }
+                    isWatchAppInstalled = installed
+                    isReachable = reachable
+                    if installed, let conversations = conversationManager?.conversations {
+                        syncConversationsToWatch(conversations)
+                    }
+                }
+            }
+
+            nonisolated func handleSessionReachabilityDidChange(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let reachable = session.isReachable
+                Task { @MainActor in
+                    guard isCurrentCallback(sessionID: sessionID, activation: activation) else { return }
+                    isReachable = reachable
+                    if reachable, let conversations = conversationManager?.conversations {
+                        syncConversationsToWatch(conversations)
+                    }
+                }
+            }
+
+            nonisolated func handleSession(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken,
+                didReceiveMessage message: [String: Any]
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let message = UncheckedSendableWrapper(message)
+                sessionEventQueue.enqueue { [weak self] in
+                    guard let self,
+                          self.isCurrentCallback(sessionID: sessionID, activation: activation)
+                    else {
+                        return
+                    }
+                    _ = await self.handleReceivedMessage(message.value)
+                }
+            }
+
+            nonisolated func handleSession(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken,
+                didReceiveMessage message: [String: Any],
+                replyHandler: @escaping ([String: Any]) -> Void
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let message = UncheckedSendableWrapper(message)
+                let replyHandler = UncheckedSendableWrapper(replyHandler)
+                sessionEventQueue.enqueue { [weak self] in
+                    guard let self,
+                          self.isCurrentCallback(sessionID: sessionID, activation: activation)
+                    else {
+                        replyHandler.value([WatchMessageKeys.status: "staleSession"])
+                        return
+                    }
+                    await replyHandler.value(
+                        self.handleReceivedMessage(message.value) ?? [WatchMessageKeys.status: "received"]
+                    )
+                }
+            }
+
+            nonisolated func handleSession(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken,
+                didReceiveUserInfo userInfo: [String: Any]
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let userInfo = UncheckedSendableWrapper(userInfo)
+                sessionEventQueue.enqueue { [weak self] in
+                    guard let self,
+                          self.isCurrentCallback(sessionID: sessionID, activation: activation)
+                    else {
+                        return
+                    }
+                    _ = await self.handleReceivedMessage(userInfo.value)
+                }
+            }
+
+            nonisolated func handleSession(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken,
+                didReceive file: WCSessionFile
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                guard activationFence.isCurrent(activation),
+                      callbackIdentityFence.isCurrent(
+                          sessionID: sessionID,
+                          activation: activation
+                      )
+                else {
+                    return
+                }
+
+                let capture: Result<WatchMutationFileCapture, WatchMutationFileTransportError>
+                do {
+                    capture = try .success(WatchMutationFileTransport.capture(
+                        fileURL: file.fileURL,
+                        metadata: file.metadata ?? [:],
+                        sessionIsCurrent: true
+                    ))
+                } catch let error as WatchMutationFileTransportError {
+                    capture = .failure(error)
+                } catch {
+                    capture = .failure(.unreadableFile)
+                }
+                sessionEventQueue.enqueue { [weak self] in
+                    guard let self,
+                          self.isCurrentCallback(sessionID: sessionID, activation: activation)
+                    else {
+                        return
+                    }
+                    switch capture {
+                    case let .success(captured):
+                        do {
+                            let received = try WatchMutationFileTransport.decode(captured)
+                            _ = await self.handleMutation(
+                                received.mutation,
+                                schemaVersion: NSNumber(value: received.schemaVersion)
+                            )
+                        } catch {
                             DiagnosticsLogger.log(
                                 .watchConnectivity,
-                                level: .default,
-                                message: "⚠️ Skipping memory facts sync - data too large",
-                                metadata: ["size": "\(factsData.count)", "factCount": "\(facts.count)"]
+                                level: .error,
+                                message: "❌ Rejected Watch mutation file",
+                                metadata: ["error": error.localizedDescription]
+                            )
+                        }
+                    case let .failure(error):
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .error,
+                            message: "❌ Rejected Watch mutation file",
+                            metadata: ["error": error.localizedDescription]
+                        )
+                    }
+                }
+            }
+        }
+
+    #endif
+
+    #if os(watchOS)
+
+        @MainActor
+        // swiftlint:disable:next type_body_length
+        final class WatchConnectivityService: NSObject, ObservableObject {
+            static let shared = WatchConnectivityService()
+            @Published private(set) var isReachable = false
+            @Published private(set) var lastSyncDate: Date?
+            @Published var selectedModel: String = ""
+            @Published var availableModels: [String] = []
+            @Published private(set) var defaultSystemPrompt = WatchDefaultSystemPromptPersistence.load()
+
+            private nonisolated let activationFence = WatchSessionActivationFence()
+            private nonisolated let sessionEventQueue = WatchSessionEventQueue()
+            private let legacyDeliveryTracker = WatchLegacyDeliveryTracker()
+            private let legacyOperationTracker = WatchLegacyOperationTracker()
+            private let legacyAcknowledgementRetryTracker = WatchLegacyAcknowledgementRetryTracker()
+            private var session: WCSession?
+            private var sessionDelegate: WatchSessionDelegateProxy?
+            private var conversationStore: WatchConversationStore?
+            private var configuredStoreID: ObjectIdentifier?
+            private var queuedMutationOperationIDs: Set<UUID> = []
+            private var queuedMutationFileOperationIDs: Set<UUID> = []
+            private var interactiveMutationOperationIDs: Set<UUID> = []
+            private var mutationFileURLs: [UUID: URL] = [:]
+            private var mutationRetryAttempts: [UUID: Int] = [:]
+            private var mutationRetryTasks: [UUID: Task<Void, Never>] = [:]
+            private var peerSyncMode: WatchPeerSyncMode = .unknown
+            private var pageCycleCoordinator = WatchPageCycleCoordinator()
+            private let pageCycleRetryController = WatchPageCycleRequestRetryController()
+            private var modelMetadataAccumulator = WatchModelMetadataCycleAccumulator()
+            private var pendingModelMetadataEpoch: UUID?
+            private var appliedModelMetadataEpoch = UserDefaults.standard
+                .string(forKey: WatchSyncPersistenceKeys.appliedModelMetadataEpoch)
+                .flatMap(UUID.init(uuidString:))
+            private var pageCycleHandshakeTracker = WatchPageCycleHandshakeTracker()
+            private var syncRequestPending = false
+
+            override private init() {
+                super.init()
+                setupSession()
+            }
+
+            private func setupSession() {
+                guard WCSession.isSupported() else {
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .info,
+                        message: "WatchConnectivity not supported"
+                    )
+                    return
+                }
+
+                activateSession(WCSession.default)
+
+                DiagnosticsLogger.log(
+                    .watchConnectivity,
+                    level: .info,
+                    message: "⌚ Watch WatchConnectivity session activating"
+                )
+            }
+
+            private func activateSession(_ targetSession: WCSession) {
+                retirePageCycle()
+                let activation = activationFence.beginActivation()
+                let delegate = WatchSessionDelegateProxy(
+                    owner: self,
+                    activation: activation
+                )
+                session = targetSession
+                sessionDelegate = delegate
+                targetSession.delegate = delegate
+                targetSession.activate()
+            }
+
+            func configure(with store: WatchConversationStore) {
+                conversationStore = store
+                let storeID = ObjectIdentifier(store)
+                if configuredStoreID != storeID {
+                    configuredStoreID = storeID
+                }
+
+                guard let session, let activation = sessionDelegate?.activation else { return }
+                let sessionID = ObjectIdentifier(session)
+                let context = UncheckedSendableWrapper(session.receivedApplicationContext)
+                sessionEventQueue.enqueue { [weak self] in
+                    guard let self,
+                          self.isCurrentCallback(sessionID: sessionID, activation: activation)
+                    else {
+                        return
+                    }
+                    if !context.value.isEmpty {
+                        self.processContext(context.value)
+                    }
+                    self.flushPendingMutations()
+                }
+            }
+
+            func enqueueMutation(_ mutation: WatchConversationMutation) {
+                let envelope = durableEnvelope(for: mutation)
+                legacyDeliveryTracker.recordTitleMutation(envelope)
+                if legacyAcknowledgementRetryTracker.contains(operationID: envelope.operationID) {
+                    retryPendingLocalAcknowledgements()
+                    if legacyAcknowledgementRetryTracker.contains(operationID: envelope.operationID) {
+                        scheduleMutationRetry(for: envelope.operationID)
+                    }
+                    return
+                }
+
+                guard let session, session.activationState == .activated else {
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .info,
+                        message: "⌚ Mutation remains durable until WatchConnectivity activates",
+                        metadata: ["operationId": mutation.operationID.uuidString]
+                    )
+                    return
+                }
+
+                do {
+                    var legacyResult: WatchLegacySendResult?
+                    if peerSyncMode != .revisioned {
+                        legacyResult = try WatchLegacyMutationSender.prepare(
+                            envelope,
+                            tracker: legacyDeliveryTracker
+                        )
+                    }
+                    if let legacyResult, !legacyResult.componentIDs.isEmpty {
+                        legacyOperationTracker.begin(envelope, result: legacyResult)
+                        let outstandingComponentIDs = Set(session.outstandingUserInfoTransfers.compactMap {
+                            $0.userInfo[WatchMessageKeys.legacyComponentId] as? String
+                        })
+                        for userInfo in legacyResult.userInfos where
+                            !outstandingComponentIDs.contains(
+                                userInfo[WatchMessageKeys.legacyComponentId] as? String ?? ""
+                            )
+                        {
+                            session.transferUserInfo(userInfo)
+                        }
+                    }
+                    if peerSyncMode == .legacy {
+                        guard let legacyResult else { return }
+                        if legacyResult.requiresEchoRetry {
+                            requestSync()
+                            scheduleMutationRetry(for: envelope.operationID)
+                        }
+                        if legacyResult.componentIDs.isEmpty,
+                           legacyResult.awaitingEchoComponentIDs.isEmpty,
+                           legacyResult.fullyRepresented
+                        {
+                            requestSync()
+                            scheduleMutationRetry(for: envelope.operationID)
+                        }
+                        return
+                    }
+                    let message = try mutationMessage(envelope)
+                    queueReliableMutation(message, mutation: envelope, session: session)
+                    sendInteractiveMutation(message, mutation: envelope, session: session)
+                } catch let error as WatchSyncPayloadBuilderError {
+                    guard case .mutationExceedsBudget = error else {
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .error,
+                            message: "❌ Failed to encode Watch mutation",
+                            metadata: ["error": error.localizedDescription]
+                        )
+                        return
+                    }
+                    do {
+                        try queueMutationFile(envelope, session: session)
+                    } catch {
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .error,
+                            message: "❌ Failed to queue oversized Watch mutation file",
+                            metadata: ["error": error.localizedDescription]
+                        )
+                        scheduleMutationRetry(for: envelope.operationID)
+                    }
+                } catch {
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .error,
+                        message: "❌ Failed to encode Watch mutation",
+                        metadata: ["error": error.localizedDescription]
+                    )
+                }
+            }
+
+            func requestSync() {
+                let request = pageCycleCoordinator.pendingRequest.map {
+                    WatchSyncRequestIdentity.pageCycle($0)
+                } ?? .freshCycle
+                retainSyncRequest(request)
+                sendSyncRequest(request)
+            }
+
+            private func sendSyncRequest(_ request: WatchSyncRequestIdentity) {
+                guard let session,
+                      session.activationState == .activated,
+                      let activation = sessionDelegate?.activation
+                else {
+                    syncRequestPending = true
+                    return
+                }
+
+                var message: [String: Any] = [
+                    WatchMessageKeys.type: WatchMessageKeys.typeRequestSync,
+                    WatchMessageKeys.peerId: conversationStore?.peerID.uuidString
+                        ?? WatchSyncIdentity.legacyPeerID.uuidString,
+                    WatchMessageKeys.schemaVersion: NSNumber(value: WatchSyncSnapshot.currentSchemaVersion)
+                ]
+                if let pageCycleRequest = request.pageCycleRequest,
+                   let requestData = try? JSONEncoder().encode(pageCycleRequest)
+                {
+                    message[WatchMessageKeys.pageCycleRequest] = requestData
+                }
+
+                if session.isReachable {
+                    let sessionID = ObjectIdentifier(session)
+                    let sessionWrapper = UncheckedSendableWrapper(session)
+                    let messageWrapper = UncheckedSendableWrapper(message)
+                    session.sendMessage(message, replyHandler: nil) { [weak self] error in
+                        let errorDescription = error.localizedDescription
+                        Task { @MainActor [weak self] in
+                            guard let self,
+                                  self.isCurrentCallback(
+                                      sessionID: sessionID,
+                                      activation: activation
+                                  ),
+                                  self.syncRequestIdentity(in: messageWrapper.value)
+                                  == self.pageCycleRetryController.pendingRequest
+                            else {
+                                return
+                            }
+                            self.queueReliableSyncRequestIfNeeded(
+                                messageWrapper.value,
+                                session: sessionWrapper.value
+                            )
+                            DiagnosticsLogger.log(
+                                .watchConnectivity,
+                                level: .error,
+                                message: "❌ Failed to request immediate sync; queued reliable fallback",
+                                metadata: ["error": errorDescription]
                             )
                         }
                     }
+                } else {
+                    queueReliableSyncRequestIfNeeded(message, session: session)
                 }
-
-                try session.updateApplicationContext(context)
-                lastSyncDate = Date()
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "📱→⌚ Synced \(watchConversations.count) conversations to Watch",
-                    metadata: ["count": "\(watchConversations.count)"]
-                )
-            } catch {
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .error,
-                    message: "❌ Failed to sync to Watch",
-                    metadata: ["error": error.localizedDescription]
-                )
-            }
-        }
-
-        /// Handle new message from Watch
-        private func handleNewMessage(from watchMessage: WatchMessage, conversationId: UUID) {
-            guard let conversationManager else { return }
-
-            // Find the conversation or create it if it doesn't exist
-            if let conversation = conversationManager.conversations.first(where: { $0.id == conversationId }) {
-                let message = watchMessage.toMessage()
-                conversationManager.addMessage(to: conversation, message: message)
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "📱 Received message from Watch",
-                    metadata: ["conversationId": conversationId.uuidString]
-                )
-            } else {
-                // Conversation doesn't exist, create it
-                let model = AIService.shared.selectedModel
-                let newConversation = Conversation(
-                    id: conversationId,
-                    title: "Watch Chat",
-                    createdAt: Date(),
-                    model: model
-                )
-                conversationManager.insertConversationFromSync(newConversation)
-
-                // Now add the message
-                let message = watchMessage.toMessage()
-                conversationManager.addMessage(to: newConversation, message: message)
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "📱 Created new conversation from Watch",
-                    metadata: ["conversationId": conversationId.uuidString]
-                )
-            }
-        }
-
-        /// Handle new conversation created on Watch
-        private func handleNewConversation(_ watchConversation: WatchConversation) {
-            guard let conversationManager else { return }
-
-            // Check if conversation already exists
-            if conversationManager.conversations.contains(where: { $0.id == watchConversation.id }) {
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .debug,
-                    message: "📱 Conversation already exists",
-                    metadata: ["conversationId": watchConversation.id.uuidString]
-                )
-                return
+                syncRequestPending = false
             }
 
-            // Create the conversation on iPhone
-            let conversation = watchConversation.toConversation()
-            conversationManager.insertConversationFromSync(conversation)
-
-            DiagnosticsLogger.log(
-                .watchConnectivity,
-                level: .info,
-                message: "📱 Created conversation from Watch",
-                metadata: ["conversationId": watchConversation.id.uuidString, "title": watchConversation.title]
-            )
-        }
-
-        /// Handle title update from Watch
-        private func handleTitleUpdate(conversationId: UUID, newTitle: String) {
-            guard let conversationManager else { return }
-
-            if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) {
-                conversationManager.conversations[index].title = newTitle
-                conversationManager.save(conversationManager.conversations[index])
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "📱 Updated conversation title from Watch",
-                    metadata: ["conversationId": conversationId.uuidString, "title": newTitle]
-                )
-            }
-        }
-    }
-
-    extension WatchConnectivityService: WCSessionDelegate {
-        nonisolated func session(
-            _ session: WCSession,
-            activationDidCompleteWith activationState: WCSessionActivationState,
-            error: Error?
-        ) {
-            let watchAppInstalled = session.isWatchAppInstalled
-            let reachable = session.isReachable
-            let stateRawValue = activationState.rawValue
-            let errorDescription = error?.localizedDescription
-            Task { @MainActor in
-                if let errorDescription {
-                    DiagnosticsLogger.log(
-                        .watchConnectivity,
-                        level: .error,
-                        message: "❌ iOS session activation failed",
-                        metadata: ["error": errorDescription]
-                    )
-                    return
+            private func retainSyncRequest(_ request: WatchSyncRequestIdentity?) {
+                let previousRequest = pageCycleRetryController.pendingRequest
+                if previousRequest != request,
+                   let previousRequest,
+                   let session
+                {
+                    cancelReliableSyncRequest(previousRequest, session: session)
                 }
-
-                isWatchAppInstalled = watchAppInstalled
-                isReachable = reachable
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "📱 iOS session activated",
-                    metadata: [
-                        "state": "\(stateRawValue)",
-                        "watchAppInstalled": "\(watchAppInstalled)",
-                        "reachable": "\(reachable)"
-                    ]
-                )
-
-                // Trigger initial sync if Watch is available
-                if watchAppInstalled, let conversations = conversationManager?.conversations {
-                    syncConversationsToWatch(conversations)
+                pageCycleRetryController.retain(request) { [weak self] request in
+                    self?.sendSyncRequest(request)
                 }
             }
-        }
 
-        nonisolated func sessionDidBecomeInactive(_: WCSession) {
-            DiagnosticsLogger.log(
-                .watchConnectivity,
-                level: .info,
-                message: "📱 iOS session became inactive"
-            )
-        }
-
-        nonisolated func sessionDidDeactivate(_ session: WCSession) {
-            DiagnosticsLogger.log(
-                .watchConnectivity,
-                level: .info,
-                message: "📱 iOS session deactivated"
-            )
-            // Reactivate session for switching between Watches
-            session.activate()
-        }
-
-        nonisolated func sessionWatchStateDidChange(_ session: WCSession) {
-            let watchAppInstalled = session.isWatchAppInstalled
-            let reachable = session.isReachable
-            Task { @MainActor in
-                isWatchAppInstalled = watchAppInstalled
-                isReachable = reachable
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "📱 Watch state changed",
-                    metadata: [
-                        "watchAppInstalled": "\(watchAppInstalled)",
-                        "reachable": "\(reachable)"
-                    ]
-                )
-            }
-        }
-
-        nonisolated func sessionReachabilityDidChange(_ session: WCSession) {
-            let reachable = session.isReachable
-            Task { @MainActor in
-                isReachable = reachable
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "📱 Watch reachability changed",
-                    metadata: ["reachable": "\(reachable)"]
-                )
-            }
-        }
-
-        nonisolated func session(_: WCSession, didReceiveMessage message: [String: Any]) {
-            nonisolated(unsafe) let message = message
-            Task { @MainActor in
-                handleReceivedMessage(message)
-            }
-        }
-
-        nonisolated func session(
-            _: WCSession,
-            didReceiveMessage message: [String: Any],
-            replyHandler: @escaping ([String: Any]) -> Void
-        ) {
-            nonisolated(unsafe) let message = message
-            nonisolated(unsafe) let replyHandler = replyHandler
-            Task { @MainActor in
-                handleReceivedMessage(message)
-                replyHandler(["status": "received"])
-            }
-        }
-
-        nonisolated func session(_: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
-            nonisolated(unsafe) let userInfo = userInfo
-            Task { @MainActor in
-                handleReceivedMessage(userInfo)
-            }
-        }
-
-        @MainActor
-        private func handleReceivedMessage(_ message: [String: Any]) {
-            guard let type = message[WatchMessageKeys.type] as? String else { return }
-
-            switch type {
-            case WatchMessageKeys.typeNewMessage:
-                // Handle new message from Watch
-                guard let messageData = message[WatchMessageKeys.newMessage] as? Data,
-                      let conversationIdString = message[WatchMessageKeys.conversationId] as? String,
-                      let conversationId = UUID(uuidString: conversationIdString)
+            private func queueReliableSyncRequestIfNeeded(
+                _ message: [String: Any],
+                session: WCSession
+            ) {
+                guard let request = syncRequestIdentity(in: message),
+                      request == pageCycleRetryController.pendingRequest
                 else {
                     return
                 }
-
-                do {
-                    let watchMessage = try JSONDecoder().decode(WatchMessage.self, from: messageData)
-                    handleNewMessage(from: watchMessage, conversationId: conversationId)
-                } catch {
-                    DiagnosticsLogger.log(
-                        .watchConnectivity,
-                        level: .error,
-                        message: "❌ Failed to decode message from Watch",
-                        metadata: ["error": error.localizedDescription]
-                    )
+                let alreadyQueued = session.outstandingUserInfoTransfers.contains { transfer in
+                    syncRequestIdentity(in: transfer.userInfo) == request
                 }
-
-            case WatchMessageKeys.typeNewConversation:
-                // Handle new conversation created on Watch
-                guard let conversationData = message[WatchMessageKeys.conversation] as? Data else {
-                    return
-                }
-
-                do {
-                    let watchConversation = try JSONDecoder().decode(WatchConversation.self, from: conversationData)
-                    handleNewConversation(watchConversation)
-                } catch {
-                    DiagnosticsLogger.log(
-                        .watchConnectivity,
-                        level: .error,
-                        message: "❌ Failed to decode conversation from Watch",
-                        metadata: ["error": error.localizedDescription]
-                    )
-                }
-
-            case WatchMessageKeys.typeRequestSync:
-                // Watch requested a sync
-                if let conversations = conversationManager?.conversations {
-                    syncConversationsToWatch(conversations)
-                }
-
-            case WatchMessageKeys.typeTitleUpdate:
-                // Handle title update from Watch
-                guard let conversationIdString = message[WatchMessageKeys.conversationId] as? String,
-                      let conversationId = UUID(uuidString: conversationIdString),
-                      let newTitle = message[WatchMessageKeys.title] as? String
-                else {
-                    return
-                }
-                handleTitleUpdate(conversationId: conversationId, newTitle: newTitle)
-
-            default:
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "📱 Unknown message type from Watch",
-                    metadata: ["type": type]
-                )
-            }
-        }
-    }
-
-#endif
-
-// MARK: - watchOS Side
-
-#if os(watchOS)
-
-    /// WatchConnectivity service for the Watch app
-    /// Receives conversations from iPhone and sends new messages back
-    @MainActor
-    final class WatchConnectivityService: NSObject, ObservableObject {
-        static let shared = WatchConnectivityService()
-
-        @Published private(set) var isReachable = false
-        @Published private(set) var lastSyncDate: Date?
-        @Published var selectedModel: String = ""
-        @Published var availableModels: [String] = []
-
-        private var session: WCSession?
-        private var conversationStore: WatchConversationStore?
-
-        override private init() {
-            super.init()
-            setupSession()
-        }
-
-        private func setupSession() {
-            guard WCSession.isSupported() else {
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "WatchConnectivity not supported"
-                )
-                return
-            }
-
-            session = WCSession.default
-            session?.delegate = self
-            session?.activate()
-
-            DiagnosticsLogger.log(
-                .watchConnectivity,
-                level: .info,
-                message: "⌚ Watch WatchConnectivity session activating"
-            )
-        }
-
-        /// Configure with WatchConversationStore
-        func configure(with store: WatchConversationStore) {
-            conversationStore = store
-        }
-
-        /// Request sync from iPhone
-        func requestSync() {
-            guard let session, session.isReachable else {
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ iPhone not reachable for sync request"
-                )
-                return
-            }
-
-            let message: [String: Any] = [
-                WatchMessageKeys.type: WatchMessageKeys.typeRequestSync
-            ]
-
-            session.sendMessage(message, replyHandler: nil) { error in
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .error,
-                    message: "❌ Failed to request sync",
-                    metadata: ["error": error.localizedDescription]
-                )
-            }
-        }
-
-        /// Send a new message to iPhone
-        func sendMessage(_ watchMessage: WatchMessage, conversationId: UUID) {
-            guard let session else { return }
-
-            do {
-                let messageData = try JSONEncoder().encode(watchMessage)
-                let message: [String: Any] = [
-                    WatchMessageKeys.type: WatchMessageKeys.typeNewMessage,
-                    WatchMessageKeys.newMessage: messageData,
-                    WatchMessageKeys.conversationId: conversationId.uuidString
-                ]
-
-                if session.isReachable {
-                    session.sendMessage(message, replyHandler: nil) { error in
-                        DiagnosticsLogger.log(
-                            .watchConnectivity,
-                            level: .error,
-                            message: "❌ Failed to send message to iPhone",
-                            metadata: ["error": error.localizedDescription]
-                        )
-                    }
-                } else {
-                    // Use transferUserInfo for reliable delivery when not reachable
-                    session.transferUserInfo(message)
-                }
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚→📱 Sent message to iPhone",
-                    metadata: ["conversationId": conversationId.uuidString]
-                )
-            } catch {
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .error,
-                    message: "❌ Failed to encode message for iPhone",
-                    metadata: ["error": error.localizedDescription]
-                )
-            }
-        }
-
-        /// Send a new conversation to iPhone
-        func sendConversation(_ conversation: WatchConversation) {
-            guard let session else { return }
-
-            do {
-                let conversationData = try JSONEncoder().encode(conversation)
-                let message: [String: Any] = [
-                    WatchMessageKeys.type: WatchMessageKeys.typeNewConversation,
-                    WatchMessageKeys.conversation: conversationData
-                ]
-
-                if session.isReachable {
-                    session.sendMessage(message, replyHandler: nil) { error in
-                        DiagnosticsLogger.log(
-                            .watchConnectivity,
-                            level: .error,
-                            message: "❌ Failed to send conversation to iPhone",
-                            metadata: ["error": error.localizedDescription]
-                        )
-                    }
-                } else {
-                    // Use transferUserInfo for reliable delivery when not reachable
-                    session.transferUserInfo(message)
-                }
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚→📱 Sent conversation to iPhone",
-                    metadata: ["conversationId": conversation.id.uuidString]
-                )
-            } catch {
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .error,
-                    message: "❌ Failed to encode conversation for iPhone",
-                    metadata: ["error": error.localizedDescription]
-                )
-            }
-        }
-
-        /// Send a title update to iPhone
-        func sendTitleUpdate(conversationId: UUID, newTitle: String) {
-            guard let session else { return }
-
-            let message: [String: Any] = [
-                WatchMessageKeys.type: WatchMessageKeys.typeTitleUpdate,
-                WatchMessageKeys.conversationId: conversationId.uuidString,
-                WatchMessageKeys.title: newTitle
-            ]
-
-            if session.isReachable {
-                session.sendMessage(message, replyHandler: nil) { error in
-                    DiagnosticsLogger.log(
-                        .watchConnectivity,
-                        level: .error,
-                        message: "❌ Failed to send title update to iPhone",
-                        metadata: ["error": error.localizedDescription]
-                    )
-                }
-            } else {
-                // Use transferUserInfo for reliable delivery when not reachable
+                guard !alreadyQueued else { return }
                 session.transferUserInfo(message)
             }
 
-            DiagnosticsLogger.log(
-                .watchConnectivity,
-                level: .info,
-                message: "⌚→📱 Sent title update to iPhone",
-                metadata: ["conversationId": conversationId.uuidString, "title": newTitle]
-            )
-        }
-
-        /// Process received application context from iPhone
-        private func processContext(_ context: [String: Any]) {
-            processConversationsFromContext(context)
-            processModelSettingsFromContext(context)
-            processAPIKeysFromContext(context)
-            processTavilySettingsFromContext(context)
-            processWebFetchSettingsFromContext(context)
-            processMemoryFromContext(context)
-
-            if let syncTimestamp = context[WatchContextKeys.lastSyncDate] as? TimeInterval {
-                lastSyncDate = Date(timeIntervalSince1970: syncTimestamp)
-            }
-        }
-
-        /// Process conversations data from iPhone context
-        private func processConversationsFromContext(_ context: [String: Any]) {
-            guard let conversationsData = context[WatchContextKeys.conversations] as? Data else { return }
-            do {
-                let watchConversations = try JSONDecoder().decode(
-                    [WatchConversation].self,
-                    from: conversationsData
-                )
-                conversationStore?.updateConversations(watchConversations)
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Received \(watchConversations.count) conversations from iPhone"
-                )
-            } catch {
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .error,
-                    message: "❌ Failed to decode conversations from iPhone",
-                    metadata: ["error": error.localizedDescription]
-                )
-            }
-        }
-
-        /// Process model settings from iPhone context
-        private func processModelSettingsFromContext(_ context: [String: Any]) {
-            if let model = context[WatchContextKeys.selectedModel] as? String {
-                selectedModel = model
-                AIService.shared.selectedModel = model
+            private func cancelReliableSyncRequest(
+                _ request: WatchSyncRequestIdentity,
+                session: WCSession
+            ) {
+                for transfer in session.outstandingUserInfoTransfers
+                    where syncRequestIdentity(in: transfer.userInfo) == request
+                {
+                    transfer.cancel()
+                }
             }
 
-            if let models = context[WatchContextKeys.availableModels] as? [String] {
-                availableModels = models
+            private func syncRequestIdentity(
+                in message: [String: Any]
+            ) -> WatchSyncRequestIdentity? {
+                guard message[WatchMessageKeys.type] as? String == WatchMessageKeys.typeRequestSync else {
+                    return nil
+                }
+                guard let requestData = message[WatchMessageKeys.pageCycleRequest] as? Data else {
+                    return .freshCycle
+                }
+                guard let request = try? JSONDecoder().decode(
+                    WatchSyncPageCycleRequest.self,
+                    from: requestData
+                ) else {
+                    return nil
+                }
+                return .pageCycle(request)
             }
 
-            if let customModels = context[WatchContextKeys.customModels] as? [String] {
-                AIService.shared.customModels = customModels
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Updated custom models from iPhone",
-                    metadata: ["count": "\(customModels.count)"]
-                )
+            private func retirePageCycle() {
+                if let pendingRequest = pageCycleRetryController.pendingRequest,
+                   let session
+                {
+                    cancelReliableSyncRequest(pendingRequest, session: session)
+                }
+                pageCycleRetryController.cancel()
+                pageCycleCoordinator.reset()
+                modelMetadataAccumulator.reset()
+                conversationStore?.resetPageCycleManifest()
             }
 
-            if let providerRaw = context[WatchContextKeys.defaultProvider] as? String,
-               let provider = AIProvider(rawValue: providerRaw)
-            {
-                AIService.shared.provider = provider
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Updated default provider from iPhone",
-                    metadata: ["provider": providerRaw]
-                )
+            func sendMessage(_: WatchMessage, conversationId: UUID) {
+                enqueueLatestMutation(for: conversationId)
             }
 
-            processModelProviderMappings(context)
-            processModelEndpointSettings(context)
-        }
+            func sendConversation(_ conversation: WatchConversation) {
+                enqueueLatestMutation(for: conversation.id)
+            }
 
-        /// Process model provider mappings from context
-        private func processModelProviderMappings(_ context: [String: Any]) {
-            if let providersDict = context[WatchContextKeys.modelProviders] as? [String: String] {
-                var modelProviders: [String: AIProvider] = [:]
-                for (model, providerRaw) in providersDict {
-                    if let provider = AIProvider(rawValue: providerRaw) {
-                        modelProviders[model] = provider
+            func sendTitleUpdate(conversationId: UUID, newTitle _: String) {
+                enqueueLatestMutation(for: conversationId)
+            }
+
+            private func enqueueLatestMutation(for conversationID: UUID) {
+                guard let mutation = conversationStore?.pendingMutationsForSync
+                    .filter({ $0.conversationID == conversationID })
+                    .max(by: { $0.revision < $1.revision })
+                else {
+                    return
+                }
+                enqueueMutation(mutation)
+            }
+
+            private func durableEnvelope(for mutation: WatchConversationMutation) -> WatchConversationMutation {
+                conversationStore?.pendingMutationsForSync
+                    .filter { $0.conversationID == mutation.conversationID }
+                    .max { $0.revision < $1.revision } ?? mutation
+            }
+
+            private func mutationMessage(_ mutation: WatchConversationMutation) throws -> [String: Any] {
+                let payload = try WatchSyncPayloadBuilder.buildMutation(mutation)
+                return [
+                    WatchMessageKeys.type: WatchMessageKeys.typeMutation,
+                    WatchMessageKeys.mutation: payload.data,
+                    WatchMessageKeys.operationId: mutation.operationID.uuidString,
+                    WatchMessageKeys.conversationId: mutation.conversationID.uuidString,
+                    WatchMessageKeys.schemaVersion: NSNumber(value: WatchSyncSnapshot.currentSchemaVersion)
+                ]
+            }
+
+            private func queueReliableMutation(
+                _ message: [String: Any],
+                mutation: WatchConversationMutation,
+                session: WCSession
+            ) {
+                guard !queuedMutationOperationIDs.contains(mutation.operationID),
+                      !hasOutstandingTransfer(for: mutation.operationID, session: session)
+                else {
+                    return
+                }
+                queuedMutationOperationIDs.insert(mutation.operationID)
+                session.transferUserInfo(message)
+            }
+
+            private func queueMutationFile(
+                _ mutation: WatchConversationMutation,
+                session: WCSession
+            ) throws {
+                guard !queuedMutationFileOperationIDs.contains(mutation.operationID),
+                      !WatchMutationFileTransport.hasOutstandingTransfer(
+                          operationID: mutation.operationID,
+                          session: session
+                      )
+                else {
+                    return
+                }
+
+                let fileURL = try WatchMutationFileTransport.transfer(mutation, session: session)
+                queuedMutationFileOperationIDs.insert(mutation.operationID)
+                mutationFileURLs[mutation.operationID] = fileURL
+            }
+
+            private func sendInteractiveMutation(
+                _ message: [String: Any],
+                mutation: WatchConversationMutation,
+                session: WCSession
+            ) {
+                guard session.isReachable,
+                      interactiveMutationOperationIDs.insert(mutation.operationID).inserted
+                else {
+                    return
+                }
+
+                session.sendMessage(message) { [weak self] reply in
+                    Task { @MainActor in
+                        self?.interactiveMutationOperationIDs.remove(mutation.operationID)
+                        self?.processMutationAcknowledgement(reply, fallback: mutation)
+                    }
+                } errorHandler: { [weak self] error in
+                    Task { @MainActor in
+                        self?.interactiveMutationOperationIDs.remove(mutation.operationID)
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .info,
+                            message: "⌚ Immediate mutation send failed; reliable transfer remains queued",
+                            metadata: ["error": error.localizedDescription]
+                        )
                     }
                 }
-                AIService.shared.modelProviders = modelProviders
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Updated model providers from iPhone",
-                    metadata: ["count": "\(modelProviders.count)"]
-                )
             }
 
-            if let modelUsesGitHubOAuth = context[WatchContextKeys.modelUsesGitHubOAuth] as? [String: Bool] {
-                AIService.shared.modelUsesGitHubOAuth = modelUsesGitHubOAuth
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Updated GitHub OAuth flags from iPhone",
-                    metadata: ["count": "\(modelUsesGitHubOAuth.count)"]
-                )
-            }
-        }
-
-        /// Process model endpoint settings from context
-        private func processModelEndpointSettings(_ context: [String: Any]) {
-            if let modelEndpoints = context[WatchContextKeys.modelEndpoints] as? [String: String] {
-                AIService.shared.modelEndpoints = modelEndpoints
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Updated model endpoints from iPhone",
-                    metadata: ["count": "\(modelEndpoints.count)"]
-                )
-            }
-
-            if let endpointTypesDict = context[WatchContextKeys.modelEndpointTypes] as? [String: String] {
-                var modelEndpointTypes: [String: APIEndpointType] = [:]
-                for (model, typeRaw) in endpointTypesDict {
-                    if let endpointType = APIEndpointType(rawValue: typeRaw) {
-                        modelEndpointTypes[model] = endpointType
-                    }
+            private func processMutationAcknowledgement(
+                _ reply: [String: Any],
+                fallback mutation: WatchConversationMutation
+            ) {
+                guard let revision = WatchSyncValueDecoder.revision(reply[WatchMessageKeys.acknowledgedRevision]) else { return }
+                let conversationID = (reply[WatchMessageKeys.conversationId] as? String)
+                    .flatMap(UUID.init(uuidString:)) ?? mutation.conversationID
+                guard conversationID == mutation.conversationID,
+                      conversationStore?.acknowledgeWatchRevision(
+                          conversationID: conversationID,
+                          revision: revision
+                      ) == true
+                else {
+                    scheduleMutationRetry(for: mutation.operationID)
+                    return
                 }
-                AIService.shared.modelEndpointTypes = modelEndpointTypes
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Updated model endpoint types from iPhone",
-                    metadata: ["count": "\(modelEndpointTypes.count)"]
-                )
-            }
-        }
-
-        /// Process API keys from iPhone context
-        private func processAPIKeysFromContext(_ context: [String: Any]) {
-            if let modelAPIKeys = context[WatchContextKeys.modelAPIKeys] as? [String: String], !modelAPIKeys.isEmpty {
-                AIService.shared.modelAPIKeys = modelAPIKeys
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Received model API keys from iPhone",
-                    metadata: ["count": "\(modelAPIKeys.count)"]
-                )
+                cancelReliableTransfers(for: mutation.operationID)
+                cancelMutationRetry(for: mutation.operationID)
             }
 
-            if let githubToken = context[WatchContextKeys.githubAccessToken] as? String, !githubToken.isEmpty {
-                GitHubOAuthService.shared.setAccessTokenFromWatch(githubToken)
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Received GitHub access token from iPhone"
-                )
-            }
-        }
-
-        /// Process Tavily web search settings from iPhone context
-        private func processTavilySettingsFromContext(_ context: [String: Any]) {
-            if let tavilyKey = context[WatchContextKeys.tavilyAPIKey] as? String {
-                if !tavilyKey.isEmpty {
-                    AIService.shared.tavilyAPIKey = tavilyKey
-                    TavilyService.shared.apiKey = tavilyKey
-                    DiagnosticsLogger.log(
-                        .watchConnectivity,
-                        level: .info,
-                        message: "⌚ Received Tavily API key from iPhone"
+            private func retryPendingLocalAcknowledgements() {
+                guard let conversationStore else { return }
+                let acknowledged = legacyAcknowledgementRetryTracker.retry { conversationID, revision in
+                    conversationStore.acknowledgeWatchRevision(
+                        conversationID: conversationID,
+                        revision: revision
                     )
-                } else {
+                }
+                for acknowledgement in acknowledged {
+                    cancelReliableTransfers(for: acknowledgement.operationID)
+                    cancelMutationRetry(for: acknowledgement.operationID)
+                }
+            }
+
+            private func flushPendingMutations() {
+                retryPendingLocalAcknowledgements()
+                for mutation in conversationStore?.pendingMutationsForSync ?? [] where
+                    !legacyAcknowledgementRetryTracker.contains(operationID: mutation.operationID)
+                {
+                    enqueueMutation(mutation)
+                }
+            }
+
+            private func scheduleMutationRetry(for operationID: UUID) {
+                guard mutationRetryTasks[operationID] == nil else { return }
+                let attempt = mutationRetryAttempts[operationID, default: 0]
+                mutationRetryAttempts[operationID] = attempt + 1
+                let delay = WatchMutationRetryBackoff.seconds(forAttempt: attempt)
+                mutationRetryTasks[operationID] = Task { @MainActor [weak self] in
+                    do {
+                        try await Task.sleep(for: .seconds(delay))
+                    } catch {
+                        return
+                    }
+                    guard let self else { return }
+                    self.mutationRetryTasks.removeValue(forKey: operationID)
+                    guard let mutation = self.conversationStore?.pendingMutationsForSync.first(where: {
+                        $0.operationID == operationID
+                    }) else {
+                        self.mutationRetryAttempts.removeValue(forKey: operationID)
+                        return
+                    }
+                    self.enqueueMutation(mutation)
+                }
+            }
+
+            private func cancelMutationRetry(for operationID: UUID) {
+                mutationRetryTasks.removeValue(forKey: operationID)?.cancel()
+                mutationRetryAttempts.removeValue(forKey: operationID)
+            }
+
+            private func hasOutstandingTransfer(for operationID: UUID, session: WCSession) -> Bool {
+                session.outstandingUserInfoTransfers.contains { transfer in
+                    (transfer.userInfo[WatchMessageKeys.operationId] as? String) == operationID.uuidString
+                }
+            }
+
+            private func cancelReliableTransfers(for operationID: UUID) {
+                if let session {
+                    for transfer in session.outstandingUserInfoTransfers where
+                        (transfer.userInfo[WatchMessageKeys.operationId] as? String) == operationID.uuidString
+                    {
+                        transfer.cancel()
+                    }
+                    for transfer in session.outstandingFileTransfers where
+                        (transfer.file.metadata?[WatchMessageKeys.operationId] as? String) == operationID.uuidString
+                    {
+                        transfer.cancel()
+                    }
+                }
+                queuedMutationOperationIDs.remove(operationID)
+                queuedMutationFileOperationIDs.remove(operationID)
+                legacyOperationTracker.cancel(operationID: operationID)
+                legacyAcknowledgementRetryTracker.cancel(operationID: operationID)
+                if let fileURL = mutationFileURLs.removeValue(forKey: operationID) {
+                    try? FileManager.default.removeItem(at: fileURL)
+                }
+            }
+
+            private func processContext(_ context: [String: Any]) {
+                retryPendingLocalAcknowledgements()
+                let applicationMode = processConversationsFromContext(context)
+                guard applicationMode.appliesSnapshotSettings else { return }
+                processModelSettingsFromContext(context, mode: applicationMode)
+                processAPIKeysFromContext(context, mode: applicationMode)
+                processTavilySettingsFromContext(context, mode: applicationMode)
+                processWebFetchSettingsFromContext(context)
+                processMemoryFromContext(context)
+                let updatedDefaultSystemPrompt = WatchDefaultSystemPromptReducer.value(
+                    current: defaultSystemPrompt,
+                    incoming: context[WatchContextKeys.defaultSystemPrompt]
+                )
+                if updatedDefaultSystemPrompt != defaultSystemPrompt {
+                    defaultSystemPrompt = updatedDefaultSystemPrompt
+                    WatchDefaultSystemPromptPersistence.store(updatedDefaultSystemPrompt)
+                }
+
+                if let syncTimestamp = context[WatchContextKeys.lastSyncDate] as? TimeInterval {
+                    lastSyncDate = Date(timeIntervalSince1970: syncTimestamp)
+                }
+            }
+
+            private func processConversationsFromContext(
+                _ context: [String: Any]
+            ) -> WatchContextApplicationMode {
+                let legacyConversations = (context[WatchContextKeys.conversations] as? Data).flatMap {
+                    try? JSONDecoder().decode([WatchConversation].self, from: $0)
+                }
+
+                var rejectedRevisionedSnapshot = false
+                if let data = context[WatchContextKeys.syncSnapshot] as? Data {
+                    do {
+                        let snapshot = try JSONDecoder().decode(WatchSyncSnapshot.self, from: data)
+                        if WatchSyncSnapshot.supportsSchemaVersion(snapshot.schemaVersion) {
+                            peerSyncMode = .revisioned
+                            legacyDeliveryTracker.reset()
+                            legacyAcknowledgementRetryTracker.reset()
+                            legacyOperationTracker.reset()
+                            _ = conversationStore?.clearLegacyDeliveryCoverage()
+                            let pageMetadata = (context[WatchContextKeys.syncPageCycle] as? Data)
+                                .flatMap {
+                                    try? JSONDecoder().decode(WatchSyncPageCycleMetadata.self, from: $0)
+                                }
+                            let pendingBefore = Set(
+                                conversationStore?.pendingMutationsForSync.map(\.operationID) ?? []
+                            )
+                            let applyOutcome: WatchSyncSnapshotApplyOutcome = if let pageMetadata,
+                                                                                 pageMetadata.isValid(for: snapshot)
+                            {
+                                conversationStore?.applySyncSnapshot(
+                                    snapshot,
+                                    pageCycleMetadata: pageMetadata
+                                ) ?? .persistenceFailed
+                            } else {
+                                conversationStore?.applySyncSnapshot(snapshot) ?? .persistenceFailed
+                            }
+                            let pendingAfter = Set(
+                                conversationStore?.pendingMutationsForSync.map(\.operationID) ?? []
+                            )
+                            for operationID in pendingBefore.subtracting(pendingAfter) {
+                                cancelReliableTransfers(for: operationID)
+                                cancelMutationRetry(for: operationID)
+                            }
+
+                            if let pageMetadata {
+                                guard pageMetadata.isValid(for: snapshot) else {
+                                    if pageCycleCoordinator.pendingRequest != nil {
+                                        requestSync()
+                                    }
+                                    flushPendingMutations()
+                                    return .ignore
+                                }
+
+                                pageCycleHandshakeTracker.pageCycleReceived()
+                                let pageUpdate = pageCycleCoordinator.receive(
+                                    pageMetadata,
+                                    after: applyOutcome
+                                )
+                                retainSyncRequest(pageUpdate.pendingRequest.map {
+                                    WatchSyncRequestIdentity.pageCycle($0)
+                                })
+                                if pageUpdate.pendingRequest != nil || pageUpdate.requiresFreshCycle {
+                                    requestSync()
+                                }
+                                if applyOutcome == .persistenceFailed {
+                                    DiagnosticsLogger.log(
+                                        .watchConnectivity,
+                                        level: .error,
+                                        message: "⌚ Snapshot page was not durable; retaining exact continuation",
+                                        metadata: [
+                                            "cycleId": pageMetadata.cycleID.uuidString,
+                                            "pageIndex": "\(pageMetadata.cursor.pageIndex)"
+                                        ]
+                                    )
+                                }
+                                flushPendingMutations()
+                                guard pageUpdate.acceptedPage else { return .ignore }
+                                return .page(
+                                    cycleID: pageMetadata.cycleID,
+                                    completesCycle: pageUpdate.completedCycle,
+                                    metadataComplete: pageMetadata.modelMetadataCycleIsAuthoritative
+                                )
+                            }
+
+                            flushPendingMutations()
+                            guard applyOutcome.isDurable else {
+                                if applyOutcome == .persistenceFailed {
+                                    requestSync()
+                                }
+                                return .ignore
+                            }
+
+                            if snapshot.schemaVersion == WatchSyncSnapshot.currentSchemaVersion {
+                                switch pageCycleHandshakeTracker.disposition(
+                                    sourceID: snapshot.sourceID,
+                                    snapshotRevision: snapshot.revision,
+                                    pendingRequest: pageCycleRetryController.pendingRequest
+                                ) {
+                                case .requestFreshCycle:
+                                    retirePageCycle()
+                                    requestSync()
+                                case .preservePendingFreshCycle:
+                                    break
+                                case .retireWithoutRequest:
+                                    retirePageCycle()
+                                }
+                            } else {
+                                retirePageCycle()
+                            }
+                            return .standalone(
+                                after: applyOutcome,
+                                metadataIsComplete: WatchModelMetadataCompleteness
+                                    .isExplicitlyComplete(in: context)
+                            )
+                        }
+                        rejectedRevisionedSnapshot = true
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .error,
+                            message: "Ignoring unsupported Watch sync schema and trying legacy payload",
+                            metadata: ["schemaVersion": "\(snapshot.schemaVersion)"]
+                        )
+                    } catch {
+                        rejectedRevisionedSnapshot = true
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .error,
+                            message: "❌ Failed to decode Watch sync snapshot",
+                            metadata: ["error": error.localizedDescription]
+                        )
+                    }
+                }
+
+                if let legacyConversations {
+                    reconcileLegacyDeliveryEchoes(legacyConversations)
+                    conversationStore?.updateConversations(legacyConversations)
+                    adoptLegacyPeerMode()
+                    return .legacy(
+                        metadataIsComplete: WatchModelMetadataCompleteness
+                            .legacyContextIsComplete(in: context)
+                    )
+                }
+
+                guard !rejectedRevisionedSnapshot else { return .ignore }
+                retirePageCycle()
+                return .legacy(
+                    metadataIsComplete: WatchModelMetadataCompleteness
+                        .legacyContextIsComplete(in: context)
+                )
+            }
+
+            private func reconcileLegacyDeliveryEchoes(_ echoedConversations: [WatchConversation]) {
+                guard let conversationStore else { return }
+                for mutation in conversationStore.pendingMutationsForSync {
+                    let reconciliation = legacyDeliveryTracker.reconcile(
+                        mutation,
+                        echoedConversations: echoedConversations
+                    )
+                    guard conversationStore.markLegacyComponentsDelivered(
+                        reconciliation.matchedComponents,
+                        for: mutation
+                    ) else {
+                        scheduleMutationRetry(for: mutation.operationID)
+                        continue
+                    }
+                    for component in reconciliation.matchedComponents {
+                        let userInfo = component.deliveryUserInfo(for: mutation)
+                        legacyDeliveryTracker.confirm(userInfo)
+                    }
+
+                    guard WatchLegacyEchoReconciler.canAcknowledge(
+                        mutation,
+                        currentMatches: reconciliation.matchedComponents,
+                        durableCoverage: conversationStore.durableLegacyDeliveryCoverage(
+                            for: mutation.conversationID
+                        )
+                    ) else {
+                        continue
+                    }
+                    legacyAcknowledgementRetryTracker.retain(mutation)
+                    guard conversationStore.acknowledgeWatchRevision(
+                        conversationID: mutation.conversationID,
+                        revision: mutation.revision
+                    ) else {
+                        scheduleMutationRetry(for: mutation.operationID)
+                        continue
+                    }
+                    cancelReliableTransfers(for: mutation.operationID)
+                    cancelMutationRetry(for: mutation.operationID)
+                }
+            }
+
+            private func adoptLegacyPeerMode() {
+                retirePageCycle()
+                peerSyncMode = .legacy
+                flushPendingMutations()
+            }
+
+            private func processModelSettingsFromContext(
+                _ context: [String: Any],
+                mode: WatchContextApplicationMode
+            ) {
+                if case .ignore = mode {
+                    return
+                }
+
+                let page = WatchModelMetadataPage(context: context)
+                let incomingEpoch = (context[WatchContextKeys.modelMetadataEpoch] as? String)
+                    .flatMap(UUID.init(uuidString:))
+                var state = currentModelMetadataState()
+                let epochToPersist = WatchModelMetadataContextReducer.apply(
+                    page,
+                    mode: mode,
+                    incomingEpoch: incomingEpoch,
+                    appliedEpoch: appliedModelMetadataEpoch,
+                    pendingEpoch: &pendingModelMetadataEpoch,
+                    accumulator: &modelMetadataAccumulator,
+                    to: &state
+                )
+                applyModelMetadataState(state)
+                if let epochToPersist {
+                    appliedModelMetadataEpoch = epochToPersist
+                    UserDefaults.standard.set(
+                        epochToPersist.uuidString,
+                        forKey: WatchSyncPersistenceKeys.appliedModelMetadataEpoch
+                    )
+                }
+            }
+
+            private func currentModelMetadataState() -> WatchModelMetadataState {
+                WatchModelMetadataState(
+                    selectedModel: selectedModel,
+                    availableModels: availableModels,
+                    customModels: AIService.shared.customModels,
+                    defaultProvider: AIService.shared.provider.rawValue,
+                    modelProviders: AIService.shared.modelProviders.mapValues(\.rawValue),
+                    modelEndpoints: AIService.shared.modelEndpoints,
+                    modelEndpointTypes: AIService.shared.modelEndpointTypes.mapValues(\.rawValue),
+                    modelUsesGitHubOAuth: AIService.shared.modelUsesGitHubOAuth,
+                    modelAPIKeys: AIService.shared.modelAPIKeys
+                )
+            }
+
+            private func applyModelMetadataState(_ state: WatchModelMetadataState) {
+                selectedModel = state.selectedModel
+                AIService.shared.selectedModel = state.selectedModel
+                availableModels = state.availableModels
+                AIService.shared.customModels = state.customModels
+                if let provider = AIProvider(rawValue: state.defaultProvider) {
+                    AIService.shared.provider = provider
+                }
+                AIService.shared.modelProviders = state.modelProviders.reduce(into: [:]) { result, pair in
+                    if let provider = AIProvider(rawValue: pair.value) {
+                        result[pair.key] = provider
+                    }
+                }
+                AIService.shared.modelEndpoints = state.modelEndpoints
+                AIService.shared.modelEndpointTypes = state.modelEndpointTypes.reduce(into: [:]) { result, pair in
+                    if let endpointType = APIEndpointType(rawValue: pair.value) {
+                        result[pair.key] = endpointType
+                    }
+                }
+                AIService.shared.modelUsesGitHubOAuth = state.modelUsesGitHubOAuth
+                AIService.shared.modelAPIKeys = state.modelAPIKeys
+            }
+
+            private func processAPIKeysFromContext(
+                _ context: [String: Any],
+                mode: WatchContextApplicationMode
+            ) {
+                if let githubToken = context[WatchContextKeys.githubAccessToken] as? String {
+                    if githubToken.isEmpty {
+                        GitHubOAuthService.shared.signOut()
+                    } else {
+                        GitHubOAuthService.shared.setAccessTokenFromWatch(githubToken)
+                    }
+                } else if mode.treatsOmittedCredentialsAsRemoved {
+                    GitHubOAuthService.shared.signOut()
+                }
+            }
+
+            private func processTavilySettingsFromContext(
+                _ context: [String: Any],
+                mode: WatchContextApplicationMode
+            ) {
+                if let key = context[WatchContextKeys.tavilyAPIKey] as? String {
+                    AIService.shared.tavilyAPIKey = key
+                    TavilyService.shared.apiKey = key
+                } else if mode.treatsOmittedCredentialsAsRemoved {
                     AIService.shared.tavilyAPIKey = ""
                     TavilyService.shared.apiKey = ""
+                }
+                if let enabled = context[WatchContextKeys.tavilyEnabled] as? Bool {
+                    AIService.shared.tavilyEnabled = enabled
+                    AIService.shared.webSearchEnabled = enabled
+                    TavilyService.shared.isEnabled = enabled
+                }
+            }
+
+            private func processWebFetchSettingsFromContext(_ context: [String: Any]) {
+                if let enabled = context[WatchContextKeys.webFetchEnabled] as? Bool {
+                    WebFetchService.shared.isEnabled = enabled
+                }
+            }
+
+            private func processMemoryFromContext(_ context: [String: Any]) {
+                if let enabled = context[WatchContextKeys.memoryEnabled] as? Bool {
+                    MemoryContextProvider.shared.setMemoryEnabled(enabled)
+                    if !enabled {
+                        UserMemoryService.shared.loadFactsFromSync([])
+                        return
+                    }
+                }
+                if let data = context[WatchContextKeys.memoryFacts] as? Data {
+                    if data.isEmpty {
+                        UserMemoryService.shared.loadFactsFromSync([])
+                    } else if let facts = try? JSONDecoder().decode([UserMemoryFact].self, from: data) {
+                        UserMemoryService.shared.loadFactsFromSync(facts)
+                    }
+                }
+            }
+
+            private func isCurrentCallback(
+                sessionID: ObjectIdentifier,
+                activation: WatchSessionActivationToken
+            ) -> Bool {
+                guard activationFence.isCurrent(activation), let session else { return false }
+                return ObjectIdentifier(session) == sessionID
+            }
+        }
+
+        extension WatchConnectivityService {
+            nonisolated func handleSessionActivation(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken,
+                state activationState: WCSessionActivationState,
+                error: Error?
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let reachable = session.isReachable
+                let receivedContext = UncheckedSendableWrapper(session.receivedApplicationContext)
+                let errorDescription = error?.localizedDescription
+                sessionEventQueue.enqueue { [weak self] in
+                    guard let self,
+                          self.isCurrentCallback(sessionID: sessionID, activation: activation)
+                    else {
+                        return
+                    }
+                    if let errorDescription {
+                        DiagnosticsLogger.log(
+                            .watchConnectivity,
+                            level: .error,
+                            message: "❌ Watch session activation failed",
+                            metadata: ["error": errorDescription]
+                        )
+                        return
+                    }
+                    self.isReachable = reachable
+                    self.peerSyncMode = .unknown
+                    self.pageCycleHandshakeTracker.reset()
+                    if self.configuredStoreID == nil, let conversationStore = self.conversationStore {
+                        conversationStore.initializeFromDisk()
+                        self.configuredStoreID = ObjectIdentifier(conversationStore)
+                    }
+                    if !receivedContext.value.isEmpty {
+                        self.processContext(receivedContext.value)
+                    }
+                    self.flushPendingMutations()
+                    if self.syncRequestPending || receivedContext.value.isEmpty {
+                        self.requestSync()
+                    }
                     DiagnosticsLogger.log(
                         .watchConnectivity,
                         level: .info,
-                        message: "⌚ Cleared Tavily API key (removed on iPhone)"
+                        message: "⌚ Watch session activated",
+                        metadata: ["state": "\(activationState.rawValue)", "reachable": "\(reachable)"]
                     )
                 }
             }
-            if let tavilyEnabled = context[WatchContextKeys.tavilyEnabled] as? Bool {
-                AIService.shared.tavilyEnabled = tavilyEnabled
-                AIService.shared.webSearchEnabled = tavilyEnabled
-                TavilyService.shared.isEnabled = tavilyEnabled
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Updated web search settings from iPhone",
-                    metadata: ["enabled": "\(tavilyEnabled)"]
-                )
-            }
-        }
 
-        /// Process web fetch settings from iPhone context
-        private func processWebFetchSettingsFromContext(_ context: [String: Any]) {
-            if let webFetchEnabled = context[WatchContextKeys.webFetchEnabled] as? Bool {
-                WebFetchService.shared.isEnabled = webFetchEnabled
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Updated web fetch enabled state from iPhone",
-                    metadata: ["enabled": "\(webFetchEnabled)"]
-                )
-            }
-        }
-
-        /// Process memory settings from iPhone context
-        private func processMemoryFromContext(_ context: [String: Any]) {
-            if let memoryEnabled = context[WatchContextKeys.memoryEnabled] as? Bool {
-                MemoryContextProvider.shared.setMemoryEnabled(memoryEnabled)
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Updated memory enabled state from iPhone",
-                    metadata: ["enabled": "\(memoryEnabled)"]
-                )
-
-                // Clear facts when memory is disabled on iPhone
-                if !memoryEnabled {
-                    UserMemoryService.shared.loadFactsFromSync([])
-                    DiagnosticsLogger.log(
-                        .watchConnectivity,
-                        level: .info,
-                        message: "⌚ Cleared memory facts (memory disabled on iPhone)"
-                    )
-                    return
+            nonisolated func handleSessionReachabilityDidChange(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let reachable = session.isReachable
+                sessionEventQueue.enqueue { [weak self] in
+                    guard let self,
+                          self.isCurrentCallback(sessionID: sessionID, activation: activation)
+                    else {
+                        return
+                    }
+                    self.isReachable = reachable
+                    if reachable {
+                        self.flushPendingMutations()
+                        self.requestSync()
+                    }
                 }
             }
 
-            // Decode and load facts
-            if let factsData = context[WatchContextKeys.memoryFacts] as? Data {
-                do {
-                    let facts = try JSONDecoder().decode([UserMemoryFact].self, from: factsData)
-                    UserMemoryService.shared.loadFactsFromSync(facts)
-                    DiagnosticsLogger.log(
-                        .watchConnectivity,
-                        level: .info,
-                        message: "⌚ Received memory facts from iPhone",
-                        metadata: ["count": "\(facts.count)"]
-                    )
-                } catch {
-                    // Log and skip - keep existing facts on decode failure
-                    DiagnosticsLogger.log(
-                        .watchConnectivity,
-                        level: .error,
-                        message: "⌚ Failed to decode memory facts from iPhone",
-                        metadata: ["error": "\(error.localizedDescription)"]
-                    )
+            nonisolated func handleSession(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken,
+                didReceiveApplicationContext applicationContext: [String: Any]
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let applicationContext = UncheckedSendableWrapper(applicationContext)
+                sessionEventQueue.enqueue { [weak self] in
+                    guard let self,
+                          self.isCurrentCallback(sessionID: sessionID, activation: activation)
+                    else {
+                        return
+                    }
+                    self.processContext(applicationContext.value)
                 }
             }
-        }
-    }
 
-    extension WatchConnectivityService: WCSessionDelegate {
-        nonisolated func session(
-            _ session: WCSession,
-            activationDidCompleteWith activationState: WCSessionActivationState,
-            error: Error?
-        ) {
-            let reachable = session.isReachable
-            let stateRawValue = activationState.rawValue
-            let errorDescription = error?.localizedDescription
-            let receivedContext = session.receivedApplicationContext
-            nonisolated(unsafe) let receivedContextUnsafe = receivedContext
-            Task { @MainActor in
-                if let errorDescription {
-                    DiagnosticsLogger.log(
-                        .watchConnectivity,
-                        level: .error,
-                        message: "❌ Watch session activation failed",
-                        metadata: ["error": errorDescription]
-                    )
-                    return
+            nonisolated func handleSession(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken,
+                didFinish userInfoTransfer: WCSessionUserInfoTransfer,
+                error: Error?
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let operationID = (userInfoTransfer.userInfo[WatchMessageKeys.operationId] as? String)
+                    .flatMap(UUID.init(uuidString:))
+                let legacyComponentID = userInfoTransfer.userInfo[WatchMessageKeys.legacyComponentId] as? String
+                let succeeded = error == nil
+                Task { @MainActor in
+                    guard isCurrentCallback(sessionID: sessionID, activation: activation), let operationID else {
+                        return
+                    }
+                    let pendingMutations = conversationStore?.pendingMutationsForSync ?? []
+                    if let legacyComponentID {
+                        let pendingMutation = WatchLegacyTransferCompletionResolver.pendingMutation(
+                            originalOperationID: operationID,
+                            componentID: legacyComponentID,
+                            pendingMutations: pendingMutations
+                        )
+                        legacyDeliveryTracker.recordTransferCompletion(
+                            componentID: legacyComponentID,
+                            succeeded: succeeded && pendingMutation != nil
+                        )
+                        if succeeded, let pendingMutation {
+                            requestSync()
+                            scheduleMutationRetry(for: pendingMutation.operationID)
+                        } else if let pendingMutation {
+                            scheduleMutationRetry(for: pendingMutation.operationID)
+                        }
+                        return
+                    }
+
+                    queuedMutationOperationIDs.remove(operationID)
+                    if pendingMutations.contains(where: { $0.operationID == operationID }) {
+                        scheduleMutationRetry(for: operationID)
+                    }
                 }
+            }
 
-                isReachable = reachable
-
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ Watch session activated",
-                    metadata: [
-                        "state": "\(stateRawValue)",
-                        "reachable": "\(reachable)"
-                    ]
-                )
-
-                // Initialize conversation store from disk now that session is ready
-                conversationStore?.initializeFromDisk()
-
-                // Process any existing context
-                if !receivedContextUnsafe.isEmpty {
-                    processContext(receivedContextUnsafe)
+            nonisolated func handleSession(
+                _ session: WCSession,
+                activation: WatchSessionActivationToken,
+                didFinish fileTransfer: WCSessionFileTransfer,
+                error _: Error?
+            ) {
+                let sessionID = ObjectIdentifier(session)
+                let operationID = (fileTransfer.file.metadata?[WatchMessageKeys.operationId] as? String)
+                    .flatMap(UUID.init(uuidString:))
+                let fileURL = fileTransfer.file.fileURL
+                Task { @MainActor in
+                    guard isCurrentCallback(sessionID: sessionID, activation: activation), let operationID else {
+                        try? FileManager.default.removeItem(at: fileURL)
+                        return
+                    }
+                    queuedMutationFileOperationIDs.remove(operationID)
+                    mutationFileURLs.removeValue(forKey: operationID)
+                    try? FileManager.default.removeItem(at: fileURL)
+                    if conversationStore?.pendingMutationsForSync.contains(where: {
+                        $0.operationID == operationID
+                    }) == true {
+                        scheduleMutationRetry(for: operationID)
+                    }
                 }
             }
         }
 
-        nonisolated func sessionReachabilityDidChange(_ session: WCSession) {
-            let reachable = session.isReachable
-            Task { @MainActor in
-                isReachable = reachable
+    #endif
 
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .info,
-                    message: "⌚ iPhone reachability changed",
-                    metadata: ["reachable": "\(reachable)"]
-                )
-            }
-        }
-
-        nonisolated func session(
-            _: WCSession,
-            didReceiveApplicationContext applicationContext: [String: Any]
-        ) {
-            nonisolated(unsafe) let applicationContext = applicationContext
-            Task { @MainActor in
-                processContext(applicationContext)
-            }
-        }
-    }
-
-#endif  // os(watchOS)
-
-#endif  // os(iOS) || os(watchOS)
+#endif

--- a/Sources/Ayna/Services/WatchConnectivitySupport.swift
+++ b/Sources/Ayna/Services/WatchConnectivitySupport.swift
@@ -1,0 +1,2799 @@
+// swiftlint:disable file_length
+//
+//  WatchConnectivitySupport.swift
+//  ayna
+//
+//  Thread-safe identity fencing shared by iOS and watchOS WCSession delegates.
+//
+
+import Combine
+import CoreFoundation
+import CryptoKit
+import Foundation
+
+struct WatchMutationReply: Sendable {
+    let status: String
+    let conversationID: UUID
+    let operationID: UUID
+    let acknowledgedRevision: WatchSyncRevision?
+
+    static func retry(for mutation: WatchConversationMutation) -> Self {
+        Self(
+            status: "retry",
+            conversationID: mutation.conversationID,
+            operationID: mutation.operationID,
+            acknowledgedRevision: nil
+        )
+    }
+
+    static func unsupported(for mutation: WatchConversationMutation) -> Self {
+        Self(
+            status: "unsupported",
+            conversationID: mutation.conversationID,
+            operationID: mutation.operationID,
+            acknowledgedRevision: nil
+        )
+    }
+
+    static func acknowledged(
+        _ mutation: WatchConversationMutation,
+        revision: WatchSyncRevision
+    ) -> Self {
+        Self(
+            status: "acknowledged",
+            conversationID: mutation.conversationID,
+            operationID: mutation.operationID,
+            acknowledgedRevision: revision
+        )
+    }
+
+    var message: [String: Any] {
+        var result: [String: Any] = [
+            "type": "watchConversationMutationAck",
+            "status": status,
+            "conversationId": conversationID.uuidString,
+            "operationId": operationID.uuidString
+        ]
+        if let acknowledgedRevision {
+            result["acknowledgedRevision"] = NSNumber(value: acknowledgedRevision)
+        }
+        return result
+    }
+}
+
+private struct WatchLegacyTitleDelivery: Codable {
+    var title: String
+    var revision: WatchSyncRevision?
+}
+
+private struct WatchLegacyTitleSequenceEntry: Codable, Equatable {
+    var title: String
+    var revision: WatchSyncRevision
+}
+
+enum WatchLegacyComponentIdentity {
+    static func create(conversationID: UUID, revision: WatchSyncRevision) -> String {
+        "create:\(conversationID.uuidString):\(revision)"
+    }
+
+    static func message(messageID: UUID, revision: WatchSyncRevision) -> String {
+        "message:\(messageID.uuidString):\(revision)"
+    }
+
+    static func title(conversationID: UUID, revision: WatchSyncRevision) -> String {
+        "title:\(conversationID.uuidString):\(revision)"
+    }
+
+    static func requiredComponentIDs(for mutation: WatchConversationMutation) -> Set<String> {
+        guard !mutation.fields.contains(.delete) else { return [] }
+        var componentIDs: Set<String> = []
+        if mutation.fields.contains(.create) {
+            componentIDs.insert(create(
+                conversationID: mutation.conversationID,
+                revision: mutation.createRevision ?? mutation.revision
+            ))
+        }
+        if mutation.fields.contains(.messages) {
+            for message in mutation.messageChanges {
+                componentIDs.insert(self.message(
+                    messageID: message.id,
+                    revision: mutation.messageChangeRevisions[message.id] ?? mutation.revision
+                ))
+            }
+        }
+        if mutation.fields.contains(.create) || mutation.fields.contains(.title) {
+            componentIDs.insert(title(
+                conversationID: mutation.conversationID,
+                revision: mutation.titleRevision ?? mutation.createRevision ?? mutation.revision
+            ))
+        }
+        return componentIDs
+    }
+}
+
+enum WatchLegacyTransferCompletionResolver {
+    static func pendingMutation(
+        originalOperationID: UUID,
+        componentID: String,
+        pendingMutations: [WatchConversationMutation]
+    ) -> WatchConversationMutation? {
+        let matches = pendingMutations.filter {
+            WatchLegacyComponentIdentity.requiredComponentIDs(for: $0).contains(componentID)
+        }
+        return matches.first { $0.operationID == originalOperationID } ?? matches.max {
+            if $0.revision != $1.revision {
+                return $0.revision < $1.revision
+            }
+            return $0.operationID.uuidString < $1.operationID.uuidString
+        }
+    }
+}
+
+private struct WatchLegacyDeliveryTrackerState: Codable {
+    var createdConversationIDs: Set<UUID> = []
+    var messageRevisions: [UUID: [UUID: WatchSyncRevision]] = [:]
+    var titleDeliveries: [UUID: WatchLegacyTitleDelivery] = [:]
+    var titleSequences: [UUID: [WatchLegacyTitleSequenceEntry]] = [:]
+    var configurationRevisions: [UUID: WatchSyncRevision] = [:]
+    var awaitingEchoComponentIDs: Set<String> = []
+    var awaitingEchoAttempts: [String: Int] = [:]
+
+    private enum CodingKeys: String, CodingKey {
+        case createdConversationIDs
+        case messageRevisions
+        case titleDeliveries
+        case titleSequences
+        case titles
+        case configurationRevisions
+        case awaitingEchoComponentIDs
+        case awaitingEchoAttempts
+    }
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        createdConversationIDs = try container.decodeIfPresent(
+            Set<UUID>.self,
+            forKey: .createdConversationIDs
+        ) ?? []
+        messageRevisions = try container.decodeIfPresent(
+            [UUID: [UUID: WatchSyncRevision]].self,
+            forKey: .messageRevisions
+        ) ?? [:]
+        configurationRevisions = try container.decodeIfPresent(
+            [UUID: WatchSyncRevision].self,
+            forKey: .configurationRevisions
+        ) ?? [:]
+        awaitingEchoComponentIDs = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .awaitingEchoComponentIDs
+        ) ?? []
+        awaitingEchoAttempts = try container.decodeIfPresent(
+            [String: Int].self,
+            forKey: .awaitingEchoAttempts
+        ) ?? [:]
+        titleSequences = try container.decodeIfPresent(
+            [UUID: [WatchLegacyTitleSequenceEntry]].self,
+            forKey: .titleSequences
+        ) ?? [:]
+
+        if let deliveries = try container.decodeIfPresent(
+            [UUID: WatchLegacyTitleDelivery].self,
+            forKey: .titleDeliveries
+        ) {
+            titleDeliveries = deliveries
+        } else {
+            let legacyTitles = try container.decodeIfPresent(
+                [UUID: String].self,
+                forKey: .titles
+            ) ?? [:]
+            titleDeliveries = legacyTitles.mapValues {
+                WatchLegacyTitleDelivery(title: $0, revision: nil)
+            }
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(createdConversationIDs, forKey: .createdConversationIDs)
+        try container.encode(messageRevisions, forKey: .messageRevisions)
+        try container.encode(titleDeliveries, forKey: .titleDeliveries)
+        try container.encode(titleSequences, forKey: .titleSequences)
+        try container.encode(configurationRevisions, forKey: .configurationRevisions)
+        try container.encode(awaitingEchoComponentIDs, forKey: .awaitingEchoComponentIDs)
+        try container.encode(awaitingEchoAttempts, forKey: .awaitingEchoAttempts)
+    }
+}
+
+struct WatchLegacyMessageSendSelection: Sendable {
+    let messages: [WatchMessage]
+    let awaitingEchoComponentIDs: Set<String>
+}
+
+@MainActor
+final class WatchLegacyDeliveryTracker {
+    private static let maximumAwaitingEchoAttempts = 3
+
+    private let userDefaults: UserDefaults
+    private let persistenceKey: String
+    private var state: WatchLegacyDeliveryTrackerState
+
+    init(
+        userDefaults: UserDefaults = .standard,
+        persistenceKey: String = "com.sertacozercan.ayna.watch.legacyDeliveryState"
+    ) {
+        self.userDefaults = userDefaults
+        self.persistenceKey = persistenceKey
+        if let data = userDefaults.data(forKey: persistenceKey),
+           let decoded = try? JSONDecoder().decode(WatchLegacyDeliveryTrackerState.self, from: data)
+        {
+            state = decoded
+        } else {
+            state = WatchLegacyDeliveryTrackerState()
+        }
+    }
+
+    func reset() {
+        state = WatchLegacyDeliveryTrackerState()
+        persist()
+    }
+
+    func needsCreate(conversationID: UUID) -> Bool {
+        !state.createdConversationIDs.contains(conversationID)
+    }
+
+    func pendingMessages(from mutation: WatchConversationMutation) -> [WatchMessage] {
+        let revisions = state.messageRevisions[mutation.conversationID] ?? [:]
+        return mutation.messageChanges.filter { message in
+            let revision = mutation.messageChangeRevisions[message.id] ?? mutation.revision
+            return revision > revisions[message.id, default: 0]
+        }
+    }
+
+    func pendingMessageBatch(
+        from mutation: WatchConversationMutation,
+        maximumCount: Int
+    ) -> [WatchMessage] {
+        pendingMessageSendSelection(
+            from: mutation,
+            maximumCount: maximumCount
+        ).messages
+    }
+
+    func pendingMessageSendSelection(
+        from mutation: WatchConversationMutation,
+        maximumCount: Int
+    ) -> WatchLegacyMessageSendSelection {
+        guard maximumCount > 0 else {
+            return WatchLegacyMessageSendSelection(
+                messages: [],
+                awaitingEchoComponentIDs: []
+            )
+        }
+        let revisions = state.messageRevisions[mutation.conversationID] ?? [:]
+        let candidates = mutation.messageChanges.compactMap { message -> (WatchMessage, String)? in
+            let revision = mutation.messageChangeRevisions[message.id] ?? mutation.revision
+            guard revision > revisions[message.id, default: 0] else { return nil }
+            return (
+                message,
+                WatchLegacyComponentIdentity.message(messageID: message.id, revision: revision)
+            )
+        }
+        let awaitingBefore = state.awaitingEchoComponentIDs
+        let echoState = advanceAwaitingEcho(candidates.map(\.1))
+        let neverSent = candidates.filter {
+            !awaitingBefore.contains($0.1) && !echoState.deferred.contains($0.1)
+        }.map(\.0)
+        let expiredRetransmissions = candidates.filter {
+            echoState.expired.contains($0.1)
+        }.map(\.0)
+        let availableCapacity = max(0, maximumCount - echoState.deferred.count)
+        return WatchLegacyMessageSendSelection(
+            messages: Array((neverSent + expiredRetransmissions).prefix(availableCapacity)),
+            awaitingEchoComponentIDs: echoState.deferred
+        )
+    }
+
+    func needsTitle(
+        conversationID: UUID,
+        title: String,
+        revision: WatchSyncRevision
+    ) -> Bool {
+        guard let delivery = state.titleDeliveries[conversationID],
+              let deliveredRevision = delivery.revision
+        else {
+            return true
+        }
+        if revision != deliveredRevision {
+            return revision > deliveredRevision
+        }
+        return delivery.title != title
+    }
+
+    func recordTitleMutation(_ mutation: WatchConversationMutation) {
+        guard mutation.fields.contains(.create) || mutation.fields.contains(.title) else { return }
+        let revision = mutation.titleRevision ?? mutation.createRevision ?? mutation.revision
+        guard recordTitleSequence(
+            conversationID: mutation.conversationID,
+            title: mutation.conversation.title,
+            revision: revision
+        ) else {
+            return
+        }
+        persist()
+    }
+
+    func reconcile(
+        _ mutation: WatchConversationMutation,
+        echoedConversations: [WatchConversation]
+    ) -> WatchLegacyEchoReconciliation {
+        let titleRevision = mutation.titleRevision ?? mutation.createRevision ?? mutation.revision
+        return WatchLegacyEchoReconciler.reconcile(
+            mutation,
+            echoedConversations: echoedConversations
+        ) { [self] echo in
+            guard titleEchoRequiresFreshEvidence(
+                conversationID: mutation.conversationID,
+                title: mutation.conversation.title,
+                revision: titleRevision
+            ) else {
+                return true
+            }
+            if echo.watchRevision > 0 {
+                return echo.watchRevision >= titleRevision
+            }
+            return echo.updatedAt > mutation.conversation.updatedAt
+        }
+    }
+
+    func configurationIsRepresented(
+        by mutation: WatchConversationMutation,
+        createWillBeSent: Bool
+    ) -> Bool {
+        guard mutation.fields.contains(.configuration) else { return true }
+        let revision = max(mutation.createRevision ?? 0, mutation.configurationRevision ?? 0)
+        return revision <= state.configurationRevisions[mutation.conversationID, default: 0] || createWillBeSent
+    }
+
+    func advanceAwaitingEcho(
+        _ componentIDs: [String]
+    ) -> (deferred: Set<String>, expired: Set<String>) {
+        var deferred: Set<String> = []
+        var expired: Set<String> = []
+        var stateChanged = false
+        for componentID in Set(componentIDs) where state.awaitingEchoComponentIDs.contains(componentID) {
+            let attempts = state.awaitingEchoAttempts[componentID, default: 0]
+            if attempts >= Self.maximumAwaitingEchoAttempts {
+                state.awaitingEchoComponentIDs.remove(componentID)
+                state.awaitingEchoAttempts.removeValue(forKey: componentID)
+                expired.insert(componentID)
+            } else {
+                state.awaitingEchoAttempts[componentID] = attempts + 1
+                deferred.insert(componentID)
+            }
+            stateChanged = true
+        }
+        if stateChanged {
+            persist()
+        }
+        return (deferred, expired)
+    }
+
+    func recordTransferCompletion(componentID: String, succeeded: Bool) {
+        guard !componentID.isEmpty else { return }
+        let changed: Bool
+        if succeeded {
+            let inserted = state.awaitingEchoComponentIDs.insert(componentID).inserted
+            let attemptsChanged = state.awaitingEchoAttempts.updateValue(0, forKey: componentID) != 0
+            changed = inserted || attemptsChanged
+        } else {
+            let removed = state.awaitingEchoComponentIDs.remove(componentID) != nil
+            let removedAttempts = state.awaitingEchoAttempts.removeValue(forKey: componentID) != nil
+            changed = removed || removedAttempts
+        }
+        if changed {
+            persist()
+        }
+    }
+
+    func isAwaitingEcho(componentID: String) -> Bool {
+        state.awaitingEchoComponentIDs.contains(componentID)
+    }
+
+    func confirm(_ userInfo: [String: Any]) {
+        guard let conversationID = (userInfo[WatchMessageKeys.conversationId] as? String)
+            .flatMap(UUID.init(uuidString:)),
+            let kind = userInfo[WatchMessageKeys.legacyComponentKind] as? String
+        else {
+            return
+        }
+        let clearedAwaitingEcho = legacyComponentID(from: userInfo).map {
+            let removed = state.awaitingEchoComponentIDs.remove($0) != nil
+            let removedAttempts = state.awaitingEchoAttempts.removeValue(forKey: $0) != nil
+            return removed || removedAttempts
+        } ?? false
+
+        switch kind {
+        case WatchMessageKeys.legacyComponentCreate:
+            state.createdConversationIDs.insert(conversationID)
+            if let revision = WatchSyncValueDecoder.revision(
+                userInfo[WatchMessageKeys.configurationRevision]
+            ) {
+                state.configurationRevisions[conversationID] = max(
+                    state.configurationRevisions[conversationID, default: 0],
+                    revision
+                )
+            }
+        case WatchMessageKeys.legacyComponentMessage:
+            guard let messageID = (userInfo[WatchMessageKeys.messageId] as? String)
+                .flatMap(UUID.init(uuidString:)),
+                let revision = WatchSyncValueDecoder.revision(userInfo[WatchMessageKeys.mutationRevision])
+            else {
+                if clearedAwaitingEcho {
+                    persist()
+                }
+                return
+            }
+            var revisions = state.messageRevisions[conversationID] ?? [:]
+            revisions[messageID] = max(revisions[messageID, default: 0], revision)
+            state.messageRevisions[conversationID] = revisions
+        case WatchMessageKeys.legacyComponentTitle:
+            guard let title = userInfo[WatchMessageKeys.title] as? String else { return }
+            let revision = WatchSyncValueDecoder.revision(userInfo[WatchMessageKeys.mutationRevision])
+            if let deliveredRevision = state.titleDeliveries[conversationID]?.revision {
+                guard let revision, revision >= deliveredRevision else {
+                    if clearedAwaitingEcho {
+                        persist()
+                    }
+                    return
+                }
+            }
+            if let revision {
+                _ = recordTitleSequence(
+                    conversationID: conversationID,
+                    title: title,
+                    revision: revision
+                )
+            }
+            state.titleDeliveries[conversationID] = WatchLegacyTitleDelivery(
+                title: title,
+                revision: revision
+            )
+        default:
+            if clearedAwaitingEcho {
+                persist()
+            }
+            return
+        }
+        persist()
+    }
+
+    private func legacyComponentID(from userInfo: [String: Any]) -> String? {
+        if let componentID = userInfo[WatchMessageKeys.legacyComponentId] as? String {
+            return componentID
+        }
+        guard let kind = userInfo[WatchMessageKeys.legacyComponentKind] as? String,
+              let revision = WatchSyncValueDecoder.revision(userInfo[WatchMessageKeys.mutationRevision])
+        else {
+            return nil
+        }
+        switch kind {
+        case WatchMessageKeys.legacyComponentCreate:
+            guard let conversationID = (userInfo[WatchMessageKeys.conversationId] as? String)
+                .flatMap(UUID.init(uuidString:))
+            else {
+                return nil
+            }
+            return WatchLegacyComponentIdentity.create(
+                conversationID: conversationID,
+                revision: revision
+            )
+        case WatchMessageKeys.legacyComponentMessage:
+            guard let messageID = (userInfo[WatchMessageKeys.messageId] as? String)
+                .flatMap(UUID.init(uuidString:))
+            else {
+                return nil
+            }
+            return WatchLegacyComponentIdentity.message(
+                messageID: messageID,
+                revision: revision
+            )
+        case WatchMessageKeys.legacyComponentTitle:
+            guard let conversationID = (userInfo[WatchMessageKeys.conversationId] as? String)
+                .flatMap(UUID.init(uuidString:))
+            else {
+                return nil
+            }
+            return WatchLegacyComponentIdentity.title(
+                conversationID: conversationID,
+                revision: revision
+            )
+        default:
+            return nil
+        }
+    }
+
+    private func recordTitleSequence(
+        conversationID: UUID,
+        title: String,
+        revision: WatchSyncRevision
+    ) -> Bool {
+        var sequence = state.titleSequences[conversationID] ?? []
+        if let index = sequence.firstIndex(where: { $0.revision == revision }) {
+            guard sequence[index].title != title else { return false }
+            sequence[index].title = title
+        } else {
+            sequence.append(WatchLegacyTitleSequenceEntry(title: title, revision: revision))
+        }
+        sequence.sort { $0.revision < $1.revision }
+        state.titleSequences[conversationID] = sequence
+        return true
+    }
+
+    private func titleEchoRequiresFreshEvidence(
+        conversationID: UUID,
+        title: String,
+        revision: WatchSyncRevision
+    ) -> Bool {
+        var sequence = state.titleSequences[conversationID] ?? []
+        if let delivery = state.titleDeliveries[conversationID] {
+            let deliveredEntry = WatchLegacyTitleSequenceEntry(
+                title: delivery.title,
+                revision: delivery.revision ?? 0
+            )
+            if !sequence.contains(deliveredEntry) {
+                sequence.append(deliveredEntry)
+            }
+        }
+        sequence.sort { $0.revision < $1.revision }
+
+        guard let previousMatchingRevision = sequence.last(where: {
+            $0.revision < revision && $0.title == title
+        })?.revision else {
+            return false
+        }
+        return sequence.contains {
+            $0.revision > previousMatchingRevision
+                && $0.revision < revision
+                && $0.title != title
+        }
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        userDefaults.set(data, forKey: persistenceKey)
+    }
+}
+
+enum WatchLegacyEchoComponent: Equatable, Hashable, Sendable {
+    case create(revision: WatchSyncRevision)
+    case title(revision: WatchSyncRevision)
+    case configuration(revision: WatchSyncRevision)
+    case message(id: UUID, revision: WatchSyncRevision)
+
+    var shouldRecordInStoreCoverage: Bool {
+        // Store create coverage also suppresses title and configuration replay. Keep those
+        // components independent until the complete representable mutation is acknowledged.
+        if case .create = self {
+            return false
+        }
+        return true
+    }
+
+    func deliveryUserInfo(for mutation: WatchConversationMutation) -> [String: Any] {
+        var userInfo: [String: Any] = [
+            WatchMessageKeys.conversationId: mutation.conversationID.uuidString,
+            WatchMessageKeys.operationId: mutation.operationID.uuidString,
+            WatchMessageKeys.peerId: mutation.peerID.uuidString
+        ]
+        switch self {
+        case let .create(revision):
+            userInfo[WatchMessageKeys.legacyComponentKind] = WatchMessageKeys.legacyComponentCreate
+            userInfo[WatchMessageKeys.mutationRevision] = NSNumber(value: revision)
+        case let .title(revision):
+            userInfo[WatchMessageKeys.legacyComponentKind] = WatchMessageKeys.legacyComponentTitle
+            userInfo[WatchMessageKeys.mutationRevision] = NSNumber(value: revision)
+            userInfo[WatchMessageKeys.title] = mutation.conversation.title
+        case let .configuration(revision):
+            userInfo[WatchMessageKeys.legacyComponentKind] = WatchMessageKeys.legacyComponentCreate
+            userInfo[WatchMessageKeys.configurationRevision] = NSNumber(value: revision)
+        case let .message(id, revision):
+            userInfo[WatchMessageKeys.legacyComponentKind] = WatchMessageKeys.legacyComponentMessage
+            userInfo[WatchMessageKeys.messageId] = id.uuidString
+            userInfo[WatchMessageKeys.mutationRevision] = NSNumber(value: revision)
+        }
+        return userInfo
+    }
+}
+
+enum WatchLegacyConversationMerger {
+    static func mergeCreate(
+        _ watchConversation: WatchConversation,
+        into existingConversation: Conversation?
+    ) -> Conversation {
+        let created = watchConversation.toConversation()
+        guard var existingConversation else { return created }
+
+        existingConversation.title = created.title
+        existingConversation.model = created.model
+        existingConversation.systemPromptMode = created.systemPromptMode
+        existingConversation.temperature = created.temperature
+        existingConversation.createdAt = created.createdAt
+        existingConversation.updatedAt = max(existingConversation.updatedAt, created.updatedAt)
+
+        var existingMessageIDs = Set(existingConversation.messages.map(\.id))
+        for message in created.messages where existingMessageIDs.insert(message.id).inserted {
+            existingConversation.messages.append(message)
+        }
+        return existingConversation
+    }
+}
+
+struct WatchLegacyEchoReconciliation: Equatable, Sendable {
+    let matchedComponents: [WatchLegacyEchoComponent]
+    let unsupportedFields: WatchConversationMutationFields
+    let canAcknowledgeMutation: Bool
+}
+
+enum WatchLegacyEchoReconciler {
+    static func reconcile(
+        _ mutation: WatchConversationMutation,
+        echoedConversations: [WatchConversation],
+        titleEchoIsCurrent: (WatchConversation) -> Bool = { _ in true }
+    ) -> WatchLegacyEchoReconciliation {
+        let requiredComponents = requiredComponents(for: mutation)
+        let unsupportedFields = unsupportedFields(for: mutation)
+        guard let echo = echoedConversations.first(where: {
+            $0.id == mutation.conversationID
+        }) else {
+            return WatchLegacyEchoReconciliation(
+                matchedComponents: [],
+                unsupportedFields: unsupportedFields,
+                canAcknowledgeMutation: false
+            )
+        }
+
+        var matchedComponents: [WatchLegacyEchoComponent] = []
+        if mutation.fields.contains(.create),
+           configurationMatches(mutation.conversation, echo)
+        {
+            matchedComponents.append(.create(
+                revision: mutation.createRevision ?? mutation.revision
+            ))
+        }
+        if mutation.fields.contains(.create) || mutation.fields.contains(.title),
+           echo.title == mutation.conversation.title,
+           titleEchoIsCurrent(echo)
+        {
+            matchedComponents.append(.title(
+                revision: mutation.titleRevision ?? mutation.createRevision ?? mutation.revision
+            ))
+        }
+        if mutation.fields.contains(.create), configurationMatches(mutation.conversation, echo) {
+            matchedComponents.append(.configuration(
+                revision: mutation.configurationRevision ?? mutation.createRevision ?? mutation.revision
+            ))
+        }
+        if mutation.fields.contains(.messages) {
+            let echoedMessages = Dictionary(
+                echo.messages.map { ($0.id, $0) },
+                uniquingKeysWith: { _, latest in latest }
+            )
+            for message in mutation.messageChanges where echoedMessages[message.id] == message {
+                matchedComponents.append(.message(
+                    id: message.id,
+                    revision: mutation.messageChangeRevisions[message.id] ?? mutation.revision
+                ))
+            }
+        }
+
+        return WatchLegacyEchoReconciliation(
+            matchedComponents: matchedComponents,
+            unsupportedFields: unsupportedFields,
+            canAcknowledgeMutation: unsupportedFields.isEmpty
+                && !requiredComponents.isEmpty
+                && matchedComponents == requiredComponents
+        )
+    }
+
+    static func canAcknowledge(
+        _ mutation: WatchConversationMutation,
+        currentMatches: [WatchLegacyEchoComponent],
+        durableCoverage: WatchMutationDeliveryCoverage?
+    ) -> Bool {
+        let requiredComponents = requiredComponents(for: mutation)
+        guard unsupportedFields(for: mutation).isEmpty,
+              !requiredComponents.isEmpty
+        else {
+            return false
+        }
+
+        let currentMatches = Set(currentMatches)
+        guard !currentMatches.isEmpty else { return false }
+        return requiredComponents.allSatisfy { component in
+            switch component {
+            case .create:
+                currentMatches.contains(component)
+                    || isCovered(component, by: durableCoverage)
+            case .title, .configuration, .message:
+                isCovered(component, by: durableCoverage)
+            }
+        }
+    }
+
+    private static func requiredComponents(
+        for mutation: WatchConversationMutation
+    ) -> [WatchLegacyEchoComponent] {
+        var components: [WatchLegacyEchoComponent] = []
+        if mutation.fields.contains(.create) {
+            components.append(.create(revision: mutation.createRevision ?? mutation.revision))
+        }
+        if mutation.fields.contains(.create) || mutation.fields.contains(.title) {
+            components.append(.title(
+                revision: mutation.titleRevision ?? mutation.createRevision ?? mutation.revision
+            ))
+        }
+        if mutation.fields.contains(.create) {
+            components.append(.configuration(
+                revision: mutation.configurationRevision ?? mutation.createRevision ?? mutation.revision
+            ))
+        }
+        if mutation.fields.contains(.messages) {
+            components.append(contentsOf: mutation.messageChanges.map { message in
+                .message(
+                    id: message.id,
+                    revision: mutation.messageChangeRevisions[message.id] ?? mutation.revision
+                )
+            })
+        }
+        return components
+    }
+
+    private static func unsupportedFields(
+        for mutation: WatchConversationMutation
+    ) -> WatchConversationMutationFields {
+        var fields: WatchConversationMutationFields = []
+        if mutation.fields.contains(.delete) {
+            fields.insert(.delete)
+        }
+        if mutation.fields.contains(.configuration), !mutation.fields.contains(.create) {
+            fields.insert(.configuration)
+        }
+        return fields
+    }
+
+    private static func isCovered(
+        _ component: WatchLegacyEchoComponent,
+        by coverage: WatchMutationDeliveryCoverage?
+    ) -> Bool {
+        guard let coverage else { return false }
+        switch component {
+        case let .create(revision):
+            return coverage.createRevision ?? 0 >= revision
+        case let .title(revision):
+            return coverage.titleRevision ?? 0 >= revision
+        case let .configuration(revision):
+            return coverage.configurationRevision ?? 0 >= revision
+        case let .message(id, revision):
+            return coverage.messageRevisions[id, default: 0] >= revision
+        }
+    }
+
+    private static func configurationMatches(
+        _ mutation: WatchConversation,
+        _ echo: WatchConversation
+    ) -> Bool {
+        mutation.model == echo.model
+            && mutation.temperature == echo.temperature
+            && mutation.resolvedSystemPrompt == echo.resolvedSystemPrompt
+    }
+}
+
+struct WatchMemoryFactsPayload: Equatable, Sendable {
+    let data: Data?
+    let preservesAcrossFallbacks: Bool
+}
+
+struct WatchApplicationContextAttempt {
+    let snapshotBytes: Int
+    let facts: Data?
+    let modelLimit: Int?
+    let maximumDefaultSystemPromptCharacters: Int
+
+    static func fallbacks(memoryFacts: WatchMemoryFactsPayload) -> [Self] {
+        let fallbackFacts = memoryFacts.preservesAcrossFallbacks ? memoryFacts.data : nil
+        return [
+            Self(
+                snapshotBytes: 32000,
+                facts: memoryFacts.data,
+                modelLimit: nil,
+                maximumDefaultSystemPromptCharacters: 4000
+            ),
+            Self(
+                snapshotBytes: 24000,
+                facts: fallbackFacts,
+                modelLimit: nil,
+                maximumDefaultSystemPromptCharacters: 4000
+            ),
+            Self(
+                snapshotBytes: 12000,
+                facts: fallbackFacts,
+                modelLimit: 20,
+                maximumDefaultSystemPromptCharacters: 2000
+            ),
+            Self(
+                snapshotBytes: 4000,
+                facts: fallbackFacts,
+                modelLimit: 5,
+                maximumDefaultSystemPromptCharacters: 0
+            )
+        ]
+    }
+}
+
+enum WatchPayloadStringLimiter {
+    static func limit(_ value: String, maximumCharacters: Int) -> String {
+        String(value.prefix(max(0, maximumCharacters)))
+    }
+
+    static func losslessRepresentation(
+        _ value: String,
+        maximumCharacters: Int
+    ) -> String? {
+        if value.isEmpty {
+            return ""
+        }
+        guard maximumCharacters > 0, value.count <= maximumCharacters else {
+            return nil
+        }
+        return value
+    }
+}
+
+enum WatchContextKeys {
+    static let syncSnapshot = "syncSnapshot"
+    static let syncPageCycle = "syncPageCycle"
+    static let conversations = "conversations"
+    static let selectedModel = "selectedModel"
+    static let availableModels = "availableModels"
+    static let customModels = "customModels"
+    static let defaultProvider = "defaultProvider"
+    static let modelProviders = "modelProviders"
+    static let modelEndpoints = "modelEndpoints"
+    static let modelEndpointTypes = "modelEndpointTypes"
+    static let modelUsesGitHubOAuth = "modelUsesGitHubOAuth"
+    static let modelAPIKeys = "modelAPIKeys"
+    static let removedModelDigests = "removedModelDigests"
+    static let removedModelProviderDigests = "removedModelProviderDigests"
+    static let removedModelEndpointDigests = "removedModelEndpointDigests"
+    static let removedModelEndpointTypeDigests = "removedModelEndpointTypeDigests"
+    static let removedModelGitHubOAuthDigests = "removedModelGitHubOAuthDigests"
+    static let removedModelAPIKeyDigests = "removedModelAPIKeyDigests"
+    static let modelMetadataEpoch = "modelMetadataEpoch"
+    static let modelMetadataComplete = "modelMetadataComplete"
+    static let githubAccessToken = "githubAccessToken"
+    static let tavilyAPIKey = "tavilyAPIKey"
+    static let tavilyEnabled = "tavilyEnabled"
+    static let webFetchEnabled = "webFetchEnabled"
+    static let memoryEnabled = "memoryEnabled"
+    static let memoryFacts = "memoryFacts"
+    static let defaultSystemPrompt = "defaultSystemPrompt"
+    static let lastSyncDate = "lastSyncDate"
+}
+
+enum WatchMessageKeys {
+    static let type = "type"
+    static let conversation = "conversation"
+    static let mutation = "mutation"
+    static let newMessage = "newMessage"
+    static let conversationId = "conversationId"
+    static let title = "title"
+    static let acknowledgedRevision = "acknowledgedRevision"
+    static let operationId = "operationId"
+    static let peerId = "peerId"
+    static let status = "status"
+    static let schemaVersion = "schemaVersion"
+    static let mutationRevision = "mutationRevision"
+    static let configurationRevision = "configurationRevision"
+    static let legacyComponentId = "legacyComponentId"
+    static let legacyComponentKind = "legacyComponentKind"
+    static let messageId = "messageId"
+    static let pageCycleRequest = "pageCycleRequest"
+
+    static let typeMutation = "watchConversationMutation"
+    static let typeMutationFile = "watchConversationMutationFile"
+    static let typeMutationAck = "watchConversationMutationAck"
+    static let typeNewMessage = "newMessage"
+    static let typeNewConversation = "newConversation"
+    static let typeRequestSync = "requestSync"
+    static let typeTitleUpdate = "titleUpdate"
+
+    static let legacyComponentCreate = "create"
+    static let legacyComponentMessage = "message"
+    static let legacyComponentTitle = "title"
+}
+
+enum WatchSyncMetadataCodec {
+    static func encodeRevisionMap(_ map: [UUID: WatchSyncRevision]) -> Data? {
+        let stringMap = WatchSyncRevisionMapCodec.encode(map)
+        return try? JSONEncoder().encode(stringMap)
+    }
+
+    static func decodeRevisionMap(_ data: Data?) -> [UUID: WatchSyncRevision] {
+        guard let data,
+              let stringMap = try? JSONDecoder().decode([String: WatchSyncRevision].self, from: data)
+        else {
+            return [:]
+        }
+        return WatchSyncRevisionMapCodec.decode(stringMap)
+    }
+
+    static func encodePeerRevisionMaps(
+        _ maps: [UUID: [UUID: WatchSyncRevision]]
+    ) -> Data? {
+        var stringMaps: [String: [String: WatchSyncRevision]] = [:]
+        for (peerID, revisions) in maps {
+            stringMaps[peerID.uuidString] = WatchSyncRevisionMapCodec.encode(revisions)
+        }
+        return try? JSONEncoder().encode(stringMaps)
+    }
+
+    static func decodePeerRevisionMaps(
+        _ data: Data?
+    ) -> [UUID: [UUID: WatchSyncRevision]] {
+        guard let data,
+              let stringMaps = try? JSONDecoder().decode(
+                  [String: [String: WatchSyncRevision]].self,
+                  from: data
+              )
+        else {
+            return [:]
+        }
+        var decodedMaps: [UUID: [UUID: WatchSyncRevision]] = [:]
+        for (peerID, revisions) in stringMaps {
+            guard let peerUUID = UUID(uuidString: peerID) else { continue }
+            var merged = decodedMaps[peerUUID] ?? [:]
+            WatchSyncRevisionMapCodec.merge(
+                WatchSyncRevisionMapCodec.decode(revisions),
+                into: &merged
+            )
+            decodedMaps[peerUUID] = merged
+        }
+        return decodedMaps
+    }
+}
+
+@MainActor
+enum WatchPhonePublicationBarrier {
+    static func prepare(
+        pendingOperationCount: @escaping @MainActor () -> Int,
+        reconcile: @escaping @MainActor () -> Void
+    ) -> Bool {
+        reconcile()
+        return pendingOperationCount() == 0
+    }
+}
+
+@MainActor
+enum WatchLegacyPersistenceBarrier {
+    static func perform<Changes: Publisher>(
+        pendingOperationCount: @escaping @MainActor () -> Int,
+        changes: Changes,
+        reconcile: @escaping @MainActor () -> Void,
+        apply: @escaping @MainActor () async -> Void
+    ) async where Changes.Output == Int, Changes.Failure == Never {
+        while true {
+            if pendingOperationCount() > 0 {
+                for await _ in changes.values where pendingOperationCount() == 0 {
+                    break
+                }
+            }
+
+            reconcile()
+            guard pendingOperationCount() > 0 else {
+                await apply()
+                return
+            }
+        }
+    }
+}
+
+struct WatchSyncSourceMetadata: Equatable, Sendable {
+    let sourceID: UUID
+    let snapshotRevision: WatchSyncRevision
+
+    static func resolve(
+        persistedSourceID: String?,
+        persistedSnapshotRevision: Any?,
+        replacementSourceID: UUID
+    ) -> Self {
+        guard let persistedSourceID,
+              let sourceID = UUID(uuidString: persistedSourceID),
+              let snapshotRevision = WatchSyncValueDecoder.revision(persistedSnapshotRevision)
+        else {
+            return Self(sourceID: replacementSourceID, snapshotRevision: 0)
+        }
+        return Self(sourceID: sourceID, snapshotRevision: snapshotRevision)
+    }
+}
+
+enum WatchSyncPersistenceKeys {
+    static let sourceID = "com.sertacozercan.ayna.watchSync.sourceID"
+    static let snapshotRevision = "com.sertacozercan.ayna.watchSync.snapshotRevision"
+    static let acknowledgedWatchRevisions = "com.sertacozercan.ayna.watchSync.acknowledgedWatchRevisions"
+    static let acknowledgedWatchRevisionsByPeer =
+        "com.sertacozercan.ayna.watchSync.acknowledgedWatchRevisionsByPeer"
+    static let activeWatchPeerID = "com.sertacozercan.ayna.watchSync.activeWatchPeerID"
+    static let tombstoneRevisions = "com.sertacozercan.ayna.watchSync.tombstoneRevisions"
+    static let authoritativeConversationIDs = "com.sertacozercan.ayna.watchSync.authoritativeConversationIDs"
+    static let modelRemovalTracker = "com.sertacozercan.ayna.watchSync.modelRemovalTracker"
+    static let appliedModelMetadataEpoch = "com.sertacozercan.ayna.watchSync.appliedModelMetadataEpoch"
+    static let legacyPlaceholderConversationIDs =
+        "com.sertacozercan.ayna.watchSync.legacyPlaceholderConversationIDs"
+    static let defaultSystemPrompt = "com.sertacozercan.ayna.watchSync.defaultSystemPrompt"
+}
+
+enum WatchApplicationContextSizer {
+    static let maximumSafeBytes = 60000
+
+    static func size(_ context: [String: Any]) -> Int {
+        guard PropertyListSerialization.propertyList(context, isValidFor: .binary) else { return .max }
+        return (try? PropertyListSerialization.data(
+            fromPropertyList: context,
+            format: .binary,
+            options: 0
+        ).count) ?? .max
+    }
+
+    static func isWithinSafeLimit(_ context: [String: Any]) -> Bool {
+        size(context) <= maximumSafeBytes
+    }
+}
+
+struct WatchPeerCapabilityState: Equatable, Sendable {
+    enum Event: Equatable, Sendable {
+        case reset
+        case advertisedMaximumSchema(Int?)
+        case receivedMutation
+    }
+
+    private(set) var supportsCurrentSchema = false
+
+    mutating func apply(_ event: Event) {
+        switch event {
+        case .reset:
+            supportsCurrentSchema = false
+        case let .advertisedMaximumSchema(schemaVersion):
+            supportsCurrentSchema = schemaVersion.map {
+                $0 >= WatchSyncSnapshot.currentSchemaVersion
+            } ?? false
+        case .receivedMutation:
+            break
+        }
+    }
+}
+
+enum WatchSyncCapability {
+    static func advertisedMaximumSchemaVersion(_ value: Any?) -> Int? {
+        guard let decoded = WatchSyncValueDecoder.revision(value),
+              decoded > 0,
+              let schemaVersion = Int(exactly: decoded)
+        else {
+            return nil
+        }
+        return schemaVersion
+    }
+
+    static func supportsCurrentSchema(_ advertisedMaximumSchema: Any?) -> Bool {
+        guard let advertisedMaximumSchemaVersion = advertisedMaximumSchemaVersion(
+            advertisedMaximumSchema
+        ) else {
+            return false
+        }
+        return advertisedMaximumSchemaVersion >= WatchSyncSnapshot.currentSchemaVersion
+    }
+}
+
+enum WatchMutationIngressRejection: Equatable, Sendable {
+    case malformedSchema
+    case unsupportedSchema(Int)
+    case emptyFieldMask
+    case unknownFieldMask(UInt8)
+}
+
+enum WatchMutationIngressValidation: Equatable, Sendable {
+    case accepted(schemaVersion: Int)
+    case rejected(WatchMutationIngressRejection)
+}
+
+enum WatchMutationIngressValidator {
+    private static let supportedFieldMask = WatchConversationMutationFields.fullState
+        .union(.delete)
+        .rawValue
+
+    static func validate(
+        schemaVersion value: Any?,
+        fields: WatchConversationMutationFields
+    ) -> WatchMutationIngressValidation {
+        guard let schemaVersion = WatchSyncCapability.advertisedMaximumSchemaVersion(value) else {
+            return .rejected(.malformedSchema)
+        }
+        guard WatchSyncSnapshot.supportsSchemaVersion(schemaVersion) else {
+            return .rejected(.unsupportedSchema(schemaVersion))
+        }
+        guard !fields.isEmpty else {
+            return .rejected(.emptyFieldMask)
+        }
+        let unknownFieldMask = fields.rawValue & ~supportedFieldMask
+        guard unknownFieldMask == 0 else {
+            return .rejected(.unknownFieldMask(unknownFieldMask))
+        }
+        return .accepted(schemaVersion: schemaVersion)
+    }
+}
+
+enum WatchSyncValueDecoder {
+    static func revision(_ value: Any?) -> WatchSyncRevision? {
+        guard let number = value as? NSNumber else {
+            return value as? WatchSyncRevision
+        }
+        guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
+
+        if let decimal = number as? NSDecimalNumber {
+            return revision(from: decimal)
+        }
+
+        switch String(cString: number.objCType) {
+        case "c", "s", "i", "l", "q":
+            let signed = number.int64Value
+            return signed >= 0 ? WatchSyncRevision(signed) : nil
+        case "C", "S", "I", "L", "Q":
+            return number.uint64Value
+        case "f", "d":
+            return WatchSyncRevision(exactly: number.doubleValue)
+        default:
+            return nil
+        }
+    }
+
+    private static func revision(from decimal: NSDecimalNumber) -> WatchSyncRevision? {
+        guard decimal != .notANumber else { return nil }
+        let zero = NSDecimalNumber(value: 0)
+        let maximum = NSDecimalNumber(string: String(WatchSyncRevision.max))
+        guard decimal.compare(zero) != .orderedAscending,
+              decimal.compare(maximum) != .orderedDescending
+        else {
+            return nil
+        }
+
+        let behavior = NSDecimalNumberHandler(
+            roundingMode: .down,
+            scale: 0,
+            raiseOnExactness: false,
+            raiseOnOverflow: false,
+            raiseOnUnderflow: false,
+            raiseOnDivideByZero: false
+        )
+        guard decimal.rounding(accordingToBehavior: behavior).compare(decimal) == .orderedSame else {
+            return nil
+        }
+
+        let revision = decimal.uint64Value
+        guard NSDecimalNumber(value: revision).compare(decimal) == .orderedSame else { return nil }
+        return revision
+    }
+}
+
+#if os(iOS) || os(watchOS)
+    import WatchConnectivity
+#endif
+
+@MainActor
+enum WatchLegacyMutationSender {
+    private static let maximumMessageComponentsPerBatch =
+        WatchSyncPayloadConfiguration.default.maximumMessagesPerConversation
+
+    static func prepare(
+        _ mutation: WatchConversationMutation,
+        tracker: WatchLegacyDeliveryTracker
+    ) throws -> WatchLegacySendResult {
+        guard !mutation.fields.contains(.delete) else {
+            return WatchLegacySendResult(userInfos: [], fullyRepresented: false)
+        }
+
+        var userInfos: [[String: Any]] = []
+        let createWillBeSent = mutation.fields.contains(.create) &&
+            tracker.needsCreate(conversationID: mutation.conversationID)
+        if createWillBeSent {
+            var conversation = mutation.conversation
+            conversation.messages = []
+            let revision = mutation.createRevision ?? mutation.revision
+            let componentID = WatchLegacyComponentIdentity.create(
+                conversationID: mutation.conversationID,
+                revision: revision
+            )
+            try userInfos.append([
+                WatchMessageKeys.type: WatchMessageKeys.typeNewConversation,
+                WatchMessageKeys.conversation: JSONEncoder().encode(conversation),
+                WatchMessageKeys.conversationId: mutation.conversationID.uuidString,
+                WatchMessageKeys.peerId: mutation.peerID.uuidString,
+                WatchMessageKeys.mutationRevision: NSNumber(value: revision),
+                WatchMessageKeys.configurationRevision: NSNumber(
+                    value: mutation.configurationRevision ?? mutation.createRevision ?? revision
+                ),
+                WatchMessageKeys.operationId: mutation.operationID.uuidString,
+                WatchMessageKeys.legacyComponentId: componentID,
+                WatchMessageKeys.legacyComponentKind: WatchMessageKeys.legacyComponentCreate
+            ])
+        }
+
+        var awaitingEchoComponentIDs: Set<String> = []
+        if mutation.fields.contains(.messages) {
+            let selection = tracker.pendingMessageSendSelection(
+                from: mutation,
+                maximumCount: maximumMessageComponentsPerBatch
+            )
+            awaitingEchoComponentIDs.formUnion(selection.awaitingEchoComponentIDs)
+            for messageChange in selection.messages {
+                let revision = mutation.messageChangeRevisions[messageChange.id] ?? mutation.revision
+                let componentID = WatchLegacyComponentIdentity.message(
+                    messageID: messageChange.id,
+                    revision: revision
+                )
+                try userInfos.append([
+                    WatchMessageKeys.type: WatchMessageKeys.typeNewMessage,
+                    WatchMessageKeys.newMessage: JSONEncoder().encode(messageChange),
+                    WatchMessageKeys.conversationId: mutation.conversationID.uuidString,
+                    WatchMessageKeys.peerId: mutation.peerID.uuidString,
+                    WatchMessageKeys.mutationRevision: NSNumber(value: revision),
+                    WatchMessageKeys.messageId: messageChange.id.uuidString,
+                    WatchMessageKeys.operationId: mutation.operationID.uuidString,
+                    WatchMessageKeys.legacyComponentId: componentID,
+                    WatchMessageKeys.legacyComponentKind: WatchMessageKeys.legacyComponentMessage
+                ])
+            }
+        }
+
+        let titleRevision = mutation.titleRevision ?? mutation.createRevision ?? mutation.revision
+        if mutation.fields.contains(.create) || mutation.fields.contains(.title),
+           tracker.needsTitle(
+               conversationID: mutation.conversationID,
+               title: mutation.conversation.title,
+               revision: titleRevision
+           )
+        {
+            let componentID = WatchLegacyComponentIdentity.title(
+                conversationID: mutation.conversationID,
+                revision: titleRevision
+            )
+            userInfos.append([
+                WatchMessageKeys.type: WatchMessageKeys.typeTitleUpdate,
+                WatchMessageKeys.conversationId: mutation.conversationID.uuidString,
+                WatchMessageKeys.title: mutation.conversation.title,
+                WatchMessageKeys.peerId: mutation.peerID.uuidString,
+                WatchMessageKeys.mutationRevision: NSNumber(value: titleRevision),
+                WatchMessageKeys.operationId: mutation.operationID.uuidString,
+                WatchMessageKeys.legacyComponentId: componentID,
+                WatchMessageKeys.legacyComponentKind: WatchMessageKeys.legacyComponentTitle
+            ])
+        }
+
+        let userInfoComponentIDs = userInfos.compactMap {
+            $0[WatchMessageKeys.legacyComponentId] as? String
+        }
+        let userInfoEchoState = tracker.advanceAwaitingEcho(userInfoComponentIDs)
+        awaitingEchoComponentIDs.formUnion(userInfoEchoState.deferred)
+        userInfos.removeAll { userInfo in
+            guard let componentID = userInfo[WatchMessageKeys.legacyComponentId] as? String else {
+                return false
+            }
+            return awaitingEchoComponentIDs.contains(componentID)
+        }
+        let fullyRepresented = tracker.configurationIsRepresented(
+            by: mutation,
+            createWillBeSent: createWillBeSent
+        )
+        return WatchLegacySendResult(
+            userInfos: userInfos,
+            awaitingEchoComponentIDs: awaitingEchoComponentIDs,
+            fullyRepresented: fullyRepresented
+        )
+    }
+}
+
+@MainActor
+final class WatchRecentAcknowledgementTracker {
+    private let limit: Int
+    private(set) var ids: [UUID] = []
+
+    init(limit: Int = 64) {
+        self.limit = max(1, limit)
+    }
+
+    func record(_ id: UUID) {
+        ids.removeAll { $0 == id }
+        ids.insert(id, at: 0)
+        if ids.count > limit {
+            ids.removeLast(ids.count - limit)
+        }
+    }
+}
+
+@MainActor
+enum WatchConversationSyncObserver {
+    static func observe(
+        conversationManager: ConversationManager,
+        onSync: @escaping @MainActor ([Conversation]) -> Void
+    ) -> Set<AnyCancellable> {
+        var cancellables = Set<AnyCancellable>()
+
+        conversationManager.$conversations
+            .debounce(for: .seconds(1), scheduler: RunLoop.main)
+            .sink { [weak conversationManager] _ in
+                guard let conversationManager else { return }
+                onSync(conversationManager.durableConversationsForSync())
+            }
+            .store(in: &cancellables)
+
+        conversationManager.$durableConversationRevision
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak conversationManager] _ in
+                guard let conversationManager else { return }
+                onSync(conversationManager.durableConversationsForSync())
+            }
+            .store(in: &cancellables)
+
+        conversationManager.$pendingDestructivePersistenceOperations
+            .removeDuplicates()
+            .filter { $0 == 0 }
+            .sink { [weak conversationManager] _ in
+                Task { @MainActor in
+                    guard let conversationManager else { return }
+                    onSync(conversationManager.durableConversationsForSync())
+                }
+            }
+            .store(in: &cancellables)
+
+        conversationManager.$isConversationStateAuthoritative
+            .removeDuplicates()
+            .filter(\.self)
+            .sink { [weak conversationManager] _ in
+                Task { @MainActor in
+                    guard let conversationManager else { return }
+                    onSync(conversationManager.durableConversationsForSync())
+                }
+            }
+            .store(in: &cancellables)
+
+        AIService.shared.objectWillChange
+            .merge(with: TavilyService.shared.objectWillChange)
+            .debounce(for: .seconds(1), scheduler: RunLoop.main)
+            .sink { [weak conversationManager] _ in
+                guard let conversationManager else { return }
+                onSync(conversationManager.durableConversationsForSync())
+            }
+            .store(in: &cancellables)
+
+        GitHubOAuthService.shared.$isAuthenticated
+            .map { _ in () }
+            .merge(with: GitHubOAuthService.shared.$tokenExpiresAt.map { _ in () })
+            .debounce(for: .seconds(1), scheduler: RunLoop.main)
+            .sink { [weak conversationManager] _ in
+                guard let conversationManager else { return }
+                onSync(conversationManager.durableConversationsForSync())
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(
+            for: .globalSystemPromptDidChange
+        )
+        .merge(with: NotificationCenter.default.publisher(for: .watchSyncContextDidChange))
+        .debounce(for: .seconds(1), scheduler: RunLoop.main)
+        .sink { [weak conversationManager] _ in
+            guard let conversationManager else { return }
+            onSync(conversationManager.durableConversationsForSync())
+        }
+        .store(in: &cancellables)
+
+        return cancellables
+    }
+}
+
+struct WatchModelSyncPublication: Equatable, Sendable {
+    let availableModels: [String]
+    let metadataModels: [String]
+
+    var metadataModelIDs: Set<String> {
+        Set(metadataModels)
+    }
+
+    func metadataValues<Value>(from values: [String: Value]) -> [String: Value] {
+        let includedModels = metadataModelIDs
+        return values.filter { includedModels.contains($0.key) }
+    }
+}
+
+enum WatchModelSyncSelection {
+    static func publication(
+        selectedModel: String,
+        availableModels: [String],
+        authoritativeState: PhoneWatchSyncState,
+        snapshot: WatchSyncSnapshot,
+        limit: Int?
+    ) -> WatchModelSyncPublication {
+        makePublication(
+            availableModels: selectableModels(
+                selectedModel: selectedModel,
+                availableModels: availableModels,
+                limit: limit
+            ),
+            metadataModels: models(
+                selectedModel: selectedModel,
+                availableModels: availableModels,
+                authoritativeState: authoritativeState,
+                snapshot: snapshot,
+                limit: limit
+            )
+        )
+    }
+
+    static func models(
+        selectedModel: String,
+        availableModels: [String],
+        authoritativeState: PhoneWatchSyncState,
+        snapshot: WatchSyncSnapshot,
+        limit: Int?
+    ) -> [String] {
+        var authoritativeModelsByID: [UUID: String] = [:]
+        for conversation in authoritativeState.conversations {
+            authoritativeModelsByID[conversation.id] = conversation.model
+        }
+
+        var representedRecords = snapshot.conversations.map { ($0.id, $0.model) }
+        representedRecords.append(contentsOf: snapshot.conversationConfigurations.map {
+            ($0.id, $0.model)
+        })
+        var seenConversationIDs: Set<UUID> = []
+        let referencedModels = representedRecords.compactMap { record -> String? in
+            let (conversationID, boundedModel) = record
+            guard seenConversationIDs.insert(conversationID).inserted else { return nil }
+            return authoritativeModelsByID[conversationID] ?? boundedModel
+        }
+
+        return models(
+            selectedModel: selectedModel,
+            availableModels: availableModels,
+            referencedModels: referencedModels,
+            limit: limit
+        )
+    }
+
+    static func selectableModels(
+        selectedModel: String,
+        availableModels: [String],
+        limit: Int?
+    ) -> [String] {
+        let configured = Set(availableModels.filter { !$0.isEmpty })
+        return models(
+            selectedModel: configured.contains(selectedModel) ? selectedModel : "",
+            availableModels: availableModels,
+            referencedModels: [],
+            limit: limit
+        )
+    }
+
+    static func publication(
+        selectedModel: String,
+        availableModels: [String],
+        referencedModels: [String],
+        limit: Int?
+    ) -> WatchModelSyncPublication {
+        makePublication(
+            availableModels: selectableModels(
+                selectedModel: selectedModel,
+                availableModels: availableModels,
+                limit: limit
+            ),
+            metadataModels: models(
+                selectedModel: selectedModel,
+                availableModels: availableModels,
+                referencedModels: referencedModels,
+                limit: limit
+            )
+        )
+    }
+
+    private static func makePublication(
+        availableModels: [String],
+        metadataModels: [String]
+    ) -> WatchModelSyncPublication {
+        var metadataModels = metadataModels
+        var metadataModelIDs = Set(metadataModels)
+        metadataModels.append(contentsOf: availableModels.filter {
+            metadataModelIDs.insert($0).inserted
+        })
+        return WatchModelSyncPublication(
+            availableModels: availableModels,
+            metadataModels: metadataModels
+        )
+    }
+
+    static func models(
+        selectedModel: String,
+        availableModels: [String],
+        referencedModels: [String],
+        limit: Int?
+    ) -> [String] {
+        var result: [String] = []
+        var seen: Set<String> = []
+        for model in [selectedModel] + referencedModels + availableModels
+            where !model.isEmpty && seen.insert(model).inserted
+        {
+            result.append(model)
+        }
+        guard let limit else { return result }
+        let requiredCount = Set(([selectedModel] + referencedModels).filter { !$0.isEmpty }).count
+        return Array(result.prefix(max(limit, requiredCount)))
+    }
+}
+
+enum WatchDefaultSystemPromptPersistence {
+    static func load(from userDefaults: UserDefaults = .standard) -> String? {
+        userDefaults.string(forKey: WatchSyncPersistenceKeys.defaultSystemPrompt)
+    }
+
+    static func store(
+        _ value: String?,
+        in userDefaults: UserDefaults = .standard
+    ) {
+        if let value {
+            userDefaults.set(value, forKey: WatchSyncPersistenceKeys.defaultSystemPrompt)
+        } else {
+            userDefaults.removeObject(forKey: WatchSyncPersistenceKeys.defaultSystemPrompt)
+        }
+    }
+}
+
+enum WatchDefaultSystemPromptReducer {
+    static func value(current: String?, incoming: Any?) -> String? {
+        guard let incoming = incoming as? String else { return current }
+        return incoming.isEmpty ? nil : incoming
+    }
+}
+
+enum WatchModelIdentity {
+    static func digest(_ modelID: String) -> String {
+        SHA256.hash(data: Data(modelID.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}
+
+struct WatchModelMetadataValueDigests: Codable, Equatable, Sendable {
+    var providers: [String: String] = [:]
+    var endpoints: [String: String] = [:]
+    var endpointTypes: [String: String] = [:]
+    var gitHubOAuth: [String: String] = [:]
+    var apiKeys: [String: String] = [:]
+
+    static func hashing(
+        providers: [String: String],
+        endpoints: [String: String],
+        endpointTypes: [String: String],
+        gitHubOAuth: [String: Bool],
+        apiKeys: [String: String]
+    ) -> Self {
+        Self(
+            providers: digestValues(providers, value: { $0 }),
+            endpoints: digestValues(endpoints, value: { $0 }),
+            endpointTypes: digestValues(endpointTypes, value: { $0 }),
+            gitHubOAuth: digestValues(gitHubOAuth, value: { String($0) }),
+            apiKeys: digestValues(apiKeys, value: { $0 })
+        )
+    }
+
+    private static func digestValues<Value>(
+        _ values: [String: Value],
+        value: (Value) -> String
+    ) -> [String: String] {
+        values.reduce(into: [:]) { result, entry in
+            result[WatchModelIdentity.digest(entry.key)] = WatchModelIdentity.digest(value(entry.value))
+        }
+    }
+}
+
+struct WatchModelMetadataInventory: Equatable, Sendable {
+    var modelIDs: [String]
+    var providerModelIDs: [String]
+    var endpointModelIDs: [String]
+    var endpointTypeModelIDs: [String]
+    var gitHubOAuthModelIDs: [String]
+    var apiKeyModelIDs: [String]
+    var valueDigests = WatchModelMetadataValueDigests()
+}
+
+struct WatchModelRemovalPublication: Equatable, Sendable {
+    let removedModelDigests: [String]
+    let removedProviderDigests: [String]
+    let removedEndpointDigests: [String]
+    let removedEndpointTypeDigests: [String]
+    let removedGitHubOAuthDigests: [String]
+    let removedAPIKeyDigests: [String]
+
+    var isEmpty: Bool {
+        removedModelDigests.isEmpty
+            && removedProviderDigests.isEmpty
+            && removedEndpointDigests.isEmpty
+            && removedEndpointTypeDigests.isEmpty
+            && removedGitHubOAuthDigests.isEmpty
+            && removedAPIKeyDigests.isEmpty
+    }
+}
+
+struct WatchModelRemovalTracker: Codable, Equatable, Sendable {
+    static let maximumRetiredDigestCount = 256
+
+    private struct ChangedValueDigests {
+        let providers: Set<String>
+        let endpoints: Set<String>
+        let endpointTypes: Set<String>
+        let gitHubOAuth: Set<String>
+        let apiKeys: Set<String>
+    }
+
+    private(set) var epoch: UUID
+    private(set) var publishedDigests: Set<String>
+    private(set) var retiredDigests: Set<String>
+    private(set) var publishedProviderDigests: Set<String>
+    private(set) var retiredProviderDigests: Set<String>
+    private(set) var publishedEndpointDigests: Set<String>
+    private(set) var retiredEndpointDigests: Set<String>
+    private(set) var publishedEndpointTypeDigests: Set<String>
+    private(set) var retiredEndpointTypeDigests: Set<String>
+    private(set) var publishedGitHubOAuthDigests: Set<String>
+    private(set) var retiredGitHubOAuthDigests: Set<String>
+    private(set) var publishedAPIKeyDigests: Set<String>
+    private(set) var retiredAPIKeyDigests: Set<String>
+    private(set) var publishedValueDigests: WatchModelMetadataValueDigests?
+
+    init(epoch: UUID = UUID()) {
+        self.epoch = epoch
+        publishedDigests = []
+        retiredDigests = []
+        publishedProviderDigests = []
+        retiredProviderDigests = []
+        publishedEndpointDigests = []
+        retiredEndpointDigests = []
+        publishedEndpointTypeDigests = []
+        retiredEndpointTypeDigests = []
+        publishedGitHubOAuthDigests = []
+        retiredGitHubOAuthDigests = []
+        publishedAPIKeyDigests = []
+        retiredAPIKeyDigests = []
+        publishedValueDigests = WatchModelMetadataValueDigests()
+    }
+
+    mutating func publication(
+        inventory: WatchModelMetadataInventory
+    ) -> WatchModelRemovalPublication {
+        let valueChanges = Self.changedValueDigests(
+            from: publishedValueDigests,
+            to: inventory.valueDigests
+        )
+        publishedValueDigests = inventory.valueDigests
+
+        let models = Self.advance(
+            currentModelIDs: inventory.modelIDs,
+            published: publishedDigests,
+            retired: retiredDigests
+        )
+        publishedDigests = models.published
+        retiredDigests = models.retired
+
+        let providers = Self.advance(
+            currentModelIDs: inventory.providerModelIDs,
+            published: publishedProviderDigests,
+            retired: retiredProviderDigests,
+            invalidated: valueChanges.providers,
+            retainsCurrentTombstones: true
+        )
+        publishedProviderDigests = providers.published
+        retiredProviderDigests = providers.retired
+
+        let endpoints = Self.advance(
+            currentModelIDs: inventory.endpointModelIDs,
+            published: publishedEndpointDigests,
+            retired: retiredEndpointDigests,
+            invalidated: valueChanges.endpoints,
+            retainsCurrentTombstones: true
+        )
+        publishedEndpointDigests = endpoints.published
+        retiredEndpointDigests = endpoints.retired
+
+        let endpointTypes = Self.advance(
+            currentModelIDs: inventory.endpointTypeModelIDs,
+            published: publishedEndpointTypeDigests,
+            retired: retiredEndpointTypeDigests,
+            invalidated: valueChanges.endpointTypes,
+            retainsCurrentTombstones: true
+        )
+        publishedEndpointTypeDigests = endpointTypes.published
+        retiredEndpointTypeDigests = endpointTypes.retired
+
+        let gitHubOAuth = Self.advance(
+            currentModelIDs: inventory.gitHubOAuthModelIDs,
+            published: publishedGitHubOAuthDigests,
+            retired: retiredGitHubOAuthDigests,
+            invalidated: valueChanges.gitHubOAuth,
+            retainsCurrentTombstones: true
+        )
+        publishedGitHubOAuthDigests = gitHubOAuth.published
+        retiredGitHubOAuthDigests = gitHubOAuth.retired
+
+        let apiKeys = Self.advance(
+            currentModelIDs: inventory.apiKeyModelIDs,
+            published: publishedAPIKeyDigests,
+            retired: retiredAPIKeyDigests,
+            invalidated: valueChanges.apiKeys,
+            retainsCurrentTombstones: true
+        )
+        publishedAPIKeyDigests = apiKeys.published
+        retiredAPIKeyDigests = apiKeys.retired
+
+        if retiredDigestCount > Self.maximumRetiredDigestCount {
+            rotateEpoch(seeding: inventory)
+            return WatchModelRemovalPublication(
+                removedModelDigests: [],
+                removedProviderDigests: [],
+                removedEndpointDigests: [],
+                removedEndpointTypeDigests: [],
+                removedGitHubOAuthDigests: [],
+                removedAPIKeyDigests: []
+            )
+        }
+
+        return WatchModelRemovalPublication(
+            removedModelDigests: models.retired.sorted(),
+            removedProviderDigests: providers.retired.sorted(),
+            removedEndpointDigests: endpoints.retired.sorted(),
+            removedEndpointTypeDigests: endpointTypes.retired.sorted(),
+            removedGitHubOAuthDigests: gitHubOAuth.retired.sorted(),
+            removedAPIKeyDigests: apiKeys.retired.sorted()
+        )
+    }
+
+    private var retiredDigestCount: Int {
+        retiredDigests.count
+            + retiredProviderDigests.count
+            + retiredEndpointDigests.count
+            + retiredEndpointTypeDigests.count
+            + retiredGitHubOAuthDigests.count
+            + retiredAPIKeyDigests.count
+    }
+
+    private mutating func rotateEpoch(seeding inventory: WatchModelMetadataInventory) {
+        epoch = UUID()
+        publishedDigests = Self.digests(inventory.modelIDs)
+        retiredDigests = []
+        publishedProviderDigests = Self.digests(inventory.providerModelIDs)
+        retiredProviderDigests = []
+        publishedEndpointDigests = Self.digests(inventory.endpointModelIDs)
+        retiredEndpointDigests = []
+        publishedEndpointTypeDigests = Self.digests(inventory.endpointTypeModelIDs)
+        retiredEndpointTypeDigests = []
+        publishedGitHubOAuthDigests = Self.digests(inventory.gitHubOAuthModelIDs)
+        retiredGitHubOAuthDigests = []
+        publishedAPIKeyDigests = Self.digests(inventory.apiKeyModelIDs)
+        retiredAPIKeyDigests = []
+        publishedValueDigests = inventory.valueDigests
+    }
+
+    private static func digests(_ modelIDs: [String]) -> Set<String> {
+        Set(modelIDs.filter { !$0.isEmpty }.map(WatchModelIdentity.digest))
+    }
+
+    private static func advance(
+        currentModelIDs: [String],
+        published: Set<String>,
+        retired: Set<String>,
+        invalidated: Set<String> = [],
+        retainsCurrentTombstones: Bool = false
+    ) -> (published: Set<String>, retired: Set<String>) {
+        let current = digests(currentModelIDs)
+        var nextRetired = retired
+        nextRetired.formUnion(published.subtracting(current))
+        if !retainsCurrentTombstones {
+            nextRetired.subtract(current)
+        }
+        nextRetired.formUnion(invalidated)
+        return (current, nextRetired)
+    }
+
+    private static func changedValueDigests(
+        from previous: WatchModelMetadataValueDigests?,
+        to current: WatchModelMetadataValueDigests
+    ) -> ChangedValueDigests {
+        guard let previous else {
+            return ChangedValueDigests(
+                providers: [],
+                endpoints: [],
+                endpointTypes: [],
+                gitHubOAuth: [],
+                apiKeys: []
+            )
+        }
+        return ChangedValueDigests(
+            providers: changedModelDigests(from: previous.providers, to: current.providers),
+            endpoints: changedModelDigests(from: previous.endpoints, to: current.endpoints),
+            endpointTypes: changedModelDigests(from: previous.endpointTypes, to: current.endpointTypes),
+            gitHubOAuth: changedModelDigests(from: previous.gitHubOAuth, to: current.gitHubOAuth),
+            apiKeys: changedModelDigests(from: previous.apiKeys, to: current.apiKeys)
+        )
+    }
+
+    private static func changedModelDigests(
+        from previous: [String: String],
+        to current: [String: String]
+    ) -> Set<String> {
+        Set(current.compactMap { modelDigest, valueDigest in
+            guard let previousValueDigest = previous[modelDigest],
+                  previousValueDigest != valueDigest
+            else {
+                return nil
+            }
+            return modelDigest
+        })
+    }
+}
+
+struct WatchModelMetadataState: Equatable, Sendable {
+    var selectedModel: String
+    var availableModels: [String]
+    var customModels: [String]
+    var defaultProvider: String
+    var modelProviders: [String: String]
+    var modelEndpoints: [String: String]
+    var modelEndpointTypes: [String: String]
+    var modelUsesGitHubOAuth: [String: Bool]
+    var modelAPIKeys: [String: String]
+
+    mutating func merge(_ page: WatchModelMetadataPage) {
+        applyRemovals(from: page)
+        if let selectedModel = page.selectedModel {
+            self.selectedModel = selectedModel
+        }
+        if let availableModels = page.availableModels {
+            self.availableModels = mergingUnique(self.availableModels, availableModels)
+        }
+        if let customModels = page.customModels {
+            self.customModels = mergingUnique(self.customModels, customModels)
+        }
+        if let defaultProvider = page.defaultProvider {
+            self.defaultProvider = defaultProvider
+        }
+        mergeValues(page.modelProviders, into: &modelProviders)
+        mergeValues(page.modelEndpoints, into: &modelEndpoints)
+        mergeValues(page.modelEndpointTypes, into: &modelEndpointTypes)
+        mergeValues(page.modelUsesGitHubOAuth, into: &modelUsesGitHubOAuth)
+        mergeValues(page.modelAPIKeys, into: &modelAPIKeys)
+    }
+
+    mutating func replace(with page: WatchModelMetadataPage) {
+        applyRemovals(from: page)
+        if let selectedModel = page.selectedModel {
+            self.selectedModel = selectedModel
+        }
+        availableModels = mergingUnique([], page.availableModels ?? [])
+        customModels = mergingUnique([], page.customModels ?? [])
+        if let defaultProvider = page.defaultProvider {
+            self.defaultProvider = defaultProvider
+        }
+        modelProviders = page.modelProviders ?? [:]
+        modelEndpoints = page.modelEndpoints ?? [:]
+        modelEndpointTypes = page.modelEndpointTypes ?? [:]
+        modelUsesGitHubOAuth = page.modelUsesGitHubOAuth ?? [:]
+        modelAPIKeys = page.modelAPIKeys ?? [:]
+    }
+
+    mutating func resetModelSpecificState() {
+        selectedModel = ""
+        availableModels = []
+        customModels = []
+        modelProviders = [:]
+        modelEndpoints = [:]
+        modelEndpointTypes = [:]
+        modelUsesGitHubOAuth = [:]
+        modelAPIKeys = [:]
+    }
+
+    private mutating func applyRemovals(from page: WatchModelMetadataPage) {
+        removeModels(withDigests: page.removedModelDigests)
+        removeEntries(withDigests: page.removedModelProviderDigests, from: &modelProviders)
+        removeEntries(withDigests: page.removedModelEndpointDigests, from: &modelEndpoints)
+        removeEntries(withDigests: page.removedModelEndpointTypeDigests, from: &modelEndpointTypes)
+        removeEntries(withDigests: page.removedModelGitHubOAuthDigests, from: &modelUsesGitHubOAuth)
+        removeEntries(withDigests: page.removedModelAPIKeyDigests, from: &modelAPIKeys)
+    }
+
+    private func removeEntries(
+        withDigests digests: [String]?,
+        from values: inout [String: some Any]
+    ) {
+        guard let digests, !digests.isEmpty else { return }
+        let removed = Set(digests)
+        values = values.filter { !removed.contains(WatchModelIdentity.digest($0.key)) }
+    }
+
+    private mutating func removeModels(withDigests digests: [String]?) {
+        guard let digests, !digests.isEmpty else { return }
+        let removed = Set(digests)
+        let isRetained: (String) -> Bool = { !removed.contains(WatchModelIdentity.digest($0)) }
+        if !isRetained(selectedModel) {
+            selectedModel = ""
+        }
+        availableModels.removeAll { !isRetained($0) }
+        customModels.removeAll { !isRetained($0) }
+        modelProviders = modelProviders.filter { isRetained($0.key) }
+        modelEndpoints = modelEndpoints.filter { isRetained($0.key) }
+        modelEndpointTypes = modelEndpointTypes.filter { isRetained($0.key) }
+        modelUsesGitHubOAuth = modelUsesGitHubOAuth.filter { isRetained($0.key) }
+        modelAPIKeys = modelAPIKeys.filter { isRetained($0.key) }
+    }
+}
+
+struct WatchModelMetadataPage: Equatable, Sendable {
+    var selectedModel: String?
+    var availableModels: [String]?
+    var customModels: [String]?
+    var defaultProvider: String?
+    var modelProviders: [String: String]?
+    var modelEndpoints: [String: String]?
+    var modelEndpointTypes: [String: String]?
+    var modelUsesGitHubOAuth: [String: Bool]?
+    var modelAPIKeys: [String: String]?
+    var removedModelDigests: [String]?
+    var removedModelProviderDigests: [String]?
+    var removedModelEndpointDigests: [String]?
+    var removedModelEndpointTypeDigests: [String]?
+    var removedModelGitHubOAuthDigests: [String]?
+    var removedModelAPIKeyDigests: [String]?
+
+    init(
+        selectedModel: String? = nil,
+        availableModels: [String]? = nil,
+        customModels: [String]? = nil,
+        defaultProvider: String? = nil,
+        modelProviders: [String: String]? = nil,
+        modelEndpoints: [String: String]? = nil,
+        modelEndpointTypes: [String: String]? = nil,
+        modelUsesGitHubOAuth: [String: Bool]? = nil,
+        modelAPIKeys: [String: String]? = nil,
+        removedModelDigests: [String]? = nil,
+        removedModelProviderDigests: [String]? = nil,
+        removedModelEndpointDigests: [String]? = nil,
+        removedModelEndpointTypeDigests: [String]? = nil,
+        removedModelGitHubOAuthDigests: [String]? = nil,
+        removedModelAPIKeyDigests: [String]? = nil
+    ) {
+        self.selectedModel = selectedModel
+        self.availableModels = availableModels
+        self.customModels = customModels
+        self.defaultProvider = defaultProvider
+        self.modelProviders = modelProviders
+        self.modelEndpoints = modelEndpoints
+        self.modelEndpointTypes = modelEndpointTypes
+        self.modelUsesGitHubOAuth = modelUsesGitHubOAuth
+        self.modelAPIKeys = modelAPIKeys
+        self.removedModelDigests = removedModelDigests
+        self.removedModelProviderDigests = removedModelProviderDigests
+        self.removedModelEndpointDigests = removedModelEndpointDigests
+        self.removedModelEndpointTypeDigests = removedModelEndpointTypeDigests
+        self.removedModelGitHubOAuthDigests = removedModelGitHubOAuthDigests
+        self.removedModelAPIKeyDigests = removedModelAPIKeyDigests
+    }
+
+    init(context: [String: Any]) {
+        self.init(
+            selectedModel: context[WatchContextKeys.selectedModel] as? String,
+            availableModels: context[WatchContextKeys.availableModels] as? [String],
+            customModels: context[WatchContextKeys.customModels] as? [String],
+            defaultProvider: context[WatchContextKeys.defaultProvider] as? String,
+            modelProviders: context[WatchContextKeys.modelProviders] as? [String: String],
+            modelEndpoints: context[WatchContextKeys.modelEndpoints] as? [String: String],
+            modelEndpointTypes: context[WatchContextKeys.modelEndpointTypes] as? [String: String],
+            modelUsesGitHubOAuth: context[WatchContextKeys.modelUsesGitHubOAuth] as? [String: Bool],
+            modelAPIKeys: context[WatchContextKeys.modelAPIKeys] as? [String: String],
+            removedModelDigests: context[WatchContextKeys.removedModelDigests] as? [String],
+            removedModelProviderDigests: context[WatchContextKeys.removedModelProviderDigests] as? [String],
+            removedModelEndpointDigests: context[WatchContextKeys.removedModelEndpointDigests] as? [String],
+            removedModelEndpointTypeDigests: context[WatchContextKeys.removedModelEndpointTypeDigests] as? [String],
+            removedModelGitHubOAuthDigests: context[WatchContextKeys.removedModelGitHubOAuthDigests] as? [String],
+            removedModelAPIKeyDigests: context[WatchContextKeys.removedModelAPIKeyDigests] as? [String]
+        )
+    }
+
+    mutating func merge(_ page: WatchModelMetadataPage) {
+        if let selectedModel = page.selectedModel {
+            self.selectedModel = selectedModel
+        }
+        if let availableModels = page.availableModels {
+            self.availableModels = mergingUnique(self.availableModels ?? [], availableModels)
+        }
+        if let customModels = page.customModels {
+            self.customModels = mergingUnique(self.customModels ?? [], customModels)
+        }
+        if let defaultProvider = page.defaultProvider {
+            self.defaultProvider = defaultProvider
+        }
+        mergeOptionalValues(page.modelProviders, into: &modelProviders)
+        mergeOptionalValues(page.modelEndpoints, into: &modelEndpoints)
+        mergeOptionalValues(page.modelEndpointTypes, into: &modelEndpointTypes)
+        mergeOptionalValues(page.modelUsesGitHubOAuth, into: &modelUsesGitHubOAuth)
+        mergeOptionalValues(page.modelAPIKeys, into: &modelAPIKeys)
+        if let removedModelDigests = page.removedModelDigests {
+            self.removedModelDigests = mergingUnique(self.removedModelDigests ?? [], removedModelDigests)
+        }
+        if let removed = page.removedModelProviderDigests {
+            removedModelProviderDigests = mergingUnique(removedModelProviderDigests ?? [], removed)
+        }
+        if let removed = page.removedModelEndpointDigests {
+            removedModelEndpointDigests = mergingUnique(removedModelEndpointDigests ?? [], removed)
+        }
+        if let removed = page.removedModelEndpointTypeDigests {
+            removedModelEndpointTypeDigests = mergingUnique(removedModelEndpointTypeDigests ?? [], removed)
+        }
+        if let removed = page.removedModelGitHubOAuthDigests {
+            removedModelGitHubOAuthDigests = mergingUnique(removedModelGitHubOAuthDigests ?? [], removed)
+        }
+        if let removed = page.removedModelAPIKeyDigests {
+            removedModelAPIKeyDigests = mergingUnique(removedModelAPIKeyDigests ?? [], removed)
+        }
+    }
+}
+
+enum WatchModelMetadataCompleteness {
+    static func isCompletePublication(
+        snapshot: WatchSyncSnapshot,
+        modelLimit: Int?
+    ) -> Bool {
+        modelLimit == nil
+            && snapshot.authoritativeConversationIDsAreComplete
+            && snapshot.conversationConfigurationsAreComplete
+    }
+
+    static func isExplicitlyComplete(in context: [String: Any]) -> Bool {
+        context[WatchContextKeys.modelMetadataComplete] as? Bool == true
+    }
+
+    static func legacyContextIsComplete(in context: [String: Any]) -> Bool {
+        (context[WatchContextKeys.modelMetadataComplete] as? Bool) ?? true
+    }
+}
+
+struct WatchModelMetadataCycleAccumulator: Sendable {
+    private var activeCycleID: UUID?
+    private var accumulated = WatchModelMetadataPage()
+
+    mutating func apply(
+        _ page: WatchModelMetadataPage,
+        cycleID: UUID,
+        completesCycle: Bool,
+        isAuthoritative: Bool = true,
+        to state: inout WatchModelMetadataState
+    ) {
+        if activeCycleID != cycleID {
+            activeCycleID = cycleID
+            accumulated = WatchModelMetadataPage()
+        }
+        accumulated.merge(page)
+
+        if completesCycle {
+            if isAuthoritative {
+                state.replace(with: accumulated)
+            } else {
+                state.merge(accumulated)
+            }
+            reset()
+        } else {
+            state.merge(page)
+        }
+    }
+
+    mutating func applyStandaloneContext(
+        _ page: WatchModelMetadataPage,
+        isComplete: Bool,
+        to state: inout WatchModelMetadataState
+    ) {
+        reset()
+        if isComplete {
+            state.replace(with: page)
+        } else {
+            state.merge(page)
+        }
+    }
+
+    mutating func applyCompleteContext(
+        _ page: WatchModelMetadataPage,
+        to state: inout WatchModelMetadataState
+    ) {
+        applyStandaloneContext(page, isComplete: true, to: &state)
+    }
+
+    mutating func reset() {
+        activeCycleID = nil
+        accumulated = WatchModelMetadataPage()
+    }
+}
+
+enum WatchModelMetadataContextReducer {
+    static func apply(
+        _ page: WatchModelMetadataPage,
+        mode: WatchContextApplicationMode,
+        incomingEpoch: UUID?,
+        appliedEpoch: UUID?,
+        pendingEpoch: inout UUID?,
+        accumulator: inout WatchModelMetadataCycleAccumulator,
+        to state: inout WatchModelMetadataState
+    ) -> UUID? {
+        guard mode != .ignore else { return nil }
+
+        let hasUnappliedEpoch = incomingEpoch.map { $0 != appliedEpoch } ?? false
+        if hasUnappliedEpoch, pendingEpoch != incomingEpoch {
+            pendingEpoch = incomingEpoch
+            accumulator.reset()
+        } else if !hasUnappliedEpoch {
+            pendingEpoch = nil
+        }
+
+        switch mode {
+        case .ignore:
+            return nil
+        case .provisional:
+            accumulator.applyStandaloneContext(
+                page,
+                isComplete: false,
+                to: &state
+            )
+        case .complete:
+            accumulator.applyStandaloneContext(
+                page,
+                isComplete: true,
+                to: &state
+            )
+        case let .page(cycleID, completesCycle, metadataComplete):
+            accumulator.apply(
+                page,
+                cycleID: cycleID,
+                completesCycle: completesCycle,
+                isAuthoritative: metadataComplete,
+                to: &state
+            )
+        }
+
+        guard hasUnappliedEpoch,
+              mode.treatsOmittedCredentialsAsRemoved,
+              let incomingEpoch
+        else {
+            return nil
+        }
+        pendingEpoch = nil
+        return incomingEpoch
+    }
+}
+
+private func mergingUnique(_ existing: [String], _ incoming: [String]) -> [String] {
+    var result: [String] = []
+    var seen: Set<String> = []
+    for value in existing + incoming where seen.insert(value).inserted {
+        result.append(value)
+    }
+    return result
+}
+
+private func mergeValues<Value>(
+    _ incoming: [String: Value]?,
+    into existing: inout [String: Value]
+) {
+    guard let incoming else { return }
+    for (key, value) in incoming {
+        existing[key] = value
+    }
+}
+
+private func mergeOptionalValues<Value>(
+    _ incoming: [String: Value]?,
+    into existing: inout [String: Value]?
+) {
+    guard let incoming else { return }
+    var merged = existing ?? [:]
+    mergeValues(incoming, into: &merged)
+    existing = merged
+}
+
+enum WatchSyncSnapshotApplyOutcome: Equatable, Sendable {
+    case applied
+    case alreadyDurable
+    case persistenceFailed
+    case ignoredStale
+    case ignoredUnsupportedSchema
+
+    var isDurable: Bool {
+        self == .applied || self == .alreadyDurable
+    }
+}
+
+enum WatchContextApplicationMode: Equatable, Sendable {
+    case ignore
+    case provisional
+    case complete
+    case page(cycleID: UUID, completesCycle: Bool, metadataComplete: Bool)
+
+    var appliesSnapshotSettings: Bool {
+        self != .ignore
+    }
+
+    var treatsOmittedCredentialsAsRemoved: Bool {
+        switch self {
+        case .complete:
+            true
+        case let .page(_, completesCycle, metadataComplete):
+            completesCycle && metadataComplete
+        case .ignore, .provisional:
+            false
+        }
+    }
+
+    static func standalone(
+        after outcome: WatchSyncSnapshotApplyOutcome,
+        metadataIsComplete: Bool
+    ) -> Self {
+        guard outcome.isDurable else { return .ignore }
+        return metadataIsComplete ? .complete : .provisional
+    }
+
+    static func legacy(metadataIsComplete: Bool) -> Self {
+        metadataIsComplete ? .complete : .provisional
+    }
+}
+
+struct WatchPageCycleUpdate: Equatable, Sendable {
+    let pendingRequest: WatchSyncPageCycleRequest?
+    let acceptedPage: Bool
+    let completedCycle: Bool
+    let retainedForRetry: Bool
+    let requiresFreshCycle: Bool
+}
+
+struct WatchPageCycleCoordinator: Sendable {
+    private var sourceID: UUID?
+    private var lastSnapshotRevision: WatchSyncRevision = 0
+    private var activeCycleID: UUID?
+    private var expectedCursor: WatchSyncPageCycleCursor?
+    private var acceptedCursors: [Int: WatchSyncPageCycleCursor] = [:]
+    private var freshCycleRequestedForCycleID: UUID?
+
+    var pendingRequest: WatchSyncPageCycleRequest? {
+        guard let activeCycleID, let expectedCursor else { return nil }
+        return WatchSyncPageCycleRequest(cycleID: activeCycleID, cursor: expectedCursor)
+    }
+
+    mutating func reset() {
+        sourceID = nil
+        lastSnapshotRevision = 0
+        activeCycleID = nil
+        expectedCursor = nil
+        acceptedCursors = [:]
+        freshCycleRequestedForCycleID = nil
+    }
+
+    mutating func receive(_ metadata: WatchSyncPageCycleMetadata) -> WatchSyncPageCycleRequest? {
+        receive(metadata, after: .applied).pendingRequest
+    }
+
+    mutating func receive(
+        _ metadata: WatchSyncPageCycleMetadata,
+        after applyOutcome: WatchSyncSnapshotApplyOutcome
+    ) -> WatchPageCycleUpdate {
+        switch applyOutcome {
+        case .applied, .alreadyDurable:
+            receiveDurable(metadata)
+        case .persistenceFailed:
+            retainFailedPage(metadata)
+        case .ignoredStale, .ignoredUnsupportedSchema:
+            unchangedUpdate()
+        }
+    }
+
+    private mutating func receiveDurable(
+        _ metadata: WatchSyncPageCycleMetadata
+    ) -> WatchPageCycleUpdate {
+        guard metadata.isValid else { return unchangedUpdate() }
+        let sourceChanged = sourceID.map { $0 != metadata.sourceID } ?? false
+        guard sourceChanged || metadata.snapshotRevision > lastSnapshotRevision else {
+            return unchangedUpdate()
+        }
+        sourceID = metadata.sourceID
+        lastSnapshotRevision = metadata.snapshotRevision
+
+        if sourceChanged || metadata.cycleID != activeCycleID {
+            guard metadata.cursor == .initial else {
+                return freshCycleUpdate(for: metadata)
+            }
+            activeCycleID = metadata.cycleID
+            acceptedCursors = [metadata.cursor.pageIndex: metadata.cursor]
+            expectedCursor = metadata.nextCursor
+            freshCycleRequestedForCycleID = nil
+            return acceptedUpdate()
+        }
+
+        if metadata.cursor == expectedCursor {
+            acceptedCursors[metadata.cursor.pageIndex] = metadata.cursor
+            expectedCursor = metadata.nextCursor
+            return acceptedUpdate()
+        }
+
+        return unchangedUpdate()
+    }
+
+    private mutating func retainFailedPage(
+        _ metadata: WatchSyncPageCycleMetadata
+    ) -> WatchPageCycleUpdate {
+        guard metadata.isValid else { return unchangedUpdate() }
+        let sourceChanged = sourceID.map { $0 != metadata.sourceID } ?? false
+        if sourceChanged || metadata.cycleID != activeCycleID {
+            guard metadata.cursor == .initial else {
+                return freshCycleUpdate(for: metadata)
+            }
+            activeCycleID = metadata.cycleID
+            expectedCursor = metadata.cursor
+            acceptedCursors = [:]
+            freshCycleRequestedForCycleID = nil
+        }
+        return WatchPageCycleUpdate(
+            pendingRequest: pendingRequest,
+            acceptedPage: false,
+            completedCycle: false,
+            retainedForRetry: pendingRequest?.cursor == metadata.cursor,
+            requiresFreshCycle: false
+        )
+    }
+
+    private func acceptedUpdate() -> WatchPageCycleUpdate {
+        WatchPageCycleUpdate(
+            pendingRequest: pendingRequest,
+            acceptedPage: true,
+            completedCycle: expectedCursor == nil,
+            retainedForRetry: false,
+            requiresFreshCycle: false
+        )
+    }
+
+    private mutating func freshCycleUpdate(
+        for metadata: WatchSyncPageCycleMetadata
+    ) -> WatchPageCycleUpdate {
+        let requiresFreshCycle = freshCycleRequestedForCycleID != metadata.cycleID
+        freshCycleRequestedForCycleID = metadata.cycleID
+        return WatchPageCycleUpdate(
+            pendingRequest: nil,
+            acceptedPage: false,
+            completedCycle: false,
+            retainedForRetry: false,
+            requiresFreshCycle: requiresFreshCycle
+        )
+    }
+
+    private func unchangedUpdate() -> WatchPageCycleUpdate {
+        WatchPageCycleUpdate(
+            pendingRequest: pendingRequest,
+            acceptedPage: false,
+            completedCycle: false,
+            retainedForRetry: false,
+            requiresFreshCycle: false
+        )
+    }
+}
+
+struct WatchPhonePageCycleCoordinator: Sendable {
+    private var activeCycleID: UUID?
+    private var nextExpectedCursor: WatchSyncPageCycleCursor?
+    private var publishedCursors: [Int: WatchSyncPageCycleCursor] = [:]
+    private var authoritativePublishedCursors: Set<WatchSyncPageCycleCursor> = []
+    private var modelMetadataPagesAreLossless = true
+
+    mutating func beginCycle(id: UUID = UUID()) -> WatchSyncPageCycleCursor {
+        activeCycleID = id
+        nextExpectedCursor = .initial
+        publishedCursors = [:]
+        authoritativePublishedCursors = []
+        modelMetadataPagesAreLossless = true
+        return .initial
+    }
+
+    mutating func reset() {
+        activeCycleID = nil
+        nextExpectedCursor = nil
+        publishedCursors = [:]
+        authoritativePublishedCursors = []
+        modelMetadataPagesAreLossless = true
+    }
+
+    func metadataForPublication(
+        _ metadata: WatchSyncPageCycleMetadata,
+        modelMetadataPageIsLossless: Bool
+    ) -> WatchSyncPageCycleMetadata {
+        let isSequentialPage = metadata.isValid
+            && metadata.cycleID == activeCycleID
+            && metadata.cursor == nextExpectedCursor
+        let manifestIsCovered = metadata.manifest.offset + metadata.manifest.itemCount
+            == metadata.manifest.totalCount
+        let configurationsAreCovered = metadata.configurations.offset
+            + metadata.configurations.itemCount == metadata.configurations.totalCount
+        let isAuthoritativeRetry = metadata.isValid
+            && metadata.cycleID == activeCycleID
+            && authoritativePublishedCursors.contains(metadata.cursor)
+        let cycleIsAuthoritative = (isSequentialPage || isAuthoritativeRetry)
+            && metadata.nextCursor == nil
+            && manifestIsCovered
+            && configurationsAreCovered
+            && modelMetadataPagesAreLossless
+            && modelMetadataPageIsLossless
+        return WatchSyncPageCycleMetadata(
+            cycleID: metadata.cycleID,
+            sourceID: metadata.sourceID,
+            snapshotRevision: metadata.snapshotRevision,
+            cursor: metadata.cursor,
+            manifest: metadata.manifest,
+            configurations: metadata.configurations,
+            tombstones: metadata.tombstones,
+            modelMetadataCycleIsAuthoritative: cycleIsAuthoritative
+        )
+    }
+
+    mutating func recordPublished(
+        _ metadata: WatchSyncPageCycleMetadata,
+        modelMetadataPageIsLossless: Bool = true
+    ) {
+        guard metadata.isValid, metadata.cycleID == activeCycleID else { return }
+        publishedCursors[metadata.cursor.pageIndex] = metadata.cursor
+        if metadata.modelMetadataCycleIsAuthoritative,
+           modelMetadataPageIsLossless
+        {
+            authoritativePublishedCursors.insert(metadata.cursor)
+        }
+        guard metadata.cursor == nextExpectedCursor else { return }
+        modelMetadataPagesAreLossless = modelMetadataPagesAreLossless
+            && modelMetadataPageIsLossless
+        nextExpectedCursor = metadata.nextCursor
+    }
+
+    func publication(for request: WatchSyncPageCycleRequest) -> WatchSyncPageCycleCursor? {
+        publicationRequest(for: request)?.cursor
+    }
+
+    func publicationRequest(
+        for request: WatchSyncPageCycleRequest
+    ) -> WatchSyncPageCycleRequest? {
+        guard let activeCycleID else { return nil }
+        let cursor: WatchSyncPageCycleCursor? = if request.cycleID != activeCycleID {
+            publishedCursors[WatchSyncPageCycleCursor.initial.pageIndex]
+                ?? nextExpectedCursor
+                ?? .initial
+        } else if let published = publishedCursors[request.cursor.pageIndex],
+                  published == request.cursor
+        {
+            request.cursor
+        } else if request.cursor == nextExpectedCursor {
+            request.cursor
+        } else {
+            nextExpectedCursor
+        }
+        guard let cursor else { return nil }
+        return WatchSyncPageCycleRequest(cycleID: activeCycleID, cursor: cursor)
+    }
+}
+
+enum WatchPeerSyncMode: Sendable {
+    case unknown
+    case revisioned
+    case legacy
+}
+
+final class WatchSessionCallbackIdentityFence: @unchecked Sendable {
+    private struct Identity: Equatable {
+        let sessionID: ObjectIdentifier
+        let activation: WatchSessionActivationToken
+    }
+
+    private let lock = NSLock()
+    private var identity: Identity?
+
+    func activate(
+        sessionID: ObjectIdentifier,
+        activation: WatchSessionActivationToken
+    ) {
+        lock.lock()
+        identity = Identity(sessionID: sessionID, activation: activation)
+        lock.unlock()
+    }
+
+    func isCurrent(
+        sessionID: ObjectIdentifier,
+        activation: WatchSessionActivationToken
+    ) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return identity == Identity(sessionID: sessionID, activation: activation)
+    }
+}
+
+enum WatchMutationFileTransportError: Error, Equatable, LocalizedError, Sendable {
+    case staleSession
+    case invalidMetadata
+    case unsupportedSchema(Int)
+    case unreadableFile
+    case nonRegularFile
+    case emptyFile
+    case exceedsMaximum(actualBytes: Int, maximumBytes: Int)
+    case changedDuringRead(expectedBytes: Int, actualBytes: Int)
+    case malformedPayload
+    case metadataIdentityMismatch
+
+    var errorDescription: String? {
+        switch self {
+        case .staleSession:
+            "The Watch mutation file belongs to a stale session."
+        case .invalidMetadata:
+            "The Watch mutation file metadata is invalid."
+        case let .unsupportedSchema(schemaVersion):
+            "The Watch mutation file schema \(schemaVersion) is unsupported."
+        case .unreadableFile:
+            "The Watch mutation file cannot be read."
+        case .nonRegularFile:
+            "The Watch mutation file is not a regular file."
+        case .emptyFile:
+            "The Watch mutation file is empty."
+        case let .exceedsMaximum(actualBytes, maximumBytes):
+            "The Watch mutation file is \(actualBytes) bytes; the maximum is \(maximumBytes)."
+        case let .changedDuringRead(expectedBytes, actualBytes):
+            "The Watch mutation file changed from \(expectedBytes) to \(actualBytes) bytes while reading."
+        case .malformedPayload:
+            "The Watch mutation file payload is malformed."
+        case .metadataIdentityMismatch:
+            "The Watch mutation file payload does not match its metadata identity."
+        }
+    }
+}
+
+struct WatchMutationFileReception: Equatable, Sendable {
+    let mutation: WatchConversationMutation
+    let schemaVersion: Int
+    let byteCount: Int
+}
+
+struct WatchMutationFileCapture: Equatable, Sendable {
+    fileprivate let data: Data
+    fileprivate let operationID: UUID
+    fileprivate let conversationID: UUID
+    let schemaVersion: Int
+
+    var byteCount: Int {
+        data.count
+    }
+}
+
+enum WatchMutationFileTransport {
+    /// File transfer is reserved for mutations beyond the 48 KB message budget. Four MiB leaves
+    /// more than 80x headroom for legitimate coalesced text/tool mutations while bounding the
+    /// synchronous delegate work needed before WatchConnectivity invalidates its temporary URL.
+    static let maximumBytes = 4 * 1024 * 1024
+
+    private static let readChunkBytes = 64 * 1024
+
+    static func receive(
+        fileURL: URL,
+        metadata: [String: Any],
+        sessionIsCurrent: Bool
+    ) throws -> WatchMutationFileReception {
+        try decode(capture(
+            fileURL: fileURL,
+            metadata: metadata,
+            sessionIsCurrent: sessionIsCurrent
+        ))
+    }
+
+    static func capture(
+        fileURL: URL,
+        metadata: [String: Any],
+        sessionIsCurrent: Bool
+    ) throws -> WatchMutationFileCapture {
+        guard sessionIsCurrent else {
+            throw WatchMutationFileTransportError.staleSession
+        }
+        let metadata = try validatedMetadata(metadata)
+        let data = try boundedData(from: fileURL)
+        return WatchMutationFileCapture(
+            data: data,
+            operationID: metadata.operationID,
+            conversationID: metadata.conversationID,
+            schemaVersion: metadata.schemaVersion
+        )
+    }
+
+    static func decode(
+        _ capture: WatchMutationFileCapture
+    ) throws -> WatchMutationFileReception {
+        let mutation: WatchConversationMutation
+        do {
+            mutation = try JSONDecoder().decode(
+                WatchConversationMutation.self,
+                from: capture.data
+            )
+        } catch {
+            throw WatchMutationFileTransportError.malformedPayload
+        }
+        guard mutation.operationID == capture.operationID,
+              mutation.conversationID == capture.conversationID
+        else {
+            throw WatchMutationFileTransportError.metadataIdentityMismatch
+        }
+        return WatchMutationFileReception(
+            mutation: mutation,
+            schemaVersion: capture.schemaVersion,
+            byteCount: capture.byteCount
+        )
+    }
+
+    static func encodedData(
+        for mutation: WatchConversationMutation
+    ) throws -> Data {
+        let data = try WatchSyncPayloadBuilder.encodeMutation(mutation)
+        try validateByteCount(data.count)
+        return data
+    }
+
+    private struct Metadata {
+        let operationID: UUID
+        let conversationID: UUID
+        let schemaVersion: Int
+    }
+
+    private static func validatedMetadata(
+        _ metadata: [String: Any]
+    ) throws -> Metadata {
+        guard metadata[WatchMessageKeys.type] as? String == WatchMessageKeys.typeMutationFile,
+              let operationID = (metadata[WatchMessageKeys.operationId] as? String)
+              .flatMap(UUID.init(uuidString:)),
+              let conversationID = (metadata[WatchMessageKeys.conversationId] as? String)
+              .flatMap(UUID.init(uuidString:)),
+              let schemaVersion = WatchSyncCapability.advertisedMaximumSchemaVersion(
+                  metadata[WatchMessageKeys.schemaVersion]
+              )
+        else {
+            throw WatchMutationFileTransportError.invalidMetadata
+        }
+        guard WatchSyncSnapshot.supportsSchemaVersion(schemaVersion) else {
+            throw WatchMutationFileTransportError.unsupportedSchema(schemaVersion)
+        }
+        return Metadata(
+            operationID: operationID,
+            conversationID: conversationID,
+            schemaVersion: schemaVersion
+        )
+    }
+
+    private static func boundedData(from fileURL: URL) throws -> Data {
+        let resourceValues: URLResourceValues
+        do {
+            resourceValues = try fileURL.resourceValues(forKeys: [
+                .isRegularFileKey,
+                .fileSizeKey
+            ])
+        } catch {
+            throw WatchMutationFileTransportError.unreadableFile
+        }
+        guard resourceValues.isRegularFile == true else {
+            throw WatchMutationFileTransportError.nonRegularFile
+        }
+        guard let expectedByteCount = resourceValues.fileSize else {
+            throw WatchMutationFileTransportError.unreadableFile
+        }
+        try validateByteCount(expectedByteCount)
+
+        let fileHandle: FileHandle
+        do {
+            fileHandle = try FileHandle(forReadingFrom: fileURL)
+        } catch {
+            throw WatchMutationFileTransportError.unreadableFile
+        }
+        defer { try? fileHandle.close() }
+
+        var data = Data()
+        data.reserveCapacity(expectedByteCount)
+        do {
+            while data.count <= maximumBytes {
+                let remainingByteCount = maximumBytes + 1 - data.count
+                guard remainingByteCount > 0,
+                      let chunk = try fileHandle.read(
+                          upToCount: min(readChunkBytes, remainingByteCount)
+                      ),
+                      !chunk.isEmpty
+                else {
+                    break
+                }
+                data.append(chunk)
+            }
+        } catch {
+            throw WatchMutationFileTransportError.unreadableFile
+        }
+        try validateByteCount(data.count)
+        guard data.count == expectedByteCount else {
+            throw WatchMutationFileTransportError.changedDuringRead(
+                expectedBytes: expectedByteCount,
+                actualBytes: data.count
+            )
+        }
+        return data
+    }
+
+    private static func validateByteCount(_ byteCount: Int) throws {
+        guard byteCount > 0 else {
+            throw WatchMutationFileTransportError.emptyFile
+        }
+        guard byteCount <= maximumBytes else {
+            throw WatchMutationFileTransportError.exceedsMaximum(
+                actualBytes: byteCount,
+                maximumBytes: maximumBytes
+            )
+        }
+    }
+}
+
+#if os(watchOS)
+    @MainActor
+    extension WatchMutationFileTransport {
+        static func hasOutstandingTransfer(
+            operationID: UUID,
+            session: WCSession
+        ) -> Bool {
+            session.outstandingFileTransfers.contains { transfer in
+                (transfer.file.metadata?[WatchMessageKeys.operationId] as? String) == operationID.uuidString
+            }
+        }
+
+        static func transfer(
+            _ mutation: WatchConversationMutation,
+            session: WCSession
+        ) throws -> URL {
+            let data = try encodedData(for: mutation)
+            let fileURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ayna-watch-mutation-\(mutation.operationID.uuidString)")
+                .appendingPathExtension("json")
+            try data.write(to: fileURL, options: .atomic)
+            session.transferFile(fileURL, metadata: [
+                WatchMessageKeys.type: WatchMessageKeys.typeMutationFile,
+                WatchMessageKeys.operationId: mutation.operationID.uuidString,
+                WatchMessageKeys.conversationId: mutation.conversationID.uuidString,
+                WatchMessageKeys.schemaVersion: NSNumber(value: WatchSyncSnapshot.currentSchemaVersion)
+            ])
+            return fileURL
+        }
+    }
+#endif
+
+enum WatchMutationMetadataMerger {
+    static func merge(
+        reduction: PhoneWatchMutationReduction,
+        conversationID: UUID,
+        acknowledgements: inout [UUID: WatchSyncRevision],
+        tombstones: inout [UUID: WatchSyncRevision]
+    ) {
+        if let revision = reduction.state.acknowledgedWatchRevisions[conversationID] {
+            acknowledgements[conversationID] = max(acknowledgements[conversationID] ?? 0, revision)
+        }
+        if let revision = reduction.state.tombstoneRevisions[conversationID] {
+            tombstones[conversationID] = max(tombstones[conversationID] ?? 0, revision)
+        }
+    }
+}

--- a/Sources/Ayna/Services/WatchSyncProtocol.swift
+++ b/Sources/Ayna/Services/WatchSyncProtocol.swift
@@ -568,20 +568,26 @@ struct WatchConversationMutation: Codable, Equatable, Identifiable, Sendable {
         after acknowledgedRevision: WatchSyncRevision,
         coverage: WatchMutationDeliveryCoverage? = nil
     ) -> Bool {
-        max(createRevision ?? 0, titleRevision ?? 0) > max(
-            acknowledgedRevision,
-            max(coverage?.createRevision ?? 0, coverage?.titleRevision ?? 0)
+        let localRevision = Swift.max(createRevision ?? 0, titleRevision ?? 0)
+        let coveredRevision = Swift.max(
+            coverage?.createRevision ?? 0,
+            coverage?.titleRevision ?? 0
         )
+        let requiredRevision = Swift.max(acknowledgedRevision, coveredRevision)
+        return localRevision > requiredRevision
     }
 
     func changesConfiguration(
         after acknowledgedRevision: WatchSyncRevision,
         coverage: WatchMutationDeliveryCoverage? = nil
     ) -> Bool {
-        max(createRevision ?? 0, configurationRevision ?? 0) > max(
-            acknowledgedRevision,
-            max(coverage?.createRevision ?? 0, coverage?.configurationRevision ?? 0)
+        let localRevision = Swift.max(createRevision ?? 0, configurationRevision ?? 0)
+        let coveredRevision = Swift.max(
+            coverage?.createRevision ?? 0,
+            coverage?.configurationRevision ?? 0
         )
+        let requiredRevision = Swift.max(acknowledgedRevision, coveredRevision)
+        return localRevision > requiredRevision
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1663,7 +1669,7 @@ enum WatchSyncPayloadBuilder {
                 pageCycleCursor: pageCycleCursor
             )
         )
-        let configurationCursorAdvanceCount = pageCycleCursor.map { cursor in
+        let cursorAdvanceCount = pageCycleCursor.map { cursor in
             configurationCursorAdvanceCount(
                 in: allConfigurations,
                 delivered: snapshot.conversationConfigurations,
@@ -1674,7 +1680,7 @@ enum WatchSyncPayloadBuilder {
         } ?? snapshot.conversationConfigurations.count
         return SnapshotBuildResult(
             payload: WatchSyncPayload(snapshot: snapshot, data: data),
-            configurationCursorAdvanceCount: configurationCursorAdvanceCount,
+            configurationCursorAdvanceCount: cursorAdvanceCount,
             unavailablePromptIDs: transportPlan.unavailablePromptIDs
         )
     }

--- a/Sources/Ayna/Services/WatchSyncProtocol.swift
+++ b/Sources/Ayna/Services/WatchSyncProtocol.swift
@@ -1,0 +1,2370 @@
+// swiftlint:disable file_length
+import Foundation
+
+typealias WatchSyncRevision = UInt64
+
+enum WatchSyncRevisionMapCodec {
+    static func decode(_ encoded: [String: WatchSyncRevision]) -> [UUID: WatchSyncRevision] {
+        var decoded: [UUID: WatchSyncRevision] = [:]
+        for (key, revision) in encoded {
+            guard let id = UUID(uuidString: key) else { continue }
+            decoded[id] = max(decoded[id] ?? 0, revision)
+        }
+        return decoded
+    }
+
+    static func encode(_ revisions: [UUID: WatchSyncRevision]) -> [String: WatchSyncRevision] {
+        var encoded: [String: WatchSyncRevision] = [:]
+        for (id, revision) in revisions {
+            encoded[id.uuidString] = revision
+        }
+        return encoded
+    }
+
+    static func merge(
+        _ revisions: [UUID: WatchSyncRevision],
+        into destination: inout [UUID: WatchSyncRevision]
+    ) {
+        for (id, revision) in revisions {
+            destination[id] = max(destination[id] ?? 0, revision)
+        }
+    }
+}
+
+struct WatchMutationDeliveryCoverage: Codable, Equatable, Sendable {
+    var createRevision: WatchSyncRevision?
+    var titleRevision: WatchSyncRevision?
+    var configurationRevision: WatchSyncRevision?
+    var messageRevisions: [UUID: WatchSyncRevision] = [:]
+}
+
+enum WatchSyncIdentity {
+    static let legacySourceID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    static let legacyPeerID = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+}
+
+/// Canonicalizes conversation collections at sync protocol boundaries.
+///
+/// Duplicate phone conversation IDs choose the greatest `updatedAt`. Duplicate Watch IDs choose
+/// the greatest `watchRevision`, then `updatedAt`. Exact ties choose the lexicographically greatest
+/// stable encoding, so the winner is independent of input order. Within a Watch conversation, the
+/// last value for a duplicate message ID wins while its first position is retained.
+enum WatchConversationCanonicalizer {
+    static func phoneConversations(
+        _ conversations: some Sequence<Conversation>
+    ) -> [Conversation] {
+        var byID: [UUID: Conversation] = [:]
+        for conversation in conversations {
+            if let existing = byID[conversation.id] {
+                if prefersPhoneConversation(conversation, over: existing) {
+                    byID[conversation.id] = conversation
+                }
+            } else {
+                byID[conversation.id] = conversation
+            }
+        }
+        return byID.values.sorted(by: phoneConversationSort)
+    }
+
+    static func watchConversation(_ conversation: WatchConversation) -> WatchConversation {
+        var canonical = conversation
+        var messages: [WatchMessage] = []
+        var indexByID: [UUID: Int] = [:]
+        for message in conversation.messages {
+            if let index = indexByID[message.id] {
+                messages[index] = message
+            } else {
+                indexByID[message.id] = messages.count
+                messages.append(message)
+            }
+        }
+        canonical.messages = messages
+        return canonical
+    }
+
+    static func watchConversations(
+        _ conversations: some Sequence<WatchConversation>
+    ) -> [WatchConversation] {
+        var byID: [UUID: WatchConversation] = [:]
+        for value in conversations {
+            let conversation = watchConversation(value)
+            if let existing = byID[conversation.id] {
+                if prefersWatchConversation(conversation, over: existing) {
+                    byID[conversation.id] = conversation
+                }
+            } else {
+                byID[conversation.id] = conversation
+            }
+        }
+        return byID.values.sorted(by: watchConversationSort)
+    }
+
+    static func uniqueIDs(_ ids: some Sequence<UUID>) -> [UUID] {
+        var seen: Set<UUID> = []
+        return ids.filter { seen.insert($0).inserted }
+    }
+
+    static func requestConfigurations(
+        _ configurations: some Sequence<WatchConversationRequestConfiguration>
+    ) -> [WatchConversationRequestConfiguration] {
+        var order: [UUID] = []
+        var byID: [UUID: WatchConversationRequestConfiguration] = [:]
+        for configuration in configurations {
+            if let existing = byID[configuration.id] {
+                if stableEncoding(existing).lexicographicallyPrecedes(stableEncoding(configuration)) {
+                    byID[configuration.id] = configuration
+                }
+            } else {
+                order.append(configuration.id)
+                byID[configuration.id] = configuration
+            }
+        }
+        return order.compactMap { byID[$0] }
+    }
+
+    private static func prefersPhoneConversation(
+        _ candidate: Conversation,
+        over existing: Conversation
+    ) -> Bool {
+        if candidate.updatedAt != existing.updatedAt {
+            return candidate.updatedAt > existing.updatedAt
+        }
+        return stableEncoding(existing).lexicographicallyPrecedes(stableEncoding(candidate))
+    }
+
+    private static func prefersWatchConversation(
+        _ candidate: WatchConversation,
+        over existing: WatchConversation
+    ) -> Bool {
+        if candidate.watchRevision != existing.watchRevision {
+            return candidate.watchRevision > existing.watchRevision
+        }
+        if candidate.updatedAt != existing.updatedAt {
+            return candidate.updatedAt > existing.updatedAt
+        }
+        return stableEncoding(existing).lexicographicallyPrecedes(stableEncoding(candidate))
+    }
+
+    private static func stableEncoding(_ value: some Encodable) -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return (try? encoder.encode(value)) ?? Data()
+    }
+
+    private static func phoneConversationSort(_ lhs: Conversation, _ rhs: Conversation) -> Bool {
+        if lhs.updatedAt != rhs.updatedAt {
+            return lhs.updatedAt > rhs.updatedAt
+        }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func watchConversationSort(
+        _ lhs: WatchConversation,
+        _ rhs: WatchConversation
+    ) -> Bool {
+        if lhs.updatedAt != rhs.updatedAt {
+            return lhs.updatedAt > rhs.updatedAt
+        }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+}
+
+struct WatchSyncPageCycleCursor: Codable, Equatable, Hashable, Sendable {
+    let pageIndex: Int
+    let manifestOffset: Int
+    let configurationOffset: Int
+    let tombstoneOffset: Int
+    /// True when every configuration consumed before this cursor was delivered losslessly.
+    let precedingConfigurationsAreLossless: Bool
+
+    init(
+        pageIndex: Int,
+        manifestOffset: Int,
+        configurationOffset: Int,
+        tombstoneOffset: Int,
+        precedingConfigurationsAreLossless: Bool = true
+    ) {
+        self.pageIndex = pageIndex
+        self.manifestOffset = manifestOffset
+        self.configurationOffset = configurationOffset
+        self.tombstoneOffset = tombstoneOffset
+        self.precedingConfigurationsAreLossless = precedingConfigurationsAreLossless
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case pageIndex
+        case manifestOffset
+        case configurationOffset
+        case tombstoneOffset
+        case precedingConfigurationsAreLossless
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        pageIndex = try container.decode(Int.self, forKey: .pageIndex)
+        manifestOffset = try container.decode(Int.self, forKey: .manifestOffset)
+        configurationOffset = try container.decode(Int.self, forKey: .configurationOffset)
+        tombstoneOffset = try container.decode(Int.self, forKey: .tombstoneOffset)
+        precedingConfigurationsAreLossless = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .precedingConfigurationsAreLossless
+        ) ?? true
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(pageIndex, forKey: .pageIndex)
+        try container.encode(manifestOffset, forKey: .manifestOffset)
+        try container.encode(configurationOffset, forKey: .configurationOffset)
+        try container.encode(tombstoneOffset, forKey: .tombstoneOffset)
+        try container.encode(
+            precedingConfigurationsAreLossless,
+            forKey: .precedingConfigurationsAreLossless
+        )
+    }
+
+    var isValid: Bool {
+        pageIndex >= 0 && manifestOffset >= 0 && configurationOffset >= 0 && tombstoneOffset >= 0
+    }
+
+    static let initial = Self(
+        pageIndex: 0,
+        manifestOffset: 0,
+        configurationOffset: 0,
+        tombstoneOffset: 0
+    )
+}
+
+struct WatchSyncPageSection: Codable, Equatable, Sendable {
+    let offset: Int
+    /// Number of records present in the payload.
+    let itemCount: Int
+    let totalCount: Int
+    /// Number of source records consumed to prevent a deferred record from pinning the cursor.
+    let cursorAdvanceCount: Int
+    /// True when a delivered configuration intentionally clears an unavailable prompt.
+    let containsUnavailablePromptGate: Bool
+
+    init(
+        offset: Int,
+        itemCount: Int,
+        totalCount: Int,
+        cursorAdvanceCount: Int? = nil,
+        containsUnavailablePromptGate: Bool = false
+    ) {
+        self.offset = offset
+        self.itemCount = itemCount
+        self.totalCount = totalCount
+        self.cursorAdvanceCount = cursorAdvanceCount ?? itemCount
+        self.containsUnavailablePromptGate = containsUnavailablePromptGate
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case offset
+        case itemCount
+        case totalCount
+        case cursorAdvanceCount
+        case containsUnavailablePromptGate
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        offset = try container.decode(Int.self, forKey: .offset)
+        itemCount = try container.decode(Int.self, forKey: .itemCount)
+        totalCount = try container.decode(Int.self, forKey: .totalCount)
+        cursorAdvanceCount = try container.decodeIfPresent(
+            Int.self,
+            forKey: .cursorAdvanceCount
+        ) ?? itemCount
+        containsUnavailablePromptGate = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .containsUnavailablePromptGate
+        ) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(offset, forKey: .offset)
+        try container.encode(itemCount, forKey: .itemCount)
+        try container.encode(totalCount, forKey: .totalCount)
+        try container.encode(cursorAdvanceCount, forKey: .cursorAdvanceCount)
+        try container.encode(
+            containsUnavailablePromptGate,
+            forKey: .containsUnavailablePromptGate
+        )
+    }
+
+    var isValid: Bool {
+        offset >= 0 && itemCount >= 0 && totalCount >= 0 && cursorAdvanceCount >= itemCount
+            && offset <= totalCount && cursorAdvanceCount <= totalCount - offset
+    }
+
+    var isLossless: Bool {
+        itemCount == cursorAdvanceCount && !containsUnavailablePromptGate
+    }
+
+    var nextOffset: Int? {
+        guard isValid, offset < totalCount, cursorAdvanceCount > 0 else { return nil }
+        let next = offset + cursorAdvanceCount
+        return next < totalCount ? next : nil
+    }
+}
+
+struct WatchSyncPageCycleMetadata: Codable, Equatable, Sendable {
+    let cycleID: UUID
+    let sourceID: UUID
+    let snapshotRevision: WatchSyncRevision
+    let cursor: WatchSyncPageCycleCursor
+    let manifest: WatchSyncPageSection
+    let configurations: WatchSyncPageSection
+    let tombstones: WatchSyncPageSection
+    let modelMetadataCycleIsAuthoritative: Bool
+
+    init(
+        cycleID: UUID,
+        sourceID: UUID,
+        snapshotRevision: WatchSyncRevision,
+        cursor: WatchSyncPageCycleCursor,
+        manifest: WatchSyncPageSection,
+        configurations: WatchSyncPageSection,
+        tombstones: WatchSyncPageSection,
+        modelMetadataCycleIsAuthoritative: Bool = false
+    ) {
+        self.cycleID = cycleID
+        self.sourceID = sourceID
+        self.snapshotRevision = snapshotRevision
+        self.cursor = cursor
+        self.manifest = manifest
+        self.configurations = configurations
+        self.tombstones = tombstones
+        self.modelMetadataCycleIsAuthoritative = modelMetadataCycleIsAuthoritative
+            && cursor.precedingConfigurationsAreLossless
+            && configurations.isLossless
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case cycleID
+        case sourceID
+        case snapshotRevision
+        case cursor
+        case manifest
+        case configurations
+        case tombstones
+        case modelMetadataCycleIsAuthoritative
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        cycleID = try container.decode(UUID.self, forKey: .cycleID)
+        sourceID = try container.decode(UUID.self, forKey: .sourceID)
+        snapshotRevision = try container.decode(WatchSyncRevision.self, forKey: .snapshotRevision)
+        cursor = try container.decode(WatchSyncPageCycleCursor.self, forKey: .cursor)
+        manifest = try container.decode(WatchSyncPageSection.self, forKey: .manifest)
+        configurations = try container.decode(WatchSyncPageSection.self, forKey: .configurations)
+        tombstones = try container.decode(WatchSyncPageSection.self, forKey: .tombstones)
+        let decodedModelMetadataCycleIsAuthoritative = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .modelMetadataCycleIsAuthoritative
+        ) ?? false
+        modelMetadataCycleIsAuthoritative = decodedModelMetadataCycleIsAuthoritative
+            && cursor.precedingConfigurationsAreLossless
+            && configurations.isLossless
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(cycleID, forKey: .cycleID)
+        try container.encode(sourceID, forKey: .sourceID)
+        try container.encode(snapshotRevision, forKey: .snapshotRevision)
+        try container.encode(cursor, forKey: .cursor)
+        try container.encode(manifest, forKey: .manifest)
+        try container.encode(configurations, forKey: .configurations)
+        try container.encode(tombstones, forKey: .tombstones)
+        try container.encode(
+            modelMetadataCycleIsAuthoritative,
+            forKey: .modelMetadataCycleIsAuthoritative
+        )
+    }
+
+    var isValid: Bool {
+        let sections = [manifest, configurations, tombstones]
+        return cursor.isValid && sections.allSatisfy(\.isValid)
+            && sections.allSatisfy { $0.offset >= $0.totalCount || $0.cursorAdvanceCount > 0 }
+            && cursor.manifestOffset == manifest.offset
+            && cursor.configurationOffset == configurations.offset
+            && cursor.tombstoneOffset == tombstones.offset
+    }
+
+    func isValid(for snapshot: WatchSyncSnapshot) -> Bool {
+        guard isValid,
+              sourceID == snapshot.sourceID,
+              snapshotRevision == snapshot.revision,
+              WatchSyncRevision(exactly: cursor.pageIndex) == snapshot.paginationCursor
+        else {
+            return false
+        }
+        return manifest.itemCount == snapshot.authoritativeConversationIDs.count
+            && configurations.itemCount == snapshot.conversationConfigurations.count
+            && tombstones.itemCount == snapshot.tombstones.count
+    }
+
+    var nextCursor: WatchSyncPageCycleCursor? {
+        guard isValid else { return nil }
+        let manifestOffset = manifest.nextOffset
+        let configurationOffset = configurations.nextOffset
+        let tombstoneOffset = tombstones.nextOffset
+        guard manifestOffset != nil || configurationOffset != nil || tombstoneOffset != nil else {
+            return nil
+        }
+        let (nextPageIndex, overflow) = cursor.pageIndex.addingReportingOverflow(1)
+        guard !overflow else { return nil }
+        return WatchSyncPageCycleCursor(
+            pageIndex: nextPageIndex,
+            manifestOffset: manifestOffset ?? manifest.totalCount,
+            configurationOffset: configurationOffset ?? configurations.totalCount,
+            tombstoneOffset: tombstoneOffset ?? tombstones.totalCount,
+            precedingConfigurationsAreLossless: cursor.precedingConfigurationsAreLossless
+                && configurations.isLossless
+        )
+    }
+}
+
+struct WatchSyncPageCycleRequest: Codable, Equatable, Sendable {
+    let cycleID: UUID
+    let cursor: WatchSyncPageCycleCursor
+}
+
+enum WatchSyncRequestIdentity: Equatable, Sendable {
+    case freshCycle
+    case pageCycle(WatchSyncPageCycleRequest)
+
+    var pageCycleRequest: WatchSyncPageCycleRequest? {
+        guard case let .pageCycle(request) = self else { return nil }
+        return request
+    }
+}
+
+struct WatchSyncPageCyclePayload: Equatable, Sendable {
+    let snapshot: WatchSyncSnapshot
+    let data: Data
+    let metadata: WatchSyncPageCycleMetadata
+}
+
+enum WatchMutationRetryBackoff {
+    static func seconds(forAttempt attempt: Int) -> TimeInterval {
+        let boundedAttempt = min(max(0, attempt), 4)
+        return min(60, 5 * pow(2, Double(boundedAttempt)))
+    }
+}
+
+@MainActor
+final class WatchMutationProcessingQueue {
+    private var tail = Task { @MainActor in }
+
+    func enqueue<Output: Sendable>(
+        _ operation: @escaping @MainActor @Sendable () async -> Output
+    ) async -> Output {
+        let predecessor = tail
+        let task = Task { @MainActor in
+            await predecessor.value
+            return await operation()
+        }
+        tail = Task { @MainActor in
+            _ = await task.value
+        }
+        return await task.value
+    }
+}
+
+struct WatchConversationTombstone: Codable, Equatable, Identifiable, Sendable {
+    let conversationID: UUID
+    var revision: WatchSyncRevision
+
+    var id: UUID {
+        conversationID
+    }
+
+    var watchRevision: WatchSyncRevision {
+        get { revision }
+        set { revision = newValue }
+    }
+
+    init(conversationID: UUID, revision: WatchSyncRevision) {
+        self.conversationID = conversationID
+        self.revision = revision
+    }
+
+    init(conversationID: UUID, watchRevision: WatchSyncRevision) {
+        self.init(conversationID: conversationID, revision: watchRevision)
+    }
+}
+
+struct WatchConversationMutationFields: OptionSet, Codable, Equatable, Hashable, Sendable {
+    let rawValue: UInt8
+
+    static let create = Self(rawValue: 1 << 0)
+    static let title = Self(rawValue: 1 << 1)
+    static let messages = Self(rawValue: 1 << 2)
+    static let delete = Self(rawValue: 1 << 3)
+    static let configuration = Self(rawValue: 1 << 4)
+
+    static let fullState: Self = [.create, .title, .messages, .configuration]
+}
+
+typealias WatchConversationMutationFlags = WatchConversationMutationFields
+
+/// A durable Watch-originated mutation. Every envelope carries a full bounded state so
+/// queued operations can be safely coalesced while the flags retain mutation intent.
+struct WatchConversationMutation: Codable, Equatable, Identifiable, Sendable {
+    typealias Fields = WatchConversationMutationFields
+
+    let operationID: UUID
+    var peerID: UUID
+    var revision: WatchSyncRevision
+    var conversation: WatchConversation
+    var fields: WatchConversationMutationFields
+    var createRevision: WatchSyncRevision?
+    var titleRevision: WatchSyncRevision?
+    var configurationRevision: WatchSyncRevision?
+    var messageChanges: [WatchMessage]
+    var messageChangeRevisions: [UUID: WatchSyncRevision]
+
+    var id: UUID {
+        operationID
+    }
+
+    var conversationID: UUID {
+        conversation.id
+    }
+
+    var fieldFlags: WatchConversationMutationFields {
+        get { fields }
+        set { fields = newValue }
+    }
+
+    func messageChanges(
+        after acknowledgedRevision: WatchSyncRevision,
+        coverage: WatchMutationDeliveryCoverage? = nil
+    ) -> [WatchMessage] {
+        messageChanges.filter {
+            (messageChangeRevisions[$0.id] ?? revision) > max(
+                acknowledgedRevision,
+                coverage?.messageRevisions[$0.id] ?? 0
+            )
+        }
+    }
+
+    func changesCreate(
+        after acknowledgedRevision: WatchSyncRevision,
+        coverage: WatchMutationDeliveryCoverage? = nil
+    ) -> Bool {
+        (createRevision ?? 0) > max(
+            acknowledgedRevision,
+            coverage?.createRevision ?? 0
+        )
+    }
+
+    func changesTitle(
+        after acknowledgedRevision: WatchSyncRevision,
+        coverage: WatchMutationDeliveryCoverage? = nil
+    ) -> Bool {
+        max(createRevision ?? 0, titleRevision ?? 0) > max(
+            acknowledgedRevision,
+            max(coverage?.createRevision ?? 0, coverage?.titleRevision ?? 0)
+        )
+    }
+
+    func changesConfiguration(
+        after acknowledgedRevision: WatchSyncRevision,
+        coverage: WatchMutationDeliveryCoverage? = nil
+    ) -> Bool {
+        max(createRevision ?? 0, configurationRevision ?? 0) > max(
+            acknowledgedRevision,
+            max(coverage?.createRevision ?? 0, coverage?.configurationRevision ?? 0)
+        )
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case operationID
+        case peerID
+        case revision
+        case conversation
+        case fields
+        case createRevision
+        case titleRevision
+        case configurationRevision
+        case messageChanges
+        case messageChangeRevisions
+    }
+
+    init(
+        operationID: UUID = UUID(),
+        peerID: UUID = WatchSyncIdentity.legacyPeerID,
+        revision: WatchSyncRevision,
+        conversation: WatchConversation,
+        fields: WatchConversationMutationFields,
+        createRevision: WatchSyncRevision? = nil,
+        titleRevision: WatchSyncRevision? = nil,
+        configurationRevision: WatchSyncRevision? = nil,
+        messageChanges: [WatchMessage] = [],
+        messageChangeRevisions: [UUID: WatchSyncRevision]? = nil
+    ) {
+        self.operationID = operationID
+        self.peerID = peerID
+        self.revision = revision
+        var state = conversation
+        state.watchRevision = revision
+        state.messages = []
+        self.conversation = state
+        self.fields = fields
+        self.createRevision = createRevision ?? (fields.contains(.create) ? revision : nil)
+        self.titleRevision = titleRevision ?? (fields.contains(.title) ? revision : nil)
+        self.configurationRevision = configurationRevision
+            ?? (fields.contains(.configuration) ? revision : nil)
+        self.messageChanges = messageChanges
+        self.messageChangeRevisions = messageChangeRevisions
+            ?? Dictionary(
+                messageChanges.map { ($0.id, revision) },
+                uniquingKeysWith: { _, new in new }
+            )
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        operationID = try container.decode(UUID.self, forKey: .operationID)
+        peerID = try container.decodeIfPresent(UUID.self, forKey: .peerID)
+            ?? WatchSyncIdentity.legacyPeerID
+        revision = try container.decode(WatchSyncRevision.self, forKey: .revision)
+        conversation = try container.decode(WatchConversation.self, forKey: .conversation)
+        fields = try container.decode(WatchConversationMutationFields.self, forKey: .fields)
+        createRevision = try container.decodeIfPresent(WatchSyncRevision.self, forKey: .createRevision)
+            ?? (fields.contains(.create) ? revision : nil)
+        titleRevision = try container.decodeIfPresent(WatchSyncRevision.self, forKey: .titleRevision)
+            ?? (fields.contains(.title) ? revision : nil)
+        configurationRevision = try container.decodeIfPresent(
+            WatchSyncRevision.self,
+            forKey: .configurationRevision
+        ) ?? (fields.contains(.configuration) ? revision : nil)
+        let decodedMessageChanges = try container.decodeIfPresent([WatchMessage].self, forKey: .messageChanges)
+            ?? (fields.contains(.messages) ? conversation.messages : [])
+        messageChanges = decodedMessageChanges
+        let encodedRevisions = try container.decodeIfPresent(
+            [String: WatchSyncRevision].self,
+            forKey: .messageChangeRevisions
+        ) ?? [:]
+        let normalizedRevisions = WatchSyncRevisionMapCodec.decode(encodedRevisions)
+        var decodedRevisionMap: [UUID: WatchSyncRevision] = [:]
+        for message in decodedMessageChanges {
+            decodedRevisionMap[message.id] = normalizedRevisions[message.id] ?? revision
+        }
+        messageChangeRevisions = decodedRevisionMap
+        conversation.watchRevision = revision
+        conversation.messages = []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(operationID, forKey: .operationID)
+        try container.encode(peerID, forKey: .peerID)
+        try container.encode(revision, forKey: .revision)
+        try container.encode(conversation, forKey: .conversation)
+        try container.encode(fields, forKey: .fields)
+        try container.encodeIfPresent(createRevision, forKey: .createRevision)
+        try container.encodeIfPresent(titleRevision, forKey: .titleRevision)
+        try container.encodeIfPresent(configurationRevision, forKey: .configurationRevision)
+        try container.encode(messageChanges, forKey: .messageChanges)
+        try container.encode(
+            WatchSyncRevisionMapCodec.encode(messageChangeRevisions),
+            forKey: .messageChangeRevisions
+        )
+    }
+
+    func coalescing(with other: Self) -> Self? {
+        guard conversationID == other.conversationID else { return nil }
+
+        let preferred: Self = if revision != other.revision {
+            revision > other.revision ? self : other
+        } else {
+            operationID.uuidString >= other.operationID.uuidString ? self : other
+        }
+
+        let combinedFields = fields.union(other.fields)
+        let combinedChanges = preferred.fields.contains(.delete)
+            ? (messages: [], revisions: [:])
+            : Self.mergedMessageChanges(
+                older: preferred.operationID == operationID ? other : self,
+                newer: preferred
+            )
+
+        return Self(
+            operationID: preferred.operationID,
+            peerID: preferred.peerID,
+            revision: max(revision, other.revision),
+            conversation: preferred.conversation,
+            fields: preferred.fields.contains(.delete) ? [.delete] : combinedFields,
+            createRevision: Self.maximum(createRevision, other.createRevision),
+            titleRevision: Self.maximum(titleRevision, other.titleRevision),
+            configurationRevision: Self.maximum(configurationRevision, other.configurationRevision),
+            messageChanges: combinedChanges.messages,
+            messageChangeRevisions: combinedChanges.revisions
+        )
+    }
+
+    static func coalesced(_ mutations: [Self]) -> [Self] {
+        var byConversation: [UUID: Self] = [:]
+        for mutation in mutations {
+            if let existing = byConversation[mutation.conversationID] {
+                byConversation[mutation.conversationID] = existing.coalescing(with: mutation)
+            } else {
+                byConversation[mutation.conversationID] = mutation
+            }
+        }
+        return byConversation.values.sorted {
+            if $0.revision != $1.revision {
+                return $0.revision < $1.revision
+            }
+            return $0.conversationID.uuidString < $1.conversationID.uuidString
+        }
+    }
+
+    private static func mergedMessageChanges(
+        older: Self,
+        newer: Self
+    ) -> (messages: [WatchMessage], revisions: [UUID: WatchSyncRevision]) {
+        var orderedIDs: [UUID] = []
+        var byID: [UUID: WatchMessage] = [:]
+        var revisions: [UUID: WatchSyncRevision] = [:]
+        for mutation in [older, newer] {
+            for message in mutation.messageChanges {
+                let revision = mutation.messageChangeRevisions[message.id] ?? mutation.revision
+                if byID[message.id] == nil {
+                    orderedIDs.append(message.id)
+                }
+                if revision >= revisions[message.id, default: 0] {
+                    byID[message.id] = message
+                    revisions[message.id] = revision
+                }
+            }
+        }
+        return (orderedIDs.compactMap { byID[$0] }, revisions)
+    }
+
+    private static func maximum(
+        _ lhs: WatchSyncRevision?,
+        _ rhs: WatchSyncRevision?
+    ) -> WatchSyncRevision? {
+        switch (lhs, rhs) {
+        case let (lhs?, rhs?): max(lhs, rhs)
+        case let (value?, nil), let (nil, value?): value
+        case (nil, nil): nil
+        }
+    }
+}
+
+struct PhoneWatchSyncState: Equatable, Sendable {
+    var peerID: UUID?
+    var conversations: [Conversation]
+    var acknowledgedWatchRevisions: [UUID: WatchSyncRevision]
+    var tombstoneRevisions: [UUID: WatchSyncRevision]
+
+    init(
+        peerID: UUID? = WatchSyncIdentity.legacyPeerID,
+        conversations: [Conversation] = [],
+        acknowledgedWatchRevisions: [UUID: WatchSyncRevision] = [:],
+        tombstoneRevisions: [UUID: WatchSyncRevision] = [:]
+    ) {
+        self.peerID = peerID
+        self.conversations = WatchConversationCanonicalizer.phoneConversations(conversations)
+        self.acknowledgedWatchRevisions = acknowledgedWatchRevisions
+        self.tombstoneRevisions = tombstoneRevisions
+    }
+}
+
+typealias PhoneWatchMutationState = PhoneWatchSyncState
+
+enum PhoneWatchMutationDisposition: Equatable, Sendable {
+    case applied
+    case deleted
+    case rejectedStale
+    case rejectedDeletedTombstone
+    case rejectedMissingCreate
+}
+
+struct PhoneWatchMutationReduction: Equatable, Sendable {
+    var state: PhoneWatchSyncState
+    let disposition: PhoneWatchMutationDisposition
+
+    var wasApplied: Bool {
+        disposition == .applied || disposition == .deleted
+    }
+}
+
+enum PhoneWatchMutationReducer {
+    static func reduce(
+        _ state: PhoneWatchSyncState,
+        mutation: WatchConversationMutation,
+        tombstoneRevision: WatchSyncRevision? = nil
+    ) -> PhoneWatchMutationReduction {
+        var canonicalState = state
+        canonicalState.conversations = WatchConversationCanonicalizer.phoneConversations(state.conversations)
+        var next = canonicalState
+        if next.peerID != mutation.peerID {
+            next.peerID = mutation.peerID
+            next.acknowledgedWatchRevisions = [:]
+        }
+        let conversationID = mutation.conversationID
+        let acknowledged = next.acknowledgedWatchRevisions[conversationID] ?? 0
+
+        guard mutation.revision > acknowledged else {
+            return PhoneWatchMutationReduction(state: canonicalState, disposition: .rejectedStale)
+        }
+
+        if let tombstoneRevision = next.tombstoneRevisions[conversationID] {
+            next.acknowledgedWatchRevisions[conversationID] = mutation.revision
+            next.tombstoneRevisions[conversationID] = tombstoneRevision
+            next.conversations.removeAll { $0.id == conversationID }
+            return PhoneWatchMutationReduction(
+                state: next,
+                disposition: .rejectedDeletedTombstone
+            )
+        }
+
+        if mutation.fields.contains(.delete) {
+            next.conversations.removeAll { $0.id == conversationID }
+            next.acknowledgedWatchRevisions[conversationID] = mutation.revision
+            next.tombstoneRevisions[conversationID] = tombstoneRevision ?? mutation.revision
+            return PhoneWatchMutationReduction(state: next, disposition: .deleted)
+        }
+
+        if let index = next.conversations.firstIndex(where: { $0.id == conversationID }) {
+            next.conversations[index] = merge(
+                phone: next.conversations[index],
+                mutation: mutation,
+                acknowledgedRevision: acknowledged
+            )
+        } else if mutation.changesCreate(after: acknowledged) {
+            var created = mutation.conversation.toConversation()
+            created.messages = mergeMessages(
+                phone: [],
+                watch: mutation.messageChanges(after: acknowledged)
+            )
+            next.conversations.append(created)
+        } else {
+            next.acknowledgedWatchRevisions[conversationID] = mutation.revision
+            return PhoneWatchMutationReduction(state: next, disposition: .rejectedMissingCreate)
+        }
+
+        next.acknowledgedWatchRevisions[conversationID] = mutation.revision
+        next.conversations.sort(by: conversationSort)
+        return PhoneWatchMutationReduction(state: next, disposition: .applied)
+    }
+
+    static func reduce(
+        _ state: PhoneWatchSyncState,
+        mutations: [WatchConversationMutation]
+    ) -> PhoneWatchSyncState {
+        WatchConversationMutation.coalesced(mutations).reduce(state) { current, mutation in
+            reduce(current, mutation: mutation).state
+        }
+    }
+
+    private static func merge(
+        phone: Conversation,
+        mutation: WatchConversationMutation,
+        acknowledgedRevision: WatchSyncRevision
+    ) -> Conversation {
+        let watch = mutation.conversation
+        var merged = phone
+
+        if mutation.changesTitle(after: acknowledgedRevision) {
+            merged.title = watch.title
+        }
+        if mutation.fields.contains(.create) || mutation.fields.contains(.messages) {
+            merged.messages = mergeMessages(
+                phone: phone.messages,
+                watch: mutation.messageChanges(after: acknowledgedRevision)
+            )
+        }
+
+        if mutation.changesConfiguration(after: acknowledgedRevision) {
+            merged.model = watch.model
+            merged.temperature = watch.temperature
+        }
+        merged.updatedAt = max(phone.updatedAt, watch.updatedAt)
+        return merged
+    }
+
+    private static func mergeMessages(phone: [Message], watch: [WatchMessage]) -> [Message] {
+        var result: [Message] = []
+        var indexByID: [UUID: Int] = [:]
+
+        for message in phone where indexByID[message.id] == nil {
+            indexByID[message.id] = result.count
+            result.append(message)
+        }
+
+        for watchMessage in watch {
+            let converted = watchMessage.toMessage()
+            if let index = indexByID[watchMessage.id] {
+                result[index] = converted
+            } else {
+                indexByID[watchMessage.id] = result.count
+                result.append(converted)
+            }
+        }
+        return result
+    }
+
+    private static func conversationSort(_ lhs: Conversation, _ rhs: Conversation) -> Bool {
+        if lhs.updatedAt != rhs.updatedAt {
+            return lhs.updatedAt > rhs.updatedAt
+        }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+}
+
+typealias WatchPhoneMutationReducer = PhoneWatchMutationReducer
+
+struct WatchSyncLocalState: Equatable, Sendable {
+    var sourceID: UUID?
+    var peerID: UUID
+    var lastSnapshotRevision: WatchSyncRevision
+    var conversations: [WatchConversation]
+    var pendingMutations: [WatchConversationMutation]
+    var pendingDrafts: [UUID: WatchConversationDraft]
+    var localDeliveryCoverage: [UUID: WatchMutationDeliveryCoverage]
+
+    init(
+        sourceID: UUID? = nil,
+        peerID: UUID = WatchSyncIdentity.legacyPeerID,
+        lastSnapshotRevision: WatchSyncRevision = 0,
+        conversations: [WatchConversation] = [],
+        pendingMutations: [WatchConversationMutation] = [],
+        pendingDrafts: [UUID: WatchConversationDraft] = [:],
+        localDeliveryCoverage: [UUID: WatchMutationDeliveryCoverage] = [:]
+    ) {
+        self.sourceID = sourceID
+        self.peerID = peerID
+        self.lastSnapshotRevision = lastSnapshotRevision
+        self.conversations = WatchConversationCanonicalizer.watchConversations(conversations)
+        self.pendingMutations = pendingMutations
+        self.pendingDrafts = pendingDrafts
+        self.localDeliveryCoverage = localDeliveryCoverage
+    }
+}
+
+struct WatchConversationDraft: Codable, Equatable, Identifiable, Sendable {
+    var conversation: WatchConversation
+    var ownedMessageIDs: Set<UUID>
+    /// Mutation intent retained locally when the conversation revision cannot advance.
+    /// Optional for backward-compatible decoding of drafts persisted before overflow handling.
+    var deferredMutationFields: WatchConversationMutationFields?
+
+    init(
+        conversation: WatchConversation,
+        ownedMessageIDs: Set<UUID>,
+        deferredMutationFields: WatchConversationMutationFields? = nil
+    ) {
+        self.conversation = conversation
+        self.ownedMessageIDs = ownedMessageIDs
+        self.deferredMutationFields = deferredMutationFields
+    }
+
+    var id: UUID {
+        conversation.id
+    }
+
+    var deferredFields: WatchConversationMutationFields {
+        deferredMutationFields ?? []
+    }
+}
+
+typealias WatchSnapshotState = WatchSyncLocalState
+
+enum WatchSnapshotReconciliationDisposition: Equatable, Sendable {
+    case applied
+    case ignoredStale
+    case ignoredUnsupportedSchema
+}
+
+struct WatchSnapshotReconciliation: Equatable, Sendable {
+    var state: WatchSyncLocalState
+    let disposition: WatchSnapshotReconciliationDisposition
+}
+
+enum WatchSnapshotReconciler {
+    static func reconcile(
+        _ snapshot: WatchSyncSnapshot,
+        with state: WatchSyncLocalState
+    ) -> WatchSnapshotReconciliation {
+        var canonicalState = state
+        canonicalState.conversations = WatchConversationCanonicalizer.watchConversations(state.conversations)
+        guard WatchSyncSnapshot.supportsSchemaVersion(snapshot.schemaVersion) else {
+            return WatchSnapshotReconciliation(state: canonicalState, disposition: .ignoredUnsupportedSchema)
+        }
+
+        let sourceChanged = canonicalState.sourceID.map { $0 != snapshot.sourceID } ?? false
+        guard sourceChanged || snapshot.revision > canonicalState.lastSnapshotRevision else {
+            return WatchSnapshotReconciliation(state: canonicalState, disposition: .ignoredStale)
+        }
+
+        let acknowledgements = snapshot.acknowledgedPeerID == canonicalState.peerID
+            ? snapshot.acknowledgedWatchRevisions
+            : [:]
+
+        let tombstones = tombstoneDictionary(snapshot.tombstones)
+        let manifest = Set(snapshot.authoritativeConversationIDs).subtracting(tombstones.keys)
+        let cachedConversations = dictionaryByID(canonicalState.conversations)
+        let original = if sourceChanged, snapshot.authoritativeConversationIDsAreComplete {
+            cachedConversations.filter { manifest.contains($0.key) }
+        } else {
+            cachedConversations
+        }
+        let remote = dictionaryByID(snapshot.conversations.filter {
+            tombstones[$0.id] == nil &&
+                (!snapshot.authoritativeConversationIDsAreComplete || manifest.contains($0.id))
+        })
+
+        var reconciled: [UUID: WatchConversation] = snapshot.authoritativeConversationIDsAreComplete
+            ? [:]
+            : original.filter { tombstones[$0.key] == nil }
+        if !snapshot.authoritativeConversationIDsAreComplete {
+            for (conversationID, var retained) in reconciled {
+                retained.watchRevision = max(
+                    retained.watchRevision,
+                    acknowledgements[conversationID] ?? 0
+                )
+                reconciled[conversationID] = retained
+            }
+        }
+        for conversationID in manifest {
+            if let body = remote[conversationID] {
+                reconciled[conversationID] = body
+            } else if var retained = original[conversationID] {
+                retained.watchRevision = max(
+                    retained.watchRevision,
+                    acknowledgements[conversationID] ?? 0
+                )
+                reconciled[conversationID] = retained
+            }
+        }
+        for (conversationID, body) in remote {
+            reconciled[conversationID] = body
+        }
+        for configuration in snapshot.conversationConfigurations
+            where tombstones[configuration.id] == nil
+        {
+            guard var retained = reconciled[configuration.id] else { continue }
+            configuration.apply(to: &retained)
+            reconciled[configuration.id] = retained
+        }
+
+        let remaining = canonicalState.pendingMutations.filter { mutation in
+            guard tombstones[mutation.conversationID] == nil else { return false }
+            let acknowledgement = max(
+                acknowledgements[mutation.conversationID] ?? 0,
+                0
+            )
+            return mutation.revision > acknowledgement
+        }
+        let pendingMutations = WatchConversationMutation.coalesced(remaining)
+        let pendingDeleteIDs = Set(
+            pendingMutations
+                .filter { $0.fields.contains(.delete) }
+                .map(\.conversationID)
+        )
+
+        for mutation in pendingMutations {
+            replay(
+                mutation,
+                acknowledgedRevision: acknowledgements[mutation.conversationID] ?? 0,
+                coverage: canonicalState.localDeliveryCoverage[mutation.conversationID],
+                into: &reconciled
+            )
+        }
+
+        let pendingMutationIDs = Set(pendingMutations.map(\.conversationID))
+        var remainingDrafts = canonicalState.pendingDrafts.filter { conversationID, _ in
+            tombstones[conversationID] == nil &&
+                (!snapshot.authoritativeConversationIDsAreComplete ||
+                    manifest.contains(conversationID) ||
+                    pendingMutationIDs.contains(conversationID))
+        }
+        for (conversationID, draft) in remainingDrafts where !pendingDeleteIDs.contains(conversationID) {
+            if draft.deferredFields.contains(.delete) {
+                reconciled.removeValue(forKey: conversationID)
+                continue
+            }
+
+            var remoteConversation = reconciled[conversationID] ?? draft.conversation
+            if draft.deferredFields.contains(.title) {
+                remoteConversation.title = draft.conversation.title
+            }
+            if draft.deferredFields.contains(.configuration) {
+                remoteConversation.model = draft.conversation.model
+                remoteConversation.temperature = draft.conversation.temperature
+            }
+            remoteConversation.messages = mergeWatchMessages(
+                remote: remoteConversation.messages,
+                local: draft.conversation.messages.filter { draft.ownedMessageIDs.contains($0.id) }
+            )
+            remoteConversation.updatedAt = max(remoteConversation.updatedAt, draft.conversation.updatedAt)
+            remoteConversation.watchRevision = max(
+                remoteConversation.watchRevision,
+                draft.conversation.watchRevision
+            )
+            reconciled[conversationID] = remoteConversation
+            remainingDrafts[conversationID] = WatchConversationDraft(
+                conversation: remoteConversation,
+                ownedMessageIDs: draft.ownedMessageIDs,
+                deferredMutationFields: draft.deferredMutationFields
+            )
+        }
+
+        let conversations = reconciled.values.sorted(by: watchConversationSort)
+        let next = WatchSyncLocalState(
+            sourceID: snapshot.sourceID,
+            peerID: canonicalState.peerID,
+            lastSnapshotRevision: snapshot.revision,
+            conversations: conversations,
+            pendingMutations: pendingMutations,
+            pendingDrafts: remainingDrafts,
+            localDeliveryCoverage: canonicalState.localDeliveryCoverage
+        )
+        return WatchSnapshotReconciliation(state: next, disposition: .applied)
+    }
+
+    private static func replay(
+        _ mutation: WatchConversationMutation,
+        acknowledgedRevision: WatchSyncRevision,
+        coverage: WatchMutationDeliveryCoverage?,
+        into conversations: inout [UUID: WatchConversation]
+    ) {
+        if mutation.fields.contains(.delete) {
+            conversations.removeValue(forKey: mutation.conversationID)
+            return
+        }
+
+        let applicableMessageChanges = mutation.messageChanges(
+            after: acknowledgedRevision,
+            coverage: coverage
+        )
+        let changesCreate = mutation.changesCreate(
+            after: acknowledgedRevision,
+            coverage: coverage
+        )
+        let changesTitle = mutation.changesTitle(
+            after: acknowledgedRevision,
+            coverage: coverage
+        )
+        let changesConfiguration = mutation.changesConfiguration(
+            after: acknowledgedRevision,
+            coverage: coverage
+        )
+        guard var current = conversations[mutation.conversationID] else {
+            guard changesCreate || changesTitle || changesConfiguration || !applicableMessageChanges.isEmpty else {
+                return
+            }
+            var created = mutation.conversation
+            created.messages = mergeWatchMessages(remote: [], local: applicableMessageChanges)
+            conversations[mutation.conversationID] = created
+            return
+        }
+
+        let local = mutation.conversation
+        if changesTitle {
+            current.title = local.title
+        }
+        if mutation.fields.contains(.create) || mutation.fields.contains(.messages) {
+            current.messages = mergeWatchMessages(remote: current.messages, local: applicableMessageChanges)
+        }
+        if changesConfiguration {
+            current.model = local.model
+            current.temperature = local.temperature
+        }
+        if changesCreate {
+            current.resolvedSystemPrompt = local.resolvedSystemPrompt
+        }
+        current.updatedAt = max(current.updatedAt, local.updatedAt)
+        current.watchRevision = max(current.watchRevision, mutation.revision)
+        conversations[mutation.conversationID] = current
+    }
+
+    private static func mergeWatchMessages(
+        remote: [WatchMessage],
+        local: [WatchMessage]
+    ) -> [WatchMessage] {
+        var result: [WatchMessage] = []
+        var indexByID: [UUID: Int] = [:]
+        for message in remote where indexByID[message.id] == nil {
+            indexByID[message.id] = result.count
+            result.append(message)
+        }
+        for message in local {
+            if let index = indexByID[message.id] {
+                result[index] = message
+            } else {
+                indexByID[message.id] = result.count
+                result.append(message)
+            }
+        }
+        return result
+    }
+
+    private static func dictionaryByID(_ conversations: [WatchConversation]) -> [UUID: WatchConversation] {
+        var result: [UUID: WatchConversation] = [:]
+        for conversation in conversations {
+            if let existing = result[conversation.id] {
+                if preferredState(conversation, over: existing) {
+                    result[conversation.id] = conversation
+                }
+            } else {
+                result[conversation.id] = conversation
+            }
+        }
+        return result
+    }
+
+    private static func preferredState(
+        _ candidate: WatchConversation,
+        over existing: WatchConversation
+    ) -> Bool {
+        if candidate.watchRevision != existing.watchRevision {
+            return candidate.watchRevision > existing.watchRevision
+        }
+        return watchConversationSort(candidate, existing)
+    }
+
+    private static func tombstoneDictionary(
+        _ tombstones: [WatchConversationTombstone]
+    ) -> [UUID: WatchSyncRevision] {
+        var result: [UUID: WatchSyncRevision] = [:]
+        for tombstone in tombstones {
+            result[tombstone.conversationID] = max(
+                result[tombstone.conversationID] ?? 0,
+                tombstone.revision
+            )
+        }
+        return result
+    }
+
+    private static func watchConversationSort(
+        _ lhs: WatchConversation,
+        _ rhs: WatchConversation
+    ) -> Bool {
+        if lhs.updatedAt != rhs.updatedAt {
+            return lhs.updatedAt > rhs.updatedAt
+        }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+}
+
+typealias WatchSyncSnapshotReconciler = WatchSnapshotReconciler
+
+struct WatchSyncPayloadConfiguration: Equatable, Sendable {
+    var maximumConversations = 10
+    var maximumMessagesPerConversation = 20
+    var maximumContentCharacters = 4000
+    var maximumTitleCharacters = 160
+    /// Legacy sizing threshold. Model identifiers remain lossless; byte pressure removes records instead.
+    var maximumModelCharacters = 160
+    var maximumSystemPromptCharacters = 4000
+    var maximumToolCallsPerMessage = 4
+    var maximumToolMetadataBytes = 2048
+    var maximumCitationsPerMessage = 8
+    var maximumCitationCharacters = 512
+    var maximumAcknowledgements = 64
+    var maximumTombstones = 32
+    var maximumManifestConversationIDs = 256
+    var maximumConversationConfigurations = 64
+    var byteBudget = 50000
+
+    static let `default` = Self()
+
+    init() {}
+
+    init(
+        byteBudget: Int,
+        maximumConversations: Int = 10,
+        maximumMessagesPerConversation: Int = 20,
+        maximumContentCharacters: Int = 4000
+    ) {
+        self.byteBudget = byteBudget
+        self.maximumConversations = maximumConversations
+        self.maximumMessagesPerConversation = maximumMessagesPerConversation
+        self.maximumContentCharacters = maximumContentCharacters
+    }
+}
+
+typealias WatchSyncPayloadLimits = WatchSyncPayloadConfiguration
+
+enum WatchSyncPayloadBuilderError: Error, Equatable {
+    case invalidByteBudget(Int)
+    case invalidPageCycleCursor
+    case irreducibleSnapshotExceedsBudget(actualBytes: Int, budget: Int)
+    case pageCycleCannotProgress
+    case mutationExceedsBudget(actualBytes: Int, budget: Int)
+}
+
+/// Publishes an explicit empty default prompt when the current fallback cannot carry the full value.
+///
+/// The phone's durable preference is never changed. A volatile argument-domain override exists only
+/// until the synchronous application-context publication finishes, then the original value is restored.
+enum WatchDefaultSystemPromptPublicationGate {
+    private static let argumentDomainName = "NSArgumentDomain"
+    private static let preferenceKey = "globalSystemPrompt"
+
+    private struct ActiveOverride {
+        let defaults: UserDefaults
+        let previousValue: Any?
+        let hadPreviousValue: Bool
+        let generation: UInt64
+    }
+
+    private final class State: @unchecked Sendable {
+        let lock = NSLock()
+        var nextGeneration: UInt64 = 0
+        var overrides: [ObjectIdentifier: ActiveOverride] = [:]
+    }
+
+    private static let state = State()
+
+    static func maximumCharacters(for configuration: WatchSyncPayloadConfiguration) -> Int {
+        switch configuration.byteBudget {
+        case 32000, 24000:
+            4000
+        case 12000:
+            2000
+        case 4000:
+            0
+        default:
+            max(0, configuration.maximumSystemPromptCharacters)
+        }
+    }
+
+    static func prepareForSnapshotBuild(defaults: UserDefaults = AppPreferences.storage) {
+        restoreOverride(for: ObjectIdentifier(defaults), generation: nil)
+    }
+
+    @discardableResult
+    static func installIfNeeded(
+        configuration: WatchSyncPayloadConfiguration,
+        defaults: UserDefaults = AppPreferences.storage,
+        schedulesAutomaticRestore: Bool = true
+    ) -> Bool {
+        guard Thread.isMainThread else { return false }
+        prepareForSnapshotBuild(defaults: defaults)
+
+        let prompt = defaults.string(forKey: preferenceKey) ?? ""
+        let maximumCharacters = maximumCharacters(for: configuration)
+        guard !prompt.isEmpty,
+              maximumCharacters == 0 || prompt.count > maximumCharacters
+        else {
+            return false
+        }
+
+        let identifier = ObjectIdentifier(defaults)
+        state.lock.lock()
+        let nextGeneration = state.nextGeneration.addingReportingOverflow(1)
+        state.nextGeneration = nextGeneration.overflow ? 1 : nextGeneration.partialValue
+        var argumentDomain = defaults.volatileDomain(forName: argumentDomainName)
+        let previousValue = argumentDomain[preferenceKey]
+        let hadPreviousValue = previousValue != nil
+        argumentDomain[preferenceKey] = ""
+        defaults.setVolatileDomain(argumentDomain, forName: argumentDomainName)
+        let generation = state.nextGeneration
+        state.overrides[identifier] = ActiveOverride(
+            defaults: defaults,
+            previousValue: previousValue,
+            hadPreviousValue: hadPreviousValue,
+            generation: generation
+        )
+        state.lock.unlock()
+
+        if schedulesAutomaticRestore {
+            Task { @MainActor in
+                restoreOverride(for: identifier, generation: generation)
+            }
+        }
+        return true
+    }
+
+    private static func restoreOverride(
+        for identifier: ObjectIdentifier,
+        generation: UInt64?
+    ) {
+        state.lock.lock()
+        guard let active = state.overrides[identifier],
+              generation == nil || active.generation == generation
+        else {
+            state.lock.unlock()
+            return
+        }
+        state.overrides.removeValue(forKey: identifier)
+        var argumentDomain = active.defaults.volatileDomain(forName: argumentDomainName)
+        if active.hadPreviousValue, let previousValue = active.previousValue {
+            argumentDomain[preferenceKey] = previousValue
+        } else {
+            argumentDomain.removeValue(forKey: preferenceKey)
+        }
+        active.defaults.setVolatileDomain(argumentDomain, forName: argumentDomainName)
+        state.lock.unlock()
+    }
+}
+
+// swiftlint:disable:next type_body_length
+enum WatchSyncPayloadBuilder {
+    typealias Configuration = WatchSyncPayloadConfiguration
+
+    private struct Page<Element> {
+        let values: [Element]
+        let isComplete: Bool
+    }
+
+    private struct SnapshotBuildResult {
+        let payload: WatchSyncPayload
+        let configurationCursorAdvanceCount: Int
+        let unavailablePromptIDs: Set<UUID>
+    }
+
+    private struct RequestConfigurationTransportPlan {
+        let values: [WatchConversationRequestConfiguration]
+        let unavailablePromptIDs: Set<UUID>
+        let deferredConfigurationIDs: Set<UUID>
+    }
+
+    private struct SnapshotTrimContext {
+        let budget: Int
+        let acknowledgementPriority: [UUID]
+        let protectedAcknowledgementIDs: Set<UUID>
+        let tombstonePriority: [UUID]
+        let manifestValues: [UUID]
+        let manifestMaximumCount: Int
+        let configurationValues: [WatchConversationRequestConfiguration]
+        let configurationMaximumCount: Int
+        let deferredConfigurationIDs: Set<UUID>
+        let unavailablePromptIDs: Set<UUID>
+        let configurationIncludesBodies: Bool
+        let paginationCursor: WatchSyncRevision
+        let pageCycleCursor: WatchSyncPageCycleCursor?
+    }
+
+    private struct MessageRemovalCandidate {
+        let conversation: Int
+        let message: Int
+        let timestamp: Date
+        let id: String
+    }
+
+    static func build(
+        conversations: [Conversation],
+        sourceID: UUID = WatchSyncIdentity.legacySourceID,
+        snapshotRevision: WatchSyncRevision,
+        paginationCursor: WatchSyncRevision? = nil,
+        acknowledgedPeerID: UUID? = WatchSyncIdentity.legacyPeerID,
+        acknowledgedWatchRevisions: [UUID: WatchSyncRevision] = [:],
+        prioritizedAcknowledgementIDs: [UUID] = [],
+        tombstoneRevisions: [UUID: WatchSyncRevision] = [:],
+        configuration: Configuration = .default,
+        resolvedSystemPrompt: ((Conversation) -> String?)? = nil,
+        pageCycleCursor: WatchSyncPageCycleCursor? = nil
+    ) throws -> WatchSyncPayload {
+        let defaults = AppPreferences.storage
+        WatchDefaultSystemPromptPublicationGate.prepareForSnapshotBuild(defaults: defaults)
+        let result = try buildSnapshot(
+            conversations: conversations,
+            sourceID: sourceID,
+            snapshotRevision: snapshotRevision,
+            paginationCursor: paginationCursor,
+            acknowledgedPeerID: acknowledgedPeerID,
+            acknowledgedWatchRevisions: acknowledgedWatchRevisions,
+            prioritizedAcknowledgementIDs: prioritizedAcknowledgementIDs,
+            tombstoneRevisions: tombstoneRevisions,
+            configuration: configuration,
+            resolvedSystemPrompt: resolvedSystemPrompt,
+            pageCycleCursor: pageCycleCursor
+        ).payload
+        WatchDefaultSystemPromptPublicationGate.installIfNeeded(
+            configuration: configuration,
+            defaults: defaults
+        )
+        return result
+    }
+
+    // swiftlint:disable:next function_body_length function_parameter_count
+    private static func buildSnapshot(
+        conversations: [Conversation],
+        sourceID: UUID,
+        snapshotRevision: WatchSyncRevision,
+        paginationCursor: WatchSyncRevision?,
+        acknowledgedPeerID: UUID?,
+        acknowledgedWatchRevisions: [UUID: WatchSyncRevision],
+        prioritizedAcknowledgementIDs: [UUID],
+        tombstoneRevisions: [UUID: WatchSyncRevision],
+        configuration: Configuration,
+        resolvedSystemPrompt: ((Conversation) -> String?)?,
+        pageCycleCursor: WatchSyncPageCycleCursor?
+    ) throws -> SnapshotBuildResult {
+        guard configuration.byteBudget > 0 else {
+            throw WatchSyncPayloadBuilderError.invalidByteBudget(configuration.byteBudget)
+        }
+
+        let sorted = WatchConversationCanonicalizer.phoneConversations(conversations)
+        let resolvedConversations = sorted.map { conversation in
+            (
+                conversation: conversation,
+                resolvedSystemPrompt: resolvedSystemPrompt?(conversation)
+            )
+        }
+        let resolvedPaginationCursor = paginationCursor ?? (snapshotRevision > 0 ? snapshotRevision - 1 : 0)
+        let fullConfigurations = resolvedConversations.map { resolved in
+            boundedRequestConfiguration(
+                resolved.conversation,
+                configuration: configuration,
+                resolvedSystemPrompt: resolved.resolvedSystemPrompt
+            )
+        }
+        let transportPlan = try requestConfigurationTransportPlan(
+            fullConfigurations,
+            sourceID: sourceID,
+            snapshotRevision: snapshotRevision,
+            paginationCursor: resolvedPaginationCursor,
+            acknowledgedPeerID: acknowledgedPeerID,
+            configuration: configuration
+        )
+        let allConfigurations = transportPlan.values
+        let configurationByID = Dictionary(
+            allConfigurations.map { ($0.id, $0) },
+            uniquingKeysWith: { existing, _ in existing }
+        )
+        let bodies = resolvedConversations
+            .prefix(max(0, configuration.maximumConversations))
+            .filter { !transportPlan.deferredConfigurationIDs.contains($0.conversation.id) }
+            .map { resolved in
+                boundedConversation(
+                    resolved.conversation,
+                    acknowledgedRevision: acknowledgedWatchRevisions[resolved.conversation.id] ?? 0,
+                    configuration: configuration,
+                    resolvedSystemPrompt: configurationByID[resolved.conversation.id]?.resolvedSystemPrompt
+                )
+            }
+        let allManifestIDs = sorted.map(\.id)
+        let manifestPage = if let pageCycleCursor {
+            page(
+                allManifestIDs,
+                maximumCount: configuration.maximumManifestConversationIDs,
+                offset: pageCycleCursor.manifestOffset
+            )
+        } else {
+            page(
+                allManifestIDs,
+                maximumCount: configuration.maximumManifestConversationIDs,
+                cursor: resolvedPaginationCursor
+            )
+        }
+        let manifest = manifestPage.values
+        let manifestSet = Set(allManifestIDs)
+        let configurationIncludesBodies = pageCycleCursor != nil
+        let deferredConfigurationIDs = try transportPlan.deferredConfigurationIDs.union(
+            irreducibleConfigurationIDs(
+                in: allConfigurations,
+                sourceID: sourceID,
+                snapshotRevision: snapshotRevision,
+                paginationCursor: resolvedPaginationCursor,
+                acknowledgedPeerID: acknowledgedPeerID,
+                configuration: configuration,
+                pageCycleCursor: pageCycleCursor
+            )
+        )
+        let configurationPage = requestConfigurationPage(
+            allConfigurations,
+            bodyIDs: configurationIncludesBodies ? [] : Set(bodies.map(\.id)),
+            maximumCount: configuration.maximumConversationConfigurations,
+            cursor: resolvedPaginationCursor,
+            offset: pageCycleCursor?.configurationOffset,
+            deferredConfigurationIDs: deferredConfigurationIDs
+        )
+        let protectedAcknowledgementIDs = Set(prioritizedAcknowledgementIDs + manifest)
+        var acknowledgementIDs: [UUID] = []
+        var seenAcknowledgementIDs: Set<UUID> = []
+        for id in prioritizedAcknowledgementIDs + manifest
+            where acknowledgedWatchRevisions[id] != nil && seenAcknowledgementIDs.insert(id).inserted
+        {
+            acknowledgementIDs.append(id)
+        }
+        for entry in acknowledgedWatchRevisions.sorted(by: { lhs, rhs in
+            if lhs.value != rhs.value {
+                return lhs.value > rhs.value
+            }
+            return lhs.key.uuidString < rhs.key.uuidString
+        }) where seenAcknowledgementIDs.insert(entry.key).inserted {
+            acknowledgementIDs.append(entry.key)
+        }
+        let boundedAcknowledgementIDs = Array(
+            acknowledgementIDs.prefix(max(0, configuration.maximumAcknowledgements))
+        )
+        var boundedAcknowledgements: [UUID: WatchSyncRevision] = [:]
+        for id in boundedAcknowledgementIDs {
+            boundedAcknowledgements[id] = acknowledgedWatchRevisions[id]
+        }
+        let sortedTombstones = tombstoneRevisions
+            .filter { !manifestSet.contains($0.key) }
+            .sorted { lhs, rhs in
+                if lhs.value != rhs.value {
+                    return lhs.value > rhs.value
+                }
+                return lhs.key.uuidString < rhs.key.uuidString
+            }
+        // Legacy schema-3 publication rotates pages; explicit cycles use exact offsets.
+        let tombstonePage = if let pageCycleCursor {
+            page(
+                sortedTombstones,
+                maximumCount: configuration.maximumTombstones,
+                offset: pageCycleCursor.tombstoneOffset
+            )
+        } else {
+            rotate(
+                sortedTombstones,
+                limit: configuration.maximumTombstones,
+                cursor: resolvedPaginationCursor
+            )
+        }
+        let boundedTombstoneEntries = tombstonePage.values
+        let boundedTombstones = Dictionary(uniqueKeysWithValues: boundedTombstoneEntries)
+        var snapshot = WatchSyncSnapshot(
+            snapshotRevision: snapshotRevision,
+            sourceID: sourceID,
+            paginationCursor: resolvedPaginationCursor,
+            conversations: bodies,
+            authoritativeConversationIDs: manifest,
+            authoritativeConversationIDsAreComplete: manifestPage.isComplete,
+            conversationConfigurations: configurationPage.values,
+            conversationConfigurationsAreComplete: configurationPage.isComplete
+                && transportPlan.unavailablePromptIDs.isEmpty,
+            acknowledgedPeerID: acknowledgedPeerID,
+            acknowledgedWatchRevisions: boundedAcknowledgements,
+            tombstoneRevisions: boundedTombstones
+        )
+        let data = try trimAndEncode(
+            &snapshot,
+            context: SnapshotTrimContext(
+                budget: configuration.byteBudget,
+                acknowledgementPriority: boundedAcknowledgementIDs,
+                protectedAcknowledgementIDs: protectedAcknowledgementIDs,
+                tombstonePriority: boundedTombstoneEntries.map(\.key),
+                manifestValues: allManifestIDs,
+                manifestMaximumCount: configuration.maximumManifestConversationIDs,
+                configurationValues: allConfigurations,
+                configurationMaximumCount: configuration.maximumConversationConfigurations,
+                deferredConfigurationIDs: deferredConfigurationIDs,
+                unavailablePromptIDs: transportPlan.unavailablePromptIDs,
+                configurationIncludesBodies: configurationIncludesBodies,
+                paginationCursor: resolvedPaginationCursor,
+                pageCycleCursor: pageCycleCursor
+            )
+        )
+        let configurationCursorAdvanceCount = pageCycleCursor.map { cursor in
+            configurationCursorAdvanceCount(
+                in: allConfigurations,
+                delivered: snapshot.conversationConfigurations,
+                deferredConfigurationIDs: deferredConfigurationIDs,
+                maximumCount: configuration.maximumConversationConfigurations,
+                offset: cursor.configurationOffset
+            )
+        } ?? snapshot.conversationConfigurations.count
+        return SnapshotBuildResult(
+            payload: WatchSyncPayload(snapshot: snapshot, data: data),
+            configurationCursorAdvanceCount: configurationCursorAdvanceCount,
+            unavailablePromptIDs: transportPlan.unavailablePromptIDs
+        )
+    }
+
+    static func build(
+        state: PhoneWatchSyncState,
+        sourceID: UUID = WatchSyncIdentity.legacySourceID,
+        snapshotRevision: WatchSyncRevision,
+        paginationCursor: WatchSyncRevision? = nil,
+        prioritizedAcknowledgementIDs: [UUID] = [],
+        configuration: Configuration = .default,
+        resolvedSystemPrompt: ((Conversation) -> String?)? = nil,
+        pageCycleCursor: WatchSyncPageCycleCursor? = nil
+    ) throws -> WatchSyncPayload {
+        try build(
+            conversations: state.conversations,
+            sourceID: sourceID,
+            snapshotRevision: snapshotRevision,
+            paginationCursor: paginationCursor,
+            acknowledgedPeerID: state.peerID,
+            acknowledgedWatchRevisions: state.acknowledgedWatchRevisions,
+            prioritizedAcknowledgementIDs: prioritizedAcknowledgementIDs,
+            tombstoneRevisions: state.tombstoneRevisions,
+            configuration: configuration,
+            resolvedSystemPrompt: resolvedSystemPrompt,
+            pageCycleCursor: pageCycleCursor
+        )
+    }
+
+    static func buildPageCycle(
+        state: PhoneWatchSyncState,
+        sourceID: UUID = WatchSyncIdentity.legacySourceID,
+        snapshotRevision: WatchSyncRevision,
+        cycleID: UUID,
+        cursor: WatchSyncPageCycleCursor,
+        prioritizedAcknowledgementIDs: [UUID] = [],
+        configuration: Configuration = .default,
+        resolvedSystemPrompt: ((Conversation) -> String?)? = nil
+    ) throws -> WatchSyncPageCyclePayload {
+        let defaults = AppPreferences.storage
+        WatchDefaultSystemPromptPublicationGate.prepareForSnapshotBuild(defaults: defaults)
+        guard cursor.isValid,
+              let paginationCursor = WatchSyncRevision(exactly: cursor.pageIndex)
+        else {
+            throw WatchSyncPayloadBuilderError.invalidPageCycleCursor
+        }
+        var canonicalState = state
+        canonicalState.conversations = WatchConversationCanonicalizer.phoneConversations(state.conversations)
+        let buildResult = try buildSnapshot(
+            conversations: canonicalState.conversations,
+            sourceID: sourceID,
+            snapshotRevision: snapshotRevision,
+            paginationCursor: paginationCursor,
+            acknowledgedPeerID: canonicalState.peerID,
+            acknowledgedWatchRevisions: canonicalState.acknowledgedWatchRevisions,
+            prioritizedAcknowledgementIDs: prioritizedAcknowledgementIDs,
+            tombstoneRevisions: canonicalState.tombstoneRevisions,
+            configuration: configuration,
+            resolvedSystemPrompt: resolvedSystemPrompt,
+            pageCycleCursor: cursor
+        )
+        let activeIDs = Set(canonicalState.conversations.map(\.id))
+        var snapshot = buildResult.payload.snapshot
+        let configurationCount = canonicalState.conversations.count
+        let tombstoneCount = state.tombstoneRevisions.keys.reduce(into: 0) { count, id in
+            if !activeIDs.contains(id) {
+                count += 1
+            }
+        }
+        if cursor.manifestOffset >= canonicalState.conversations.count {
+            snapshot.authoritativeConversationIDs = []
+            snapshot.authoritativeConversationIDsAreComplete = canonicalState.conversations.isEmpty
+        }
+        if cursor.configurationOffset >= configurationCount {
+            snapshot.conversationConfigurations = []
+            snapshot.conversationConfigurationsAreComplete = configurationCount == 0
+        }
+        if cursor.tombstoneOffset >= tombstoneCount {
+            snapshot.tombstones = []
+        }
+        let data = try encode(snapshot)
+        let metadata = WatchSyncPageCycleMetadata(
+            cycleID: cycleID,
+            sourceID: sourceID,
+            snapshotRevision: snapshotRevision,
+            cursor: cursor,
+            manifest: WatchSyncPageSection(
+                offset: cursor.manifestOffset,
+                itemCount: snapshot.authoritativeConversationIDs.count,
+                totalCount: canonicalState.conversations.count
+            ),
+            configurations: WatchSyncPageSection(
+                offset: cursor.configurationOffset,
+                itemCount: snapshot.conversationConfigurations.count,
+                totalCount: configurationCount,
+                cursorAdvanceCount: buildResult.configurationCursorAdvanceCount,
+                containsUnavailablePromptGate: snapshot.conversationConfigurations.contains {
+                    buildResult.unavailablePromptIDs.contains($0.id)
+                }
+            ),
+            tombstones: WatchSyncPageSection(
+                offset: cursor.tombstoneOffset,
+                itemCount: snapshot.tombstones.count,
+                totalCount: tombstoneCount
+            )
+        )
+        let sections = [metadata.manifest, metadata.configurations, metadata.tombstones]
+        guard sections.allSatisfy({
+            $0.offset >= $0.totalCount || $0.cursorAdvanceCount > 0
+        }) else {
+            throw WatchSyncPayloadBuilderError.pageCycleCannotProgress
+        }
+        let payload = WatchSyncPageCyclePayload(
+            snapshot: snapshot,
+            data: data,
+            metadata: metadata
+        )
+        WatchDefaultSystemPromptPublicationGate.installIfNeeded(
+            configuration: configuration,
+            defaults: defaults
+        )
+        return payload
+    }
+
+    static func encode(_ snapshot: WatchSyncSnapshot) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(snapshot)
+    }
+
+    static func buildMutation(
+        _ mutation: WatchConversationMutation,
+        byteBudget: Int = 48000,
+        configuration _: Configuration = .default
+    ) throws -> WatchMutationPayload {
+        guard byteBudget > 0 else {
+            throw WatchSyncPayloadBuilderError.invalidByteBudget(byteBudget)
+        }
+
+        let data = try encodeMutation(mutation)
+        guard data.count <= byteBudget else {
+            throw WatchSyncPayloadBuilderError.mutationExceedsBudget(
+                actualBytes: data.count,
+                budget: byteBudget
+            )
+        }
+        return WatchMutationPayload(mutation: mutation, data: data)
+    }
+
+    static func encodeMutation(_ mutation: WatchConversationMutation) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(mutation)
+    }
+
+    private static func trimAndEncode(
+        _ snapshot: inout WatchSyncSnapshot,
+        context: SnapshotTrimContext
+    ) throws -> Data {
+        var boundedManifestCount = min(
+            max(0, context.manifestMaximumCount),
+            context.manifestValues.count
+        )
+        var boundedConfigurationCount = min(
+            max(0, context.configurationMaximumCount),
+            context.configurationValues.count
+        )
+        var data = try encode(snapshot)
+        while data.count > context.budget {
+            if removeOldestMessage(from: &snapshot.conversations) {
+                data = try encode(snapshot)
+                continue
+            }
+            if !snapshot.conversations.isEmpty {
+                snapshot.conversations.removeLast()
+                refreshRequestConfigurationPage(
+                    in: &snapshot,
+                    values: context.configurationValues,
+                    maximumCount: boundedConfigurationCount,
+                    cursor: context.paginationCursor,
+                    offset: context.pageCycleCursor?.configurationOffset,
+                    deferredConfigurationIDs: context.deferredConfigurationIDs,
+                    unavailablePromptIDs: context.unavailablePromptIDs,
+                    includeBodyConfigurations: context.configurationIncludesBodies
+                )
+                data = try encode(snapshot)
+                continue
+            }
+            if removeLowestPriorityMetadata(
+                from: &snapshot,
+                acknowledgementPriority: context.acknowledgementPriority,
+                protectedAcknowledgementIDs: context.protectedAcknowledgementIDs,
+                tombstonePriority: context.tombstonePriority
+            ) {
+                data = try encode(snapshot)
+                continue
+            }
+            if boundedConfigurationCount > 1 {
+                boundedConfigurationCount -= 1
+                refreshRequestConfigurationPage(
+                    in: &snapshot,
+                    values: context.configurationValues,
+                    maximumCount: boundedConfigurationCount,
+                    cursor: context.paginationCursor,
+                    offset: context.pageCycleCursor?.configurationOffset,
+                    deferredConfigurationIDs: context.deferredConfigurationIDs,
+                    unavailablePromptIDs: context.unavailablePromptIDs,
+                    includeBodyConfigurations: context.configurationIncludesBodies
+                )
+                data = try encode(snapshot)
+                continue
+            }
+            if boundedManifestCount > 0 {
+                boundedManifestCount -= 1
+                let manifestPage = if let pageCycleCursor = context.pageCycleCursor {
+                    page(
+                        context.manifestValues,
+                        maximumCount: boundedManifestCount,
+                        offset: pageCycleCursor.manifestOffset
+                    )
+                } else {
+                    page(
+                        context.manifestValues,
+                        maximumCount: boundedManifestCount,
+                        cursor: context.paginationCursor
+                    )
+                }
+                snapshot.authoritativeConversationIDs = manifestPage.values
+                snapshot.authoritativeConversationIDsAreComplete = manifestPage.isComplete
+                data = try encode(snapshot)
+                continue
+            }
+            if boundedConfigurationCount > 0 {
+                boundedConfigurationCount -= 1
+                refreshRequestConfigurationPage(
+                    in: &snapshot,
+                    values: context.configurationValues,
+                    maximumCount: boundedConfigurationCount,
+                    cursor: context.paginationCursor,
+                    offset: context.pageCycleCursor?.configurationOffset,
+                    deferredConfigurationIDs: context.deferredConfigurationIDs,
+                    unavailablePromptIDs: context.unavailablePromptIDs,
+                    includeBodyConfigurations: context.configurationIncludesBodies
+                )
+                data = try encode(snapshot)
+                continue
+            }
+            throw WatchSyncPayloadBuilderError.irreducibleSnapshotExceedsBudget(
+                actualBytes: data.count,
+                budget: context.budget
+            )
+        }
+        return data
+    }
+
+    private static func removeLowestPriorityMetadata(
+        from snapshot: inout WatchSyncSnapshot,
+        acknowledgementPriority: [UUID],
+        protectedAcknowledgementIDs: Set<UUID>,
+        tombstonePriority: [UUID]
+    ) -> Bool {
+        if let acknowledgementID = acknowledgementPriority.reversed().first(where: {
+            snapshot.acknowledgedWatchRevisions[$0] != nil && !protectedAcknowledgementIDs.contains($0)
+        }) {
+            snapshot.acknowledgedWatchRevisions.removeValue(forKey: acknowledgementID)
+            return true
+        }
+
+        let presentTombstoneIDs = Set(snapshot.tombstones.map(\.conversationID))
+        if let tombstoneID = tombstonePriority.dropFirst().reversed().first(where: {
+            presentTombstoneIDs.contains($0)
+        }) {
+            snapshot.tombstones.removeAll { $0.conversationID == tombstoneID }
+            return true
+        }
+
+        if let acknowledgementID = acknowledgementPriority.reversed().first(where: {
+            snapshot.acknowledgedWatchRevisions[$0] != nil
+        }) {
+            snapshot.acknowledgedWatchRevisions.removeValue(forKey: acknowledgementID)
+            return true
+        }
+
+        if let tombstoneID = tombstonePriority.reversed().first(where: {
+            presentTombstoneIDs.contains($0)
+        }) {
+            snapshot.tombstones.removeAll { $0.conversationID == tombstoneID }
+            return true
+        }
+
+        return false
+    }
+
+    private static func removeOldestMessage(
+        from conversations: inout [WatchConversation]
+    ) -> Bool {
+        var candidate: MessageRemovalCandidate?
+        for conversationIndex in conversations.indices {
+            for messageIndex in conversations[conversationIndex].messages.indices {
+                let message = conversations[conversationIndex].messages[messageIndex]
+                let proposed = MessageRemovalCandidate(
+                    conversation: conversationIndex,
+                    message: messageIndex,
+                    timestamp: message.timestamp,
+                    id: message.id.uuidString
+                )
+                if let current = candidate {
+                    if proposed.timestamp < current.timestamp
+                        || (proposed.timestamp == current.timestamp && proposed.id < current.id)
+                    {
+                        candidate = proposed
+                    }
+                } else {
+                    candidate = proposed
+                }
+            }
+        }
+        guard let candidate else { return false }
+        conversations[candidate.conversation].messages.remove(at: candidate.message)
+        return true
+    }
+
+    private static func page<Element>(
+        _ values: [Element],
+        maximumCount: Int,
+        cursor: WatchSyncRevision
+    ) -> Page<Element> {
+        guard !values.isEmpty else {
+            return Page(values: [], isComplete: true)
+        }
+
+        let boundedMaximum = max(0, maximumCount)
+        guard boundedMaximum < values.count else {
+            return Page(values: values, isComplete: true)
+        }
+        guard boundedMaximum > 0 else {
+            return Page(values: [], isComplete: false)
+        }
+
+        let pageCount = ((values.count - 1) / boundedMaximum) + 1
+        let pageIndex = Int(cursor % WatchSyncRevision(pageCount))
+        let start = pageIndex * boundedMaximum
+        let end = min(values.count, start + boundedMaximum)
+        return Page(values: Array(values[start ..< end]), isComplete: false)
+    }
+
+    private static func page<Element>(
+        _ values: [Element],
+        maximumCount: Int,
+        offset: Int
+    ) -> Page<Element> {
+        guard !values.isEmpty else {
+            return Page(values: [], isComplete: true)
+        }
+
+        let boundedOffset = max(0, offset)
+        let boundedMaximum = max(0, maximumCount)
+        guard boundedOffset < values.count else {
+            return Page(values: [], isComplete: false)
+        }
+        guard boundedMaximum > 0 else {
+            return Page(values: [], isComplete: false)
+        }
+
+        let end = min(values.count, boundedOffset + boundedMaximum)
+        let isComplete = boundedOffset == 0 && end == values.count
+        return Page(values: Array(values[boundedOffset ..< end]), isComplete: isComplete)
+    }
+
+    private static func rotate<T>(_ values: [T], limit: Int, cursor: WatchSyncRevision) -> Page<T> {
+        let selected = page(values, maximumCount: limit, cursor: cursor)
+        guard !selected.isComplete, selected.values.count > 1 else { return selected }
+        let pageCount = ((values.count - 1) / limit) + 1
+        let cycle = cursor / WatchSyncRevision(pageCount)
+        let offset = Int(cycle % WatchSyncRevision(selected.values.count))
+        guard offset > 0 else { return selected }
+        let rotated = Array(selected.values[offset...]) + Array(selected.values[..<offset])
+        return Page(values: rotated, isComplete: false)
+    }
+
+    private static func requestConfigurationTransportPlan(
+        _ values: [WatchConversationRequestConfiguration],
+        sourceID: UUID,
+        snapshotRevision: WatchSyncRevision,
+        paginationCursor: WatchSyncRevision,
+        acknowledgedPeerID: UUID?,
+        configuration: Configuration
+    ) throws -> RequestConfigurationTransportPlan {
+        var transportedValues: [WatchConversationRequestConfiguration] = []
+        var unavailablePromptIDs: Set<UUID> = []
+        var deferredConfigurationIDs: Set<UUID> = []
+
+        for value in values {
+            guard value.resolvedSystemPrompt != nil,
+                  try !configurationFits(
+                      value,
+                      sourceID: sourceID,
+                      snapshotRevision: snapshotRevision,
+                      paginationCursor: paginationCursor,
+                      acknowledgedPeerID: acknowledgedPeerID,
+                      byteBudget: configuration.byteBudget
+                  )
+            else {
+                transportedValues.append(value)
+                continue
+            }
+
+            var availabilityGate = value
+            availabilityGate.resolvedSystemPrompt = nil
+            if try configurationFits(
+                availabilityGate,
+                sourceID: sourceID,
+                snapshotRevision: snapshotRevision,
+                paginationCursor: paginationCursor,
+                acknowledgedPeerID: acknowledgedPeerID,
+                byteBudget: configuration.byteBudget
+            ) {
+                transportedValues.append(availabilityGate)
+                unavailablePromptIDs.insert(value.id)
+            } else {
+                transportedValues.append(value)
+                deferredConfigurationIDs.insert(value.id)
+            }
+        }
+
+        return RequestConfigurationTransportPlan(
+            values: transportedValues,
+            unavailablePromptIDs: unavailablePromptIDs,
+            deferredConfigurationIDs: deferredConfigurationIDs
+        )
+    }
+
+    private static func configurationFits(
+        _ candidate: WatchConversationRequestConfiguration,
+        sourceID: UUID,
+        snapshotRevision: WatchSyncRevision,
+        paginationCursor: WatchSyncRevision,
+        acknowledgedPeerID: UUID?,
+        byteBudget: Int
+    ) throws -> Bool {
+        let minimalSnapshot = WatchSyncSnapshot(
+            snapshotRevision: snapshotRevision,
+            sourceID: sourceID,
+            paginationCursor: paginationCursor,
+            conversations: [],
+            authoritativeConversationIDs: [],
+            authoritativeConversationIDsAreComplete: false,
+            conversationConfigurations: [candidate],
+            conversationConfigurationsAreComplete: false,
+            acknowledgedPeerID: acknowledgedPeerID,
+            acknowledgedWatchRevisions: [:],
+            tombstoneRevisions: [:]
+        )
+        return try encode(minimalSnapshot).count <= byteBudget
+    }
+
+    private static func irreducibleConfigurationIDs(
+        in values: [WatchConversationRequestConfiguration],
+        sourceID: UUID,
+        snapshotRevision: WatchSyncRevision,
+        paginationCursor: WatchSyncRevision,
+        acknowledgedPeerID: UUID?,
+        configuration: Configuration,
+        pageCycleCursor: WatchSyncPageCycleCursor?
+    ) throws -> Set<UUID> {
+        guard let pageCycleCursor else { return [] }
+        let candidates = page(
+            values,
+            maximumCount: configuration.maximumConversationConfigurations,
+            offset: pageCycleCursor.configurationOffset
+        ).values
+        guard !candidates.isEmpty else { return [] }
+
+        let singleConfigurationIsComplete = pageCycleCursor.configurationOffset == 0
+            && values.count == 1
+        var deferredIDs: Set<UUID> = []
+        for candidate in candidates {
+            let minimalSnapshot = WatchSyncSnapshot(
+                snapshotRevision: snapshotRevision,
+                sourceID: sourceID,
+                paginationCursor: paginationCursor,
+                conversations: [],
+                authoritativeConversationIDs: [],
+                authoritativeConversationIDsAreComplete: false,
+                conversationConfigurations: [candidate],
+                conversationConfigurationsAreComplete: singleConfigurationIsComplete,
+                acknowledgedPeerID: acknowledgedPeerID,
+                acknowledgedWatchRevisions: [:],
+                tombstoneRevisions: [:]
+            )
+            if try encode(minimalSnapshot).count > configuration.byteBudget {
+                deferredIDs.insert(candidate.id)
+            }
+        }
+        return deferredIDs
+    }
+
+    private static func configurationCursorAdvanceCount(
+        in values: [WatchConversationRequestConfiguration],
+        delivered: [WatchConversationRequestConfiguration],
+        deferredConfigurationIDs: Set<UUID>,
+        maximumCount: Int,
+        offset: Int
+    ) -> Int {
+        let boundedMaximum = max(0, maximumCount)
+        guard offset >= 0, offset < values.count, boundedMaximum > 0 else { return 0 }
+        let end = min(values.count, offset + boundedMaximum)
+        var sourceIndex = offset
+        var deliveredIndex = 0
+
+        while sourceIndex < end {
+            let candidate = values[sourceIndex]
+            if deferredConfigurationIDs.contains(candidate.id) {
+                sourceIndex += 1
+                continue
+            }
+            guard deliveredIndex < delivered.count,
+                  candidate == delivered[deliveredIndex]
+            else {
+                break
+            }
+            sourceIndex += 1
+            deliveredIndex += 1
+        }
+
+        guard deliveredIndex == delivered.count else { return 0 }
+        return sourceIndex - offset
+    }
+
+    private static func requestConfigurationPage(
+        _ values: [WatchConversationRequestConfiguration],
+        bodyIDs: Set<UUID>,
+        maximumCount: Int,
+        cursor: WatchSyncRevision,
+        offset: Int? = nil,
+        deferredConfigurationIDs: Set<UUID> = []
+    ) -> Page<WatchConversationRequestConfiguration> {
+        let filtered = values.filter { !bodyIDs.contains($0.id) }
+        let selected = if let offset {
+            page(filtered, maximumCount: maximumCount, offset: offset)
+        } else {
+            page(filtered, maximumCount: maximumCount, cursor: cursor)
+        }
+        guard !deferredConfigurationIDs.isEmpty else { return selected }
+        let delivered = selected.values.filter { !deferredConfigurationIDs.contains($0.id) }
+        return Page(
+            values: delivered,
+            isComplete: selected.isComplete && delivered.count == selected.values.count
+        )
+    }
+
+    private static func refreshRequestConfigurationPage(
+        in snapshot: inout WatchSyncSnapshot,
+        values: [WatchConversationRequestConfiguration],
+        maximumCount: Int,
+        cursor: WatchSyncRevision,
+        offset: Int? = nil,
+        deferredConfigurationIDs: Set<UUID> = [],
+        unavailablePromptIDs: Set<UUID> = [],
+        includeBodyConfigurations: Bool = false
+    ) {
+        let configurationPage = requestConfigurationPage(
+            values,
+            bodyIDs: includeBodyConfigurations ? [] : Set(snapshot.conversations.map(\.id)),
+            maximumCount: maximumCount,
+            cursor: cursor,
+            offset: offset,
+            deferredConfigurationIDs: deferredConfigurationIDs
+        )
+        snapshot.conversationConfigurations = configurationPage.values
+        snapshot.conversationConfigurationsAreComplete = configurationPage.isComplete
+            && unavailablePromptIDs.isEmpty
+    }
+
+    private static func boundedRequestConfiguration(
+        _ conversation: Conversation,
+        configuration _: Configuration,
+        resolvedSystemPrompt: String?
+    ) -> WatchConversationRequestConfiguration {
+        WatchConversationRequestConfiguration(
+            id: conversation.id,
+            model: conversation.model,
+            temperature: conversation.temperature,
+            resolvedSystemPrompt: resolvedSystemPrompt
+        )
+    }
+
+    private static func boundedConversation(
+        _ conversation: Conversation,
+        acknowledgedRevision: WatchSyncRevision,
+        configuration: Configuration,
+        resolvedSystemPrompt: String?
+    ) -> WatchConversation {
+        var boundedConversation = WatchConversation(
+            from: conversation,
+            resolvedSystemPrompt: resolvedSystemPrompt,
+            watchRevision: acknowledgedRevision,
+            maximumMessages: max(0, configuration.maximumMessagesPerConversation)
+        )
+        boundedConversation.title = bounded(
+            boundedConversation.title,
+            maximum: configuration.maximumTitleCharacters
+        )
+        boundedConversation.messages = boundedConversation.messages.map {
+            boundedMessage($0, configuration: configuration)
+        }
+        return boundedConversation
+    }
+
+    private static func boundedMessage(
+        _ message: WatchMessage,
+        configuration: Configuration
+    ) -> WatchMessage {
+        var result = message
+        result.content = bounded(message.content, maximum: configuration.maximumContentCharacters)
+        result.toolCalls = message.toolCalls.map { calls in
+            Array(calls.prefix(max(0, configuration.maximumToolCallsPerMessage))).compactMap {
+                boundedToolCall($0, configuration: configuration)
+            }
+        }
+        result.citations = message.citations.map { citations in
+            Array(citations.prefix(max(0, configuration.maximumCitationsPerMessage))).map {
+                CitationReference(
+                    number: $0.number,
+                    title: bounded($0.title, maximum: configuration.maximumCitationCharacters),
+                    url: bounded($0.url, maximum: configuration.maximumCitationCharacters),
+                    favicon: $0.favicon.map {
+                        bounded($0, maximum: configuration.maximumCitationCharacters)
+                    }
+                )
+            }
+        }
+        return result
+    }
+
+    private static func boundedToolCall(
+        _ call: MCPToolCall,
+        configuration: Configuration
+    ) -> MCPToolCall? {
+        let byteLimit = max(0, configuration.maximumToolMetadataBytes)
+        guard byteLimit > 0 else { return nil }
+
+        var arguments = call.arguments
+        var result = call.result.map { bounded($0, maximum: byteLimit) }
+        var error = call.error.map { bounded($0, maximum: byteLimit) }
+        var toolName = bounded(call.toolName, maximum: min(byteLimit, 256))
+        var identifier = bounded(call.id, maximum: min(byteLimit, 256))
+
+        func makeCall() -> MCPToolCall {
+            MCPToolCall(
+                id: identifier,
+                toolName: toolName,
+                arguments: arguments,
+                result: result,
+                error: error,
+                timestamp: call.timestamp
+            )
+        }
+
+        var candidate = makeCall()
+        while encodedSize(candidate) > byteLimit, let key = arguments.keys.sorted().last {
+            arguments.removeValue(forKey: key)
+            candidate = makeCall()
+        }
+        while encodedSize(candidate) > byteLimit, result?.isEmpty == false {
+            result = result.map { String($0.prefix(max(0, $0.count / 2))) }
+            candidate = makeCall()
+        }
+        while encodedSize(candidate) > byteLimit, error?.isEmpty == false {
+            error = error.map { String($0.prefix(max(0, $0.count / 2))) }
+            candidate = makeCall()
+        }
+        while encodedSize(candidate) > byteLimit, toolName.count > 1 {
+            toolName = String(toolName.prefix(max(1, toolName.count / 2)))
+            candidate = makeCall()
+        }
+        while encodedSize(candidate) > byteLimit, identifier.count > 1 {
+            identifier = String(identifier.prefix(max(1, identifier.count / 2)))
+            candidate = makeCall()
+        }
+        return encodedSize(candidate) <= byteLimit ? candidate : nil
+    }
+
+    private static func encodedSize(_ call: MCPToolCall) -> Int {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return (try? encoder.encode(call).count) ?? .max
+    }
+
+    private static func bounded(_ value: String, maximum: Int) -> String {
+        String(value.prefix(max(0, maximum)))
+    }
+}

--- a/Sources/Ayna/Services/WebFetchService.swift
+++ b/Sources/Ayna/Services/WebFetchService.swift
@@ -6,107 +6,504 @@
 //  Available on macOS, iOS, and watchOS.
 //
 
-#if !os(watchOS)
-    import CFNetwork
-#endif
+import Darwin
 import Foundation
 import os.log
+
+// MARK: - Host Resolution
+
+/// Injectable hostname-resolution boundary used by request and redirect validation.
+struct HostResolver: Sendable {
+    static let system = HostResolver { host in
+        try await AppleHostResolver.addresses(for: host)
+    }
+
+    private let resolve: @Sendable (String) async throws -> [String]
+
+    init(_ resolve: @escaping @Sendable (String) async throws -> [String]) {
+        self.resolve = resolve
+    }
+
+    func addresses(for host: String) async throws -> [String] {
+        try await resolve(host)
+    }
+}
+
+private enum HostResolutionError: LocalizedError, Sendable {
+    case lookupFailed(host: String, code: Int32, message: String)
+    case addressConversionFailed(host: String, code: Int32, message: String)
+    case noAddresses(host: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .lookupFailed(host, code, message):
+            "DNS lookup for '\(host)' failed with code \(code): \(message)"
+        case let .addressConversionFailed(host, code, message):
+            "DNS address conversion for '\(host)' failed with code \(code): \(message)"
+        case let .noAddresses(host):
+            "DNS lookup for '\(host)' returned no IP addresses"
+        }
+    }
+}
+
+private enum AppleHostResolver {
+    static func addresses(for host: String) async throws -> [String] {
+        try await Task.detached(priority: .utility) {
+            try resolveSynchronously(host)
+        }.value
+    }
+
+    private static func resolveSynchronously(_ host: String) throws -> [String] {
+        let resolved = try resolve(host, family: AF_UNSPEC)
+        let originalIPv4 = (try? resolve(host, family: AF_INET)) ?? []
+        var seen: Set<String> = []
+        return (resolved + originalIPv4).filter { seen.insert($0).inserted }
+    }
+
+    private static func resolve(_ host: String, family: Int32) throws -> [String] {
+        var hints = addrinfo()
+        hints.ai_flags = AI_NUMERICSERV
+        hints.ai_family = family
+        hints.ai_socktype = SOCK_STREAM
+        hints.ai_protocol = IPPROTO_TCP
+
+        var result: UnsafeMutablePointer<addrinfo>?
+        let lookupStatus = host.withCString { hostname in
+            getaddrinfo(hostname, nil, &hints, &result)
+        }
+
+        guard lookupStatus == 0 else {
+            throw HostResolutionError.lookupFailed(
+                host: host,
+                code: lookupStatus,
+                message: errorMessage(for: lookupStatus)
+            )
+        }
+
+        guard let firstResult = result else {
+            throw HostResolutionError.noAddresses(host: host)
+        }
+        defer { freeaddrinfo(firstResult) }
+
+        var addresses: [String] = []
+        var currentResult: UnsafeMutablePointer<addrinfo>? = firstResult
+        while let addressInfo = currentResult {
+            guard let socketAddress = addressInfo.pointee.ai_addr else {
+                throw HostResolutionError.noAddresses(host: host)
+            }
+
+            var buffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            let conversionStatus = getnameinfo(
+                socketAddress,
+                addressInfo.pointee.ai_addrlen,
+                &buffer,
+                socklen_t(buffer.count),
+                nil,
+                0,
+                NI_NUMERICHOST
+            )
+            guard conversionStatus == 0 else {
+                throw HostResolutionError.addressConversionFailed(
+                    host: host,
+                    code: conversionStatus,
+                    message: errorMessage(for: conversionStatus)
+                )
+            }
+
+            let addressBytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+            guard let address = String(bytes: addressBytes, encoding: .utf8) else {
+                throw HostResolutionError.addressConversionFailed(
+                    host: host,
+                    code: EAI_FAIL,
+                    message: "Numeric address was not valid UTF-8"
+                )
+            }
+            if !addresses.contains(address) {
+                addresses.append(address)
+            }
+            currentResult = addressInfo.pointee.ai_next
+        }
+
+        guard !addresses.isEmpty else {
+            throw HostResolutionError.noAddresses(host: host)
+        }
+        return addresses
+    }
+
+    private static func errorMessage(for code: Int32) -> String {
+        guard let message = gai_strerror(code) else {
+            return "Unknown DNS error"
+        }
+        return String(cString: message)
+    }
+}
+
+// MARK: - Request Deadline
+
+private enum WebFetchRequestDeadlineError: LocalizedError, Sendable {
+    case timedOut
+
+    var errorDescription: String? {
+        "The request timed out."
+    }
+
+    var webFetchError: WebFetchError {
+        .networkError(underlying: errorDescription ?? "The request timed out.")
+    }
+}
+
+/// One-shot unstructured race that does not await the losing task during teardown.
+/// This is required because the system resolver can remain blocked in `getaddrinfo` after cancellation.
+private final class WebFetchDeadlineRace<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Error>?
+    private var outcome: Result<Value, Error>?
+    private var tasks: [Task<Void, Never>] = []
+
+    func start(
+        continuation: CheckedContinuation<Value, Error>,
+        clock: ContinuousClock,
+        deadline: ContinuousClock.Instant,
+        operation: @escaping @Sendable () async throws -> Value
+    ) {
+        guard install(continuation) else { return }
+
+        let deadlineTask = Task { [self] in
+            do {
+                try await clock.sleep(until: deadline)
+            } catch {
+                return
+            }
+            complete(with: .failure(WebFetchRequestDeadlineError.timedOut))
+        }
+        register(deadlineTask)
+
+        let operationTask = Task { [self] in
+            guard clock.now < deadline else {
+                complete(with: .failure(WebFetchRequestDeadlineError.timedOut))
+                return
+            }
+
+            do {
+                let value = try await operation()
+                guard clock.now < deadline else {
+                    complete(with: .failure(WebFetchRequestDeadlineError.timedOut))
+                    return
+                }
+                complete(with: .success(value))
+            } catch {
+                if clock.now >= deadline {
+                    complete(with: .failure(WebFetchRequestDeadlineError.timedOut))
+                } else {
+                    complete(with: .failure(error))
+                }
+            }
+        }
+        register(operationTask)
+    }
+
+    func cancel() {
+        complete(with: .failure(CancellationError()))
+    }
+
+    private func install(_ continuation: CheckedContinuation<Value, Error>) -> Bool {
+        let completedOutcome: Result<Value, Error>? = lock.withLock {
+            if let outcome {
+                return outcome
+            }
+            self.continuation = continuation
+            return nil
+        }
+
+        if let completedOutcome {
+            continuation.resume(with: completedOutcome)
+            return false
+        }
+        return true
+    }
+
+    private func register(_ task: Task<Void, Never>) {
+        let shouldCancel = lock.withLock {
+            guard outcome == nil else { return true }
+            tasks.append(task)
+            return false
+        }
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    private func complete(with outcome: Result<Value, Error>) {
+        let completion: (CheckedContinuation<Value, Error>?, [Task<Void, Never>])? = lock.withLock {
+            guard self.outcome == nil else { return nil }
+            self.outcome = outcome
+            let completion = (continuation, tasks)
+            continuation = nil
+            tasks.removeAll()
+            return completion
+        }
+
+        guard let completion else { return }
+        for task in completion.1 {
+            task.cancel()
+        }
+        completion.0?.resume(with: outcome)
+    }
+}
+
+private struct WebFetchRequestDeadline: Sendable {
+    private let clock: ContinuousClock
+    private let instant: ContinuousClock.Instant
+
+    init(timeoutSeconds: TimeInterval) {
+        let clock = ContinuousClock()
+        self.clock = clock
+        instant = clock.now.advanced(by: .seconds(max(0, timeoutSeconds)))
+    }
+
+    var remainingTimeInterval: TimeInterval {
+        let remaining = clock.now.duration(to: instant)
+        guard remaining > .zero else { return 0 }
+        let components = remaining.components
+        return TimeInterval(components.seconds) +
+            TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
+    }
+
+    func check() throws {
+        guard clock.now < instant else {
+            throw WebFetchRequestDeadlineError.timedOut
+        }
+    }
+
+    func perform<Value: Sendable>(
+        _ operation: @escaping @Sendable () async throws -> Value
+    ) async throws -> Value {
+        try check()
+
+        let race = WebFetchDeadlineRace<Value>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                race.start(
+                    continuation: continuation,
+                    clock: clock,
+                    deadline: instant,
+                    operation: operation
+                )
+            }
+        } onCancel: {
+            race.cancel()
+        }
+    }
+}
 
 // MARK: - Shared SSRF Protection
 
 /// Shared private-host detection used by both redirect validation and fetch-path validation.
 enum SSRFProtection {
-    /// Checks if a host string is a private/internal address
+    /// Checks whether a host string is a loopback, link-local, or private IP address.
     static func isPrivateHost(_ host: String) -> Bool {
-        let lowercased = host.lowercased()
-
-        // Localhost variants
-        if lowercased == "localhost" || lowercased == "127.0.0.1" || lowercased == "::1" {
+        let normalizedHost = normalizedIPAddressCandidate(host)
+        if normalizedHost == "localhost" {
             return true
         }
 
-        // Block 0.0.0.0 (binds to all interfaces)
-        if lowercased == "0.0.0.0" {
-            return true
+        if let bytes = ipv4Bytes(from: normalizedHost) {
+            return isPrivateIPv4(bytes)
         }
 
-        // IPv6 private/local ranges (only check if host is an IPv6 address)
-        if lowercased.contains(":") {
-            // fd00::/8 - Unique local addresses
-            if lowercased.hasPrefix("fd") {
-                return true
-            }
-            // fe80::/10 - Link-local addresses
-            if lowercased.hasPrefix("fe80:") {
-                return true
-            }
-            // fc00::/7 - Unique local addresses (includes fd00::/8)
-            if lowercased.hasPrefix("fc") {
-                return true
-            }
-        }
-
-        // Check for IP addresses in private ranges
-        let parts = lowercased.split(separator: ".")
-        if parts.count == 4, let first = Int(parts[0]), let second = Int(parts[1]) {
-            if first == 127 { return true } // Loopback
-            if first == 10 { return true }
-            if first == 172, (16 ... 31).contains(second) { return true }
-            if first == 192, second == 168 { return true }
-            if first == 169, second == 254 { return true } // Link-local / cloud metadata
-            if first == 0 { return true } // "This" network
-            // RFC 6598 CGNAT (100.64.0.0/10)
-            if first == 100, (64 ... 127).contains(second) { return true }
-            // RFC 2544 Benchmark (198.18.0.0/15)
-            if first == 198, (18 ... 19).contains(second) { return true }
+        if let bytes = ipv6Bytes(from: normalizedHost) {
+            return isPrivateIPv6(bytes)
         }
 
         return false
     }
 
-    /// Resolves a hostname and returns the first private/internal IP if one is found.
-    static func resolvedPrivateIPAddress(for host: String) async -> String? {
-        #if !os(watchOS)
-        let hostRef = CFHostCreateWithName(nil, host as CFString).takeRetainedValue()
-        var resolved = DarwinBoolean(false)
+    private static func isIPAddress(_ host: String) -> Bool {
+        let normalizedHost = normalizedIPAddressCandidate(host)
+        return ipv4Bytes(from: normalizedHost) != nil || ipv6Bytes(from: normalizedHost) != nil
+    }
 
-        CFHostStartInfoResolution(hostRef, .addresses, nil)
-        guard let addresses = CFHostGetAddressing(hostRef, &resolved)?.takeUnretainedValue() as? [Data],
-              resolved.boolValue
+    private static func normalizedIPAddressCandidate(_ host: String) -> String {
+        var normalizedHost = host.lowercased()
+        if normalizedHost.hasPrefix("["), normalizedHost.hasSuffix("]") {
+            normalizedHost.removeFirst()
+            normalizedHost.removeLast()
+        }
+        if normalizedHost.contains(":"), let zoneIndex = normalizedHost.firstIndex(of: "%") {
+            normalizedHost = String(normalizedHost[..<zoneIndex])
+        }
+        return normalizedHost
+    }
+
+    private static func ipv4Bytes(from addressString: String) -> [UInt8]? {
+        var address = in_addr()
+        let result = addressString.withCString { inet_pton(AF_INET, $0, &address) }
+        guard result == 1 else { return nil }
+        return withUnsafeBytes(of: &address) { Array($0) }
+    }
+
+    private static func ipv6Bytes(from addressString: String) -> [UInt8]? {
+        var address = in6_addr()
+        let result = addressString.withCString { inet_pton(AF_INET6, $0, &address) }
+        guard result == 1 else { return nil }
+        return withUnsafeBytes(of: &address) { Array($0) }
+    }
+
+    private static func isPrivateIPv4(_ bytes: [UInt8]) -> Bool {
+        guard bytes.count == 4 else { return true }
+        let first = bytes[0]
+        let second = bytes[1]
+
+        if first == 0 || first == 10 || first == 127 {
+            return true
+        }
+        if first == 100, (64 ... 127).contains(second) {
+            return true
+        }
+        if first == 169, second == 254 {
+            return true
+        }
+        if first == 172, (16 ... 31).contains(second) {
+            return true
+        }
+        if first == 192, second == 168 {
+            return true
+        }
+        if first == 198, (18 ... 19).contains(second) {
+            return true
+        }
+        return false
+    }
+
+    private static func isPrivateIPv6(_ bytes: [UInt8]) -> Bool {
+        guard bytes.count == 16 else { return true }
+
+        if bytes.allSatisfy({ $0 == 0 }) {
+            return true
+        }
+        if bytes.dropLast().allSatisfy({ $0 == 0 }), bytes.last == 1 {
+            return true
+        }
+        if bytes[0] & 0xFE == 0xFC {
+            return true
+        }
+        if bytes[0] == 0xFE, bytes[1] & 0xC0 == 0x80 {
+            return true
+        }
+        if bytes[0] == 0xFE, bytes[1] & 0xC0 == 0xC0 {
+            return true
+        }
+
+        let isWellKnownNAT64 = Array(bytes.prefix(12)) == [
+            0x00, 0x64, 0xFF, 0x9B,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00
+        ]
+        if isWellKnownNAT64 {
+            return isPrivateIPv4(Array(bytes.suffix(4)))
+        }
+
+        let isLocalUseNAT64 = Array(bytes.prefix(6)) == [0x00, 0x64, 0xFF, 0x9B, 0x00, 0x01]
+        if isLocalUseNAT64 {
+            return true
+        }
+
+        let isIPv4Mapped = bytes.prefix(10).allSatisfy { $0 == 0 } &&
+            bytes[10] == 0xFF && bytes[11] == 0xFF
+        let isIPv4Compatible = bytes.prefix(12).allSatisfy { $0 == 0 }
+        if isIPv4Mapped || isIPv4Compatible {
+            return isPrivateIPv4(Array(bytes.suffix(4)))
+        }
+
+        return false
+    }
+
+    /// Validates a URL's literal host and all resolved IP addresses.
+    fileprivate static func validate(
+        _ url: URL,
+        reportedAs urlString: String,
+        using resolver: HostResolver = .system,
+        deadline: WebFetchRequestDeadline
+    ) async throws {
+        guard let host = url.host,
+              let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "http"
         else {
-            return nil
+            throw WebFetchError.invalidURL(url: urlString)
         }
 
-        for addressData in addresses {
-            let ipString = addressData.withUnsafeBytes { pointer -> String? in
-                guard let sockaddr = pointer.baseAddress?.assumingMemoryBound(to: sockaddr.self) else {
-                    return nil
-                }
+        if isPrivateHost(host) {
+            throw WebFetchError.ssrfBlocked(url: urlString)
+        }
 
-                if sockaddr.pointee.sa_family == UInt8(AF_INET) {
-                    var addr = sockaddr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee }
-                    var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
-                    inet_ntop(AF_INET, &addr.sin_addr, &buffer, socklen_t(INET_ADDRSTRLEN))
-                    return String(bytes: buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, encoding: .utf8)
-                } else if sockaddr.pointee.sa_family == UInt8(AF_INET6) {
-                    var addr = sockaddr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { $0.pointee }
-                    var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
-                    inet_ntop(AF_INET6, &addr.sin6_addr, &buffer, socklen_t(INET6_ADDRSTRLEN))
-                    return String(bytes: buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, encoding: .utf8)
-                }
-
-                return nil
+        let addresses: [String]
+        do {
+            addresses = try await deadline.perform {
+                try await resolver.addresses(for: host)
             }
+        } catch let error as WebFetchRequestDeadlineError {
+            throw error
+        } catch {
+            throw resolutionFailure(host: host, reason: error.localizedDescription)
+        }
 
-            if let ipString, isPrivateHost(ipString) {
-                return ipString
+        guard !addresses.isEmpty else {
+            throw resolutionFailure(host: host, reason: "No IP addresses returned")
+        }
+
+        for address in addresses {
+            guard isIPAddress(address) else {
+                throw resolutionFailure(host: host, reason: "Resolver returned a non-numeric address: \(address)")
+            }
+            if isPrivateHost(address) {
+                DiagnosticsLogger.log(
+                    .aiService,
+                    level: .default,
+                    message: "🌐 WebFetch: DNS resolution blocked private address",
+                    metadata: ["host": host, "ip": address]
+                )
+                throw WebFetchError.ssrfBlocked(url: urlString)
             }
         }
 
-        return nil
-        #else
-        return nil
-        #endif
+        try deadline.check()
+    }
+
+    static func validateConnectedAddresses(
+        _ addresses: [String],
+        reportedAs urlString: String,
+        isProxyConnection: Bool = false
+    ) throws {
+        guard !isProxyConnection else {
+            throw WebFetchError.networkError(
+                underlying: "Connected origin endpoint cannot be verified through a proxy"
+            )
+        }
+        guard !addresses.isEmpty else {
+            throw WebFetchError.networkError(
+                underlying: "Connected origin endpoint did not report a numeric IP address"
+            )
+        }
+        for address in addresses {
+            guard isIPAddress(address) else {
+                throw WebFetchError.networkError(
+                    underlying: "Connected endpoint was not a numeric IP address: \(address)"
+                )
+            }
+            if isPrivateHost(address) {
+                DiagnosticsLogger.log(
+                    .aiService,
+                    level: .default,
+                    message: "🌐 WebFetch: connected endpoint blocked private address",
+                    metadata: ["url": urlString, "ip": address]
+                )
+                throw WebFetchError.ssrfBlocked(url: urlString)
+            }
+        }
+    }
+
+    private static func resolutionFailure(host: String, reason: String) -> WebFetchError {
+        .networkError(underlying: "DNS resolution failed for '\(host)': \(reason)")
     }
 }
 
@@ -164,9 +561,78 @@ enum WebFetchError: Error, LocalizedError, Sendable {
 
 // MARK: - SSRF Redirect Protection
 
+private final class RequestValidationState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var rejection: WebFetchError?
+    private var collectedEndpointMetrics = false
+    private var isFinished = false
+
+    func record(_ error: WebFetchError) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isFinished, rejection == nil else { return }
+        rejection = error
+    }
+
+    func recordEndpointMetricsCollected() {
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        collectedEndpointMetrics = true
+        lock.unlock()
+    }
+
+    func finish() {
+        lock.lock()
+        isFinished = true
+        lock.unlock()
+    }
+
+    func isActive() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !isFinished
+    }
+
+    func recordedExplicitRejection() -> WebFetchError? {
+        lock.lock()
+        defer { lock.unlock() }
+        return rejection
+    }
+
+    func recordedRejection(requiresEndpointMetrics: Bool) -> WebFetchError? {
+        lock.lock()
+        defer { lock.unlock() }
+        if let rejection {
+            return rejection
+        }
+        guard requiresEndpointMetrics, !collectedEndpointMetrics else { return nil }
+        return .networkError(
+            underlying: "Connected origin endpoint metrics were unavailable"
+        )
+    }
+}
+
 /// URLSession delegate that validates redirect targets against private IP ranges.
 /// Prevents SSRF bypass via HTTP redirects (e.g., 302 to http://169.254.169.254/).
 final class SSRFRedirectValidator: NSObject, URLSessionTaskDelegate, Sendable {
+    private let resolver: HostResolver
+    private let deadline: WebFetchRequestDeadline
+    private let requiresConnectedEndpointVerification: Bool
+    private let state = RequestValidationState()
+
+    fileprivate init(
+        resolver: HostResolver = .system,
+        deadline: WebFetchRequestDeadline,
+        requiresConnectedEndpointVerification: Bool = true
+    ) {
+        self.resolver = resolver
+        self.deadline = deadline
+        self.requiresConnectedEndpointVerification = requiresConnectedEndpointVerification
+    }
+
     func urlSession(
         _: URLSession,
         task _: URLSessionTask,
@@ -174,21 +640,76 @@ final class SSRFRedirectValidator: NSObject, URLSessionTaskDelegate, Sendable {
         newRequest request: URLRequest,
         completionHandler: @escaping @Sendable (URLRequest?) -> Void
     ) {
-        guard let url = request.url,
-              let host = url.host,
-              url.scheme == "https" || url.scheme == "http",
-              !Self.isPrivateHost(host)
-        else {
-            // Block redirect to private/internal address or non-HTTP scheme
-            completionHandler(nil)
-            return
+        Task {
+            do {
+                guard let url = request.url else {
+                    throw WebFetchError.invalidURL(url: request.url?.absoluteString ?? "")
+                }
+                try await SSRFProtection.validate(
+                    url,
+                    reportedAs: url.absoluteString,
+                    using: resolver,
+                    deadline: deadline
+                )
+                completionHandler(state.isActive() ? request : nil)
+            } catch let error as WebFetchError {
+                state.record(error)
+                completionHandler(nil)
+            } catch let error as WebFetchRequestDeadlineError {
+                state.record(error.webFetchError)
+                completionHandler(nil)
+            } catch {
+                state.record(.networkError(underlying: error.localizedDescription))
+                completionHandler(nil)
+            }
         }
-        completionHandler(request)
     }
 
-    /// Checks if a host is a private/internal address
-    static func isPrivateHost(_ host: String) -> Bool {
-        SSRFProtection.isPrivateHost(host)
+    func urlSession(
+        _: URLSession,
+        task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
+        guard requiresConnectedEndpointVerification else { return }
+        state.recordEndpointMetricsCollected()
+        let urlString = task.currentRequest?.url?.absoluteString
+            ?? task.originalRequest?.url?.absoluteString
+            ?? ""
+        guard !metrics.transactionMetrics.isEmpty else {
+            state.record(.networkError(
+                underlying: "Connected origin endpoint metrics contained no transactions"
+            ))
+            return
+        }
+        for transaction in metrics.transactionMetrics {
+            do {
+                try SSRFProtection.validateConnectedAddresses(
+                    transaction.remoteAddress.map { [$0] } ?? [],
+                    reportedAs: urlString,
+                    isProxyConnection: transaction.isProxyConnection
+                )
+            } catch let error as WebFetchError {
+                state.record(error)
+                return
+            } catch {
+                state.record(.networkError(underlying: error.localizedDescription))
+                return
+            }
+        }
+    }
+
+    func recordedRejection() -> WebFetchError? {
+        state.recordedRejection(
+            requiresEndpointMetrics: requiresConnectedEndpointVerification
+        )
+    }
+
+    func recordedExplicitRejection() -> WebFetchError? {
+        state.recordedExplicitRejection()
+    }
+
+    func finish() {
+        state.finish()
     }
 }
 
@@ -268,47 +789,70 @@ enum WebFetchRequestExecutor {
         configuration.httpCookieAcceptPolicy = .never
         configuration.httpShouldSetCookies = false
         configuration.waitsForConnectivity = false
-        return URLSession(configuration: configuration, delegate: SSRFRedirectValidator(), delegateQueue: nil)
+        configuration.connectionProxyDictionary = [:]
+        return URLSession(configuration: configuration)
     }()
 
     static func fetchText(
         from urlString: String,
         timeoutSeconds: TimeInterval,
         maxResponseSize: Int,
-        session: URLSession = sharedSession
+        session: URLSession = sharedSession,
+        resolver: HostResolver = .system,
+        requiresConnectedEndpointVerification: Bool = true
     ) async throws -> String {
-        guard let parsedURL = URL(string: urlString),
-              let host = parsedURL.host,
-              parsedURL.scheme == "https" || parsedURL.scheme == "http"
-        else {
+        let deadline = WebFetchRequestDeadline(timeoutSeconds: timeoutSeconds)
+
+        guard let parsedURL = URL(string: urlString) else {
             throw WebFetchError.invalidURL(url: urlString)
         }
 
-        if SSRFProtection.isPrivateHost(host) {
-            throw WebFetchError.ssrfBlocked(url: urlString)
-        }
-
-        if let resolvedPrivateIP = await SSRFProtection.resolvedPrivateIPAddress(for: host) {
-            DiagnosticsLogger.log(
-                .aiService,
-                level: .default,
-                message: "🌐 WebFetch: DNS rebinding blocked",
-                metadata: ["host": host, "ip": resolvedPrivateIP]
+        do {
+            try await SSRFProtection.validate(
+                parsedURL,
+                reportedAs: urlString,
+                using: resolver,
+                deadline: deadline
             )
-            throw WebFetchError.ssrfBlocked(url: urlString)
+        } catch let error as WebFetchRequestDeadlineError {
+            throw error.webFetchError
         }
 
         var request = URLRequest(url: parsedURL)
         request.httpMethod = "GET"
-        request.timeoutInterval = timeoutSeconds
+        request.timeoutInterval = max(deadline.remainingTimeInterval, 0.001)
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        let configuredRequest = request
 
         let data: Data
         let response: URLResponse
+        // URLSession does not expose a pre-connect endpoint hook. Preflight resolution,
+        // proxy rejection, and post-transaction endpoint verification are all required before
+        // this GET response can be exposed; full IP pinning would require a custom TLS transport.
+        let redirectValidator = SSRFRedirectValidator(
+            resolver: resolver,
+            deadline: deadline,
+            requiresConnectedEndpointVerification: requiresConnectedEndpointVerification
+        )
+        defer { redirectValidator.finish() }
         do {
-            (data, response) = try await session.data(for: request)
+            (data, response) = try await deadline.perform {
+                try await session.data(for: configuredRequest, delegate: redirectValidator)
+            }
+        } catch let error as WebFetchRequestDeadlineError {
+            if let redirectError = redirectValidator.recordedExplicitRejection() {
+                throw redirectError
+            }
+            throw error.webFetchError
         } catch {
+            if let redirectError = redirectValidator.recordedRejection() {
+                throw redirectError
+            }
             throw WebFetchError.networkError(underlying: error.localizedDescription)
+        }
+
+        if let redirectError = redirectValidator.recordedRejection() {
+            throw redirectError
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -344,7 +888,12 @@ final class WebFetchService {
     static let shared = WebFetchService()
 
     /// Whether the service is enabled
-    var isEnabled: Bool = true
+    var isEnabled: Bool = true {
+        didSet {
+            guard oldValue != isEnabled else { return }
+            NotificationCenter.default.post(name: .watchSyncContextDidChange, object: nil)
+        }
+    }
 
     /// Timeout for requests in seconds
     var timeoutSeconds: Int = 30

--- a/Sources/Ayna/Services/WebFetchService.swift
+++ b/Sources/Ayna/Services/WebFetchService.swift
@@ -298,9 +298,9 @@ private struct WebFetchRequestDeadline: Sendable {
 
 // MARK: - Shared SSRF Protection
 
-/// Shared private-host detection used by both redirect validation and fetch-path validation.
+/// Shared private, local, and non-unicast host detection used by redirect and fetch validation.
 enum SSRFProtection {
-    /// Checks whether a host string is a loopback, link-local, or private IP address.
+    /// Checks whether a host is loopback, link-local, private, multicast, or reserved non-unicast.
     static func isPrivateHost(_ host: String) -> Bool {
         let normalizedHost = normalizedIPAddressCandidate(host)
         if normalizedHost == "localhost" {
@@ -372,6 +372,9 @@ enum SSRFProtection {
         if first == 198, (18 ... 19).contains(second) {
             return true
         }
+        if first >= 224 {
+            return true
+        }
         return false
     }
 
@@ -391,6 +394,9 @@ enum SSRFProtection {
             return true
         }
         if bytes[0] == 0xFE, bytes[1] & 0xC0 == 0xC0 {
+            return true
+        }
+        if bytes[0] == 0xFF {
             return true
         }
 

--- a/Sources/Ayna/Services/WebSearchCoordinator.swift
+++ b/Sources/Ayna/Services/WebSearchCoordinator.swift
@@ -134,16 +134,15 @@ final class WebSearchCoordinator: ObservableObject {
         }
 
         // Try primary provider, then fallback
-        let response: WebSearchResponse
-        if tavilyService.isConfigured {
-            response = await searchWithTavilyFallbackToDDG(
+        let response: WebSearchResponse = if tavilyService.isConfigured {
+            await searchWithTavilyFallbackToDDG(
                 query: query,
                 topic: topic,
                 searchDepth: searchDepth,
                 maxResults: maxResults
             )
         } else {
-            response = await searchWithDDGFallbackToError(
+            await searchWithDDGFallbackToError(
                 query: query,
                 maxResults: maxResults
             )
@@ -173,6 +172,9 @@ final class WebSearchCoordinator: ObservableObject {
             )
             return tavilyResponse.toWebSearchResponse()
         } catch {
+            guard !Task.isCancelled else {
+                return cancelledResponse(query: query, provider: .tavily)
+            }
             log(.default, "⚠️ Tavily search failed, falling back to DuckDuckGo", metadata: [
                 "error": error.localizedDescription,
             ])
@@ -188,6 +190,9 @@ final class WebSearchCoordinator: ObservableObject {
         do {
             return try await ddgService.search(query: query, maxResults: maxResults)
         } catch {
+            guard !Task.isCancelled else {
+                return cancelledResponse(query: query, provider: .duckDuckGo)
+            }
             log(.error, "❌ All search providers failed", metadata: [
                 "error": error.localizedDescription,
             ])
@@ -199,6 +204,16 @@ final class WebSearchCoordinator: ObservableObject {
                 provider: .duckDuckGo
             )
         }
+    }
+
+    private func cancelledResponse(query: String, provider: WebSearchProvider) -> WebSearchResponse {
+        WebSearchResponse(
+            query: query,
+            answer: nil,
+            results: [],
+            responseTime: 0,
+            provider: provider
+        )
     }
 
     // MARK: - Logging

--- a/Sources/Ayna/Utilities/AppPreferences.swift
+++ b/Sources/Ayna/Utilities/AppPreferences.swift
@@ -1,6 +1,11 @@
 import Foundation
 import os
 
+extension Notification.Name {
+    static let globalSystemPromptDidChange = Notification.Name("globalSystemPromptDidChange")
+    static let watchSyncContextDidChange = Notification.Name("watchSyncContextDidChange")
+}
+
 /// Centralizes access to UserDefaults so tests can swap in isolated suites
 /// without mutating the real application preferences.
 private final class DefaultsState: @unchecked Sendable {
@@ -51,7 +56,11 @@ enum AppPreferences {
     /// Returns an empty string by default (no system prompt).
     static var globalSystemPrompt: String {
         get { storage.string(forKey: globalSystemPromptKey) ?? "" }
-        set { storage.set(newValue, forKey: globalSystemPromptKey) }
+        set {
+            guard newValue != globalSystemPrompt else { return }
+            storage.set(newValue, forKey: globalSystemPromptKey)
+            NotificationCenter.default.post(name: .globalSystemPromptDidChange, object: nil)
+        }
     }
 
     // MARK: - Attach from App (macOS only)

--- a/Sources/Ayna/Utilities/DeepLinkManager.swift
+++ b/Sources/Ayna/Utilities/DeepLinkManager.swift
@@ -20,6 +20,7 @@ enum DeepLinkError: LocalizedError {
     case invalidEndpointType(String)
     case modelAlreadyExists(String)
     case modelNotFound(String)
+    case confirmationInProgress
     case unknownAction(String)
 
     var errorDescription: String? {
@@ -36,6 +37,8 @@ enum DeepLinkError: LocalizedError {
             "Model '\(name)' already exists"
         case let .modelNotFound(name):
             "Model '\(name)' not found"
+        case .confirmationInProgress:
+            "Another model confirmation is already in progress"
         case let .unknownAction(action):
             "Unknown action: \(action)"
         }
@@ -55,6 +58,8 @@ enum DeepLinkError: LocalizedError {
             "Use a different model name or remove the existing model first"
         case .modelNotFound:
             "Check that the model name is correct"
+        case .confirmationInProgress:
+            "Finish or cancel the current model confirmation, then try again"
         case .unknownAction:
             "Supported actions: add-model, chat"
         }
@@ -113,17 +118,24 @@ enum DeepLinkAction: Equatable {
 final class DeepLinkManager: ObservableObject {
     static let shared = DeepLinkManager()
 
-    /// Pending add-model request awaiting user confirmation
-    @Published var pendingAddModel: AddModelRequest?
+    private struct PendingConfirmation {
+        let request: AddModelRequest
+        let deferredChat: ChatRequest?
+    }
 
-    /// Pending chat request to be executed (stored while waiting for add-model confirmation)
-    @Published var pendingChat: ChatRequest?
+    /// Pending add-model request awaiting user confirmation
+    @Published private(set) var pendingAddModel: AddModelRequest?
+
+    /// Pending chat exposed for diagnostics and compatibility with existing tests.
+    var pendingChat: ChatRequest? {
+        pendingConfirmation?.deferredChat ?? readyChatQueue.first
+    }
 
     /// Error message to display in error banner
-    @Published var errorMessage: String?
+    @Published private(set) var errorMessage: String?
 
     /// Recovery suggestion for the current error
-    @Published var errorRecoverySuggestion: String?
+    @Published private(set) var errorRecoverySuggestion: String?
 
     /// Whether a confirmation sheet should be shown
     var showAddModelConfirmation: Bool {
@@ -131,6 +143,8 @@ final class DeepLinkManager: ObservableObject {
     }
 
     private let aiService: AIService
+    private var pendingConfirmation: PendingConfirmation?
+    private var readyChatQueue: [ChatRequest] = []
 
     init(aiService: AIService? = nil) {
         self.aiService = aiService ?? .shared
@@ -159,8 +173,7 @@ final class DeepLinkManager: ObservableObject {
 
             switch action {
             case let .addModel(request):
-                // Show confirmation dialog instead of adding immediately
-                pendingAddModel = request
+                try installConfirmation(request, deferredChat: nil)
                 DiagnosticsLogger.log(
                     .app,
                     level: .info,
@@ -174,9 +187,7 @@ final class DeepLinkManager: ObservableObject {
                     let modelExists = aiService.customModels.contains(modelConfig.name)
                     print("🔗 DEBUG: modelConfig.name=\(modelConfig.name), modelExists=\(modelExists), customModels=\(aiService.customModels)")
                     if !modelExists {
-                        // Model doesn't exist - show add confirmation first, store chat for after
-                        pendingAddModel = modelConfig
-                        pendingChat = request
+                        try installConfirmation(modelConfig, deferredChat: request)
                         DiagnosticsLogger.log(
                             .app,
                             level: .fault,
@@ -190,7 +201,7 @@ final class DeepLinkManager: ObservableObject {
                         )
                     } else {
                         // Model exists - proceed with chat directly
-                        pendingChat = request
+                        enqueueReadyChat(request)
                         DiagnosticsLogger.log(
                             .app,
                             level: .info,
@@ -202,8 +213,8 @@ final class DeepLinkManager: ObservableObject {
                         )
                     }
                 } else {
-                    // No config provided - proceed with chat directly
-                    pendingChat = request
+                    try validateModelAvailability(for: request)
+                    enqueueReadyChat(request)
                     DiagnosticsLogger.log(
                         .app,
                         level: .info,
@@ -242,11 +253,18 @@ final class DeepLinkManager: ObservableObject {
 
     /// Confirm and execute the pending add-model request
     /// If there's a pending chat request, it will proceed after adding the model
-    func confirmAddModel() {
-        guard let request = pendingAddModel else { return }
+    func confirmAddModel(expectedRequestID: UUID) {
+        guard let confirmation = pendingConfirmation,
+              let request = pendingAddModel,
+              confirmation.request.id == request.id,
+              request.id == expectedRequestID
+        else { return }
 
         do {
             try addModelConfig(request)
+            if let deferredChat = confirmation.deferredChat {
+                readyChatQueue.append(deferredChat)
+            }
             DiagnosticsLogger.log(
                 .app,
                 level: .info,
@@ -255,27 +273,27 @@ final class DeepLinkManager: ObservableObject {
             )
             // Note: pendingChat is preserved so the chat can proceed
         } catch let error as DeepLinkError {
-            errorMessage = error.errorDescription
-            errorRecoverySuggestion = error.recoverySuggestion
-            // Clear pending chat on error since the model wasn't added
-            pendingChat = nil
+            present(error)
         } catch {
             errorMessage = ErrorPresenter.userMessage(for: error)
             errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
-            pendingChat = nil
         }
 
+        pendingConfirmation = nil
         pendingAddModel = nil
     }
 
     /// Cancel the pending add-model request
     /// Also clears any pending chat that was waiting for the model
-    func cancelAddModel() {
+    func cancelAddModel(expectedRequestID: UUID) {
+        guard let confirmation = pendingConfirmation,
+              let request = pendingAddModel,
+              confirmation.request.id == request.id,
+              request.id == expectedRequestID
+        else { return }
+
+        pendingConfirmation = nil
         pendingAddModel = nil
-        // Also clear pending chat if it was part of unified flow
-        if pendingChat?.modelConfig != nil {
-            pendingChat = nil
-        }
         DiagnosticsLogger.log(
             .app,
             level: .info,
@@ -289,12 +307,52 @@ final class DeepLinkManager: ObservableObject {
         errorRecoverySuggestion = nil
     }
 
-    /// Clear the pending chat request (after it's been processed)
-    func clearPendingChat() {
-        pendingChat = nil
+    /// Atomically return and clear the next ready chat request in FIFO order.
+    func consumeNextReadyChat() -> ChatRequest? {
+        popNextReadyChat()
     }
 
     // MARK: - Private Methods
+
+    private func enqueueReadyChat(_ request: ChatRequest) {
+        readyChatQueue.append(request)
+    }
+
+    private func installConfirmation(_ request: AddModelRequest, deferredChat: ChatRequest?) throws {
+        guard pendingConfirmation == nil else {
+            throw DeepLinkError.confirmationInProgress
+        }
+
+        pendingConfirmation = PendingConfirmation(request: request, deferredChat: deferredChat)
+        pendingAddModel = request
+    }
+
+    private func popNextReadyChat() -> ChatRequest? {
+        while !readyChatQueue.isEmpty {
+            let request = readyChatQueue.removeFirst()
+            if isModelAvailable(for: request) {
+                return request
+            }
+            present(DeepLinkError.modelNotFound(request.model ?? ""))
+        }
+        return nil
+    }
+
+    private func validateModelAvailability(for request: ChatRequest) throws {
+        guard isModelAvailable(for: request) else {
+            throw DeepLinkError.modelNotFound(request.model ?? "")
+        }
+    }
+
+    private func isModelAvailable(for request: ChatRequest) -> Bool {
+        guard let model = request.model else { return true }
+        return aiService.customModels.contains(model)
+    }
+
+    private func present(_ error: DeepLinkError) {
+        errorMessage = error.errorDescription
+        errorRecoverySuggestion = error.recoverySuggestion
+    }
 
     /// Parse a URL into a deep link action
     private func parseURL(_ url: URL) throws -> DeepLinkAction {
@@ -334,9 +392,7 @@ final class DeepLinkManager: ObservableObject {
     private func extractParameters(from components: URLComponents) -> [String: String] {
         var params: [String: String] = [:]
         components.queryItems?.forEach { item in
-            if let value = item.value {
-                params[item.name] = value
-            }
+            params[item.name] = item.value ?? ""
         }
         return params
     }
@@ -344,9 +400,11 @@ final class DeepLinkManager: ObservableObject {
     /// Parse add-model action parameters
     private func parseAddModel(params: [String: String]) throws -> DeepLinkAction {
         // Name is required
-        guard let name = params["name"], !name.isEmpty else {
+        guard let rawName = params["name"] else {
             throw DeepLinkError.missingRequiredParameter("name")
         }
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { throw DeepLinkError.missingRequiredParameter("name") }
 
         // Provider (optional, defaults to OpenAI)
         let provider: AIProvider
@@ -409,7 +467,16 @@ final class DeepLinkManager: ObservableObject {
     /// Supports unified flow: if provider/endpoint/key/type params are present along with model,
     /// creates a model config that will be used to add the model if it doesn't exist
     private func parseChat(params: [String: String]) throws -> DeepLinkAction {
-        let model = params["model"]
+        let model: String?
+        if let rawModel = params["model"] {
+            let trimmedModel = rawModel.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedModel.isEmpty else {
+                throw DeepLinkError.missingRequiredParameter("model")
+            }
+            model = trimmedModel
+        } else {
+            model = nil
+        }
 
         // Check if model configuration params are provided (unified add+chat flow)
         var modelConfig: AddModelRequest?

--- a/Sources/Ayna/Utilities/TestIdentifiers.swift
+++ b/Sources/Ayna/Utilities/TestIdentifiers.swift
@@ -80,6 +80,7 @@ enum TestIdentifiers {
         static let emptyState = "watch.emptyState"
         static let newChatButton = "watch.newChatButton"
         static let modelSelectorButton = "watch.modelSelectorButton"
+        static let newChatView = "watch.newChat.view"
 
         // Chat view identifiers (flattened to avoid nesting violation)
         static let chatMessagesList = "watch.chat.messagesList"

--- a/Sources/Ayna/ViewModels/ConversationManager.swift
+++ b/Sources/Ayna/ViewModels/ConversationManager.swift
@@ -16,18 +16,22 @@ import SwiftUI
     import UniformTypeIdentifiers
 #endif
 
+extension Notification.Name {
+    static let conversationDeleteRolledBack = Notification.Name("conversationDeleteRolledBack")
+}
+
 @MainActor
 final class ConversationManager: ObservableObject {
     @Published var conversations: [Conversation] = []
-    @Published var selectedConversationId: UUID?
+    @Published var selectedConversationId: UUID? {
+        didSet { selectionRevision &+= 1 }
+    }
 
     static let newConversationId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
 
-    private let store: EncryptedConversationStore
     private let persistenceCoordinator: ConversationPersistenceCoordinator
     var loadingTask: Task<Void, Never>?
-    private var isLoaded = false
-    private let saveDebounceDuration: Duration
+    private var selectionRevision: UInt64 = 0
 
     // Performance: O(1) conversation index lookup cache
     private var conversationIndexCache: [UUID: Int] = [:]
@@ -35,6 +39,9 @@ final class ConversationManager: ObservableObject {
     // Performance: Spotlight indexing debounce (3 seconds per conversation)
     private var indexingDebounceTasks: [UUID: Task<Void, Never>] = [:]
     private let indexingDebounceDuration: Duration = .seconds(3)
+    #if !os(watchOS)
+        private var spotlightOperationTail = Task<Void, Never> {}
+    #endif
 
     private func logManager(
         _ message: String,
@@ -94,229 +101,157 @@ final class ConversationManager: ObservableObject {
     }
 
     init(
-        store: EncryptedConversationStore? = nil,
+        store: (any ConversationStoreAdapter)? = nil,
         saveDebounceDuration: Duration = .milliseconds(200)
     ) {
-        let effectiveStore = store ?? .shared
-        self.store = effectiveStore
-        self.saveDebounceDuration = saveDebounceDuration
+        let effectiveStore = store ?? EncryptedConversationStore.shared
         persistenceCoordinator = ConversationPersistenceCoordinator(
             store: effectiveStore,
             debounceDuration: saveDebounceDuration
         )
-        loadingTask = Task {
-            await loadConversations()
-        }
 
-        // Listen for save failures to reload data from disk
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleSaveFailure(_:)),
-            name: .conversationSaveFailed,
-            object: nil
-        )
-    }
-
-    @objc private func handleSaveFailure(_ notification: Notification) {
-        guard let conversationId = notification.userInfo?["conversationId"] as? UUID else { return }
-
-        logManager(
-            "🔄 Reloading conversations after save failure",
-            level: .info,
-            metadata: ["failedId": conversationId.uuidString]
-        )
-
-        // Reload all conversations from disk to restore consistent state
-        Task {
-            await loadConversations()
+        let initialLoad = persistenceCoordinator.load()
+        loadingTask = Task { [weak self] in
+            await self?.consumeLoad(initialLoad)
         }
     }
 
     // MARK: - Persistence
 
     func save(_ conversation: Conversation) {
-        // Delegate to the actor for thread-safe, debounced persistence
-        Task {
-            if !isLoaded {
-                _ = await loadingTask?.value
-            }
-
-            await persistenceCoordinator.enqueueSave(conversation)
-            #if !os(watchOS)
-                indexConversation(conversation)
-            #endif
-        }
+        guard let current = self.conversation(byId: conversation.id) else { return }
+        persistenceCoordinator.apply(current, mode: .coalesced)
+        #if !os(watchOS)
+            indexConversation(current)
+        #endif
     }
 
     @discardableResult
     func saveImmediately(_ conversation: Conversation) -> Task<Void, Never> {
-        Task {
-            if !isLoaded {
-                _ = await loadingTask?.value
-            }
+        guard let current = self.conversation(byId: conversation.id) else {
+            return Task {}
+        }
 
-            do {
-                try await persistenceCoordinator.saveImmediately(conversation)
-                #if !os(watchOS)
-                    indexConversation(conversation)
-                #endif
-            } catch {
-                logManager(
-                    "❌ Failed to save conversation",
-                    level: .error,
-                    metadata: ["id": conversation.id.uuidString, "error": error.localizedDescription]
-                )
-            }
+        let receipt = persistenceCoordinator.apply(current, mode: .immediate)
+        #if !os(watchOS)
+            indexConversation(current)
+        #endif
+
+        return Task {
+            await receipt?.value
         }
     }
 
-    /// Flushes all pending debounced saves immediately.
-    /// Call on app termination to prevent data loss.
+    /// Flushes every persistence operation accepted before this call.
     func flushPendingSaves() async {
-        await persistenceCoordinator.flushPendingSaves()
+        let receipt = persistenceCoordinator.flush()
+        await receipt.value
     }
 
-    func delete(_ conversationId: UUID) {
-        Task {
-            do {
-                try await persistenceCoordinator.delete(conversationId)
-                MemoryContextProvider.shared.removeConversationSummary(for: conversationId)
-                await loadConversations()
-                if selectedConversationId == conversationId {
-                    selectedConversationId = nil
-                }
-            } catch {
-                logManager(
-                    "❌ Failed to delete conversation",
-                    level: .error,
-                    metadata: ["id": conversationId.uuidString, "error": error.localizedDescription]
-                )
-            }
-        }
-    }
-
-    private func loadConversations() async {
-        do {
-            var decodedFromDisk = try await store.loadConversations()
-
-            // Validate and fix models that no longer exist
-            let availableModels = AIService.shared.customModels
-            let defaultModel = AIService.shared.selectedModel
-
-            for index in decodedFromDisk.indices where !availableModels.contains(decodedFromDisk[index].model) {
-                // Model no longer exists, update to default
-                decodedFromDisk[index].model = defaultModel
-                let conversationToSave = decodedFromDisk[index]
-                Task {
-                    do {
-                        try await store.save(conversationToSave)
-                    } catch {
-                        DiagnosticsLogger.log(
-                            .conversationManager,
-                            level: .error,
-                            message: "Failed to save conversation",
-                            metadata: ["error": "\(error)"]
-                        )
-                    }
-                }
-            }
-
-            // Dirty-wins reconciliation:
-            // - Disk is the authoritative snapshot for non-dirty conversations
-            // - In-memory wins for conversations that have pending saves queued
-            let dirtyIds = await persistenceCoordinator.pendingConversationIds()
-            let memoryById = Dictionary(conversations.map { ($0.id, $0) }, uniquingKeysWith: { existing, new in
-                DiagnosticsLogger.log(.conversationManager, level: .default, message: "Duplicate conversation ID in memory", metadata: ["id": "\(new.id)"])
-                return new
-            })
-            let diskById = Dictionary(decodedFromDisk.map { ($0.id, $0) }, uniquingKeysWith: { existing, new in
-                DiagnosticsLogger.log(.conversationManager, level: .default, message: "Duplicate conversation ID on disk", metadata: ["id": "\(new.id)"])
-                return new
-            })
-
-            var reconciled: [Conversation] = []
-            reconciled.reserveCapacity(max(memoryById.count, diskById.count))
-
-            // Start from disk snapshot
-            for diskConversation in decodedFromDisk {
-                if dirtyIds.contains(diskConversation.id), let memoryConversation = memoryById[diskConversation.id] {
-                    reconciled.append(memoryConversation)
-                } else {
-                    reconciled.append(diskConversation)
-                }
-            }
-
-            // Add any dirty in-memory conversations not present on disk yet (e.g., newly created)
-            for dirtyId in dirtyIds {
-                if diskById[dirtyId] == nil, let memoryConversation = memoryById[dirtyId] {
-                    reconciled.append(memoryConversation)
-                }
-            }
-
-            // Sort by updated date descending to ensure correct order
-            reconciled.sort { $0.updatedAt > $1.updatedAt }
-
-            conversations = reconciled
-
-            // If selected conversation no longer exists, clear selection
-            if let selectedId = selectedConversationId,
-               !conversations.contains(where: { $0.id == selectedId })
-            {
-                selectedConversationId = nil
-            }
-
-            // Rebuild the index cache after loading and sorting
-            rebuildIndexCache()
-
-            isLoaded = true
-
-            logManager(
-                "✅ Loaded \(conversations.count) conversations",
-                level: .info,
-                metadata: ["count": "\(conversations.count)"]
-            )
-
-            // Index all conversations for Spotlight
-            #if !os(watchOS)
-                indexAllConversations()
-            #endif
-        } catch {
+    private func consumeLoad(_ receipt: PersistenceReceipt<ConversationLoadResult>) async {
+        switch await receipt.value {
+        case let .loaded(loaded):
+            applyLoadedConversations(loaded)
+        case let .failed(error):
             logManager(
                 "❌ Failed to load conversations",
                 level: .error,
-                metadata: ["error": error.localizedDescription]
+                metadata: ["error": error]
             )
-            if conversations.isEmpty {
-                conversations = []
-                conversationIndexCache.removeAll()
-            }
-            isLoaded = true
+        case .superseded:
+            break
         }
+    }
+
+    private func applyLoadedConversations(_ loaded: [Conversation]) {
+        var repaired = loaded
+        let availableModels = AIService.shared.customModels
+        let defaultModel = AIService.shared.selectedModel
+        var repairedIDs: [UUID] = []
+
+        for index in repaired.indices where !availableModels.contains(repaired[index].model) {
+            repaired[index].model = defaultModel
+            repairedIDs.append(repaired[index].id)
+        }
+
+        repaired.sort { lhs, rhs in
+            if lhs.updatedAt == rhs.updatedAt {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.updatedAt > rhs.updatedAt
+        }
+        conversations = repaired
+
+        if let selectedId = selectedConversationId,
+           !conversations.contains(where: { $0.id == selectedId })
+        {
+            selectedConversationId = nil
+        }
+
+        rebuildIndexCache()
+
+        for id in repairedIDs {
+            guard let current = conversation(byId: id) else { continue }
+            persistenceCoordinator.apply(current, mode: .immediate)
+        }
+
+        logManager(
+            "✅ Loaded \(conversations.count) conversations",
+            level: .info,
+            metadata: ["count": "\(conversations.count)"]
+        )
+
+        #if !os(watchOS)
+            indexAllConversations()
+        #endif
     }
 
     /// Public method to reload conversations from storage.
     /// Used for pull-to-refresh on iOS.
     func reloadConversations() async {
         logManager("🔄 Reloading conversations from storage", level: .info)
-        await loadConversations()
+        let receipt = persistenceCoordinator.load()
+        await consumeLoad(receipt)
     }
 
-    func clearAllConversations() {
-        conversations.removeAll()
-        conversationIndexCache.removeAll()
-        Task {
-            // Cancel all pending saves in the coordinator
-            await persistenceCoordinator.cancelAllPendingSaves()
+    @discardableResult
+    func clearAllConversations() -> Task<Void, Never> {
+        let beforeClear = conversations
+        let selectedBeforeClear = selectedConversationId
+        let receipt = persistenceCoordinator.clear(beforeClear)
 
-            do {
-                try store.clear()
-                logManager("🧹 Cleared encrypted conversation store", level: .info)
-            } catch {
-                logManager(
-                    "⚠️ Failed to clear conversation store",
+        conversations.removeAll(keepingCapacity: true)
+        conversationIndexCache.removeAll(keepingCapacity: true)
+        selectedConversationId = nil
+        let rollbackSelectionRevision = selectionRevision
+        #if !os(watchOS)
+            indexAllConversations()
+        #endif
+
+        return Task { @MainActor [weak self] in
+            let result = await receipt.value
+            guard let self else { return }
+
+            switch result {
+            case .cleared, .superseded:
+                break
+            case let .failed(restored, error):
+                self.conversations = restored
+                self.rebuildIndexCache()
+                if self.selectionRevision == rollbackSelectionRevision,
+                   let selectedBeforeClear,
+                   self.conversations.contains(where: { $0.id == selectedBeforeClear })
+                {
+                    self.selectedConversationId = selectedBeforeClear
+                }
+                self.logManager(
+                    "⚠️ Restored conversations after clear failure",
                     level: .error,
-                    metadata: ["error": error.localizedDescription]
+                    metadata: ["error": error, "count": "\(self.conversations.count)"]
                 )
+                #if !os(watchOS)
+                    self.indexAllConversations()
+                #endif
             }
         }
     }
@@ -390,17 +325,62 @@ final class ConversationManager: ObservableObject {
         return conversation
     }
 
-    func deleteConversation(_ conversation: Conversation) {
-        if let index = getConversationIndex(for: conversation.id) {
-            let id = conversation.id
-            conversations.remove(at: index)
-            updateCacheForRemoval(id: id, at: index)
-            MemoryContextProvider.shared.removeConversationSummary(for: id)
-            Task {
-                try? await store.delete(id)
+    @discardableResult
+    func deleteConversation(_ conversation: Conversation) -> Task<Void, Never>? {
+        guard let index = getConversationIndex(for: conversation.id) else { return nil }
+
+        let current = conversations[index]
+        let id = current.id
+        let wasSelected = selectedConversationId == id
+        let receipt = persistenceCoordinator.delete(current)
+
+        conversations.remove(at: index)
+        updateCacheForRemoval(id: id, at: index)
+        if wasSelected {
+            selectedConversationId = nil
+        }
+        let rollbackSelectionRevision = selectionRevision
+
+        return Task { @MainActor [weak self] in
+            let result = await receipt.value
+            guard let self else { return }
+
+            switch result {
+            case .deleted:
+                MemoryContextProvider.shared.removeConversationSummary(for: id)
                 #if !os(watchOS)
-                    deindexConversation(id: id)
+                    self.deindexConversation(id: id)
                 #endif
+            case let .failed(restored, error):
+                if self.getConversationIndex(for: id) == nil {
+                    let insertionIndex = min(index, self.conversations.count)
+                    self.conversations.insert(restored, at: insertionIndex)
+                    self.updateCacheForInsertion(at: insertionIndex)
+                    var restoredSelection = false
+                    if wasSelected,
+                       self.selectionRevision == rollbackSelectionRevision
+                    {
+                        self.selectedConversationId = id
+                        restoredSelection = true
+                    }
+                    #if !os(watchOS)
+                        self.indexConversation(restored)
+                    #endif
+                    if restoredSelection {
+                        NotificationCenter.default.post(
+                            name: .conversationDeleteRolledBack,
+                            object: nil,
+                            userInfo: ["conversationId": id]
+                        )
+                    }
+                }
+                self.logManager(
+                    "❌ Failed to delete conversation; restored it in the UI",
+                    level: .error,
+                    metadata: ["id": id.uuidString, "error": error]
+                )
+            case .superseded:
+                break
             }
         }
     }
@@ -866,7 +846,9 @@ final class ConversationManager: ObservableObject {
             onReasoning: nil
         )
     }
+}
 
+private extension ConversationManager {
     // MARK: - Spotlight Indexing
 
     #if !os(watchOS)
@@ -927,9 +909,8 @@ final class ConversationManager: ObservableObject {
                     return
                 }
 
-                // Perform the actual indexing on a background thread
                 let conversationCopy = latestConversation
-                Task.detached(priority: .utility) {
+                enqueueSpotlightOperation {
                     let item = ConversationManager.createSearchableItem(for: conversationCopy)
 
                     do {
@@ -953,7 +934,7 @@ final class ConversationManager: ObservableObject {
             indexingDebounceTasks[conversation.id]?.cancel()
             indexingDebounceTasks.removeValue(forKey: conversation.id)
 
-            Task.detached(priority: .utility) {
+            enqueueSpotlightOperation {
                 let item = ConversationManager.createSearchableItem(for: conversation)
 
                 do {
@@ -972,7 +953,7 @@ final class ConversationManager: ObservableObject {
         private func indexAllConversations() {
             let conversationsToIndex = conversations
 
-            Task.detached(priority: .utility) {
+            enqueueSpotlightOperation {
                 do {
                     // Clear existing index first to ensure clean state
                     try await CSSearchableIndex.default().deleteSearchableItems(withDomainIdentifiers: [
@@ -1005,20 +986,33 @@ final class ConversationManager: ObservableObject {
             indexingDebounceTasks[id]?.cancel()
             indexingDebounceTasks.removeValue(forKey: id)
 
-            CSSearchableIndex.default().deleteSearchableItems(withIdentifiers: [id.uuidString]) { error in
-                if let error {
-                    Task { @MainActor in
-                        self.logManager(
-                            "❌ Spotlight deletion error",
-                            level: .error,
-                            metadata: ["error": error.localizedDescription]
-                        )
-                    }
+            enqueueSpotlightOperation {
+                do {
+                    try await CSSearchableIndex.default().deleteSearchableItems(withIdentifiers: [id.uuidString])
+                } catch {
+                    DiagnosticsLogger.log(
+                        .conversationManager,
+                        level: .error,
+                        message: "❌ Spotlight deletion error",
+                        metadata: ["error": error.localizedDescription]
+                    )
                 }
             }
         }
-    #endif
 
+        private func enqueueSpotlightOperation(
+            _ operation: @escaping @Sendable () async -> Void
+        ) {
+            let predecessor = spotlightOperationTail
+            spotlightOperationTail = Task.detached(priority: .utility) {
+                await predecessor.value
+                await operation()
+            }
+        }
+    #endif
+}
+
+extension ConversationManager {
     // MARK: - Search and Filter
 
     nonisolated func searchConversationsAsync(query: String, conversations: [Conversation]) async

--- a/Sources/Ayna/ViewModels/ConversationManager.swift
+++ b/Sources/Ayna/ViewModels/ConversationManager.swift
@@ -21,16 +21,26 @@ extension Notification.Name {
 }
 
 @MainActor
+// swiftlint:disable:next type_body_length
 final class ConversationManager: ObservableObject {
     @Published var conversations: [Conversation] = []
     @Published var selectedConversationId: UUID? {
         didSet { selectionRevision &+= 1 }
     }
 
+    @Published private(set) var pendingDestructivePersistenceOperations = 0
+    @Published private(set) var isConversationStateAuthoritative = false
+    @Published private(set) var durableConversationRevision: UInt64 = 0
+
     static let newConversationId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
 
     private let persistenceCoordinator: ConversationPersistenceCoordinator
+    private let loadRetryBaseDelay: Duration
+    private let destructiveRepairRetryBaseDelay: Duration
     var loadingTask: Task<Void, Never>?
+    private var loadRetryTask: Task<Void, Never>?
+    private var destructiveRepairTasks: [ConversationSnapshotRepairToken: Task<Void, Never>] = [:]
+    private var loadRetryAttempt = 0
     private var selectionRevision: UInt64 = 0
 
     // Performance: O(1) conversation index lookup cache
@@ -102,13 +112,20 @@ final class ConversationManager: ObservableObject {
 
     init(
         store: (any ConversationStoreAdapter)? = nil,
-        saveDebounceDuration: Duration = .milliseconds(200)
+        saveDebounceDuration: Duration = .milliseconds(200),
+        loadRetryBaseDelay: Duration = .seconds(2),
+        destructiveRepairRetryBaseDelay: Duration = .seconds(2)
     ) {
         let effectiveStore = store ?? EncryptedConversationStore.shared
         persistenceCoordinator = ConversationPersistenceCoordinator(
             store: effectiveStore,
             debounceDuration: saveDebounceDuration
         )
+        self.loadRetryBaseDelay = loadRetryBaseDelay
+        self.destructiveRepairRetryBaseDelay = destructiveRepairRetryBaseDelay
+        persistenceCoordinator.observeDurableSnapshotChanges { [weak self] in
+            self?.durableConversationRevision &+= 1
+        }
 
         let initialLoad = persistenceCoordinator.load()
         loadingTask = Task { [weak self] in
@@ -127,9 +144,9 @@ final class ConversationManager: ObservableObject {
     }
 
     @discardableResult
-    func saveImmediately(_ conversation: Conversation) -> Task<Void, Never> {
+    func saveImmediately(_ conversation: Conversation) -> Task<ConversationSaveResult, Never> {
         guard let current = self.conversation(byId: conversation.id) else {
-            return Task {}
+            return Task { .superseded }
         }
 
         let receipt = persistenceCoordinator.apply(current, mode: .immediate)
@@ -138,8 +155,128 @@ final class ConversationManager: ObservableObject {
         #endif
 
         return Task {
-            await receipt?.value
+            await receipt?.value ?? .superseded
         }
+    }
+
+    func persistProposedConversation(_ conversation: Conversation) -> Task<ConversationSaveResult, Never> {
+        let receipt = persistenceCoordinator.saveProposed(conversation)
+        return Task {
+            await receipt.value
+        }
+    }
+
+    func commitPersistedConversation(_ conversation: Conversation) {
+        if let index = getConversationIndex(for: conversation.id) {
+            conversations[index] = conversation
+        } else {
+            conversations.insert(conversation, at: 0)
+            updateCacheForInsertion(at: 0)
+        }
+        #if !os(watchOS)
+            indexConversation(conversation)
+        #endif
+    }
+
+    private func beginDestructivePersistenceOperation(
+        _ repairToken: ConversationSnapshotRepairToken
+    ) {
+        pendingDestructivePersistenceOperations += 1
+
+        let supersededTokens = destructiveRepairTasks.keys.filter {
+            $0.isSuperseded(by: repairToken)
+        }
+        for supersededToken in supersededTokens {
+            destructiveRepairTasks.removeValue(forKey: supersededToken)?.cancel()
+            finishDestructivePersistenceOperation()
+        }
+    }
+
+    private func finishDestructivePersistenceOperation() {
+        pendingDestructivePersistenceOperations = max(
+            0,
+            pendingDestructivePersistenceOperations - 1
+        )
+    }
+
+    /// Keeps Watch sync behind the destructive barrier while compensating persistence retries.
+    private func retainDestructiveBarrierUntilRepairSettles(
+        _ repairToken: ConversationSnapshotRepairToken
+    ) {
+        guard destructiveRepairTasks[repairToken] == nil else { return }
+
+        let coordinator = persistenceCoordinator
+        let baseDelay = destructiveRepairRetryBaseDelay
+        destructiveRepairTasks[repairToken] = Task { @MainActor [weak self] in
+            var retryAttempt = 0
+            var retryIfNeeded = false
+
+            while !Task.isCancelled {
+                let result = await coordinator.settleCurrentSnapshot(
+                    for: repairToken,
+                    retryIfNeeded: retryIfNeeded
+                )
+                guard !Task.isCancelled, let self else { return }
+
+                switch result {
+                case .settled, .superseded:
+                    guard self.destructiveRepairTasks.removeValue(forKey: repairToken) != nil else {
+                        return
+                    }
+                    self.finishDestructivePersistenceOperation()
+                    return
+                case .failed:
+                    let scale = 1 << min(retryAttempt, 5)
+                    retryAttempt += 1
+                    do {
+                        try await Task.sleep(for: baseDelay * scale)
+                    } catch {
+                        return
+                    }
+                    retryIfNeeded = true
+                }
+            }
+        }
+    }
+
+    func persistProposedDeletion(_ conversation: Conversation) -> Task<ConversationDeleteResult, Never> {
+        persistProposedDeletion(persistenceCoordinator.delete(conversation))
+    }
+
+    func persistProposedDeletion(conversationID: UUID) -> Task<ConversationDeleteResult, Never> {
+        persistProposedDeletion(persistenceCoordinator.delete(id: conversationID))
+    }
+
+    private func persistProposedDeletion(
+        _ receipt: DestructivePersistenceReceipt<ConversationDeleteResult>
+    ) -> Task<ConversationDeleteResult, Never> {
+        beginDestructivePersistenceOperation(receipt.repairToken)
+
+        return Task { @MainActor [weak self] in
+            let result = await receipt.value
+            guard let self else { return .superseded }
+            switch result {
+            case .deleted:
+                self.finishDestructivePersistenceOperation()
+            case .failed, .superseded:
+                self.retainDestructiveBarrierUntilRepairSettles(receipt.repairToken)
+            }
+            return result
+        }
+    }
+
+    func commitPersistedDeletion(_ conversationID: UUID) {
+        if let index = getConversationIndex(for: conversationID) {
+            conversations.remove(at: index)
+            updateCacheForRemoval(id: conversationID, at: index)
+        }
+        if selectedConversationId == conversationID {
+            selectedConversationId = nil
+        }
+        MemoryContextProvider.shared.removeConversationSummary(for: conversationID)
+        #if !os(watchOS)
+            deindexConversation(id: conversationID)
+        #endif
     }
 
     /// Flushes every persistence operation accepted before this call.
@@ -148,18 +285,67 @@ final class ConversationManager: ObservableObject {
         await receipt.value
     }
 
+    func settlePersistence(for conversationID: UUID) async -> ConversationDurabilityResult {
+        await persistenceCoordinator.settleCurrentState(for: conversationID)
+    }
+
+    func durableConversationsForSync() -> [Conversation] {
+        persistenceCoordinator.durableConversations()
+    }
+
+    /// Legacy Watch deliveries do not have a retry acknowledgement. Retained ingress work
+    /// waits here outside the WCSession FIFO until the phone snapshot is authoritative.
+    func waitUntilConversationStateIsAuthoritative() async -> Bool {
+        if isConversationStateAuthoritative {
+            return true
+        }
+
+        for await authoritative in $isConversationStateAuthoritative.values {
+            guard !Task.isCancelled else { return false }
+            if authoritative {
+                return true
+            }
+        }
+        return false
+    }
+
     private func consumeLoad(_ receipt: PersistenceReceipt<ConversationLoadResult>) async {
         switch await receipt.value {
         case let .loaded(loaded):
+            loadRetryTask?.cancel()
+            loadRetryTask = nil
+            loadRetryAttempt = 0
             applyLoadedConversations(loaded)
+            isConversationStateAuthoritative = true
         case let .failed(error):
+            isConversationStateAuthoritative = false
             logManager(
                 "❌ Failed to load conversations",
                 level: .error,
                 metadata: ["error": error]
             )
+            scheduleLoadRetry()
         case .superseded:
-            break
+            if !isConversationStateAuthoritative {
+                scheduleLoadRetry()
+            }
+        }
+    }
+
+    private func scheduleLoadRetry() {
+        guard !isConversationStateAuthoritative, loadRetryTask == nil else { return }
+        let scale = 1 << min(loadRetryAttempt, 5)
+        let delay = loadRetryBaseDelay * scale
+        loadRetryAttempt += 1
+        loadRetryTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            guard let self else { return }
+            self.loadRetryTask = nil
+            await self.consumeLoad(self.persistenceCoordinator.load())
         }
     }
 
@@ -210,6 +396,8 @@ final class ConversationManager: ObservableObject {
     /// Used for pull-to-refresh on iOS.
     func reloadConversations() async {
         logManager("🔄 Reloading conversations from storage", level: .info)
+        loadRetryTask?.cancel()
+        loadRetryTask = nil
         let receipt = persistenceCoordinator.load()
         await consumeLoad(receipt)
     }
@@ -219,6 +407,7 @@ final class ConversationManager: ObservableObject {
         let beforeClear = conversations.map(resolvingInterruptedImageGeneration)
         let selectedBeforeClear = selectedConversationId
         let receipt = persistenceCoordinator.clear(beforeClear)
+        beginDestructivePersistenceOperation(receipt.repairToken)
 
         conversations.removeAll(keepingCapacity: true)
         conversationIndexCache.removeAll(keepingCapacity: true)
@@ -233,9 +422,13 @@ final class ConversationManager: ObservableObject {
             guard let self else { return }
 
             switch result {
-            case .cleared, .superseded:
-                break
+            case .cleared:
+                self.isConversationStateAuthoritative = true
+                self.finishDestructivePersistenceOperation()
+            case .superseded:
+                self.finishDestructivePersistenceOperation()
             case let .failed(restored, error):
+                self.retainDestructiveBarrierUntilRepairSettles(receipt.repairToken)
                 self.conversations = restored
                 self.rebuildIndexCache()
                 if self.selectionRevision == rollbackSelectionRevision,
@@ -326,7 +519,7 @@ final class ConversationManager: ObservableObject {
     }
 
     @discardableResult
-    func deleteConversation(_ conversation: Conversation) -> Task<Void, Never>? {
+    func deleteConversation(_ conversation: Conversation) -> Task<ConversationDeleteResult, Never>? {
         guard let index = getConversationIndex(for: conversation.id) else { return nil }
 
         let current = conversations[index]
@@ -334,6 +527,7 @@ final class ConversationManager: ObservableObject {
         let wasSelected = selectedConversationId == id
         let rollbackSnapshot = resolvingInterruptedImageGeneration(in: current)
         let receipt = persistenceCoordinator.delete(rollbackSnapshot)
+        beginDestructivePersistenceOperation(receipt.repairToken)
 
         conversations.remove(at: index)
         updateCacheForRemoval(id: id, at: index)
@@ -344,15 +538,25 @@ final class ConversationManager: ObservableObject {
 
         return Task { @MainActor [weak self] in
             let result = await receipt.value
-            guard let self else { return }
+            guard let self else { return .superseded }
 
             switch result {
             case .deleted:
+                self.finishDestructivePersistenceOperation()
                 MemoryContextProvider.shared.removeConversationSummary(for: id)
                 #if !os(watchOS)
                     self.deindexConversation(id: id)
                 #endif
             case let .failed(restored, error):
+                self.retainDestructiveBarrierUntilRepairSettles(receipt.repairToken)
+                guard let restored else {
+                    self.logManager(
+                        "❌ Failed to delete conversation without a rollback snapshot",
+                        level: .error,
+                        metadata: ["id": id.uuidString, "error": error]
+                    )
+                    return result
+                }
                 if self.getConversationIndex(for: id) == nil {
                     let insertionIndex = min(index, self.conversations.count)
                     self.conversations.insert(restored, at: insertionIndex)
@@ -381,8 +585,9 @@ final class ConversationManager: ObservableObject {
                     metadata: ["id": id.uuidString, "error": error]
                 )
             case .superseded:
-                break
+                self.retainDestructiveBarrierUntilRepairSettles(receipt.repairToken)
             }
+            return result
         }
     }
 

--- a/Sources/Ayna/ViewModels/ConversationManager.swift
+++ b/Sources/Ayna/ViewModels/ConversationManager.swift
@@ -216,7 +216,7 @@ final class ConversationManager: ObservableObject {
 
     @discardableResult
     func clearAllConversations() -> Task<Void, Never> {
-        let beforeClear = conversations
+        let beforeClear = conversations.map(resolvingInterruptedImageGeneration)
         let selectedBeforeClear = selectedConversationId
         let receipt = persistenceCoordinator.clear(beforeClear)
 
@@ -332,7 +332,8 @@ final class ConversationManager: ObservableObject {
         let current = conversations[index]
         let id = current.id
         let wasSelected = selectedConversationId == id
-        let receipt = persistenceCoordinator.delete(current)
+        let rollbackSnapshot = resolvingInterruptedImageGeneration(in: current)
+        let receipt = persistenceCoordinator.delete(rollbackSnapshot)
 
         conversations.remove(at: index)
         updateCacheForRemoval(id: id, at: index)
@@ -385,6 +386,35 @@ final class ConversationManager: ObservableObject {
         }
     }
 
+    private func resolvingInterruptedImageGeneration(in conversation: Conversation) -> Conversation {
+        var restored = conversation
+        var interruptedMessageIDs: Set<UUID> = []
+        for index in restored.messages.indices {
+            let message = restored.messages[index]
+            guard message.role == .assistant,
+                  message.mediaType == .image,
+                  message.imageData == nil,
+                  message.imagePath == nil,
+                  message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                continue
+            }
+            interruptedMessageIDs.insert(message.id)
+            restored.messages[index].content = "Image generation stopped"
+        }
+        guard !interruptedMessageIDs.isEmpty else { return restored }
+
+        for groupIndex in restored.responseGroups.indices {
+            for responseIndex in restored.responseGroups[groupIndex].responses.indices
+                where interruptedMessageIDs.contains(restored.responseGroups[groupIndex].responses[responseIndex].id) &&
+                restored.responseGroups[groupIndex].responses[responseIndex].status == .streaming
+            {
+                restored.responseGroups[groupIndex].responses[responseIndex].status = .failed
+            }
+        }
+        return restored
+    }
+
     func updateConversation(_ conversation: Conversation) {
         if let index = getConversationIndex(for: conversation.id) {
             conversations[index] = conversation
@@ -428,7 +458,12 @@ final class ConversationManager: ObservableObject {
         }
     }
 
-    func updateMessage(in conversation: Conversation, messageId: UUID, update: (inout Message) -> Void) {
+    @discardableResult
+    func updateMessage(
+        in conversation: Conversation,
+        messageId: UUID,
+        update: (inout Message) -> Void
+    ) -> Bool {
         if let convIndex = getConversationIndex(for: conversation.id),
            let msgIndex = conversations[convIndex].messages.firstIndex(where: { $0.id == messageId })
         {
@@ -437,7 +472,9 @@ final class ConversationManager: ObservableObject {
             conversations[convIndex].messages[msgIndex] = message
             conversations[convIndex].updatedAt = Date()
             save(conversations[convIndex])
+            return true
         }
+        return false
     }
 
     // MARK: - Safe ID-Based Access

--- a/Sources/Ayna/ViewModels/ConversationManager.swift
+++ b/Sources/Ayna/ViewModels/ConversationManager.swift
@@ -519,6 +519,7 @@ final class ConversationManager: ObservableObject {
             return false
         }
         conversations[convIndex].messages[msgIndex].content += chunk
+        conversations[convIndex].updatedAt = Date()
         return true
     }
 

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -49,11 +49,19 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
     var conversationManager: ConversationManager
     let aiService: AIService
     private let imageGenerationCoordinator = ImageGenerationCoordinator()
+        private let toolChainCoordinator = ToolChainCoordinator()
+        private let toolCallRequestRoundCoordinator = ToolCallRequestRoundCoordinator<ToolExecutionResult>()
 
     // MARK: - Tool Call State
 
     /// Tracks the depth of recursive tool calls to prevent infinite loops
     private var toolCallDepth = 0
+        private var activeAssistantMessageId: UUID?
+        private var activeMultiModelResponseGroupId: UUID?
+        private var pendingAutoSendTask: Task<Void, Never>?
+        private var pendingAutoSendID: UUID?
+        private var pendingAutoSendDraft: String?
+        private var pendingAutoSendConversationID: UUID?
 
     /// Maximum tool chain depth for iOS.
     /// Lower than macOS (25) due to mobile resource constraints and typical mobile use cases.
@@ -135,13 +143,18 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
     /// Update the conversation manager reference.
     /// Used when view model was created before environment was available.
     func configure(with manager: ConversationManager) {
+            if conversationManager !== manager {
+                cancelPendingAutoSend()
+            }
         conversationManager = manager
     }
 
     /// Configure with conversation manager and conversation ID.
     /// Used for existing conversation views.
     func configure(with manager: ConversationManager, conversationId: UUID) {
-        cancelOwnedImageOperation()
+            if self.conversationId != conversationId || conversationManager !== manager {
+                cancelOwnedOperations()
+            }
         conversationManager = manager
         self.conversationId = conversationId
 
@@ -161,7 +174,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
 
     /// Reset state for a fresh new chat session.
     func resetForNewChat() {
-        imageGenerationCoordinator.cancelCurrentOperation()
+            cancelOwnedOperations()
         conversationId = nil
         messageText = ""
         isGenerating = false
@@ -183,6 +196,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
     /// Check for and process a pending auto-send prompt from deep link.
     /// This should be called after the view model is configured with a conversation.
     private func checkAndProcessPendingPrompt() {
+            cancelPendingAutoSend()
         guard let convId = conversationId,
               let index = conversationManager.conversations.firstIndex(where: { $0.id == convId }),
               let prompt = conversationManager.conversations[index].pendingAutoSendPrompt,
@@ -198,16 +212,69 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
             metadata: ["promptLength": "\(prompt.count)"]
         )
 
-        // Clear the pending prompt to prevent re-sending
+            // Clear and persist the prompt before claiming it so view recreation cannot resend it.
         conversationManager.conversations[index].pendingAutoSendPrompt = nil
+            conversationManager.saveImmediately(conversationManager.conversations[index])
 
         // Set the message text and send
         messageText = prompt
+            pendingAutoSendDraft = prompt
+            pendingAutoSendConversationID = convId
+            let autoSendID = UUID()
+            pendingAutoSendID = autoSendID
         // Use a small delay to ensure the view is fully loaded
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(100))
-            sendMessage()
+            let task = Task { @MainActor [weak self] in
+                do {
+                    try await Task.sleep(for: .milliseconds(100))
+                } catch {
+                    return
+                }
+                guard let self,
+                      self.pendingAutoSendID == autoSendID,
+                      self.conversationId == convId,
+                      self.messageText == prompt
+                else {
+                    return
         }
+                self.pendingAutoSendTask = nil
+                self.pendingAutoSendID = nil
+                self.pendingAutoSendDraft = nil
+                self.pendingAutoSendConversationID = nil
+                self.sendMessage()
+            }
+            pendingAutoSendTask = task
+        }
+
+        @discardableResult
+        private func cancelPendingAutoSend() -> Bool {
+            let wasPending = pendingAutoSendTask != nil || pendingAutoSendID != nil
+            pendingAutoSendTask?.cancel()
+            pendingAutoSendTask = nil
+            pendingAutoSendID = nil
+            if let draft = pendingAutoSendDraft,
+               messageText == draft,
+               let claimedConversationID = pendingAutoSendConversationID,
+               let index = conversationManager.conversations.firstIndex(where: { $0.id == claimedConversationID })
+            {
+                // Return an unsent claim to durable conversation state so view disappearance,
+                // reconfiguration, or switching conversations cannot silently drop a deep link.
+                if conversationManager.conversations[index].pendingAutoSendPrompt == nil {
+                    conversationManager.conversations[index].pendingAutoSendPrompt = draft
+                    conversationManager.saveImmediately(conversationManager.conversations[index])
+                }
+                messageText = ""
+            }
+            pendingAutoSendDraft = nil
+            pendingAutoSendConversationID = nil
+            return wasPending
+        }
+
+        private func consumePendingAutoSendClaim() {
+            pendingAutoSendTask?.cancel()
+            pendingAutoSendTask = nil
+            pendingAutoSendID = nil
+            pendingAutoSendDraft = nil
+            pendingAutoSendConversationID = nil
     }
 
     /// Retry the last failed message
@@ -328,13 +395,15 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
             message: "🛑 Cancelling generation",
             metadata: logMetadata
         )
-        let cancelledImageOperation = imageGenerationCoordinator.cancelCurrentOperation()
-        if !cancelledImageOperation {
-            aiService.cancelCurrentRequest(includeImageRequests: false)
+            toolChainCoordinator.cancelCurrentOperation {
+                finalizePersistedTextGeneration()
         }
+            imageGenerationCoordinator.cancelCurrentOperation()
         isGenerating = false
         currentToolName = nil
         toolCallDepth = 0
+            activeAssistantMessageId = nil
+            activeMultiModelResponseGroupId = nil
         pendingUserMessage = nil
     }
 
@@ -362,6 +431,10 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
             )
             return
         }
+
+            // A manual send during the short deep-link delay consumes the same durable claim;
+            // cancel the delayed task without restoring or clearing the visible draft.
+            consumePendingAutoSendClaim()
 
         // Prevent sending while already generating
         guard !isGenerating else {
@@ -514,8 +587,9 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
             return
         }
 
-        // Messages to send (exclude the empty assistant message we just added)
-        var messagesToSend = Array(updatedConversation.messages.dropLast())
+            // Linearize multi-model history and omit failed/empty placeholders. The newly added
+            // empty assistant is also excluded by effective-history filtering.
+            var messagesToSend = updatedConversation.getEffectiveHistory()
 
         // Prepend system prompt if configured
         if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
@@ -547,16 +621,34 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
             tools: tools
         )
     }
+    }
 
+    private extension IOSChatViewModel {
     /// Helper method to send messages with tool call support
     private func sendMessageWithToolSupport( // swiftlint:disable:this function_body_length
         messages: [Message],
         model: String,
         conversationId: UUID,
         assistantMessageId: UUID,
-        tools: [[String: Any]]?
+        tools: [[String: Any]]?,
+        operationID existingOperationID: ToolChainCoordinator.OperationID? = nil
     ) {
         let toolsWrapper = UncheckedSendable(tools)
+        let coordinator = toolChainCoordinator
+        let roundCoordinator = toolCallRequestRoundCoordinator
+        let operationID = existingOperationID ?? coordinator.beginOperation(conversationID: conversationId)
+        if existingOperationID == nil {
+            activeMultiModelResponseGroupId = nil
+        }
+            guard coordinator.owns(operationID, conversationID: conversationId),
+                  let requestRoundID = roundCoordinator.beginRequestRound(
+                      for: operationID,
+                      coordinatedBy: coordinator
+                  )
+            else {
+                return
+            }
+            activeAssistantMessageId = assistantMessageId
 
         DiagnosticsLogger.log(
             .chatView,
@@ -568,16 +660,19 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
             ]
         )
 
-        aiService.sendMessage(
+            let request = aiService.sendMessage(
             messages: messages,
             model: model,
             stream: true,
             tools: tools,
             onChunk: { [weak self] chunk in
-                let selfRef = self
-                Task { @MainActor in
-                    guard let self = selfRef else { return }
-                    // Log first chunk received
+                    MainActor.assumeIsolated {
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId),
+                              self.activeAssistantMessageId == assistantMessageId
+                        else {
+                            return
+                        }
                     if !chunk.isEmpty {
                         DiagnosticsLogger.log(
                             .chatView,
@@ -589,10 +684,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                             ]
                         )
                     }
-                    // Clear tool indicator when we start receiving content
-                    if self.currentToolName != nil {
                         self.currentToolName = nil
-                    }
                     self.updateAssistantMessage(
                         assistantMessageId,
                         appendingChunk: chunk,
@@ -601,9 +693,13 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                 }
             },
             onComplete: { [weak self] in
-                let selfRef = self
-                Task { @MainActor in
-                    guard let self = selfRef else { return }
+                    MainActor.assumeIsolated {
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId),
+                              self.activeAssistantMessageId == assistantMessageId
+                        else {
+                            return
+                        }
 
                     DiagnosticsLogger.log(
                         .chatView,
@@ -615,290 +711,425 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                         ]
                     )
 
-                    // Only stop generating if no tool call is pending
-                    // If a tool call was requested, keep generating until tool execution completes
-                    if self.currentToolName == nil {
-                        self.isGenerating = false
-
-                        // Clear pending message on success
-                        self.pendingUserMessage = nil
-
-                        // Play message received sound
-                        SoundEngine.messageReceived()
-
-                        if let finalConversation = self.conversationManager.conversation(byId: conversationId) {
-                            self.conversationManager.save(finalConversation)
-                        }
-
-                        // Notify that conversation is ready (for new chat navigation)
-                        if self.isNewChatMode {
-                            self.onConversationCreated?(conversationId)
-                        }
-
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .info,
-                            message: "✅ Message generation completed",
-                            metadata: ["conversationId": conversationId.uuidString]
+                        let resolution = roundCoordinator.providerDidComplete(
+                            operationID: operationID,
+                            requestRoundID: requestRoundID
                         )
-                    } else {
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .info,
-                            message: "⏳ onComplete: Tool call pending, keeping isGenerating=true",
-                            metadata: ["toolName": self.currentToolName ?? "unknown"]
+                        self.handleToolRoundResolution(
+                            resolution,
+                            operationID: operationID,
+                            assistantMessageId: assistantMessageId,
+                            model: model,
+                            conversationId: conversationId,
+                            tools: toolsWrapper.value
                         )
                     }
-                }
             },
             onError: { [weak self] error in
-                let selfRef = self
-                Task { @MainActor in
-                    guard let self = selfRef else { return }
-
-                    // Handle cancellation silently - don't show error UI for user-initiated cancels
-                    if error is CancellationError {
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .info,
-                            message: "Request cancelled",
-                            metadata: ["assistantMessageId": assistantMessageId.uuidString]
-                        )
-                        self.isGenerating = false
-                        self.currentToolName = nil
-                        self.toolCallDepth = 0
-                        self.pendingUserMessage = nil
-                        return
-                    }
-
-                    DiagnosticsLogger.log(
-                        .chatView,
-                        level: .error,
-                        message: "🚨 onError callback fired",
-                        metadata: [
-                            "error": ErrorPresenter.userMessage(for: error),
-                            "assistantMessageId": assistantMessageId.uuidString
-                        ]
-                    )
-
-                    self.isGenerating = false
-
-                    // Play error sound
-                    SoundEngine.error()
-
-                    self.currentToolName = nil
-                    self.toolCallDepth = 0
-                    self.errorMessage = ErrorPresenter.userMessage(for: error)
-                    self.errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
-
-                    // Store the failed message for retry
-                    self.failedMessage = self.pendingUserMessage
-                    self.pendingUserMessage = nil
-
-                    // Remove the empty assistant placeholder message since we show error in banner
-                    self.conversationManager.removeMessage(
-                        conversationId: conversationId,
-                        messageId: assistantMessageId
-                    )
-
-                    // Still notify for navigation even on error if conversation was created
-                    if self.isNewChatMode {
-                        self.onConversationCreated?(conversationId)
-                    }
-
-                    DiagnosticsLogger.log(
-                        .chatView,
-                        level: .error,
-                        message: "❌ Message generation failed: \(ErrorPresenter.userMessage(for: error))",
-                        metadata: ["conversationId": conversationId.uuidString]
+                    MainActor.assumeIsolated {
+                        guard let self else { return }
+                        self.handleToolRequestError(
+                            error,
+                            operationID: operationID,
+                            assistantMessageId: assistantMessageId,
+                            conversationId: conversationId
                     )
                 }
             },
             onToolCallRequested: { [weak self] toolCallId, toolName, arguments in
-                let selfRef = self
                 let argumentsWrapper = UncheckedSendable(arguments)
-                let toolNameCopy = toolName
-                Task { @MainActor in
-                    guard let self = selfRef else { return }
-                    // Set currentToolName first thing to prevent race condition with onComplete
-                    // checking if tool call is pending. The stream may send [DONE] immediately
-                    // after finish_reason: "tool_calls".
-                    self.currentToolName = toolNameCopy
-                    let arguments = argumentsWrapper.value
-
-                    // Validate conversation still exists
-                    guard self.conversationManager.conversation(byId: conversationId) != nil else {
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .default,
-                            message: "⚠️ Tool call requested but conversation no longer exists"
+                    MainActor.assumeIsolated {
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId),
+                              self.activeAssistantMessageId == assistantMessageId,
+                              self.conversationManager.conversation(byId: conversationId) != nil,
+                              let toolToken = roundCoordinator.registerTool(
+                                  for: operationID,
+                                  requestRoundID: requestRoundID
                         )
-                        self.isGenerating = false
-                        self.currentToolName = nil
+                        else {
                         return
                     }
-                    DiagnosticsLogger.log(
-                        .chatView,
-                        level: .info,
-                        message: "🔧 Tool call requested: \(toolName)",
-                        metadata: ["toolName": toolName]
-                    )
 
-                    // Check depth limit
+                        if toolToken.registrationIndex == 0 {
                     guard self.toolCallDepth < self.maxToolCallDepth else {
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .error,
-                            message: "⚠️ Max tool call depth reached"
-                        )
-                        self.isGenerating = false
-                        self.currentToolName = nil
-                        self.errorMessage = "Tool call limit reached. Please try again."
-                        // Remove the empty assistant placeholder message
-                        self.conversationManager.removeMessage(
-                            conversationId: conversationId,
-                            messageId: assistantMessageId
+                                self.stopToolChainAtDepthLimit(
+                                    operationID: operationID,
+                                    assistantMessageId: assistantMessageId,
+                                    conversationId: conversationId
                         )
                         return
                     }
-
                     self.toolCallDepth += 1
+                        }
 
-                    // Store tool call in the last assistant message using safe ID-based access
-                    if let conv = self.conversationManager.conversation(byId: conversationId),
-                       let lastMessage = conv.messages.last,
-                       lastMessage.role == .assistant
-                    {
-                        let anyCodableArgs = arguments.reduce(into: [String: AnyCodable]()) { result, pair in
+                        self.currentToolName = toolName
+                        let arguments = argumentsWrapper.value
+                        let anyCodableArguments = arguments.reduce(into: [String: AnyCodable]()) { result, pair in
                             result[pair.key] = AnyCodable(pair.value)
                         }
                         let toolCall = MCPToolCall(
                             id: toolCallId,
                             toolName: toolName,
-                            arguments: anyCodableArgs
+                            arguments: anyCodableArguments
                         )
-                        self.conversationManager.updateMessage(
+                        let updatedAssistant = self.conversationManager.updateMessage(
                             conversationId: conversationId,
-                            messageId: lastMessage.id
+                            messageId: assistantMessageId
                         ) { message in
-                            message.toolCalls = [toolCall]
+                            var calls = message.toolCalls ?? []
+                            if !calls.contains(where: { $0.id == toolCallId }) {
+                                calls.append(toolCall)
+                            }
+                            message.toolCalls = calls
                         }
-                        if let updatedConv = self.conversationManager.conversation(byId: conversationId) {
-                            self.conversationManager.save(updatedConv)
+                        guard updatedAssistant else {
+                            self.stopToolChainForMissingConversation(
+                                operationID: operationID,
+                                assistantMessageId: assistantMessageId,
+                                conversationId: conversationId
+                            )
+                            return
                         }
+                        if let updatedConversation = self.conversationManager.conversation(byId: conversationId) {
+                            self.conversationManager.save(updatedConversation)
+                        }
+
+                        self.executeTool(
+                            token: toolToken,
+                            callID: toolCallId,
+                            toolName: toolName,
+                            arguments: argumentsWrapper,
+                            anyCodableArguments: anyCodableArguments,
+                            operationID: operationID,
+                            assistantMessageId: assistantMessageId,
+                            model: model,
+                            conversationId: conversationId,
+                            tools: toolsWrapper
+                        )
+                        }
+                        }
+            )
+            coordinator.onCancel(for: operationID) {
+                request.cancel()
+            }
+        }
+
+        // swiftlint:disable:next function_parameter_count
+        private func executeTool(
+            token: ToolCallRequestRoundCoordinator<ToolExecutionResult>.ToolToken,
+            callID: String,
+            toolName: String,
+            arguments: UncheckedSendable<[String: Any]>,
+            anyCodableArguments: [String: AnyCodable],
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            model: String,
+            conversationId: UUID,
+            tools: UncheckedSendable<[[String: Any]]?>
+        ) {
+            let coordinator = toolChainCoordinator
+            let roundCoordinator = toolCallRequestRoundCoordinator
+            coordinator.schedule(for: operationID, conversationID: conversationId) { [weak self] in
+                guard let self,
+                      coordinator.owns(operationID, conversationID: conversationId),
+                      self.activeAssistantMessageId == assistantMessageId
+                else {
+                    return
                     }
 
-                    // Execute the tool
-                    Task {
                         DiagnosticsLogger.log(
                             .chatView,
                             level: .info,
                             message: "⚙️ Executing tool: \(toolName)"
                         )
-
-                        // Execute built-in tool with citations (Tavily web search)
-                        let (result, citations) = await self.aiService.executeBuiltInToolWithCitations(
+                let (output, citations) = await self.aiService.executeBuiltInToolWithCitations(
                             name: toolName,
-                            arguments: argumentsWrapper.value
+                    arguments: arguments.value
                         )
+                guard coordinator.owns(operationID, conversationID: conversationId),
+                      self.activeAssistantMessageId == assistantMessageId,
+                      !Task.isCancelled
+                else {
+                    return
+                }
 
                         DiagnosticsLogger.log(
                             .chatView,
                             level: .info,
-                            message: "✅ Tool result received (\(result.count) chars, \(citations?.count ?? 0) citations)"
+                    message: "✅ Tool result received (\(output.count) chars, \(citations?.count ?? 0) citations)"
                         )
 
-                        await MainActor.run {
-                            let anyCodableArgs = argumentsWrapper.value.reduce(into: [String: AnyCodable]()) { result, pair in
-                                result[pair.key] = AnyCodable(pair.value)
+                let result = ToolExecutionResult(
+                    callID: callID,
+                    toolName: toolName,
+                    arguments: anyCodableArguments,
+                    output: output,
+                    citations: citations ?? []
+                )
+                let resolution = roundCoordinator.toolDidComplete(token, result: result)
+                self.handleToolRoundResolution(
+                    resolution,
+                    operationID: operationID,
+                    assistantMessageId: assistantMessageId,
+                    model: model,
+                    conversationId: conversationId,
+                    tools: tools.value
+                )
+            }
+        }
+
+        private func handleToolRoundResolution(
+            _ resolution: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Resolution,
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            model: String,
+            conversationId: UUID,
+            tools: [[String: Any]]?
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                return
                             }
 
-                            // For web_search, skip creating a tool message and attach citations to assistant
-                            let isWebSearch = toolName == "web_search"
+            switch resolution {
+            case .pending, .ignored:
+                return
+            case .responseCompleted:
+                finishToolSupportedResponse(
+                    operationID: operationID,
+                    assistantMessageId: assistantMessageId,
+                    conversationId: conversationId
+                )
+            case let .launchContinuation(continuation):
+                launchToolContinuation(
+                    continuation,
+                    operationID: operationID,
+                    assistantMessageId: assistantMessageId,
+                    model: model,
+                    conversationId: conversationId,
+                    tools: tools
+                )
+            }
+        }
 
-                            if !isWebSearch {
-                                // For non-web-search tools, create the tool message as before
-                                var toolMessage = Message(role: .tool, content: result)
-                                toolMessage.toolCalls = [
-                                    MCPToolCall(
-                                        id: toolCallId,
-                                        toolName: toolName,
-                                        arguments: anyCodableArgs,
-                                        result: result
+        private func launchToolContinuation(
+            _ continuation: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Continuation,
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            model: String,
+            conversationId: UUID,
+            tools: [[String: Any]]?
+        ) {
+            guard continuation.operationID == operationID,
+                  toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                return
+            }
+
+            let results = continuation.toolResults.map(\.result)
+            for result in results {
+                guard let conversation = conversationManager.conversation(byId: conversationId) else {
+                    stopToolChainForMissingConversation(
+                        operationID: operationID,
+                        assistantMessageId: assistantMessageId,
+                        conversationId: conversationId
                                     )
-                                ]
-                                guard let conv = self.conversationManager.conversation(byId: conversationId) else {
-                                    self.isGenerating = false
-                                    self.currentToolName = nil
-                                    self.toolCallDepth = 0
                                     return
                                 }
-                                self.conversationManager.addMessage(to: conv, message: toolMessage)
+                conversationManager.addMessage(to: conversation, message: result.makeMessage())
                             }
 
-                            // Continue conversation with tool result
-                            guard let updatedConv = self.conversationManager.conversation(byId: conversationId) else {
-                                self.isGenerating = false
-                                self.currentToolName = nil
-                                self.toolCallDepth = 0
+            guard let conversationWithResults = conversationManager.conversation(byId: conversationId) else {
+                stopToolChainForMissingConversation(
+                    operationID: operationID,
+                    assistantMessageId: assistantMessageId,
+                    conversationId: conversationId
+                )
                                 return
                             }
 
-                            // Add a new empty assistant message for the model's response
-                            // For web_search, attach citations to this message
                             var continuationAssistantMessage = Message(role: .assistant, content: "", model: model)
-                            if isWebSearch, let citations {
+            let citations = ToolExecutionResult.combinedCitations(from: results)
+            if !citations.isEmpty {
                                 continuationAssistantMessage.citations = citations
                             }
-                            self.conversationManager.addMessage(to: updatedConv, message: continuationAssistantMessage)
+            conversationManager.addMessage(
+                to: conversationWithResults,
+                message: continuationAssistantMessage
+            )
 
-                            // Get conversation again with new assistant message
-                            guard let convWithAssistant = self.conversationManager.conversation(byId: conversationId) else {
-                                self.isGenerating = false
-                                self.currentToolName = nil
-                                self.toolCallDepth = 0
+            guard let conversationWithAssistant = conversationManager.conversation(byId: conversationId),
+                  toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
                                 return
                             }
 
-                            // Build messages for API - exclude the continuation assistant message
-                            // The continuation message is just a placeholder for where we'll store the response
-                            var continuationMessages = Array(convWithAssistant.messages.dropLast())
-                            if isWebSearch {
-                                // Append a synthetic tool message for the API only
-                                var syntheticToolMessage = Message(role: .tool, content: result)
-                                syntheticToolMessage.toolCalls = [
-                                    MCPToolCall(
-                                        id: toolCallId,
-                                        toolName: toolName,
-                                        arguments: anyCodableArgs,
-                                        result: result
-                                    )
-                                ]
-                                // Append the tool message at the end (after the assistant with tool_calls)
-                                continuationMessages.append(syntheticToolMessage)
-                            }
-
-                            if let sysPrompt = self.conversationManager.effectiveSystemPrompt(for: convWithAssistant) {
-                                let sysMessage = Message(role: .system, content: sysPrompt)
-                                continuationMessages.insert(sysMessage, at: 0)
-                            }
-
-                            // Clear tool name since tool execution is complete
-                            // The continuation is now a regular API call
-                            self.currentToolName = nil
-
-                            self.sendMessageWithToolSupport(
-                                messages: continuationMessages,
-                                model: model,
-                                conversationId: conversationId,
-                                assistantMessageId: continuationAssistantMessage.id,
-                                tools: toolsWrapper.value
-                            )
-                        }
-                    }
-                }
+            var history = conversationWithAssistant
+            history.messages.removeAll { $0.id == continuationAssistantMessage.id }
+            var continuationMessages = history.getEffectiveHistory()
+            if let systemPrompt = conversationManager.effectiveSystemPrompt(for: conversationWithAssistant) {
+                continuationMessages.insert(Message(role: .system, content: systemPrompt), at: 0)
             }
+
+            currentToolName = nil
+            sendMessageWithToolSupport(
+                messages: continuationMessages,
+                model: model,
+                conversationId: conversationId,
+                assistantMessageId: continuationAssistantMessage.id,
+                tools: tools,
+                operationID: operationID
+                                    )
+                            }
+
+        private func finishToolSupportedResponse(
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            conversationId: UUID
+        ) {
+            guard activeAssistantMessageId == assistantMessageId,
+                  toolChainCoordinator.finishOperation(operationID)
+            else {
+                return
+                            }
+            activeAssistantMessageId = nil
+            isGenerating = false
+            currentToolName = nil
+            toolCallDepth = 0
+            pendingUserMessage = nil
+            SoundEngine.messageReceived()
+
+            if let finalConversation = conversationManager.conversation(byId: conversationId) {
+                conversationManager.save(finalConversation)
+            }
+
+            if isNewChatMode {
+                onConversationCreated?(conversationId)
+            }
+
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .info,
+                message: "✅ Message generation completed",
+                metadata: ["conversationId": conversationId.uuidString]
+            )
+        }
+
+        private func handleToolRequestError(
+            _ error: Error,
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            conversationId: UUID
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                return
+            }
+            toolChainCoordinator.cancelCurrentOperation()
+            activeAssistantMessageId = nil
+
+            if error is CancellationError {
+                DiagnosticsLogger.log(
+                    .chatView,
+                    level: .info,
+                    message: "Request cancelled",
+                    metadata: ["assistantMessageId": assistantMessageId.uuidString]
+                )
+                isGenerating = false
+                currentToolName = nil
+                toolCallDepth = 0
+                pendingUserMessage = nil
+                return
+            }
+
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .error,
+                message: "🚨 onError callback fired",
+                metadata: [
+                    "error": ErrorPresenter.userMessage(for: error),
+                    "assistantMessageId": assistantMessageId.uuidString
+                ]
+            )
+
+            isGenerating = false
+            SoundEngine.error()
+            currentToolName = nil
+            toolCallDepth = 0
+            errorMessage = ErrorPresenter.userMessage(for: error)
+            errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
+            failedMessage = pendingUserMessage
+            pendingUserMessage = nil
+            conversationManager.removeMessage(
+                                conversationId: conversationId,
+                messageId: assistantMessageId
+                            )
+            if let updatedConversation = conversationManager.conversation(byId: conversationId) {
+                conversationManager.save(updatedConversation)
+                        }
+
+            if isNewChatMode {
+                onConversationCreated?(conversationId)
+                    }
+
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .error,
+                message: "❌ Message generation failed: \(ErrorPresenter.userMessage(for: error))",
+                metadata: ["conversationId": conversationId.uuidString]
+            )
+                }
+
+        private func stopToolChainAtDepthLimit(
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            conversationId: UUID
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                return
+            }
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .error,
+                message: "⚠️ Max tool call depth reached"
         )
+            toolChainCoordinator.cancelCurrentOperation()
+            activeAssistantMessageId = nil
+            isGenerating = false
+            currentToolName = nil
+            toolCallDepth = 0
+            errorMessage = "Tool call limit reached. Please try again."
+            conversationManager.removeMessage(
+                conversationId: conversationId,
+                messageId: assistantMessageId
+            )
+            if let updatedConversation = conversationManager.conversation(byId: conversationId) {
+                conversationManager.save(updatedConversation)
+            }
+        }
+
+        private func stopToolChainForMissingConversation(
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            conversationId: UUID
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                return
+            }
+            toolChainCoordinator.cancelCurrentOperation()
+            activeAssistantMessageId = nil
+            isGenerating = false
+            currentToolName = nil
+            toolCallDepth = 0
     }
 
     /// Get the ID of the last assistant message in the conversation
@@ -1021,7 +1252,7 @@ extension IOSChatViewModel {
             )
             return
         }
-        var messagesToSend = Array(updatedConversation.messages.dropLast())
+            var messagesToSend = updatedConversation.getEffectiveHistory()
 
         // Prepend system prompt if configured
         if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
@@ -1080,7 +1311,7 @@ extension IOSChatViewModel {
             )
             return
         }
-        var messagesToSend = Array(refreshed.messages.dropLast())
+            var messagesToSend = refreshed.getEffectiveHistory()
 
         // Prepend system prompt if configured
         if let systemPrompt = conversationManager.effectiveSystemPrompt(for: refreshed) {
@@ -1159,7 +1390,7 @@ extension IOSChatViewModel {
             )
             return
         }
-        var messagesToSend = Array(updatedConversation.messages.dropLast())
+            var messagesToSend = updatedConversation.getEffectiveHistory()
 
         // Prepend system prompt if configured
         if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
@@ -1237,15 +1468,18 @@ extension IOSChatViewModel {
             messagesToSend.insert(Message(role: .system, content: systemPrompt), at: 0)
         }
 
-        // Send to all models
-        aiService.sendToMultipleModels(
+            // Send to all models under this view model's owner-specific operation.
+            let coordinator = toolChainCoordinator
+            activeAssistantMessageId = nil
+            activeMultiModelResponseGroupId = responseGroupId
+            let operationID = coordinator.beginOperation(conversationID: conversationId)
+            let request = aiService.sendToMultipleModels(
             messages: messagesToSend,
             models: models,
             temperature: updatedConversation.temperature,
             onChunk: { [weak self] model, chunk in
-                let selfRef = self
-                Task { @MainActor in
-                    guard let self = selfRef else { return }
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
+                        guard let self else { return }
                     self.processMultiModelChunk(
                         model: model,
                         chunk: chunk,
@@ -1255,9 +1489,8 @@ extension IOSChatViewModel {
                 }
             },
             onModelComplete: { [weak self] model in
-                let selfRef = self
-                Task { @MainActor in
-                    guard let self = selfRef else { return }
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
+                        guard let self else { return }
                     self.processMultiModelCompletion(
                         model: model,
                         messageIds: messageIdsByModel,
@@ -1267,13 +1500,19 @@ extension IOSChatViewModel {
                 }
             },
             onAllComplete: { [weak self] in
-                let selfRef = self
-                Task { @MainActor in
-                    guard let self = selfRef else { return }
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId)
+                        else {
+                            return
+                        }
+
                     self.isGenerating = false
                     if let convIndex = self.conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) {
-                        self.conversationManager.save(self.conversationManager.conversations[convIndex])
+                            self.conversationManager.saveImmediately(self.conversationManager.conversations[convIndex])
                     }
+                        self.activeMultiModelResponseGroupId = nil
+                        guard coordinator.finishOperation(operationID) else { return }
 
                     // Notify that conversation is ready (for new chat navigation)
                     if self.isNewChatMode {
@@ -1282,9 +1521,8 @@ extension IOSChatViewModel {
                 }
             },
             onError: { [weak self] model, error in
-                let selfRef = self
-                Task { @MainActor in
-                    guard let self = selfRef else { return }
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
+                        guard let self else { return }
                     self.processMultiModelError(
                         model: model,
                         error: error,
@@ -1297,6 +1535,9 @@ extension IOSChatViewModel {
             onPendingToolCall: nil,
             onReasoning: nil
         )
+            coordinator.onCancel(for: operationID) {
+                request.cancel()
+            }
     }
 
     /// Gets or creates a conversation configured for multi-model mode
@@ -1313,7 +1554,9 @@ extension IOSChatViewModel {
         var updatedConv = newConv
         updatedConv.activeModels = Array(selectedModels)
         updatedConv.multiModelEnabled = true
-        if let first = selectedModels.sorted().first { updatedConv.model = first }
+            if let first = selectedModels.sorted().first {
+                updatedConv.model = first
+            }
         conversationManager.updateConversation(updatedConv)
 
         DiagnosticsLogger.log(.chatView, level: .info, message: "🆕 Created new multi-model conversation",
@@ -1442,14 +1685,44 @@ extension IOSChatViewModel {
 
 // MARK: - Image Generation
 
-extension IOSChatViewModel {
-    /// Cancels only image work owned by this view model.
-    /// Used on disappearance so an old view cannot cancel a replacement owned elsewhere.
-    func cancelOwnedImageOperation() {
-        guard imageGenerationCoordinator.hasActiveOperation else { return }
-        imageGenerationCoordinator.cancelCurrentOperation()
-        isGenerating = false
-    }
+    extension IOSChatViewModel {
+        /// Cancels only image and tool-chain work owned by this view model.
+        /// Used on disappearance so an old view cannot mutate or cancel a replacement owned elsewhere.
+        func cancelOwnedOperations() {
+            let cancelledAutoSend = cancelPendingAutoSend()
+            let hadActiveTextState = activeAssistantMessageId != nil || activeMultiModelResponseGroupId != nil
+            let cancelledToolChain = toolChainCoordinator.cancelCurrentOperation {
+                finalizePersistedTextGeneration()
+            }
+            let cancelledImage = imageGenerationCoordinator.cancelCurrentOperation()
+            guard cancelledAutoSend || cancelledImage || cancelledToolChain || hadActiveTextState else { return }
+            isGenerating = false
+            currentToolName = nil
+            toolCallDepth = 0
+            activeAssistantMessageId = nil
+            activeMultiModelResponseGroupId = nil
+            pendingUserMessage = nil
+        }
+
+        private func finalizePersistedTextGeneration() {
+            let assistantMessageId = activeAssistantMessageId
+            let responseGroupId = activeMultiModelResponseGroupId
+            guard assistantMessageId != nil || responseGroupId != nil,
+                  let conversationId,
+                  let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversationId })
+            else {
+                activeMultiModelResponseGroupId = nil
+                return
+            }
+
+            ChatGenerationFinalizer.finalize(
+                conversation: &conversationManager.conversations[conversationIndex],
+                activeAssistantMessageID: assistantMessageId,
+                activeResponseGroupID: responseGroupId
+            )
+            conversationManager.saveImmediately(conversationManager.conversations[conversationIndex])
+            activeMultiModelResponseGroupId = nil
+        }
 
     /// Finds the most recent generated or selected image reference in the conversation for editing context.
     private func previousImageSource(in conversation: Conversation) -> (data: Data?, path: String?)? {

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -661,39 +661,39 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
         )
 
             let request = aiService.sendMessage(
-            messages: messages,
-            model: model,
-            stream: true,
-            tools: tools,
-            onChunk: { [weak self] chunk in
-                    MainActor.assumeIsolated {
+                messages: messages,
+                model: model,
+                stream: true,
+                tools: tools,
+                onChunk: { [weak self] chunk in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
                         guard let self,
                               coordinator.owns(operationID, conversationID: conversationId),
                               self.activeAssistantMessageId == assistantMessageId
                         else {
                             return
                         }
-                    if !chunk.isEmpty {
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .debug,
-                            message: "📥 onChunk received",
-                            metadata: [
-                                "chunkLength": "\(chunk.count)",
-                                "assistantMessageId": assistantMessageId.uuidString
-                            ]
+                        if !chunk.isEmpty {
+                            DiagnosticsLogger.log(
+                                .chatView,
+                                level: .debug,
+                                message: "📥 onChunk received",
+                                metadata: [
+                                    "chunkLength": "\(chunk.count)",
+                                    "assistantMessageId": assistantMessageId.uuidString
+                                ]
+                            )
+                        }
+                        self.currentToolName = nil
+                        self.updateAssistantMessage(
+                            assistantMessageId,
+                            appendingChunk: chunk,
+                            conversationId: conversationId
                         )
                     }
-                        self.currentToolName = nil
-                    self.updateAssistantMessage(
-                        assistantMessageId,
-                        appendingChunk: chunk,
-                        conversationId: conversationId
-                    )
-                }
-            },
-            onComplete: { [weak self] in
-                    MainActor.assumeIsolated {
+                },
+                onComplete: { [weak self] in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
                         guard let self,
                               coordinator.owns(operationID, conversationID: conversationId),
                               self.activeAssistantMessageId == assistantMessageId
@@ -701,15 +701,15 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                             return
                         }
 
-                    DiagnosticsLogger.log(
-                        .chatView,
-                        level: .info,
-                        message: "✅ onComplete called",
-                        metadata: [
-                            "currentToolName": self.currentToolName ?? "none",
-                            "assistantMessageId": assistantMessageId.uuidString
-                        ]
-                    )
+                        DiagnosticsLogger.log(
+                            .chatView,
+                            level: .info,
+                            message: "✅ onComplete called",
+                            metadata: [
+                                "currentToolName": self.currentToolName ?? "none",
+                                "assistantMessageId": assistantMessageId.uuidString
+                            ]
+                        )
 
                         let resolution = roundCoordinator.providerDidComplete(
                             operationID: operationID,
@@ -724,21 +724,21 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                             tools: toolsWrapper.value
                         )
                     }
-            },
-            onError: { [weak self] error in
-                    MainActor.assumeIsolated {
+                },
+                onError: { [weak self] error in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
                         guard let self else { return }
                         self.handleToolRequestError(
                             error,
                             operationID: operationID,
                             assistantMessageId: assistantMessageId,
                             conversationId: conversationId
-                    )
-                }
-            },
-            onToolCallRequested: { [weak self] toolCallId, toolName, arguments in
-                let argumentsWrapper = UncheckedSendable(arguments)
-                    MainActor.assumeIsolated {
+                        )
+                    }
+                },
+                onToolCallRequested: { [weak self] toolCallId, toolName, arguments in
+                    let argumentsWrapper = UncheckedSendable(arguments)
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
                         guard let self,
                               coordinator.owns(operationID, conversationID: conversationId),
                               self.activeAssistantMessageId == assistantMessageId,
@@ -746,21 +746,21 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                               let toolToken = roundCoordinator.registerTool(
                                   for: operationID,
                                   requestRoundID: requestRoundID
-                        )
+                              )
                         else {
-                        return
-                    }
+                            return
+                        }
 
                         if toolToken.registrationIndex == 0 {
-                    guard self.toolCallDepth < self.maxToolCallDepth else {
+                            guard self.toolCallDepth < self.maxToolCallDepth else {
                                 self.stopToolChainAtDepthLimit(
                                     operationID: operationID,
                                     assistantMessageId: assistantMessageId,
                                     conversationId: conversationId
-                        )
-                        return
-                    }
-                    self.toolCallDepth += 1
+                                )
+                                return
+                            }
+                            self.toolCallDepth += 1
                         }
 
                         self.currentToolName = toolName
@@ -807,8 +807,8 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                             conversationId: conversationId,
                             tools: toolsWrapper
                         )
-                        }
-                        }
+                    }
+                }
             )
             coordinator.onCancel(for: operationID) {
                 request.cancel()

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -48,6 +48,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
 
     var conversationManager: ConversationManager
     let aiService: AIService
+    private let imageGenerationCoordinator = ImageGenerationCoordinator()
 
     // MARK: - Tool Call State
 
@@ -140,6 +141,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
     /// Configure with conversation manager and conversation ID.
     /// Used for existing conversation views.
     func configure(with manager: ConversationManager, conversationId: UUID) {
+        cancelOwnedImageOperation()
         conversationManager = manager
         self.conversationId = conversationId
 
@@ -159,6 +161,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
 
     /// Reset state for a fresh new chat session.
     func resetForNewChat() {
+        imageGenerationCoordinator.cancelCurrentOperation()
         conversationId = nil
         messageText = ""
         isGenerating = false
@@ -209,6 +212,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
 
     /// Retry the last failed message
     func retryFailedMessage() {
+        guard !isGenerating else { return }
         guard let message = failedMessage else { return }
 
         DiagnosticsLogger.log(
@@ -324,7 +328,10 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
             message: "🛑 Cancelling generation",
             metadata: logMetadata
         )
-        aiService.cancelCurrentRequest()
+        let cancelledImageOperation = imageGenerationCoordinator.cancelCurrentOperation()
+        if !cancelledImageOperation {
+            aiService.cancelCurrentRequest(includeImageRequests: false)
+        }
         isGenerating = false
         currentToolName = nil
         toolCallDepth = 0
@@ -470,8 +477,13 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
             metadata: ["userMessageId": userMessage.id.uuidString]
         )
 
-        // Create placeholder assistant message
-        let assistantMessage = Message(role: .assistant, content: "")
+        // Create a capability-aware placeholder so cancellation/rollback can identify image work.
+        let requestModel = conversationManager.conversation(byId: targetConversationId)?.model ?? targetConversation.model
+        let isImageRequest = aiService.getModelCapability(requestModel) == .imageGeneration
+        var assistantMessage = Message(role: .assistant, content: "", model: requestModel)
+        if isImageRequest {
+            assistantMessage.mediaType = .image
+        }
         conversationManager.addMessage(to: targetConversation, message: assistantMessage)
 
         DiagnosticsLogger.log(
@@ -492,13 +504,12 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
             return
         }
 
-        // Check if this is an image generation model
-        let capability = aiService.getModelCapability(updatedConversation.model)
-        if capability == .imageGeneration {
+        if isImageRequest {
             generateImage(
                 text: text,
                 assistantMessage: assistantMessage,
-                conversationId: targetConversationId
+                conversationId: targetConversationId,
+                model: requestModel
             )
             return
         }
@@ -901,166 +912,6 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
         return lastMessage.id
     }
 
-    /// Retry from a specific assistant message.
-    func retryMessage(beforeMessage: Message) {
-        guard let conversation else { return }
-        let targetConversationId = conversation.id
-
-        DiagnosticsLogger.log(
-            .chatView,
-            level: .info,
-            message: "🔄 Retrying message",
-            metadata: ["conversationId": targetConversationId.uuidString]
-        )
-
-        // Find the index of the message to retry
-        guard let messageIndex = conversation.messages.firstIndex(where: { $0.id == beforeMessage.id }) else {
-            return
-        }
-
-        // Remove the assistant message and any subsequent messages
-        let updatedMessages = Array(conversation.messages.prefix(messageIndex))
-
-        // Update the conversation
-        if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == targetConversationId }) {
-            conversationManager.conversations[convIndex].messages = updatedMessages
-        }
-
-        // Create a new assistant message placeholder
-        let assistantMessage = Message(role: .assistant, content: "")
-        conversationManager.addMessage(to: conversation, message: assistantMessage)
-
-        isGenerating = true
-        errorMessage = nil
-
-        // Re-fetch conversation with updated messages
-        guard let updatedConversation = self.conversation else {
-            isGenerating = false
-            return
-        }
-        var messagesToSend = Array(updatedConversation.messages.dropLast())
-
-        // Prepend system prompt if configured
-        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
-
-        // Get available tools and use helper method
-        let tools = aiService.getAllAvailableTools()
-        toolCallDepth = 0
-
-        sendMessageWithToolSupport(
-            messages: messagesToSend,
-            model: updatedConversation.model,
-            conversationId: targetConversationId,
-            assistantMessageId: assistantMessage.id,
-            tools: tools
-        )
-    }
-
-    /// Re-send the last user message to get a new AI response after editing.
-    func resendAfterEdit() {
-        guard let conversation else { return }
-        let targetConversationId = conversation.id
-
-        guard let updatedConversation = self.conversation else { return }
-
-        isGenerating = true
-        errorMessage = nil
-
-        // Add empty assistant message placeholder
-        let assistantMessage = Message(role: .assistant, content: "", model: updatedConversation.model)
-        conversationManager.addMessage(to: conversation, message: assistantMessage)
-
-        // Build messages to send (everything except the new empty assistant message)
-        guard let refreshed = self.conversation else {
-            isGenerating = false
-            return
-        }
-        var messagesToSend = Array(refreshed.messages.dropLast())
-
-        // Prepend system prompt if configured
-        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: refreshed) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
-
-        let tools = aiService.getAllAvailableTools()
-        toolCallDepth = 0
-
-        sendMessageWithToolSupport(
-            messages: messagesToSend,
-            model: refreshed.model,
-            conversationId: targetConversationId,
-            assistantMessageId: assistantMessage.id,
-            tools: tools
-        )
-    }
-
-    /// Switch to a different model and retry the message.
-    /// This retries with the specified model without changing the conversation's default model.
-    func switchModelAndRetry(beforeMessage: Message, newModel: String) {
-        guard let conversation else { return }
-        let targetConversationId = conversation.id
-
-        DiagnosticsLogger.log(
-            .chatView,
-            level: .info,
-            message: "🔄 Switching model and retrying",
-            metadata: [
-                "conversationId": targetConversationId.uuidString,
-                "newModel": newModel,
-            ]
-        )
-
-        // Find the index of the message to retry
-        guard let messageIndex = conversation.messages.firstIndex(where: { $0.id == beforeMessage.id }) else {
-            return
-        }
-
-        // Remove the assistant message and any subsequent messages
-        let updatedMessages = Array(conversation.messages.prefix(messageIndex))
-
-        // Update the conversation
-        if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == targetConversationId }) {
-            conversationManager.conversations[convIndex].messages = updatedMessages
-        }
-
-        // Create a new assistant message placeholder with the new model
-        let assistantMessage = Message(role: .assistant, content: "", model: newModel)
-        conversationManager.addMessage(to: conversation, message: assistantMessage)
-
-        isGenerating = true
-        errorMessage = nil
-
-        // Re-fetch conversation with updated messages
-        guard let updatedConversation = self.conversation else {
-            isGenerating = false
-            return
-        }
-        var messagesToSend = Array(updatedConversation.messages.dropLast())
-
-        // Prepend system prompt if configured
-        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
-
-        // Get available tools and use helper method
-        let tools = aiService.getAllAvailableTools()
-        toolCallDepth = 0
-
-        // Use the new model for this request
-        sendMessageWithToolSupport(
-            messages: messagesToSend,
-            model: newModel,
-            conversationId: targetConversationId,
-            assistantMessageId: assistantMessage.id,
-            tools: tools
-        )
-    }
-
     // MARK: - Multi-Model Message Sending
 
     // MARK: - Private Methods
@@ -1111,11 +962,232 @@ private extension IOSChatViewModel {
     }
 }
 
+// MARK: - Message Retry and Editing
+
+extension IOSChatViewModel {
+    /// Retry from a specific assistant message.
+    func retryMessage(beforeMessage: Message) {
+        guard !isGenerating else { return }
+        guard let conversation else { return }
+        let targetConversationId = conversation.id
+        let retryModel = beforeMessage.model ?? conversation.model
+        let isImageRetry = aiService.getModelCapability(retryModel) == .imageGeneration
+
+        DiagnosticsLogger.log(
+            .chatView,
+            level: .info,
+            message: "🔄 Retrying message",
+            metadata: ["conversationId": targetConversationId.uuidString]
+        )
+
+        // Find the index of the message to retry
+        guard let messageIndex = conversation.messages.firstIndex(where: { $0.id == beforeMessage.id }) else {
+            return
+        }
+
+        // Remove the assistant message and any subsequent messages
+        let updatedMessages = Array(conversation.messages.prefix(messageIndex))
+
+        // Update the conversation
+        if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == targetConversationId }) {
+            conversationManager.conversations[convIndex].messages = updatedMessages
+        }
+
+        // Create a new assistant message placeholder
+        var assistantMessage = Message(role: .assistant, content: "", model: retryModel)
+        if isImageRetry {
+            assistantMessage.mediaType = .image
+        }
+        conversationManager.addMessage(to: conversation, message: assistantMessage)
+
+        isGenerating = true
+        errorMessage = nil
+
+        // Re-fetch conversation with updated messages
+        guard let updatedConversation = self.conversation else {
+            isGenerating = false
+            return
+        }
+        if isImageRetry {
+            guard let prompt = updatedMessages.last(where: { $0.role == .user })?.content else {
+                isGenerating = false
+                return
+            }
+            generateImage(
+                text: prompt,
+                assistantMessage: assistantMessage,
+                conversationId: targetConversationId,
+                model: retryModel
+            )
+            return
+        }
+        var messagesToSend = Array(updatedConversation.messages.dropLast())
+
+        // Prepend system prompt if configured
+        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
+            let systemMessage = Message(role: .system, content: systemPrompt)
+            messagesToSend.insert(systemMessage, at: 0)
+        }
+
+        // Get available tools and use helper method
+        let tools = aiService.getAllAvailableTools()
+        toolCallDepth = 0
+
+        sendMessageWithToolSupport(
+            messages: messagesToSend,
+            model: updatedConversation.model,
+            conversationId: targetConversationId,
+            assistantMessageId: assistantMessage.id,
+            tools: tools
+        )
+    }
+
+    /// Re-send the last user message to get a new AI response after editing.
+    func resendAfterEdit() {
+        guard !isGenerating else { return }
+        guard let conversation else { return }
+        let targetConversationId = conversation.id
+
+        guard let updatedConversation = self.conversation else { return }
+
+        isGenerating = true
+        errorMessage = nil
+
+        // Add empty assistant message placeholder
+        let resendModel = updatedConversation.model
+        let isImageResend = aiService.getModelCapability(resendModel) == .imageGeneration
+        var assistantMessage = Message(role: .assistant, content: "", model: resendModel)
+        if isImageResend {
+            assistantMessage.mediaType = .image
+        }
+        conversationManager.addMessage(to: conversation, message: assistantMessage)
+
+        // Build messages to send (everything except the new empty assistant message)
+        guard let refreshed = self.conversation else {
+            isGenerating = false
+            return
+        }
+        if isImageResend {
+            guard let prompt = refreshed.messages.dropLast().last(where: { $0.role == .user })?.content else {
+                isGenerating = false
+                return
+            }
+            generateImage(
+                text: prompt,
+                assistantMessage: assistantMessage,
+                conversationId: targetConversationId,
+                model: resendModel
+            )
+            return
+        }
+        var messagesToSend = Array(refreshed.messages.dropLast())
+
+        // Prepend system prompt if configured
+        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: refreshed) {
+            let systemMessage = Message(role: .system, content: systemPrompt)
+            messagesToSend.insert(systemMessage, at: 0)
+        }
+
+        let tools = aiService.getAllAvailableTools()
+        toolCallDepth = 0
+
+        sendMessageWithToolSupport(
+            messages: messagesToSend,
+            model: refreshed.model,
+            conversationId: targetConversationId,
+            assistantMessageId: assistantMessage.id,
+            tools: tools
+        )
+    }
+
+    /// Switch to a different model and retry the message.
+    /// This retries with the specified model without changing the conversation's default model.
+    func switchModelAndRetry(beforeMessage: Message, newModel: String) {
+        guard !isGenerating else { return }
+        guard let conversation else { return }
+        let targetConversationId = conversation.id
+        let isImageRetry = aiService.getModelCapability(newModel) == .imageGeneration
+
+        DiagnosticsLogger.log(
+            .chatView,
+            level: .info,
+            message: "🔄 Switching model and retrying",
+            metadata: [
+                "conversationId": targetConversationId.uuidString,
+                "newModel": newModel,
+            ]
+        )
+
+        // Find the index of the message to retry
+        guard let messageIndex = conversation.messages.firstIndex(where: { $0.id == beforeMessage.id }) else {
+            return
+        }
+
+        // Remove the assistant message and any subsequent messages
+        let updatedMessages = Array(conversation.messages.prefix(messageIndex))
+
+        // Update the conversation
+        if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == targetConversationId }) {
+            conversationManager.conversations[convIndex].messages = updatedMessages
+        }
+
+        // Create a new assistant message placeholder with the new model
+        var assistantMessage = Message(role: .assistant, content: "", model: newModel)
+        if isImageRetry {
+            assistantMessage.mediaType = .image
+        }
+        conversationManager.addMessage(to: conversation, message: assistantMessage)
+
+        isGenerating = true
+        errorMessage = nil
+
+        // Re-fetch conversation with updated messages
+        guard let updatedConversation = self.conversation else {
+            isGenerating = false
+            return
+        }
+        if isImageRetry {
+            guard let prompt = updatedMessages.last(where: { $0.role == .user })?.content else {
+                isGenerating = false
+                return
+            }
+            generateImage(
+                text: prompt,
+                assistantMessage: assistantMessage,
+                conversationId: targetConversationId,
+                model: newModel
+            )
+            return
+        }
+        var messagesToSend = Array(updatedConversation.messages.dropLast())
+
+        // Prepend system prompt if configured
+        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
+            let systemMessage = Message(role: .system, content: systemPrompt)
+            messagesToSend.insert(systemMessage, at: 0)
+        }
+
+        // Get available tools and use helper method
+        let tools = aiService.getAllAvailableTools()
+        toolCallDepth = 0
+
+        // Use the new model for this request
+        sendMessageWithToolSupport(
+            messages: messagesToSend,
+            model: newModel,
+            conversationId: targetConversationId,
+            assistantMessageId: assistantMessage.id,
+            tools: tools
+        )
+    }
+}
+
 // MARK: - Multi-Model Message Sending
 
 extension IOSChatViewModel {
     /// Sends a message to multiple models in parallel for comparison
     func sendToMultipleModels() {
+        guard !isGenerating else { return }
         let text = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
 
@@ -1371,10 +1443,19 @@ extension IOSChatViewModel {
 // MARK: - Image Generation
 
 extension IOSChatViewModel {
+    /// Cancels only image work owned by this view model.
+    /// Used on disappearance so an old view cannot cancel a replacement owned elsewhere.
+    func cancelOwnedImageOperation() {
+        guard imageGenerationCoordinator.hasActiveOperation else { return }
+        imageGenerationCoordinator.cancelCurrentOperation()
+        isGenerating = false
+    }
+
     /// Finds the most recent generated or selected image reference in the conversation for editing context.
     private func previousImageSource(in conversation: Conversation) -> (data: Data?, path: String?)? {
         for message in conversation.messages.reversed() {
             guard message.role == .assistant, message.mediaType == .image else { continue }
+            guard message.imageData != nil || message.imagePath != nil else { continue }
 
             if let groupId = message.responseGroupId {
                 if let group = conversation.getResponseGroup(groupId),
@@ -1391,118 +1472,146 @@ extension IOSChatViewModel {
     }
 
     /// Handles image generation or editing for a single model
-    func generateImage(text: String, assistantMessage: Message, conversationId: UUID) {
+    func generateImage(
+        text: String,
+        assistantMessage: Message,
+        conversationId: UUID,
+        model requestedModel: String? = nil
+    ) {
         guard let conversation = conversationManager.conversations.first(where: { $0.id == conversationId }) ?? conversation else {
             return
         }
 
+        let coordinator = imageGenerationCoordinator
+        let operationID = coordinator.beginOperation()
         let previousImageSource = previousImageSource(in: conversation)
-        let model = conversation.model
+        let model = requestedModel ?? conversation.model
         let assistantMessageId = assistantMessage.id
 
-        Task { [weak self] in
-            let previousImage: Data? =
-                if let data = previousImageSource?.data {
-                    data
-                } else if let path = previousImageSource?.path {
-                    await AttachmentStorage.shared.loadData(path: path)
-                } else {
-                    nil
-                }
+        let conversationManager = conversationManager
+        coordinator.onCancel(for: operationID) {
+            conversationManager.removeMessage(
+                conversationId: conversationId,
+                messageId: assistantMessageId
+            )
+            if let conversation = conversationManager.conversation(byId: conversationId) {
+                conversationManager.save(conversation)
+            }
+        }
 
-            await MainActor.run { [weak self] in
-                guard let self else { return }
-                DiagnosticsLogger.log(
-                    .chatView,
-                    level: .info,
-                    message: previousImage != nil ? "📝 Starting image edit" : "🎨 Starting image generation",
-                    metadata: ["prompt": text, "hasContext": "\(previousImage != nil)"]
-                )
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let previousImage = await self.loadImageData(from: previousImageSource)
+            guard coordinator.owns(operationID), !Task.isCancelled else { return }
 
-                let onComplete: @Sendable (Data) -> Void = { [weak self] data in
-                    Task { @MainActor [weak self] in
-                        guard let self else { return }
-                        var imagePath: String?
-                        do {
-                            imagePath = try AttachmentStorage.shared.save(data: data, extension: "png")
-                        } catch {
-                            DiagnosticsLogger.log(
-                                .chatView,
-                                level: .error,
-                                message: "❌ Failed to save generated image: \(error.localizedDescription)"
-                            )
-                        }
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .info,
+                message: previousImage != nil ? "📝 Starting image edit" : "🎨 Starting image generation",
+                metadata: ["prompt": text, "hasContext": "\(previousImage != nil)"]
+            )
 
-                        if let convIndex = self.conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
-                           let msgIndex = self.conversationManager.conversations[convIndex].messages.firstIndex(where: { $0.id == assistantMessageId })
-                        {
-                            var updatedMessage = self.conversationManager.conversations[convIndex].messages[msgIndex]
-                            updatedMessage.mediaType = .image
-                            if let path = imagePath {
-                                updatedMessage.imagePath = path
-                                updatedMessage.imageData = nil
-                            } else {
-                                updatedMessage.imageData = data
-                                updatedMessage.imagePath = nil
-                            }
-                            updatedMessage.content = ""
-                            self.conversationManager.conversations[convIndex].messages[msgIndex] = updatedMessage
-                            self.conversationManager.save(self.conversationManager.conversations[convIndex])
-                        }
-                        self.isGenerating = false
-
-                        if self.isNewChatMode {
-                            self.onConversationCreated?(conversationId)
-                        }
-
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .info,
-                            message: "✅ Image generation/edit completed"
-                        )
+            let onComplete: @Sendable (Data) -> Void = { [weak self] data in
+                coordinator.schedule(for: operationID) { [weak self] in
+                    guard let self else { return }
+                    let imagePath = await self.saveImageData(data)
+                    guard coordinator.owns(operationID), !Task.isCancelled else {
+                        await self.deleteImageData(at: imagePath)
+                        return
                     }
-                }
 
-                let onError: @Sendable (Error) -> Void = { [weak self] error in
-                    Task { @MainActor [weak self] in
-                        guard let self else { return }
-                        self.isGenerating = false
-                        self.errorMessage = error.localizedDescription
-
-                        if self.isNewChatMode {
-                            self.onConversationCreated?(conversationId)
+                    let messageUpdated = self.conversationManager.updateMessage(
+                        in: conversation,
+                        messageId: assistantMessageId
+                    ) { message in
+                        message.mediaType = .image
+                        if let imagePath {
+                            message.imagePath = imagePath
+                            message.imageData = nil
+                        } else {
+                            message.imageData = data
+                            message.imagePath = nil
                         }
-
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .error,
-                            message: "❌ Image generation/edit failed: \(error.localizedDescription)"
-                        )
+                        message.content = ""
                     }
-                }
+                    guard messageUpdated else {
+                        await self.deleteImageData(at: imagePath)
+                        _ = coordinator.finishOperation(operationID)
+                        self.isGenerating = false
+                        return
+                    }
 
-                if let previousImage {
-                    aiService.editImage(
-                        prompt: text,
-                        sourceImage: previousImage,
-                        model: model,
-                        onComplete: onComplete,
-                        onError: onError
-                    )
-                } else {
-                    aiService.generateImage(
-                        prompt: text,
-                        model: model,
-                        onComplete: onComplete,
-                        onError: onError
+                    guard coordinator.finishOperation(operationID) else { return }
+                    self.isGenerating = false
+                    if self.isNewChatMode {
+                        self.onConversationCreated?(conversationId)
+                    }
+
+                    DiagnosticsLogger.log(
+                        .chatView,
+                        level: .info,
+                        message: "✅ Image generation/edit completed"
                     )
                 }
             }
+
+            let onError: @Sendable (Error) -> Void = { [weak self] error in
+                coordinator.schedule(for: operationID) { [weak self] in
+                    guard let self, coordinator.finishOperation(operationID) else { return }
+                    self.isGenerating = false
+                    self.errorMessage = ErrorPresenter.userMessage(for: error)
+                    self.errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
+                    self.conversationManager.removeMessage(
+                        conversationId: conversationId,
+                        messageId: assistantMessageId
+                    )
+                    if let conversation = self.conversationManager.conversation(byId: conversationId) {
+                        self.conversationManager.save(conversation)
+                    }
+
+                    if self.isNewChatMode {
+                        self.onConversationCreated?(conversationId)
+                    }
+
+                    DiagnosticsLogger.log(
+                        .chatView,
+                        level: .error,
+                        message: "❌ Image generation/edit failed: \(error.localizedDescription)"
+                    )
+                }
+            }
+
+            let request: AIImageRequest? = if let previousImage {
+                self.aiService.editImage(
+                    prompt: text,
+                    sourceImage: previousImage,
+                    model: model,
+                    onComplete: onComplete,
+                    onError: onError
+                )
+            } else {
+                self.aiService.generateImage(
+                    prompt: text,
+                    model: model,
+                    onComplete: onComplete,
+                    onError: onError
+                )
+            }
+            coordinator.track(request, for: operationID)
         }
+        coordinator.track(task, for: operationID)
     }
 
     /// Generates images from multiple models in parallel for comparison
     func generateImagesWithMultipleModels(prompt: String, models: [String], conversation: Conversation) {
+        let coordinator = imageGenerationCoordinator
+        let operationID = coordinator.beginOperation()
+        guard !models.isEmpty else {
+            _ = coordinator.finishOperation(operationID)
+            isGenerating = false
+            return
+        }
+
         let conversationId = conversation.id
         let previousImageSource = previousImageSource(in: conversation)
 
@@ -1548,122 +1657,178 @@ extension IOSChatViewModel {
             conversationManager.conversations[index].responseGroups.append(responseGroup)
         }
 
-        final class CompletionTracker: @unchecked Sendable {
-            var count = 0
-        }
-        let tracker = CompletionTracker()
-        let totalCount = models.count
-
-        Task { [weak self] in
-            let previousImage: Data? =
-                if let data = previousImageSource?.data {
-                    data
-                } else if let path = previousImageSource?.path {
-                    await AttachmentStorage.shared.loadData(path: path)
-                } else {
-                    nil
+        let conversationManager = conversationManager
+        let cancelledMessageIDs = Array(messageIds.values)
+        coordinator.onCancel(for: operationID) {
+            guard let conversation = conversationManager.conversation(byId: conversationId),
+                  let responseGroup = conversation.getResponseGroup(responseGroupId)
+            else {
+                return
+            }
+            let pendingMessageIDs = ImageGenerationCoordinator.pendingMessageIDs(
+                in: responseGroup,
+                candidates: cancelledMessageIDs
+            )
+            for messageID in pendingMessageIDs {
+                conversationManager.updateMessage(conversationId: conversationId, messageId: messageID) { message in
+                    message.content = "Image generation stopped"
                 }
-
-            await MainActor.run { [weak self] in
-                guard let self else { return }
-                DiagnosticsLogger.log(
-                    .chatView,
-                    level: .info,
-                    message: previousImage != nil ? "📝 Starting multi-model image edit" : "🎨 Starting multi-model image generation",
-                    metadata: ["prompt": prompt, "models": models.joined(separator: ", "), "hasContext": "\(previousImage != nil)"]
-                )
-
-                for model in models {
-                    guard let messageId = messageIds[model] else { continue }
-
-                    let onComplete: @Sendable (Data) -> Void = { [weak self] imageData in
-                        Task { @MainActor [weak self] in
-                            guard let self else { return }
-                            self.processImageSuccess(
-                                imageData: imageData,
-                                conversationId: conversationId,
-                                messageId: messageId,
-                                responseGroupId: responseGroupId,
-                                completedCount: &tracker.count,
-                                totalCount: totalCount
-                            )
-                        }
-                    }
-
-                    let onError: @Sendable (Error) -> Void = { [weak self] error in
-                        Task { @MainActor [weak self] in
-                            guard let self else { return }
-                            self.processImageError(
-                                error: error,
-                                model: model,
-                                conversationId: conversationId,
-                                messageId: messageId,
-                                responseGroupId: responseGroupId,
-                                completedCount: &tracker.count,
-                                totalCount: totalCount
-                            )
-                        }
-                    }
-
-                    if let previousImage {
-                        aiService.editImage(prompt: prompt, sourceImage: previousImage, model: model, onComplete: onComplete, onError: onError)
-                    } else {
-                        aiService.generateImage(prompt: prompt, model: model, onComplete: onComplete, onError: onError)
-                    }
+                    conversationManager.updateResponseGroupStatus(
+                    conversationId: conversationId,
+                    responseGroupId: responseGroupId,
+                    messageId: messageID,
+                        status: .failed
+                    )
+                }
+                if let conversation = conversationManager.conversation(byId: conversationId) {
+                    conversationManager.save(conversation)
                 }
             }
+
+        let counter = MainActorCompletionCounter(total: models.count)
+
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let previousImage = await self.loadImageData(from: previousImageSource)
+            guard coordinator.owns(operationID), !Task.isCancelled else { return }
+
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .info,
+                message: previousImage != nil ? "📝 Starting multi-model image edit" : "🎨 Starting multi-model image generation",
+                metadata: [
+                    "prompt": prompt,
+                    "models": models.joined(separator: ", "),
+                    "hasContext": "\(previousImage != nil)",
+                ]
+            )
+
+            for model in models {
+                guard let messageId = messageIds[model] else { continue }
+
+                let onComplete: @Sendable (Data) -> Void = { [weak self] imageData in
+                    coordinator.schedule(for: operationID) { [weak self] in
+                        guard let self else { return }
+                        await self.processImageSuccess(
+                            imageData: imageData,
+                            conversationId: conversationId,
+                            messageId: messageId,
+                            responseGroupId: responseGroupId,
+                            counter: counter,
+                            operationID: operationID
+                        )
+                    }
+                }
+
+                let onError: @Sendable (Error) -> Void = { [weak self] error in
+                    coordinator.schedule(for: operationID) { [weak self] in
+                        guard let self else { return }
+                        self.processImageError(
+                            error: error,
+                            model: model,
+                            conversationId: conversationId,
+                            messageId: messageId,
+                            responseGroupId: responseGroupId,
+                            counter: counter,
+                            operationID: operationID
+                        )
+                    }
+                }
+
+                let request: AIImageRequest? = if let previousImage {
+                    self.aiService.editImage(
+                        prompt: prompt,
+                        sourceImage: previousImage,
+                        model: model,
+                        onComplete: onComplete,
+                        onError: onError
+                    )
+                } else {
+                    self.aiService.generateImage(
+                        prompt: prompt,
+                        model: model,
+                        onComplete: onComplete,
+                        onError: onError
+                    )
+                }
+                coordinator.track(request, for: operationID)
+            }
         }
+        coordinator.track(task, for: operationID)
     }
 
     /// Processes successful image generation for a model
-    func processImageSuccess(
+    private func processImageSuccess(
         imageData: Data,
         conversationId: UUID,
         messageId: UUID,
         responseGroupId: UUID,
-        completedCount: inout Int,
-        totalCount: Int
-    ) {
-        var imagePath: String?
-        do {
-            imagePath = try AttachmentStorage.shared.save(data: imageData, extension: "png")
-        } catch {
-            DiagnosticsLogger.log(
-                .chatView,
-                level: .error,
-                message: "❌ Failed to save generated image: \(error.localizedDescription)"
-            )
+        counter: MainActorCompletionCounter,
+        operationID: ImageGenerationCoordinator.OperationID
+    ) async {
+        let imagePath = await saveImageData(imageData)
+        guard imageGenerationCoordinator.owns(operationID), !Task.isCancelled else {
+            await deleteImageData(at: imagePath)
+            return
         }
 
-        conversationManager.updateMessage(conversationId: conversationId, messageId: messageId) { message in
+        updateImageResponseGroupStatus(
+            conversationId: conversationId,
+            responseGroupId: responseGroupId,
+            messageId: messageId,
+            status: .completed
+        )
+        guard let conversation = conversationManager.conversation(byId: conversationId) else {
+            await deleteImageData(at: imagePath)
+            counter.increment()
+            if counter.isComplete {
+                finalizeImageGenerationBatch(conversationId: conversationId, operationID: operationID)
+            }
+            return
+        }
+        let messageUpdated = conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
             message.content = ""
-            if let path = imagePath {
-                message.imagePath = path
+            if let imagePath {
+                message.imagePath = imagePath
                 message.imageData = nil
             } else {
                 message.imageData = imageData
                 message.imagePath = nil
             }
         }
+        guard messageUpdated else {
+            await deleteImageData(at: imagePath)
+            updateImageResponseGroupStatus(
+                conversationId: conversationId,
+                responseGroupId: responseGroupId,
+                messageId: messageId,
+                status: .failed
+            )
+            counter.increment()
+            if counter.isComplete {
+                finalizeImageGenerationBatch(conversationId: conversationId, operationID: operationID)
+            }
+            return
+        }
 
-        updateImageResponseGroupStatus(conversationId: conversationId, responseGroupId: responseGroupId, messageId: messageId, status: .completed)
-
-        completedCount += 1
-        if completedCount >= totalCount {
-            finalizeImageGenerationBatch(conversationId: conversationId)
+        counter.increment()
+        if counter.isComplete {
+            finalizeImageGenerationBatch(conversationId: conversationId, operationID: operationID)
         }
     }
 
     /// Processes an error during image generation for a model
-    func processImageError(
+    private func processImageError(
         error: Error,
         model: String,
         conversationId: UUID,
         messageId: UUID,
         responseGroupId: UUID,
-        completedCount: inout Int,
-        totalCount: Int
+        counter: MainActorCompletionCounter,
+        operationID: ImageGenerationCoordinator.OperationID
     ) {
+        guard imageGenerationCoordinator.owns(operationID) else { return }
+
         DiagnosticsLogger.log(
             .chatView,
             level: .error,
@@ -1671,37 +1836,82 @@ extension IOSChatViewModel {
             metadata: ["model": model]
         )
 
-        updateImageResponseGroupStatus(conversationId: conversationId, responseGroupId: responseGroupId, messageId: messageId, status: .failed)
-
+        updateImageResponseGroupStatus(
+            conversationId: conversationId,
+            responseGroupId: responseGroupId,
+            messageId: messageId,
+            status: .failed
+        )
         conversationManager.updateMessage(conversationId: conversationId, messageId: messageId) { message in
             message.content = "Image generation failed: \(error.localizedDescription)"
         }
+        if let conversation = conversationManager.conversation(byId: conversationId) {
+            conversationManager.save(conversation)
+        }
 
-        completedCount += 1
-        if completedCount >= totalCount {
-            finalizeImageGenerationBatch(conversationId: conversationId)
+        counter.increment()
+        if counter.isComplete {
+            finalizeImageGenerationBatch(conversationId: conversationId, operationID: operationID)
         }
     }
 
     /// Updates the status of a response in a response group for image generation
-    func updateImageResponseGroupStatus(conversationId: UUID, responseGroupId: UUID, messageId: UUID, status: ResponseGroup.ResponseStatus) {
-        if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
-           let groupIndex = conversationManager.conversations[convIndex].responseGroups.firstIndex(where: { $0.id == responseGroupId }),
-           let entryIndex = conversationManager.conversations[convIndex].responseGroups[groupIndex].responses.firstIndex(where: { $0.id == messageId })
+    private func updateImageResponseGroupStatus(
+        conversationId: UUID,
+        responseGroupId: UUID,
+        messageId: UUID,
+        status: ResponseGroup.ResponseStatus
+    ) {
+        if let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
+           let groupIndex = conversationManager.conversations[conversationIndex].responseGroups.firstIndex(where: {
+               $0.id == responseGroupId
+           }),
+           let entryIndex = conversationManager.conversations[conversationIndex].responseGroups[groupIndex]
+           .responses.firstIndex(where: { $0.id == messageId })
         {
-            conversationManager.conversations[convIndex].responseGroups[groupIndex].responses[entryIndex].status = status
+            conversationManager.conversations[conversationIndex].responseGroups[groupIndex].responses[entryIndex].status = status
         }
     }
 
     /// Finalizes a batch of image generation requests
-    func finalizeImageGenerationBatch(conversationId: UUID) {
+    private func finalizeImageGenerationBatch(
+        conversationId: UUID,
+        operationID: ImageGenerationCoordinator.OperationID
+    ) {
+        guard imageGenerationCoordinator.finishOperation(operationID) else { return }
         isGenerating = false
-        if let conv = conversationManager.conversation(byId: conversationId) {
-            conversationManager.save(conv)
+        if let conversation = conversationManager.conversation(byId: conversationId) {
+            conversationManager.save(conversation)
         }
         if isNewChatMode {
             onConversationCreated?(conversationId)
         }
+    }
+
+    private func loadImageData(from source: (data: Data?, path: String?)?) async -> Data? {
+        if let data = source?.data {
+            return data
+        }
+        guard let path = source?.path else { return nil }
+        return await AttachmentStorage.shared.loadData(path: path)
+    }
+
+    private func saveImageData(_ imageData: Data) async -> String? {
+        let task = Task.detached(priority: .userInitiated) {
+            try? AttachmentStorage.shared.save(data: imageData, extension: "png")
+        }
+        return await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    private func deleteImageData(at path: String?) async {
+        guard let path else { return }
+        await Task.detached(priority: .utility) {
+            AttachmentStorage.shared.delete(path: path)
+        }.value
     }
 }
 

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -1153,6 +1153,7 @@ extension IOSChatViewModel {
             models: models, userMessageId: userMessage.id, responseGroupId: responseGroupId,
             messageIds: &messageIds, placeholderMessages: &placeholderMessages
         )
+        let messageIdsByModel = messageIds
         conversationManager.addMultiModelResponse(to: targetConversation, messages: placeholderMessages, responseGroup: responseGroup)
 
         guard let updatedConversation = conversation else {
@@ -1176,7 +1177,7 @@ extension IOSChatViewModel {
                     self.processMultiModelChunk(
                         model: model,
                         chunk: chunk,
-                        messageIds: messageIds,
+                        messageIds: messageIdsByModel,
                         conversationId: conversationId
                     )
                 }
@@ -1187,7 +1188,7 @@ extension IOSChatViewModel {
                     guard let self = selfRef else { return }
                     self.processMultiModelCompletion(
                         model: model,
-                        messageIds: messageIds,
+                        messageIds: messageIdsByModel,
                         conversationId: conversationId,
                         responseGroupId: responseGroupId
                     )
@@ -1215,7 +1216,7 @@ extension IOSChatViewModel {
                     self.processMultiModelError(
                         model: model,
                         error: error,
-                        messageIds: messageIds,
+                        messageIds: messageIdsByModel,
                         conversationId: conversationId,
                         responseGroupId: responseGroupId
                     )

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -649,6 +649,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                 return
             }
             activeAssistantMessageId = assistantMessageId
+            let toolCallAdmissionGate = ToolCallRequestAdmissionGate()
 
         DiagnosticsLogger.log(
             .chatView,
@@ -736,7 +737,7 @@ private struct UncheckedSendable<T>: @unchecked Sendable {
                         )
                     }
                 },
-                onToolCallRequested: { [weak self] toolCallId, toolName, arguments in
+                onToolCallRequested: toolCallAdmissionGate.admittedCallback { [weak self] toolCallId, toolName, arguments in
                     let argumentsWrapper = UncheckedSendable(arguments)
                     coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
                         guard let self,
@@ -1266,7 +1267,7 @@ extension IOSChatViewModel {
 
         sendMessageWithToolSupport(
             messages: messagesToSend,
-            model: updatedConversation.model,
+            model: retryModel,
             conversationId: targetConversationId,
             assistantMessageId: assistantMessage.id,
             tools: tools

--- a/Sources/Ayna/ViewModels/WatchChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/WatchChatViewModel.swift
@@ -5,10 +5,66 @@
 //  Created on 11/29/25.
 //
 
+import Foundation
+
+/// Deduplicates callbacks for one provider request round and supplies IDs when the provider omits them.
+@MainActor
+final class WatchToolCallRoundRegistry {
+    private struct IDLessCallSignature: Hashable {
+        let toolName: String
+        let encodedArguments: Data
+    }
+
+    private let syntheticIDPrefix: String
+    private var registeredIDs: Set<String> = []
+    private var registeredIDLessCalls: Set<IDLessCallSignature> = []
+    private var nextSyntheticID = 0
+
+    init(roundID: UUID) {
+        syntheticIDPrefix = "watch-tool-\(roundID.uuidString.lowercased())"
+    }
+
+    /// Returns the provider ID or a stable round-local synthetic ID for a newly observed call.
+    /// Identical ID-less callbacks are indistinguishable, so their canonical tool payload is
+    /// used as the duplicate key.
+    func register(
+        providerID: String,
+        toolName: String,
+        arguments: [String: AnyCodable]
+    ) -> String? {
+        if !providerID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            guard registeredIDs.insert(providerID).inserted else { return nil }
+            return providerID
+        }
+
+        let signature = IDLessCallSignature(
+            toolName: toolName,
+            encodedArguments: Self.encode(arguments)
+        )
+        guard registeredIDLessCalls.insert(signature).inserted else { return nil }
+        return makeSyntheticID()
+    }
+
+    private func makeSyntheticID() -> String {
+        while true {
+            let candidate = "\(syntheticIDPrefix)-\(nextSyntheticID)"
+            nextSyntheticID += 1
+            if registeredIDs.insert(candidate).inserted {
+                return candidate
+            }
+        }
+    }
+
+    private static func encode(_ arguments: [String: AnyCodable]) -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return (try? encoder.encode(arguments)) ?? Data()
+    }
+}
+
 #if os(watchOS)
 
     import Combine
-    import Foundation
     import os
     import SwiftUI
     import WatchKit
@@ -18,6 +74,49 @@
     /// Handles message sending, streaming responses, and local state management
     @MainActor
     final class WatchChatViewModel: ObservableObject {
+        enum SendResult: Equatable {
+            case notConsumed
+            case consumed
+            case started
+
+            var consumedInput: Bool {
+                self != .notConsumed
+            }
+        }
+
+        struct RequestConfiguration {
+            let messages: [Message]
+            let model: String
+            let temperature: Double
+            let conversationID: UUID
+        }
+
+        private struct TitleRequestContext {
+            let conversationID: UUID
+            let fallbackTitle: String
+            let expectedTitle: String
+            let expectedRevision: UInt64
+            let expectedUpdatedAt: Date
+        }
+
+        private struct PendingResponsePromotion {
+            let conversationID: UUID
+            let assistantMessageID: UUID
+            let userMessageID: UUID?
+            let isFirstMessage: Bool
+            let userContent: String
+            let finalContent: String
+        }
+
+        private enum DraftFinalizationOutcome: Equatable {
+            case unavailable
+            case discarded
+            case promoted
+            case promotionPending
+        }
+
+        private static let responsePromotionErrorMessage = "Failed to save response. Please try again."
+
         @Published var isLoading = false
         @Published var isStreaming = false // True once first chunk received
         @Published var errorMessage: String?
@@ -28,6 +127,7 @@
         private let conversationStore: WatchConversationStore
         private let connectivityService: WatchConnectivityService
         private let aiService: AIService
+        private let requestObserver: ((RequestConfiguration) -> Void)?
         private let toolChainCoordinator = ToolChainCoordinator()
         private let toolCallRequestRoundCoordinator = ToolCallRequestRoundCoordinator<ToolExecutionResult>()
         private var currentConversationId: UUID?
@@ -36,7 +136,8 @@
         private var activeAssistantMessageId: UUID?
         private var titleRequest: AITextRequest?
         private var titleRequestID: UUID?
-        private var titleRequestFallback: (conversationID: UUID, title: String)?
+        private var titleRequestContext: TitleRequestContext?
+        private var pendingResponsePromotions: [UUID: PendingResponsePromotion] = [:]
 
         /// Maximum tool chain depth for watchOS.
         /// Intentionally low (5) due to watchOS resource constraints (memory, battery, network).
@@ -51,11 +152,13 @@
         init(
             conversationStore: WatchConversationStore = .shared,
             connectivityService: WatchConnectivityService = .shared,
-            aiService: AIService = .shared
+            aiService: AIService = .shared,
+            requestObserver: ((RequestConfiguration) -> Void)? = nil
         ) {
             self.conversationStore = conversationStore
             self.connectivityService = connectivityService
             self.aiService = aiService
+            self.requestObserver = requestObserver
         }
 
         /// Set the current conversation being viewed
@@ -73,6 +176,7 @@
             failedMessage = nil
             pendingUserMessageId = nil
             pendingContent = ""
+            restorePendingResponsePromotionState(for: id)
         }
 
         /// Play haptic feedback
@@ -80,25 +184,29 @@
             WKInterfaceDevice.current().play(type)
         }
 
-        /// Send a message in the current conversation
-        func sendMessage(_ content: String) {
+        /// Send a message in the current conversation.
+        ///
+        /// - Returns: Whether the composer input was consumed and whether a request started.
+        @discardableResult
+        func sendMessage(_ content: String) -> SendResult {
             sendMessage(content, reusingUserMessageID: nil)
         }
 
-        private func sendMessage(_ content: String, reusingUserMessageID: UUID?) {
-            guard let conversationId = currentConversationId else {
+        private func sendMessage(_ content: String, reusingUserMessageID: UUID?) -> SendResult {
+            guard let conversationId = currentConversationId,
+                  let conversation = conversationStore.conversation(for: conversationId)
+            else {
                 errorMessage = "No conversation selected"
                 playHaptic(.failure)
-                return
+                return .notConsumed
             }
             cancelTitleRequest()
-            guard let conversation = conversationStore.conversation(for: conversationId) else {
-                errorMessage = "No conversation selected"
-                playHaptic(.failure)
-                return
+            if pendingResponsePromotions[conversationId] != nil,
+               !retryPendingResponsePromotion(for: conversationId)
+            {
+                return .notConsumed
             }
 
-            // Clear any previous error
             errorMessage = nil
             failedMessage = nil
             isLoading = true
@@ -108,8 +216,6 @@
             currentToolName = nil
             toolCallDepth = 0
             lastUIUpdateTime = .distantPast
-
-            // Play haptic for message sent
             playHaptic(.click)
 
             let userContent = content
@@ -124,83 +230,99 @@
                 isFirstMessage = conversation.messages.first?.id == reusingUserMessageID
             } else {
                 userMessage = WatchMessage(from: Message(role: .user, content: content))
-            conversationStore.addMessage(userMessage, to: conversationId)
-            connectivityService.sendMessage(userMessage, conversationId: conversationId)
+                pendingUserMessageId = userMessage.id
+                guard conversationStore.addMessage(userMessage, to: conversationId) else {
+                    stopForPreparationError(
+                        "Failed to save message. Please try again.",
+                        retryContent: userContent
+                    )
+                    return .notConsumed
+                }
                 isFirstMessage = conversation.messages.isEmpty
             }
             pendingUserMessageId = userMessage.id
 
-            // Get updated conversation after committing the user message. Validate the model
-            // before adding an assistant placeholder so configuration failures cannot leave a
-            // hidden empty turn in local or synced history.
-            guard let updatedConversation = conversationStore.conversation(for: conversationId) else {
-                isLoading = false
-                isStreaming = false
-                errorMessage = "Failed to update conversation"
-                playHaptic(.failure)
-                return
+            guard var requestConversation = conversationStore.conversation(for: conversationId) else {
+                stopForPreparationError("Failed to update conversation", retryContent: userContent)
+                return .consumed
             }
 
-            // Get model from settings or conversation, but validate it's usable on watchOS
-            var model = connectivityService.selectedModel.isEmpty
-                ? updatedConversation.model
-                : connectivityService.selectedModel
-
-            // Check if the selected model is usable on watchOS
-            let provider = aiService.modelProviders[model]
-            if provider == .appleIntelligence {
-                // Fall back to first usable model
-                let usableModels = connectivityService.availableModels.filter { modelName in
-                    let modelProvider = aiService.modelProviders[modelName]
-                    return modelProvider != .appleIntelligence
+            var model = requestConversation.model
+            if aiService.modelProviders[model] == .appleIntelligence {
+                let fallback = connectivityService.availableModels.first { candidate in
+                    aiService.modelProviders[candidate] != .appleIntelligence &&
+                        aiService.isModelConfigured(candidate)
                 }
-                if let fallback = usableModels.first {
-                    model = fallback
-                } else {
-                    isLoading = false
-                    isStreaming = false
-                    errorMessage = "No compatible models available. Please add a model on iPhone."
-                    failedMessage = userContent
-                    playHaptic(.failure)
-                    return
+                guard let fallback else {
+                    stopForPreparationError(
+                        "No compatible models available. Please add a model on iPhone.",
+                        retryContent: userContent
+                    )
+                    return .consumed
                 }
+                guard conversationStore.updateModel(fallback, for: conversationId),
+                      let updated = conversationStore.conversation(for: conversationId)
+                else {
+                    stopForPreparationError(
+                        "Failed to save model selection. Please try again.",
+                        retryContent: userContent
+                    )
+                    return .consumed
+                }
+                model = fallback
+                requestConversation = updated
             }
 
-            // Check if the model is configured (has API key or doesn't need one like Apple Intelligence)
             guard aiService.isModelConfigured(model) else {
-                isLoading = false
-                isStreaming = false
-                errorMessage = "API key not configured. Please configure on iPhone."
-                failedMessage = userContent
-                playHaptic(.failure)
-                return
+                stopForPreparationError(
+                    "API key not configured. Please configure on iPhone.",
+                    retryContent: userContent
+                )
+                return .consumed
             }
 
-            let assistantMessage = WatchMessage(from: Message(role: .assistant, content: ""))
-            conversationStore.addMessage(assistantMessage, to: conversationId)
+            let assistantMessage = WatchMessage(
+                from: Message(role: .assistant, content: "", model: model)
+            )
+            var draft = requestConversation
+            draft.messages.append(assistantMessage)
+            draft.updatedAt = Date()
+            guard conversationStore.syncDraft(draft) else {
+                stopForPreparationError(
+                    "Failed to save response draft. Please try again.",
+                    retryContent: userContent
+                )
+                return .consumed
+            }
 
-            // The validated request history excludes the placeholder just added above.
-            let messagesForAPI = updatedConversation.messages.map { $0.toMessage() }
-
-            // Get available tools (Tavily web search if configured)
             let tools = aiService.getAllAvailableTools()
-
             sendMessageWithToolSupport(
-                messages: Array(messagesForAPI),
+                messages: requestConversation.effectiveHistory,
                 model: model,
+                temperature: requestConversation.temperature,
                 conversationId: conversationId,
                 assistantMessageId: assistantMessage.id,
                 tools: tools,
                 isFirstMessage: isFirstMessage,
                 userContent: userContent
             )
+            return .started
+        }
+
+        private func stopForPreparationError(_ message: String, retryContent: String?) {
+            isLoading = false
+            isStreaming = false
+            errorMessage = message
+            failedMessage = retryContent
+            playHaptic(.failure)
         }
 
         // swiftlint:disable function_body_length
         /// Send message with tool support for recursive tool calling.
-        private func sendMessageWithToolSupport(
+        private func sendMessageWithToolSupport( // swiftlint:disable:this function_parameter_count
             messages: [Message],
             model: String,
+            temperature: Double,
             conversationId: UUID,
             assistantMessageId: UUID,
             tools: [[String: Any]]?,
@@ -221,15 +343,25 @@
                 return
             }
             activeAssistantMessageId = assistantMessageId
+            let registeredToolCalls = WatchToolCallRoundRegistry(roundID: assistantMessageId)
+            requestObserver?(
+                RequestConfiguration(
+                    messages: messages,
+                    model: model,
+                    temperature: temperature,
+                    conversationID: conversationId
+                )
+            )
 
             let request = aiService.sendMessage(
                 messages: messages,
                 model: model,
+                temperature: temperature,
                 stream: true,
                 tools: tools,
                 conversationId: conversationId,
                 onChunk: { [weak self] chunk in
-                    MainActor.assumeIsolated {
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
                         guard let self,
                               coordinator.owns(operationID, conversationID: conversationId),
                               self.activeAssistantMessageId == assistantMessageId
@@ -251,11 +383,11 @@
                             )
                             self.lastUIUpdateTime = now
                         }
-                            self.currentToolName = nil
-                        }
+                        self.currentToolName = nil
+                    }
                 },
                 onComplete: { [weak self] in
-                    MainActor.assumeIsolated {
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
                         guard let self,
                               coordinator.owns(operationID, conversationID: conversationId),
                               self.activeAssistantMessageId == assistantMessageId
@@ -271,6 +403,7 @@
                             operationID: operationID,
                             assistantMessageId: assistantMessageId,
                             model: model,
+                            temperature: temperature,
                             conversationId: conversationId,
                             tools: tools,
                             isFirstMessage: isFirstMessage,
@@ -279,7 +412,7 @@
                     }
                 },
                 onError: { [weak self] error in
-                    MainActor.assumeIsolated {
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
                         guard let self else { return }
                         self.handleToolRequestError(
                             error,
@@ -293,14 +426,33 @@
                 onToolCall: nil,
                 onToolCallRequested: { [weak self] toolCallID, toolName, arguments in
                     nonisolated(unsafe) let arguments = arguments
-                    MainActor.assumeIsolated {
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
                         guard let self,
                               coordinator.owns(operationID, conversationID: conversationId),
-                              self.activeAssistantMessageId == assistantMessageId,
-                              self.conversationStore.conversation(for: conversationId) != nil,
-                              let toolToken = roundCoordinator.registerTool(
-                                  for: operationID,
-                                  requestRoundID: requestRoundID
+                              self.activeAssistantMessageId == assistantMessageId
+                        else {
+                            return
+                        }
+                        guard self.conversationStore.conversation(for: conversationId) != nil else {
+                            self.stopToolChainForMissingConversation(
+                                operationID: operationID,
+                                assistantMessageId: assistantMessageId,
+                                conversationId: conversationId,
+                                userContent: userContent
+                            )
+                            return
+                        }
+                        let anyCodableArguments = arguments.reduce(into: [String: AnyCodable]()) { result, pair in
+                            result[pair.key] = AnyCodable(pair.value)
+                        }
+                        guard let registeredToolCallID = registeredToolCalls.register(
+                            providerID: toolCallID,
+                            toolName: toolName,
+                            arguments: anyCodableArguments
+                        ),
+                            let toolToken = roundCoordinator.registerTool(
+                                for: operationID,
+                                requestRoundID: requestRoundID
                             )
                         else {
                             return
@@ -311,8 +463,9 @@
                                 self.stopToolChainAtDepthLimit(
                                     operationID: operationID,
                                     assistantMessageId: assistantMessageId,
-                                    conversationId: conversationId
-                            )
+                                    conversationId: conversationId,
+                                    userContent: userContent
+                                )
                                 return
                             }
                             self.toolCallDepth += 1
@@ -320,11 +473,8 @@
 
                         self.currentToolName = toolName
                         self.playHaptic(.click)
-                        let anyCodableArguments = arguments.reduce(into: [String: AnyCodable]()) { result, pair in
-                            result[pair.key] = AnyCodable(pair.value)
-                        }
                         let toolCall = MCPToolCall(
-                            id: toolCallID,
+                            id: registeredToolCallID,
                             toolName: toolName,
                             arguments: anyCodableArguments
                         )
@@ -336,19 +486,21 @@
                             self.stopToolChainForMissingConversation(
                                 operationID: operationID,
                                 assistantMessageId: assistantMessageId,
-                                conversationId: conversationId
+                                conversationId: conversationId,
+                                userContent: userContent
                             )
                             return
                         }
                         self.executeTool(
                             token: toolToken,
-                            callID: toolCallID,
+                            callID: registeredToolCallID,
                             toolName: toolName,
                             arguments: arguments,
                             anyCodableArguments: anyCodableArguments,
                             operationID: operationID,
                             assistantMessageId: assistantMessageId,
                             model: model,
+                            temperature: temperature,
                             conversationId: conversationId,
                             tools: tools,
                             userContent: userContent
@@ -374,6 +526,7 @@
             operationID: ToolChainCoordinator.OperationID,
             assistantMessageId: UUID,
             model: String,
+            temperature: Double,
             conversationId: UUID,
             tools: [[String: Any]]?,
             userContent: String
@@ -390,29 +543,29 @@
                     return
                 }
 
-                            DiagnosticsLogger.log(
-                                .chatView,
-                                level: .info,
+                DiagnosticsLogger.log(
+                    .chatView,
+                    level: .info,
                     message: "⌚ Tool call requested: \(toolName)",
                     metadata: ["toolName": toolName]
-                            )
+                )
                 let output: String
                 let citations: [CitationReference]?
                 if self.aiService.isBuiltInTool(toolName) {
                     (output, citations) = await self.aiService.executeBuiltInToolWithCitations(
                         name: toolName,
                         arguments: arguments
-                                )
+                    )
                 } else {
                     output = "Tool not available on Apple Watch"
                     citations = nil
-                            }
+                }
                 guard coordinator.owns(operationID, conversationID: conversationId),
                       self.activeAssistantMessageId == assistantMessageId,
                       !Task.isCancelled
                 else {
-                            return
-                        }
+                    return
+                }
 
                 let result = ToolExecutionResult(
                     callID: callID,
@@ -427,6 +580,7 @@
                     operationID: operationID,
                     assistantMessageId: assistantMessageId,
                     model: model,
+                    temperature: temperature,
                     conversationId: conversationId,
                     tools: tools,
                     isFirstMessage: false,
@@ -441,6 +595,7 @@
             operationID: ToolChainCoordinator.OperationID,
             assistantMessageId: UUID,
             model: String,
+            temperature: Double,
             conversationId: UUID,
             tools: [[String: Any]]?,
             isFirstMessage: Bool,
@@ -469,6 +624,7 @@
                     operationID: operationID,
                     assistantMessageId: assistantMessageId,
                     model: model,
+                    temperature: temperature,
                     conversationId: conversationId,
                     tools: tools,
                     userContent: userContent
@@ -476,11 +632,12 @@
             }
         }
 
-        private func launchToolContinuation(
+        private func launchToolContinuation( // swiftlint:disable:this function_parameter_count
             _ continuation: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Continuation,
             operationID: ToolChainCoordinator.OperationID,
             assistantMessageId: UUID,
             model: String,
+            temperature: Double,
             conversationId: UUID,
             tools: [[String: Any]]?,
             userContent: String
@@ -492,24 +649,56 @@
                 return
             }
 
-            if let assistantToolCallMessage = conversationStore.conversation(for: conversationId)?
-                .messages.first(where: { $0.id == assistantMessageId })
-                        {
-                connectivityService.sendMessage(assistantToolCallMessage, conversationId: conversationId)
-                            }
+            guard flushPendingContent(
+                assistantMessageId: assistantMessageId,
+                conversationId: conversationId
+            ) else {
+                toolChainCoordinator.cancelCurrentOperation()
+                failResponsePromotion(
+                    makePendingResponsePromotion(
+                        assistantMessageId: assistantMessageId,
+                        conversationId: conversationId,
+                        userContent: userContent,
+                        finalContent: pendingContent
+                    ),
+                    retryPromotion: true
+                )
+                return
+            }
+            guard var draft = conversationStore.conversation(for: conversationId) else {
+                stopToolChainForMissingConversation(
+                    operationID: operationID,
+                    assistantMessageId: assistantMessageId,
+                    conversationId: conversationId,
+                    userContent: userContent
+                )
+                return
+            }
 
             let results = continuation.toolResults.map(\.result)
             for result in results {
-                let toolMessage = WatchMessage(from: result.makeMessage())
-                conversationStore.addMessage(toolMessage, to: conversationId)
-                connectivityService.sendMessage(toolMessage, conversationId: conversationId)
-                        }
+                draft.messages.append(WatchMessage(from: result.makeMessage()))
+            }
 
             let citations = ToolExecutionResult.combinedCitations(from: results)
-            var continuation = Message(role: .assistant, content: "", model: model)
-            continuation.citations = citations.isEmpty ? nil : citations
-            let continuationMessage = WatchMessage(from: continuation)
-            conversationStore.addMessage(continuationMessage, to: conversationId)
+            var continuationMessageValue = Message(role: .assistant, content: "", model: model)
+            continuationMessageValue.citations = citations.isEmpty ? nil : citations
+            let continuationMessage = WatchMessage(from: continuationMessageValue)
+            draft.messages.append(continuationMessage)
+            draft.updatedAt = Date()
+            guard conversationStore.syncDraft(draft) else {
+                handleToolRequestError(
+                    AynaError.fileOperationFailed(
+                        operation: "save Watch tool continuation",
+                        path: nil
+                    ),
+                    operationID: operationID,
+                    assistantMessageId: assistantMessageId,
+                    conversationId: conversationId,
+                    userContent: userContent
+                )
+                return
+            }
 
             guard let updatedConversation = conversationStore.conversation(for: conversationId),
                   toolChainCoordinator.owns(operationID, conversationID: conversationId),
@@ -518,26 +707,28 @@
                 stopToolChainForMissingConversation(
                     operationID: operationID,
                     assistantMessageId: assistantMessageId,
-                    conversationId: conversationId
-                        )
+                    conversationId: conversationId,
+                    userContent: userContent
+                )
                 return
-                    }
+            }
 
-            let continuationMessages = updatedConversation.messages.dropLast().map { $0.toMessage() }
+            let continuationMessages = Array(updatedConversation.effectiveHistory.dropLast())
             streamingContent = ""
             pendingContent = ""
             currentToolName = nil
             lastUIUpdateTime = .distantPast
             sendMessageWithToolSupport(
-                messages: Array(continuationMessages),
+                messages: continuationMessages,
                 model: model,
+                temperature: temperature,
                 conversationId: conversationId,
                 assistantMessageId: continuationMessage.id,
                 tools: tools,
                 isFirstMessage: false,
                 userContent: userContent,
                 operationID: operationID
-                            )
+            )
         }
 
         private func finishToolSupportedResponse(
@@ -550,47 +741,115 @@
             guard activeAssistantMessageId == assistantMessageId,
                   toolChainCoordinator.finishOperation(operationID)
             else {
-                            return
-                        }
-
-            if !pendingContent.isEmpty {
-                streamingContent = pendingContent
-                updateAssistantMessage(
-                    assistantMessageId,
-                    in: conversationId,
-                    content: streamingContent
-                )
+                return
             }
-            conversationStore.persistCurrentState()
-            pendingContent = ""
+
+            attemptResponsePromotion(
+                PendingResponsePromotion(
+                    conversationID: conversationId,
+                    assistantMessageID: assistantMessageId,
+                    userMessageID: pendingUserMessageId,
+                    isFirstMessage: isFirstMessage,
+                    userContent: userContent,
+                    finalContent: pendingContent
+                )
+            )
+        }
+
+        @discardableResult
+        private func attemptResponsePromotion(_ pending: PendingResponsePromotion) -> Bool {
+            guard flushPendingContent(
+                assistantMessageId: pending.assistantMessageID,
+                conversationId: pending.conversationID,
+                finalContent: pending.finalContent
+            ) else {
+                failResponsePromotion(pending, retryPromotion: true)
+                return false
+            }
+
+            switch conversationStore.finishDraft(conversationID: pending.conversationID) {
+            case let .promoted(conversation):
+                completeResponsePromotion(pending, conversation: conversation)
+                return true
+            case .persistenceFailed:
+                failResponsePromotion(pending, retryPromotion: true)
+                return false
+            case .noDraft, .discardedEmptyDraft:
+                failResponsePromotion(pending, retryPromotion: false)
+                return false
+            }
+        }
+
+        private func completeResponsePromotion(
+            _ pending: PendingResponsePromotion,
+            conversation: WatchConversation
+        ) {
+            pendingResponsePromotions.removeValue(forKey: pending.conversationID)
             activeAssistantMessageId = nil
             pendingUserMessageId = nil
             isLoading = false
             isStreaming = false
             currentToolName = nil
             toolCallDepth = 0
+            errorMessage = nil
+            failedMessage = nil
             playHaptic(.success)
 
-            if let finalMessage = conversationStore.conversation(for: conversationId)?
-                .messages.first(where: { $0.id == assistantMessageId })
-            {
-                connectivityService.sendMessage(finalMessage, conversationId: conversationId)
-            }
-
-            if isFirstMessage,
-               let conversation = conversationStore.conversation(for: conversationId),
-               conversation.title == "New Chat"
-            {
-                generateTitle(for: conversationId, firstMessage: userContent)
+            if pending.isFirstMessage, conversation.title == "New Chat" {
+                generateTitle(for: pending.conversationID, firstMessage: pending.userContent)
             }
 
             streamingContent = ""
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .info,
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .info,
                 message: "⌚ Response complete",
-                metadata: ["conversationId": conversationId.uuidString]
-                        )
+                metadata: ["conversationId": pending.conversationID.uuidString]
+            )
+        }
+
+        private func failResponsePromotion(
+            _ pending: PendingResponsePromotion,
+            retryPromotion: Bool
+        ) {
+            if retryPromotion {
+                pendingResponsePromotions[pending.conversationID] = pending
+            } else {
+                pendingResponsePromotions.removeValue(forKey: pending.conversationID)
+            }
+            activeAssistantMessageId = nil
+            pendingUserMessageId = pending.userMessageID
+            isLoading = false
+            isStreaming = false
+            currentToolName = nil
+            toolCallDepth = 0
+            errorMessage = Self.responsePromotionErrorMessage
+            failedMessage = pending.userContent
+            playHaptic(.failure)
+
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .error,
+                message: "⌚ Failed to promote response draft",
+                metadata: ["conversationId": pending.conversationID.uuidString]
+            )
+        }
+
+        @discardableResult
+        private func retryPendingResponsePromotion(for conversationID: UUID) -> Bool {
+            guard let pendingResponsePromotion = pendingResponsePromotions[conversationID] else {
+                return true
+            }
+            errorMessage = nil
+            failedMessage = nil
+            return attemptResponsePromotion(pendingResponsePromotion)
+        }
+
+        private func restorePendingResponsePromotionState(for conversationID: UUID) {
+            guard let pending = pendingResponsePromotions[conversationID] else { return }
+            pendingUserMessageId = pending.userMessageID
+            errorMessage = Self.responsePromotionErrorMessage
+            failedMessage = pending.userContent
         }
 
         private func handleToolRequestError(
@@ -604,26 +863,38 @@
                   activeAssistantMessageId == assistantMessageId
             else {
                 return
-                            }
+            }
             toolChainCoordinator.cancelCurrentOperation()
+            guard flushPendingContent(
+                assistantMessageId: assistantMessageId,
+                conversationId: conversationId
+            ) else {
+                failResponsePromotion(
+                    makePendingResponsePromotion(
+                        assistantMessageId: assistantMessageId,
+                        conversationId: conversationId,
+                        userContent: userContent,
+                        finalContent: pendingContent
+                    ),
+                    retryPromotion: true
+                )
+                return
+            }
             activeAssistantMessageId = nil
 
             if error is CancellationError {
-                if !pendingContent.isEmpty {
-                    streamingContent = pendingContent
-                    updateAssistantMessage(
-                        assistantMessageId,
-                        in: conversationId,
-                        content: streamingContent
-                            )
-                }
-                conversationStore.persistCurrentState()
+                let finalizationOutcome = finalizeDraftIfNeeded(
+                    assistantMessageId: assistantMessageId,
+                    conversationId: conversationId,
+                    userContent: userContent
+                )
                 isLoading = false
                 isStreaming = false
                 currentToolName = nil
                 toolCallDepth = 0
-                pendingUserMessageId = nil
-                pendingContent = ""
+                if finalizationOutcome != .promotionPending {
+                    pendingUserMessageId = nil
+                }
                 return
             }
 
@@ -634,27 +905,34 @@
             errorMessage = ErrorPresenter.userMessage(for: error)
             failedMessage = userContent
             playHaptic(.failure)
-            pendingContent = ""
-            removeMessage(assistantMessageId, from: conversationId)
+            let finalizationOutcome = finalizeDraftIfNeeded(
+                assistantMessageId: assistantMessageId,
+                conversationId: conversationId,
+                userContent: userContent
+            )
+            if finalizationOutcome == .promoted {
+                pendingUserMessageId = nil
+            }
 
             DiagnosticsLogger.log(
                 .chatView,
                 level: .error,
                 message: "⌚ Request failed",
                 metadata: ["error": ErrorPresenter.userMessage(for: error)]
-                            )
+            )
         }
 
         private func stopToolChainAtDepthLimit(
             operationID: ToolChainCoordinator.OperationID,
             assistantMessageId: UUID,
-            conversationId: UUID
+            conversationId: UUID,
+            userContent: String
         ) {
             guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
                   activeAssistantMessageId == assistantMessageId
             else {
-                                return
-                            }
+                return
+            }
             DiagnosticsLogger.log(
                 .chatView,
                 level: .error,
@@ -662,20 +940,27 @@
             )
             toolChainCoordinator.cancelCurrentOperation()
             activeAssistantMessageId = nil
-            pendingUserMessageId = nil
             isLoading = false
             isStreaming = false
             currentToolName = nil
             toolCallDepth = 0
             errorMessage = "Tool call limit reached. Please try again."
-            removeMessage(assistantMessageId, from: conversationId)
+            let finalizationOutcome = finalizeDraftIfNeeded(
+                assistantMessageId: assistantMessageId,
+                conversationId: conversationId,
+                userContent: userContent
+            )
+            if finalizationOutcome != .promotionPending {
+                pendingUserMessageId = nil
+            }
             playHaptic(.failure)
         }
 
         private func stopToolChainForMissingConversation(
             operationID: ToolChainCoordinator.OperationID,
             assistantMessageId: UUID,
-            conversationId: UUID
+            conversationId: UUID,
+            userContent: String
         ) {
             guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
                   activeAssistantMessageId == assistantMessageId
@@ -683,13 +968,22 @@
                 return
             }
             toolChainCoordinator.cancelCurrentOperation()
+            let finalizationOutcome = finalizeDraftIfNeeded(
+                assistantMessageId: assistantMessageId,
+                conversationId: conversationId,
+                userContent: userContent
+            )
             activeAssistantMessageId = nil
-            pendingUserMessageId = nil
             isLoading = false
             isStreaming = false
             currentToolName = nil
             toolCallDepth = 0
             pendingContent = ""
+            if finalizationOutcome != .promotionPending {
+                errorMessage = "Failed to update conversation. Please try again."
+                failedMessage = userContent
+                playHaptic(.failure)
+            }
         }
 
         private func appendToolCall(
@@ -720,41 +1014,33 @@
                   let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId })
             else {
                 return false
-                        }
+            }
             conversation.messages[messageIndex].content = content
             return conversationStore.replaceConversation(conversation)
-                    }
-
-        private func removeMessage(_ messageId: UUID, from conversationId: UUID) {
-            guard var conversation = conversationStore.conversation(for: conversationId),
-                  let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId })
-            else {
-                return
-            }
-            conversation.messages.remove(at: messageIndex)
-            _ = conversationStore.replaceConversation(conversation)
         }
 
-        /// Cancel the current request
+        /// Cancel active request work without discarding a completed response promotion retry.
         func cancelRequest() {
-            flushPendingContent()
-            finalizeCancelledAssistant()
-            toolChainCoordinator.cancelCurrentOperation()
+            toolChainCoordinator.cancelCurrentOperation {
+                finalizeCancelledAssistant()
+            }
             cancelTitleRequest()
             activeAssistantMessageId = nil
             isLoading = false
             isStreaming = false
             currentToolName = nil
             toolCallDepth = 0
-            pendingContent = ""
-            playHaptic(.click)
+            if !hasPendingResponsePromotionForCurrentConversation {
+                pendingContent = ""
+                playHaptic(.click)
+            }
         }
 
-        /// Cancels work owned by this view model without producing user feedback.
+        /// Cancels active owned work without producing feedback or discarding promotion retries.
         func cancelOwnedRequest() {
-            flushPendingContent()
-            finalizeCancelledAssistant()
-            let cancelledToolRequest = toolChainCoordinator.cancelCurrentOperation()
+            let cancelledToolRequest = toolChainCoordinator.cancelCurrentOperation {
+                finalizeCancelledAssistant()
+            }
             let cancelledTitleRequest = cancelTitleRequest()
             guard cancelledToolRequest || cancelledTitleRequest else { return }
             activeAssistantMessageId = nil
@@ -762,57 +1048,163 @@
             isStreaming = false
             currentToolName = nil
             toolCallDepth = 0
-            pendingContent = ""
+            if !hasPendingResponsePromotionForCurrentConversation {
+                pendingContent = ""
+            }
+        }
+
+        private var hasPendingResponsePromotionForCurrentConversation: Bool {
+            currentConversationId.map { pendingResponsePromotions[$0] != nil } ?? false
         }
 
         private func finalizeCancelledAssistant() {
             guard let conversationId = currentConversationId,
-                  let assistantMessageId = activeAssistantMessageId,
-                  let message = conversationStore.conversation(for: conversationId)?
-                  .messages.first(where: { $0.id == assistantMessageId })
+                  let assistantMessageId = activeAssistantMessageId
             else {
                 return
             }
+            guard flushPendingContent(
+                assistantMessageId: assistantMessageId,
+                conversationId: conversationId
+            ) else {
+                failResponsePromotion(
+                    makePendingResponsePromotion(
+                        assistantMessageId: assistantMessageId,
+                        conversationId: conversationId,
+                        finalContent: pendingContent
+                    ),
+                    retryPromotion: true
+                )
+                return
+            }
+            finalizeDraftIfNeeded(
+                assistantMessageId: assistantMessageId,
+                conversationId: conversationId
+            )
+        }
 
-            if message.content.isEmpty, message.citations?.isEmpty ?? true {
-                removeMessage(assistantMessageId, from: conversationId)
+        @discardableResult
+        private func finalizeDraftIfNeeded(
+            assistantMessageId: UUID,
+            conversationId: UUID,
+            userContent: String? = nil
+        ) -> DraftFinalizationOutcome {
+            guard let conversation = conversationStore.conversation(for: conversationId),
+                  let messageIndex = conversation.messages.firstIndex(where: { $0.id == assistantMessageId })
+            else {
+                return .unavailable
+            }
+            let message = conversation.messages[messageIndex]
+            let pendingPromotion = makePendingResponsePromotion(
+                assistantMessageId: assistantMessageId,
+                conversationId: conversationId,
+                userContent: userContent,
+                finalContent: message.content
+            )
+
+            let hasAssistantState = !message.content.isEmpty ||
+                !(message.citations?.isEmpty ?? true) ||
+                !(message.toolCalls?.isEmpty ?? true)
+            let turnStartIndex = conversation.messages[...messageIndex].lastIndex {
+                $0.role == Message.Role.user.rawValue
+            } ?? messageIndex
+            let hasToolState = conversation.messages[turnStartIndex ... messageIndex].contains {
+                $0.role == Message.Role.tool.rawValue || !($0.toolCalls?.isEmpty ?? true)
+            }
+            if hasToolState, !hasAssistantState {
+                var cleaned = conversation
+                cleaned.messages.remove(at: messageIndex)
+                _ = conversationStore.replaceConversation(cleaned)
+            }
+            if hasAssistantState || hasToolState {
+                switch conversationStore.finishDraft(conversationID: conversationId) {
+                case .promoted:
+                    return .promoted
+                case .noDraft:
+                    return .unavailable
+                case .discardedEmptyDraft:
+                    return .discarded
+                case .persistenceFailed:
+                    failResponsePromotion(pendingPromotion, retryPromotion: true)
+                    return .promotionPending
+                }
             } else {
-                conversationStore.persistCurrentState()
-                connectivityService.sendMessage(message, conversationId: conversationId)
+                conversationStore.discardDraft(conversationID: conversationId)
+                return .discarded
             }
         }
 
-        private func flushPendingContent() {
-            guard let conversationId = currentConversationId,
-                  let assistantMessageId = activeAssistantMessageId,
-                  !pendingContent.isEmpty
+        private func makePendingResponsePromotion(
+            assistantMessageId: UUID,
+            conversationId: UUID,
+            userContent: String? = nil,
+            finalContent: String
+        ) -> PendingResponsePromotion {
+            let conversation = conversationStore.conversation(for: conversationId)
+            let messageIndex = conversation?.messages.firstIndex { $0.id == assistantMessageId }
+            let userMessage = messageIndex.flatMap { index in
+                conversation?.messages[...index].last { $0.role == Message.Role.user.rawValue }
+            }
+            let userMessageID = pendingUserMessageId ?? userMessage?.id
+            let isFirstMessage = userMessageID.map { conversation?.messages.first?.id == $0 } ?? false
+            return PendingResponsePromotion(
+                conversationID: conversationId,
+                assistantMessageID: assistantMessageId,
+                userMessageID: userMessageID,
+                isFirstMessage: isFirstMessage,
+                userContent: userContent ?? userMessage?.content ?? failedMessage ?? "",
+                finalContent: finalContent
+            )
+        }
+
+        @discardableResult
+        private func flushPendingContent(
+            assistantMessageId: UUID? = nil,
+            conversationId: UUID? = nil,
+            finalContent: String? = nil
+        ) -> Bool {
+            let content = finalContent ?? pendingContent
+            guard !content.isEmpty else { return true }
+            guard let conversationId = conversationId ?? currentConversationId,
+                  let assistantMessageId = assistantMessageId ?? activeAssistantMessageId
             else {
-                return
+                return false
             }
 
-            streamingContent = pendingContent
-            _ = updateAssistantMessage(
+            streamingContent = content
+            guard updateAssistantMessage(
                 assistantMessageId,
                 in: conversationId,
-                content: streamingContent
-            )
-            conversationStore.persistCurrentState()
-            pendingContent = ""
+                content: content
+            ) else {
+                return false
+            }
+            if pendingContent == content {
+                pendingContent = ""
+            }
+            return true
         }
 
         /// Retry the last failed message
         func retryFailedMessage() {
-            guard let message = failedMessage,
-                  let userMessageID = pendingUserMessageId
-            else {
+            if let currentConversationId,
+               pendingResponsePromotions[currentConversationId] != nil
+            {
+                _ = retryPendingResponsePromotion(for: currentConversationId)
                 return
             }
+            guard let message = failedMessage else { return }
+            let userMessageID = pendingUserMessageId
             failedMessage = nil
             errorMessage = nil
-            sendMessage(message, reusingUserMessageID: userMessageID)
+            if let userMessageID {
+                _ = sendMessage(message, reusingUserMessageID: userMessageID)
+            } else {
+                _ = sendMessage(message)
+            }
         }
 
-        /// Clear the failed message without retrying.
+        /// Hide the current error without discarding a durable response promotion retry.
         func dismissError() {
             pendingUserMessageId = nil
             failedMessage = nil
@@ -820,7 +1212,7 @@
         }
 
         /// Create a new conversation
-        func createNewConversation() -> UUID {
+        func createNewConversation() -> UUID? {
             // Filter to only models usable on watchOS (exclude Apple Intelligence)
             let usableModels = connectivityService.availableModels.filter { model in
                 let provider = aiService.modelProviders[model]
@@ -838,8 +1230,15 @@
                 usableModels.first ?? "gpt-4"
             }
 
-            let conversation = conversationStore.createConversation(model: model)
-            currentConversationId = conversation.id
+            guard let conversation = conversationStore.createConversation(
+                model: model,
+                resolvedSystemPrompt: connectivityService.defaultSystemPrompt
+            ) else {
+                errorMessage = "Failed to save conversation. Please try again."
+                playHaptic(.failure)
+                return nil
+            }
+            setConversation(conversation.id)
             playHaptic(.click)
             return conversation.id
         }
@@ -851,7 +1250,13 @@
             let requestID = UUID()
             let fallbackTitle = String(firstMessage.prefix(30)) + (firstMessage.count > 30 ? "..." : "")
             titleRequestID = requestID
-            titleRequestFallback = (conversationId, fallbackTitle)
+            titleRequestContext = TitleRequestContext(
+                conversationID: conversationId,
+                fallbackTitle: fallbackTitle,
+                expectedTitle: conversation.title,
+                expectedRevision: conversation.watchRevision,
+                expectedUpdatedAt: conversation.updatedAt
+            )
 
             let titlePrompt = "Generate a very short title (3-5 words maximum) for a conversation that starts with: \"\(firstMessage.prefix(200))\". Only respond with the title, nothing else."
 
@@ -861,8 +1266,8 @@
                 model: conversation.model,
                 stream: false,
                 onChunk: { [weak self] chunk in
-                    MainActor.assumeIsolated {
-                        guard let self, self.titleRequestID == requestID else { return }
+                    Task { @MainActor [weak self] in
+                        guard let self, self.canApplyTitleUpdate(requestID) else { return }
                         let cleanTitle = chunk
                             .trimmingCharacters(in: .whitespacesAndNewlines)
                             .replacingOccurrences(of: "\"", with: "")
@@ -877,17 +1282,18 @@
                     }
                 },
                 onComplete: { [weak self] in
-                    MainActor.assumeIsolated {
+                    Task { @MainActor [weak self] in
                         guard let self, self.titleRequestID == requestID else { return }
                         self.applyTitleFallbackIfNeeded(requestID)
                         self.finishTitleRequest(requestID)
                     }
                 },
                 onError: { [weak self] _ in
-                    MainActor.assumeIsolated {
+                    Task { @MainActor [weak self] in
                         guard let self, self.titleRequestID == requestID else { return }
-                        // Fallback to simple title on error
-                        self.conversationStore.renameConversation(conversationId, newTitle: fallbackTitle)
+                        if self.canApplyTitleUpdate(requestID) {
+                            self.conversationStore.renameConversation(conversationId, newTitle: fallbackTitle)
+                        }
                         self.finishTitleRequest(requestID)
                     }
                 },
@@ -904,35 +1310,48 @@
         private func cancelTitleRequest() -> Bool {
             let request = titleRequest
             let requestWasActive = request != nil || titleRequestID != nil
-            let fallback = titleRequestFallback
+            let context = titleRequestContext
             titleRequest = nil
             titleRequestID = nil
-            titleRequestFallback = nil
+            titleRequestContext = nil
 
-            if let fallback,
-               conversationStore.conversation(for: fallback.conversationID)?.title == "New Chat"
-            {
-                conversationStore.renameConversation(fallback.conversationID, newTitle: fallback.title)
+            if let context, canApplyTitleUpdate(context) {
+                conversationStore.renameConversation(
+                    context.conversationID,
+                    newTitle: context.fallbackTitle
+                )
             }
             request?.cancel()
             return requestWasActive
         }
 
         private func applyTitleFallbackIfNeeded(_ requestID: UUID) {
-            guard titleRequestID == requestID,
-                  let fallback = titleRequestFallback,
-                  conversationStore.conversation(for: fallback.conversationID)?.title == "New Chat"
-            else {
-                return
+            guard canApplyTitleUpdate(requestID), let context = titleRequestContext else { return }
+            conversationStore.renameConversation(
+                context.conversationID,
+                newTitle: context.fallbackTitle
+            )
+        }
+
+        private func canApplyTitleUpdate(_ requestID: UUID) -> Bool {
+            guard titleRequestID == requestID, let context = titleRequestContext else { return false }
+            return canApplyTitleUpdate(context)
+        }
+
+        private func canApplyTitleUpdate(_ context: TitleRequestContext) -> Bool {
+            guard let conversation = conversationStore.conversation(for: context.conversationID) else {
+                return false
             }
-            conversationStore.renameConversation(fallback.conversationID, newTitle: fallback.title)
+            return conversation.title == context.expectedTitle &&
+                conversation.watchRevision == context.expectedRevision &&
+                conversation.updatedAt == context.expectedUpdatedAt
         }
 
         private func finishTitleRequest(_ requestID: UUID) {
             guard titleRequestID == requestID else { return }
             titleRequest = nil
             titleRequestID = nil
-            titleRequestFallback = nil
+            titleRequestContext = nil
         }
     }
     // swiftlint:enable type_body_length

--- a/Sources/Ayna/ViewModels/WatchChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/WatchChatViewModel.swift
@@ -1037,12 +1037,13 @@ final class WatchToolCallRoundRegistry {
         }
 
         /// Cancels active owned work without producing feedback or discarding promotion retries.
-        func cancelOwnedRequest() {
+        @discardableResult
+        func cancelOwnedRequest() -> Bool {
             let cancelledToolRequest = toolChainCoordinator.cancelCurrentOperation {
                 finalizeCancelledAssistant()
             }
             let cancelledTitleRequest = cancelTitleRequest()
-            guard cancelledToolRequest || cancelledTitleRequest else { return }
+            guard cancelledToolRequest || cancelledTitleRequest else { return false }
             activeAssistantMessageId = nil
             isLoading = false
             isStreaming = false
@@ -1051,6 +1052,7 @@ final class WatchToolCallRoundRegistry {
             if !hasPendingResponsePromotionForCurrentConversation {
                 pendingContent = ""
             }
+            return true
         }
 
         private var hasPendingResponsePromotionForCurrentConversation: Bool {

--- a/Sources/Ayna/ViewModels/WatchChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/WatchChatViewModel.swift
@@ -13,6 +13,7 @@
     import SwiftUI
     import WatchKit
 
+    // swiftlint:disable type_body_length
     /// ViewModel for Watch chat view
     /// Handles message sending, streaming responses, and local state management
     @MainActor
@@ -27,8 +28,15 @@
         private let conversationStore: WatchConversationStore
         private let connectivityService: WatchConnectivityService
         private let aiService: AIService
+        private let toolChainCoordinator = ToolChainCoordinator()
+        private let toolCallRequestRoundCoordinator = ToolCallRequestRoundCoordinator<ToolExecutionResult>()
         private var currentConversationId: UUID?
+        private var pendingUserMessageId: UUID?
         private var toolCallDepth = 0
+        private var activeAssistantMessageId: UUID?
+        private var titleRequest: AITextRequest?
+        private var titleRequestID: UUID?
+        private var titleRequestFallback: (conversationID: UUID, title: String)?
 
         /// Maximum tool chain depth for watchOS.
         /// Intentionally low (5) due to watchOS resource constraints (memory, battery, network).
@@ -52,12 +60,18 @@
 
         /// Set the current conversation being viewed
         func setConversation(_ id: UUID) {
+            guard currentConversationId != id else { return }
+            if currentConversationId != nil {
+                cancelOwnedRequest()
+            }
             currentConversationId = id
             errorMessage = nil
             streamingContent = ""
             currentToolName = nil
             toolCallDepth = 0
+            activeAssistantMessageId = nil
             failedMessage = nil
+            pendingUserMessageId = nil
             pendingContent = ""
         }
 
@@ -68,9 +82,17 @@
 
         /// Send a message in the current conversation
         func sendMessage(_ content: String) {
-            guard let conversationId = currentConversationId,
-                  let conversation = conversationStore.conversation(for: conversationId)
-            else {
+            sendMessage(content, reusingUserMessageID: nil)
+        }
+
+        private func sendMessage(_ content: String, reusingUserMessageID: UUID?) {
+            guard let conversationId = currentConversationId else {
+                errorMessage = "No conversation selected"
+                playHaptic(.failure)
+                return
+            }
+            cancelTitleRequest()
+            guard let conversation = conversationStore.conversation(for: conversationId) else {
                 errorMessage = "No conversation selected"
                 playHaptic(.failure)
                 return
@@ -90,28 +112,27 @@
             // Play haptic for message sent
             playHaptic(.click)
 
-            // Check if this is the first user message (for title generation later)
-            let isFirstMessage = conversation.messages.isEmpty
-            let userContent = content // Capture for closure
-
-            // Create user message
-            let userMessage = WatchMessage(
-                from: Message(role: .user, content: content)
-            )
-
-            // Add to local store
+            let userContent = content
+            let userMessage: WatchMessage
+            let isFirstMessage: Bool
+            if let reusingUserMessageID,
+               let existingUserMessage = conversation.messages.first(where: {
+                   $0.id == reusingUserMessageID && $0.role == Message.Role.user.rawValue
+               })
+            {
+                userMessage = existingUserMessage
+                isFirstMessage = conversation.messages.first?.id == reusingUserMessageID
+            } else {
+                userMessage = WatchMessage(from: Message(role: .user, content: content))
             conversationStore.addMessage(userMessage, to: conversationId)
-
-            // Sync to iPhone
             connectivityService.sendMessage(userMessage, conversationId: conversationId)
+                isFirstMessage = conversation.messages.isEmpty
+            }
+            pendingUserMessageId = userMessage.id
 
-            // Create placeholder assistant message for streaming
-            let assistantMessage = WatchMessage(
-                from: Message(role: .assistant, content: "")
-            )
-            conversationStore.addMessage(assistantMessage, to: conversationId)
-
-            // Get updated conversation with messages
+            // Get updated conversation after committing the user message. Validate the model
+            // before adding an assistant placeholder so configuration failures cannot leave a
+            // hidden empty turn in local or synced history.
             guard let updatedConversation = conversationStore.conversation(for: conversationId) else {
                 isLoading = false
                 isStreaming = false
@@ -119,9 +140,6 @@
                 playHaptic(.failure)
                 return
             }
-
-            // Convert to Message array for API
-            let messagesForAPI = updatedConversation.messages.dropLast().map { $0.toMessage() }
 
             // Get model from settings or conversation, but validate it's usable on watchOS
             var model = connectivityService.selectedModel.isEmpty
@@ -142,6 +160,7 @@
                     isLoading = false
                     isStreaming = false
                     errorMessage = "No compatible models available. Please add a model on iPhone."
+                    failedMessage = userContent
                     playHaptic(.failure)
                     return
                 }
@@ -152,9 +171,16 @@
                 isLoading = false
                 isStreaming = false
                 errorMessage = "API key not configured. Please configure on iPhone."
+                failedMessage = userContent
                 playHaptic(.failure)
                 return
             }
+
+            let assistantMessage = WatchMessage(from: Message(role: .assistant, content: ""))
+            conversationStore.addMessage(assistantMessage, to: conversationId)
+
+            // The validated request history excludes the placeholder just added above.
+            let messagesForAPI = updatedConversation.messages.map { $0.toMessage() }
 
             // Get available tools (Tavily web search if configured)
             let tools = aiService.getAllAvailableTools()
@@ -163,282 +189,632 @@
                 messages: Array(messagesForAPI),
                 model: model,
                 conversationId: conversationId,
+                assistantMessageId: assistantMessage.id,
                 tools: tools,
                 isFirstMessage: isFirstMessage,
                 userContent: userContent
             )
         }
 
+        // swiftlint:disable function_body_length
         /// Send message with tool support for recursive tool calling.
-        private func sendMessageWithToolSupport( // swiftlint:disable:this function_body_length
+        private func sendMessageWithToolSupport(
             messages: [Message],
             model: String,
             conversationId: UUID,
+            assistantMessageId: UUID,
             tools: [[String: Any]]?,
             isFirstMessage: Bool,
-            userContent: String
+            userContent: String,
+            operationID existingOperationID: ToolChainCoordinator.OperationID? = nil
         ) {
             nonisolated(unsafe) let tools = tools
-            aiService.sendMessage(
+            let coordinator = toolChainCoordinator
+            let roundCoordinator = toolCallRequestRoundCoordinator
+            let operationID = existingOperationID ?? coordinator.beginOperation(conversationID: conversationId)
+            guard coordinator.owns(operationID, conversationID: conversationId),
+                  let requestRoundID = roundCoordinator.beginRequestRound(
+                      for: operationID,
+                      coordinatedBy: coordinator
+                  )
+            else {
+                return
+            }
+            activeAssistantMessageId = assistantMessageId
+
+            let request = aiService.sendMessage(
                 messages: messages,
                 model: model,
                 stream: true,
                 tools: tools,
                 conversationId: conversationId,
                 onChunk: { [weak self] chunk in
-                    Task { @MainActor in
-                        guard let self else { return }
-
-                        // Mark as streaming once we receive the first chunk
+                    MainActor.assumeIsolated {
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId),
+                              self.activeAssistantMessageId == assistantMessageId
+                        else {
+                            return
+                        }
                         if !self.isStreaming {
                             self.isStreaming = true
                         }
-
                         self.pendingContent += chunk
 
-                        // Throttle UI updates for better performance on Watch
                         let now = Date()
                         if now.timeIntervalSince(self.lastUIUpdateTime) >= self.uiUpdateInterval {
                             self.streamingContent = self.pendingContent
-                            self.conversationStore.updateLastMessage(
+                            self.updateAssistantMessage(
+                                assistantMessageId,
                                 in: conversationId,
                                 content: self.streamingContent
                             )
                             self.lastUIUpdateTime = now
                         }
-
-                        // Clear tool indicator when we start receiving content
-                        if self.currentToolName != nil {
                             self.currentToolName = nil
                         }
-                    }
                 },
                 onComplete: { [weak self] in
-                    Task { @MainActor in
-                        guard let self else { return }
-
-                        // Only complete if no tool call is pending
-                        guard self.currentToolName == nil else {
-                            DiagnosticsLogger.log(
-                                .chatView,
-                                level: .info,
-                                message: "⌚ onComplete: keeping isLoading TRUE (tool call pending)",
-                                metadata: ["toolName": self.currentToolName ?? "unknown"]
-                            )
+                    MainActor.assumeIsolated {
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId),
+                              self.activeAssistantMessageId == assistantMessageId
+                        else {
                             return
                         }
-
-                        // Flush any remaining pending content
-                        if !self.pendingContent.isEmpty {
-                            self.streamingContent = self.pendingContent
-                            self.conversationStore.updateLastMessage(
-                                in: conversationId,
-                                content: self.streamingContent
-                            )
-                        }
-                        self.conversationStore.persistCurrentState()
-                        self.pendingContent = ""
-
-                        self.isLoading = false
-                        self.isStreaming = false
-                        self.toolCallDepth = 0
-
-                        // Play success haptic
-                        self.playHaptic(.success)
-
-                        // Create final assistant message and sync to iPhone
-                        let finalMessage = WatchMessage(
-                            from: Message(role: .assistant, content: self.streamingContent)
+                        let resolution = roundCoordinator.providerDidComplete(
+                            operationID: operationID,
+                            requestRoundID: requestRoundID
                         )
-                        self.connectivityService.sendMessage(finalMessage, conversationId: conversationId)
-
-                        // Generate title if this was the first message
-                        if isFirstMessage,
-                           let conv = self.conversationStore.conversation(for: conversationId),
-                           conv.title == "New Chat"
-                        {
-                            self.generateTitle(for: conversationId, firstMessage: userContent)
-                        }
-
-                        self.streamingContent = ""
-
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .info,
-                            message: "⌚ Response complete",
-                            metadata: ["conversationId": conversationId.uuidString]
+                        self.handleToolRoundResolution(
+                            resolution,
+                            operationID: operationID,
+                            assistantMessageId: assistantMessageId,
+                            model: model,
+                            conversationId: conversationId,
+                            tools: tools,
+                            isFirstMessage: isFirstMessage,
+                            userContent: userContent
                         )
                     }
                 },
                 onError: { [weak self] error in
-                    Task { @MainActor in
+                    MainActor.assumeIsolated {
                         guard let self else { return }
-
-                        // Handle cancellation silently - don't show error UI for user-initiated cancels
-                        if error is CancellationError {
-                            DiagnosticsLogger.log(
-                                .chatView,
-                                level: .info,
-                                message: "⌚ Request cancelled"
-                            )
-                            if !self.pendingContent.isEmpty {
-                                self.streamingContent = self.pendingContent
-                                self.conversationStore.updateLastMessage(
-                                    in: conversationId,
-                                    content: self.streamingContent
-                                )
-                            }
-                            self.conversationStore.persistCurrentState()
-                            self.isLoading = false
-                            self.isStreaming = false
-                            self.currentToolName = nil
-                            self.toolCallDepth = 0
-                            self.pendingContent = ""
-                            return
-                        }
-
-                        self.isLoading = false
-                        self.isStreaming = false
-                        self.currentToolName = nil
-                        self.toolCallDepth = 0
-                        self.errorMessage = ErrorPresenter.userMessage(for: error)
-
-                        // Store the failed message for retry
-                        self.failedMessage = userContent
-
-                        // Play failure haptic
-                        self.playHaptic(.failure)
-
-                        // Remove the empty assistant message and the user message
-                        self.pendingContent = ""
-                        if var conv = self.conversationStore.conversation(for: conversationId),
-                           !conv.messages.isEmpty
-                        {
-                            // Remove assistant placeholder
-                            conv.messages.removeLast()
-                            // Remove user message (will be re-added on retry)
-                            if !conv.messages.isEmpty {
-                                conv.messages.removeLast()
-                            }
-                            _ = self.conversationStore.replaceConversation(conv)
-                        }
-
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .error,
-                            message: "⌚ Request failed",
-                            metadata: ["error": ErrorPresenter.userMessage(for: error)]
+                        self.handleToolRequestError(
+                            error,
+                            operationID: operationID,
+                            assistantMessageId: assistantMessageId,
+                            conversationId: conversationId,
+                            userContent: userContent
                         )
                     }
                 },
                 onToolCall: nil,
-                onToolCallRequested: { [weak self] _, toolName, arguments in
+                onToolCallRequested: { [weak self] toolCallID, toolName, arguments in
                     nonisolated(unsafe) let arguments = arguments
-                    let toolNameCopy = toolName
-                    Task { @MainActor in
-                        guard let self else { return }
-                        // Set currentToolName first thing to prevent race condition with onComplete
-                        // checking if tool call is pending. The stream may send [DONE] immediately
-                        // after finish_reason: "tool_calls".
-                        self.currentToolName = toolNameCopy
-
-                        // Check depth limit
-                        guard self.toolCallDepth < self.maxToolCallDepth else {
-                            DiagnosticsLogger.log(
-                                .chatView,
-                                level: .error,
-                                message: "⌚ Max tool call depth reached"
+                    MainActor.assumeIsolated {
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId),
+                              self.activeAssistantMessageId == assistantMessageId,
+                              self.conversationStore.conversation(for: conversationId) != nil,
+                              let toolToken = roundCoordinator.registerTool(
+                                  for: operationID,
+                                  requestRoundID: requestRoundID
                             )
-                            self.isLoading = false
-                            self.isStreaming = false
-                            self.currentToolName = nil
-                            self.playHaptic(.failure)
+                        else {
                             return
                         }
 
-                        self.toolCallDepth += 1
-
-                        // Play haptic for tool execution
-                        self.playHaptic(.click)
-
-                        DiagnosticsLogger.log(
-                            .chatView,
-                            level: .info,
-                            message: "⌚ Tool call requested: \(toolName)",
-                            metadata: ["toolName": toolName]
-                        )
-
-                        // Execute the tool
-                        Task { @MainActor in
-                            let result: String = if self.aiService.isBuiltInTool(toolName) {
-                                await self.aiService.executeBuiltInTool(name: toolName, arguments: arguments)
-                            } else {
-                                "Tool not available on Apple Watch"
-                            }
-
-                            // Add tool result message to local store for history consistency
-                            let toolMessage = WatchMessage(
-                                from: Message(role: .tool, content: result)
+                        if toolToken.registrationIndex == 0 {
+                            guard self.toolCallDepth < self.maxToolCallDepth else {
+                                self.stopToolChainAtDepthLimit(
+                                    operationID: operationID,
+                                    assistantMessageId: assistantMessageId,
+                                    conversationId: conversationId
                             )
-                            self.conversationStore.addMessage(toolMessage, to: conversationId)
-                            // Sync tool message to iPhone to maintain conversation parity
-                            self.connectivityService.sendMessage(toolMessage, conversationId: conversationId)
-
-                            // Add new assistant message placeholder
-                            let newAssistantMessage = WatchMessage(
-                                from: Message(role: .assistant, content: "")
-                            )
-                            self.conversationStore.addMessage(newAssistantMessage, to: conversationId)
-
-                            // Get updated messages
-                            guard let updatedConv = self.conversationStore.conversation(for: conversationId) else {
-                                self.isLoading = false
-                                self.isStreaming = false
-                                self.currentToolName = nil
                                 return
                             }
-
-                            // Build continuation messages (tool message is now in the store)
-                            let continuationMessages = updatedConv.messages.dropLast().map { $0.toMessage() }
-
-                            self.streamingContent = ""
-                            self.pendingContent = ""
-
-                            self.sendMessageWithToolSupport(
-                                messages: Array(continuationMessages),
-                                model: model,
-                                conversationId: conversationId,
-                                tools: tools,
-                                isFirstMessage: false,
-                                userContent: userContent
-                            )
+                            self.toolCallDepth += 1
                         }
+
+                        self.currentToolName = toolName
+                        self.playHaptic(.click)
+                        let anyCodableArguments = arguments.reduce(into: [String: AnyCodable]()) { result, pair in
+                            result[pair.key] = AnyCodable(pair.value)
+                        }
+                        let toolCall = MCPToolCall(
+                            id: toolCallID,
+                            toolName: toolName,
+                            arguments: anyCodableArguments
+                        )
+                        guard self.appendToolCall(
+                            toolCall,
+                            to: assistantMessageId,
+                            in: conversationId
+                        ) else {
+                            self.stopToolChainForMissingConversation(
+                                operationID: operationID,
+                                assistantMessageId: assistantMessageId,
+                                conversationId: conversationId
+                            )
+                            return
+                        }
+                        self.executeTool(
+                            token: toolToken,
+                            callID: toolCallID,
+                            toolName: toolName,
+                            arguments: arguments,
+                            anyCodableArguments: anyCodableArguments,
+                            operationID: operationID,
+                            assistantMessageId: assistantMessageId,
+                            model: model,
+                            conversationId: conversationId,
+                            tools: tools,
+                            userContent: userContent
+                        )
                     }
                 },
                 onReasoning: nil
             )
+            coordinator.onCancel(for: operationID) {
+                request.cancel()
+            }
         }
 
-        /// Cancel the current request
-        func cancelRequest() {
-            aiService.cancelCurrentRequest()
+        // swiftlint:enable function_body_length
+
+        // swiftlint:disable:next function_parameter_count
+        private func executeTool(
+            token: ToolCallRequestRoundCoordinator<ToolExecutionResult>.ToolToken,
+            callID: String,
+            toolName: String,
+            arguments: [String: Any],
+            anyCodableArguments: [String: AnyCodable],
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            model: String,
+            conversationId: UUID,
+            tools: [[String: Any]]?,
+            userContent: String
+        ) {
+            nonisolated(unsafe) let arguments = arguments
+            nonisolated(unsafe) let tools = tools
+            let coordinator = toolChainCoordinator
+            let roundCoordinator = toolCallRequestRoundCoordinator
+            coordinator.schedule(for: operationID, conversationID: conversationId) { [weak self] in
+                guard let self,
+                      coordinator.owns(operationID, conversationID: conversationId),
+                      self.activeAssistantMessageId == assistantMessageId
+                else {
+                    return
+                }
+
+                            DiagnosticsLogger.log(
+                                .chatView,
+                                level: .info,
+                    message: "⌚ Tool call requested: \(toolName)",
+                    metadata: ["toolName": toolName]
+                            )
+                let output: String
+                let citations: [CitationReference]?
+                if self.aiService.isBuiltInTool(toolName) {
+                    (output, citations) = await self.aiService.executeBuiltInToolWithCitations(
+                        name: toolName,
+                        arguments: arguments
+                                )
+                } else {
+                    output = "Tool not available on Apple Watch"
+                    citations = nil
+                            }
+                guard coordinator.owns(operationID, conversationID: conversationId),
+                      self.activeAssistantMessageId == assistantMessageId,
+                      !Task.isCancelled
+                else {
+                            return
+                        }
+
+                let result = ToolExecutionResult(
+                    callID: callID,
+                    toolName: toolName,
+                    arguments: anyCodableArguments,
+                    output: output,
+                    citations: citations ?? []
+                )
+                let resolution = roundCoordinator.toolDidComplete(token, result: result)
+                self.handleToolRoundResolution(
+                    resolution,
+                    operationID: operationID,
+                    assistantMessageId: assistantMessageId,
+                    model: model,
+                    conversationId: conversationId,
+                    tools: tools,
+                    isFirstMessage: false,
+                    userContent: userContent
+                )
+            }
+        }
+
+        // swiftlint:disable:next function_parameter_count
+        private func handleToolRoundResolution(
+            _ resolution: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Resolution,
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            model: String,
+            conversationId: UUID,
+            tools: [[String: Any]]?,
+            isFirstMessage: Bool,
+            userContent: String
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                return
+            }
+
+            switch resolution {
+            case .pending, .ignored:
+                return
+            case .responseCompleted:
+                finishToolSupportedResponse(
+                    operationID: operationID,
+                    assistantMessageId: assistantMessageId,
+                    conversationId: conversationId,
+                    isFirstMessage: isFirstMessage,
+                    userContent: userContent
+                )
+            case let .launchContinuation(continuation):
+                launchToolContinuation(
+                    continuation,
+                    operationID: operationID,
+                    assistantMessageId: assistantMessageId,
+                    model: model,
+                    conversationId: conversationId,
+                    tools: tools,
+                    userContent: userContent
+                )
+            }
+        }
+
+        private func launchToolContinuation(
+            _ continuation: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Continuation,
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            model: String,
+            conversationId: UUID,
+            tools: [[String: Any]]?,
+            userContent: String
+        ) {
+            guard continuation.operationID == operationID,
+                  toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                return
+            }
+
+            if let assistantToolCallMessage = conversationStore.conversation(for: conversationId)?
+                .messages.first(where: { $0.id == assistantMessageId })
+                        {
+                connectivityService.sendMessage(assistantToolCallMessage, conversationId: conversationId)
+                            }
+
+            let results = continuation.toolResults.map(\.result)
+            for result in results {
+                let toolMessage = WatchMessage(from: result.makeMessage())
+                conversationStore.addMessage(toolMessage, to: conversationId)
+                connectivityService.sendMessage(toolMessage, conversationId: conversationId)
+                        }
+
+            let citations = ToolExecutionResult.combinedCitations(from: results)
+            var continuation = Message(role: .assistant, content: "", model: model)
+            continuation.citations = citations.isEmpty ? nil : citations
+            let continuationMessage = WatchMessage(from: continuation)
+            conversationStore.addMessage(continuationMessage, to: conversationId)
+
+            guard let updatedConversation = conversationStore.conversation(for: conversationId),
+                  toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                stopToolChainForMissingConversation(
+                    operationID: operationID,
+                    assistantMessageId: assistantMessageId,
+                    conversationId: conversationId
+                        )
+                return
+                    }
+
+            let continuationMessages = updatedConversation.messages.dropLast().map { $0.toMessage() }
+            streamingContent = ""
+            pendingContent = ""
+            currentToolName = nil
+            lastUIUpdateTime = .distantPast
+            sendMessageWithToolSupport(
+                messages: Array(continuationMessages),
+                model: model,
+                conversationId: conversationId,
+                assistantMessageId: continuationMessage.id,
+                tools: tools,
+                isFirstMessage: false,
+                userContent: userContent,
+                operationID: operationID
+                            )
+        }
+
+        private func finishToolSupportedResponse(
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            conversationId: UUID,
+            isFirstMessage: Bool,
+            userContent: String
+        ) {
+            guard activeAssistantMessageId == assistantMessageId,
+                  toolChainCoordinator.finishOperation(operationID)
+            else {
+                            return
+                        }
+
+            if !pendingContent.isEmpty {
+                streamingContent = pendingContent
+                updateAssistantMessage(
+                    assistantMessageId,
+                    in: conversationId,
+                    content: streamingContent
+                )
+            }
+            conversationStore.persistCurrentState()
+            pendingContent = ""
+            activeAssistantMessageId = nil
+            pendingUserMessageId = nil
             isLoading = false
             isStreaming = false
             currentToolName = nil
             toolCallDepth = 0
+            playHaptic(.success)
+
+            if let finalMessage = conversationStore.conversation(for: conversationId)?
+                .messages.first(where: { $0.id == assistantMessageId })
+            {
+                connectivityService.sendMessage(finalMessage, conversationId: conversationId)
+            }
+
+            if isFirstMessage,
+               let conversation = conversationStore.conversation(for: conversationId),
+               conversation.title == "New Chat"
+            {
+                generateTitle(for: conversationId, firstMessage: userContent)
+            }
+
+            streamingContent = ""
+                        DiagnosticsLogger.log(
+                            .chatView,
+                            level: .info,
+                message: "⌚ Response complete",
+                metadata: ["conversationId": conversationId.uuidString]
+                        )
+        }
+
+        private func handleToolRequestError(
+            _ error: Error,
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            conversationId: UUID,
+            userContent: String
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                return
+                            }
+            toolChainCoordinator.cancelCurrentOperation()
+            activeAssistantMessageId = nil
+
+            if error is CancellationError {
+                if !pendingContent.isEmpty {
+                    streamingContent = pendingContent
+                    updateAssistantMessage(
+                        assistantMessageId,
+                        in: conversationId,
+                        content: streamingContent
+                            )
+                }
+                conversationStore.persistCurrentState()
+                isLoading = false
+                isStreaming = false
+                currentToolName = nil
+                toolCallDepth = 0
+                pendingUserMessageId = nil
+                pendingContent = ""
+                return
+            }
+
+            isLoading = false
+            isStreaming = false
+            currentToolName = nil
+            toolCallDepth = 0
+            errorMessage = ErrorPresenter.userMessage(for: error)
+            failedMessage = userContent
+            playHaptic(.failure)
+            pendingContent = ""
+            removeMessage(assistantMessageId, from: conversationId)
+
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .error,
+                message: "⌚ Request failed",
+                metadata: ["error": ErrorPresenter.userMessage(for: error)]
+                            )
+        }
+
+        private func stopToolChainAtDepthLimit(
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            conversationId: UUID
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                                return
+                            }
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .error,
+                message: "⌚ Max tool call depth reached"
+            )
+            toolChainCoordinator.cancelCurrentOperation()
+            activeAssistantMessageId = nil
+            pendingUserMessageId = nil
+            isLoading = false
+            isStreaming = false
+            currentToolName = nil
+            toolCallDepth = 0
+            errorMessage = "Tool call limit reached. Please try again."
+            removeMessage(assistantMessageId, from: conversationId)
+            playHaptic(.failure)
+        }
+
+        private func stopToolChainForMissingConversation(
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageId: UUID,
+            conversationId: UUID
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
+                  activeAssistantMessageId == assistantMessageId
+            else {
+                return
+            }
+            toolChainCoordinator.cancelCurrentOperation()
+            activeAssistantMessageId = nil
+            pendingUserMessageId = nil
+            isLoading = false
+            isStreaming = false
+            currentToolName = nil
+            toolCallDepth = 0
+            pendingContent = ""
+        }
+
+        private func appendToolCall(
+            _ toolCall: MCPToolCall,
+            to messageId: UUID,
+            in conversationId: UUID
+        ) -> Bool {
+            guard var conversation = conversationStore.conversation(for: conversationId),
+                  let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId })
+            else {
+                return false
+            }
+            var calls = conversation.messages[messageIndex].toolCalls ?? []
+            if !calls.contains(where: { $0.id == toolCall.id }) {
+                calls.append(toolCall)
+            }
+            conversation.messages[messageIndex].toolCalls = calls
+            return conversationStore.replaceConversation(conversation)
+        }
+
+        @discardableResult
+        private func updateAssistantMessage(
+            _ messageId: UUID,
+            in conversationId: UUID,
+            content: String
+        ) -> Bool {
+            guard var conversation = conversationStore.conversation(for: conversationId),
+                  let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId })
+            else {
+                return false
+                        }
+            conversation.messages[messageIndex].content = content
+            return conversationStore.replaceConversation(conversation)
+                    }
+
+        private func removeMessage(_ messageId: UUID, from conversationId: UUID) {
+            guard var conversation = conversationStore.conversation(for: conversationId),
+                  let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId })
+            else {
+                return
+            }
+            conversation.messages.remove(at: messageIndex)
+            _ = conversationStore.replaceConversation(conversation)
+        }
+
+        /// Cancel the current request
+        func cancelRequest() {
+            flushPendingContent()
+            finalizeCancelledAssistant()
+            toolChainCoordinator.cancelCurrentOperation()
+            cancelTitleRequest()
+            activeAssistantMessageId = nil
+            isLoading = false
+            isStreaming = false
+            currentToolName = nil
+            toolCallDepth = 0
+            pendingContent = ""
             playHaptic(.click)
+        }
+
+        /// Cancels work owned by this view model without producing user feedback.
+        func cancelOwnedRequest() {
+            flushPendingContent()
+            finalizeCancelledAssistant()
+            let cancelledToolRequest = toolChainCoordinator.cancelCurrentOperation()
+            let cancelledTitleRequest = cancelTitleRequest()
+            guard cancelledToolRequest || cancelledTitleRequest else { return }
+            activeAssistantMessageId = nil
+            isLoading = false
+            isStreaming = false
+            currentToolName = nil
+            toolCallDepth = 0
+            pendingContent = ""
+        }
+
+        private func finalizeCancelledAssistant() {
+            guard let conversationId = currentConversationId,
+                  let assistantMessageId = activeAssistantMessageId,
+                  let message = conversationStore.conversation(for: conversationId)?
+                  .messages.first(where: { $0.id == assistantMessageId })
+            else {
+                return
+            }
+
+            if message.content.isEmpty, message.citations?.isEmpty ?? true {
+                removeMessage(assistantMessageId, from: conversationId)
+            } else {
+                conversationStore.persistCurrentState()
+                connectivityService.sendMessage(message, conversationId: conversationId)
+            }
+        }
+
+        private func flushPendingContent() {
+            guard let conversationId = currentConversationId,
+                  let assistantMessageId = activeAssistantMessageId,
+                  !pendingContent.isEmpty
+            else {
+                return
+            }
+
+            streamingContent = pendingContent
+            _ = updateAssistantMessage(
+                assistantMessageId,
+                in: conversationId,
+                content: streamingContent
+            )
+            conversationStore.persistCurrentState()
+            pendingContent = ""
         }
 
         /// Retry the last failed message
         func retryFailedMessage() {
-            guard let message = failedMessage else { return }
+            guard let message = failedMessage,
+                  let userMessageID = pendingUserMessageId
+            else {
+                return
+            }
             failedMessage = nil
             errorMessage = nil
-            sendMessage(message)
+            sendMessage(message, reusingUserMessageID: userMessageID)
         }
 
-        /// Clear the failed message without retrying
+        /// Clear the failed message without retrying.
         func dismissError() {
+            pendingUserMessageId = nil
             failedMessage = nil
             errorMessage = nil
         }
@@ -471,41 +847,94 @@
         /// Generate a title for the conversation using AI
         private func generateTitle(for conversationId: UUID, firstMessage: String) {
             guard let conversation = conversationStore.conversation(for: conversationId) else { return }
+            cancelTitleRequest()
+            let requestID = UUID()
+            let fallbackTitle = String(firstMessage.prefix(30)) + (firstMessage.count > 30 ? "..." : "")
+            titleRequestID = requestID
+            titleRequestFallback = (conversationId, fallbackTitle)
 
             let titlePrompt = "Generate a very short title (3-5 words maximum) for a conversation that starts with: \"\(firstMessage.prefix(200))\". Only respond with the title, nothing else."
 
             let titleMessage = Message(role: .user, content: titlePrompt)
-            aiService.sendMessage(
+            let request = aiService.sendMessage(
                 messages: [titleMessage],
                 model: conversation.model,
                 stream: false,
                 onChunk: { [weak self] chunk in
-                    Task { @MainActor in
+                    MainActor.assumeIsolated {
+                        guard let self, self.titleRequestID == requestID else { return }
                         let cleanTitle = chunk
                             .trimmingCharacters(in: .whitespacesAndNewlines)
                             .replacingOccurrences(of: "\"", with: "")
                             .replacingOccurrences(of: "\n", with: " ")
 
                         if !cleanTitle.isEmpty {
-                            self?.conversationStore.renameConversation(conversationId, newTitle: cleanTitle)
+                            self.conversationStore.renameConversation(conversationId, newTitle: cleanTitle)
                         } else {
                             // Fallback to simple title
-                            let fallback = String(firstMessage.prefix(30)) + (firstMessage.count > 30 ? "..." : "")
-                            self?.conversationStore.renameConversation(conversationId, newTitle: fallback)
+                            self.conversationStore.renameConversation(conversationId, newTitle: fallbackTitle)
                         }
                     }
                 },
-                onComplete: { },
+                onComplete: { [weak self] in
+                    MainActor.assumeIsolated {
+                        guard let self, self.titleRequestID == requestID else { return }
+                        self.applyTitleFallbackIfNeeded(requestID)
+                        self.finishTitleRequest(requestID)
+                    }
+                },
                 onError: { [weak self] _ in
-                    Task { @MainActor in
+                    MainActor.assumeIsolated {
+                        guard let self, self.titleRequestID == requestID else { return }
                         // Fallback to simple title on error
-                        let fallback = String(firstMessage.prefix(30)) + (firstMessage.count > 30 ? "..." : "")
-                        self?.conversationStore.renameConversation(conversationId, newTitle: fallback)
+                        self.conversationStore.renameConversation(conversationId, newTitle: fallbackTitle)
+                        self.finishTitleRequest(requestID)
                     }
                 },
                 onReasoning: nil
             )
+            if titleRequestID == requestID {
+                titleRequest = request
+            } else {
+                request.cancel()
+            }
+        }
+
+        @discardableResult
+        private func cancelTitleRequest() -> Bool {
+            let request = titleRequest
+            let requestWasActive = request != nil || titleRequestID != nil
+            let fallback = titleRequestFallback
+            titleRequest = nil
+            titleRequestID = nil
+            titleRequestFallback = nil
+
+            if let fallback,
+               conversationStore.conversation(for: fallback.conversationID)?.title == "New Chat"
+            {
+                conversationStore.renameConversation(fallback.conversationID, newTitle: fallback.title)
+            }
+            request?.cancel()
+            return requestWasActive
+        }
+
+        private func applyTitleFallbackIfNeeded(_ requestID: UUID) {
+            guard titleRequestID == requestID,
+                  let fallback = titleRequestFallback,
+                  conversationStore.conversation(for: fallback.conversationID)?.title == "New Chat"
+            else {
+                return
+            }
+            conversationStore.renameConversation(fallback.conversationID, newTitle: fallback.title)
+        }
+
+        private func finishTitleRequest(_ requestID: UUID) {
+            guard titleRequestID == requestID else { return }
+            titleRequest = nil
+            titleRequestID = nil
+            titleRequestFallback = nil
         }
     }
+    // swiftlint:enable type_body_length
 
 #endif

--- a/Sources/Ayna/ViewModels/WatchChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/WatchChatViewModel.swift
@@ -32,6 +32,10 @@ final class WatchToolCallRoundRegistry {
         toolName: String,
         arguments: [String: AnyCodable]
     ) -> String? {
+        guard registeredIDs.count < ToolCallRequestRoundPolicy.maximumToolCallsPerRound else {
+            return nil
+        }
+
         if !providerID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             guard registeredIDs.insert(providerID).inserted else { return nil }
             return providerID
@@ -39,7 +43,7 @@ final class WatchToolCallRoundRegistry {
 
         let signature = IDLessCallSignature(
             toolName: toolName,
-            encodedArguments: Self.encode(arguments)
+            encodedArguments: ToolCallRequestRoundPolicy.canonicalArguments(arguments)
         )
         guard registeredIDLessCalls.insert(signature).inserted else { return nil }
         return makeSyntheticID()
@@ -55,11 +59,6 @@ final class WatchToolCallRoundRegistry {
         }
     }
 
-    private static func encode(_ arguments: [String: AnyCodable]) -> Data {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        return (try? encoder.encode(arguments)) ?? Data()
-    }
 }
 
 #if os(watchOS)
@@ -344,6 +343,7 @@ final class WatchToolCallRoundRegistry {
             }
             activeAssistantMessageId = assistantMessageId
             let registeredToolCalls = WatchToolCallRoundRegistry(roundID: assistantMessageId)
+            let toolCallAdmissionGate = ToolCallRequestAdmissionGate()
             requestObserver?(
                 RequestConfiguration(
                     messages: messages,
@@ -424,7 +424,7 @@ final class WatchToolCallRoundRegistry {
                     }
                 },
                 onToolCall: nil,
-                onToolCallRequested: { [weak self] toolCallID, toolName, arguments in
+                onToolCallRequested: toolCallAdmissionGate.admittedCallback { [weak self] toolCallID, toolName, arguments in
                     nonisolated(unsafe) let arguments = arguments
                     coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
                         guard let self,

--- a/Sources/Ayna/ViewModels/WatchConversationStore.swift
+++ b/Sources/Ayna/ViewModels/WatchConversationStore.swift
@@ -5,42 +5,214 @@
 //  Created on 11/29/25.
 //
 
-#if os(watchOS)
+#if os(watchOS) || WATCH_STORE_HOST_TESTING
 
     import Combine
     import Foundation
-    import os
-    import SwiftUI
 
-    /// Local store for conversations on Apple Watch
-    /// Receives updates from iPhone via WatchConnectivity
-    /// Persists conversations to UserDefaults for offline access
+    /// Durable local conversation state for Apple Watch.
+    ///
+    /// Committed conversations, Watch-originated mutations, and in-progress draft overlays
+    /// are persisted before any mutation is handed to WatchConnectivity. Draft overlays are
+    /// deliberately local until `finishDraft(conversationID:)` promotes them to a mutation.
     @MainActor
+    // swiftlint:disable:next type_body_length
     final class WatchConversationStore: ObservableObject {
+        enum DraftPromotionOutcome: Equatable {
+            case promoted(WatchConversation)
+            case noDraft
+            case discardedEmptyDraft
+            case persistenceFailed
+        }
+
         static let shared = WatchConversationStore()
 
-        @Published var conversations: [WatchConversation] = []
-        @Published var selectedConversationId: UUID?
-
-        private let persistenceKey = "com.sertacozercan.ayna.watch.conversations"
-        private let maxPersistedConversations = 20
-
-        private init() {
-            // Don't load from disk in init - wait for WCSession to activate first
-            // loadFromDisk() will be called by WatchConnectivityService after session activation
-            // This prevents accessing WCSession before it's ready
+        @Published private(set) var conversations: [WatchConversation] = []
+        @Published var selectedConversationId: UUID? {
+            didSet {
+                guard selectedConversationId != oldValue, let selectedConversationId else { return }
+                recordCurrentBodyAccess(for: selectedConversationId)
+            }
         }
 
-        /// Initialize store from persisted data. Called after WCSession is ready.
+        private struct PersistedState: Codable {
+            var sourceID: UUID?
+            var peerID: UUID?
+            var lastSnapshotRevision: WatchSyncRevision
+            var conversations: [WatchConversation]
+            var pendingMutations: [WatchConversationMutation]
+            var pendingDrafts: [WatchConversationDraft]
+            var legacyDeliveryCoverage: [UUID: WatchMutationDeliveryCoverage]?
+            var bodyRecency: [UUID: UInt64]?
+            var bodyRecencySequence: UInt64?
+            var lastAccessedConversationID: UUID?
+        }
+
+        private struct RuntimeState {
+            var sourceID: UUID?
+            var peerID: UUID
+            var lastSnapshotRevision: WatchSyncRevision
+            var committedConversations: [WatchConversation]
+            var pendingMutations: [WatchConversationMutation]
+            var pendingDrafts: [UUID: WatchConversationDraft]
+            var legacyDeliveryCoverage: [UUID: WatchMutationDeliveryCoverage]
+            var bodyRecency: [UUID: UInt64]
+            var bodyRecencySequence: UInt64
+            var lastAccessedConversationID: UUID?
+        }
+
+        private struct BodyCacheState: Equatable {
+            var conversations: [WatchConversation]
+            var recency: [UUID: UInt64]
+            var recencySequence: UInt64
+            var lastAccessedConversationID: UUID?
+        }
+
+        private struct PageCycleManifestAccumulator {
+            private var sourceID: UUID?
+            private var cycleID: UUID?
+            private var expectedCursor: WatchSyncPageCycleCursor?
+            private var conversationIDs: [UUID] = []
+            private var conversationIDSet: Set<UUID> = []
+
+            func snapshotForApplication(
+                _ snapshot: WatchSyncSnapshot,
+                metadata: WatchSyncPageCycleMetadata
+            ) -> WatchSyncSnapshot {
+                guard metadata.isValid(for: snapshot), accepts(metadata) else { return snapshot }
+
+                var accumulatedIDs = conversationIDs
+                var accumulatedIDSet = conversationIDSet
+                if startsNewCycle(metadata) {
+                    accumulatedIDs = []
+                    accumulatedIDSet = []
+                }
+                for conversationID in snapshot.authoritativeConversationIDs
+                    where accumulatedIDSet.insert(conversationID).inserted
+                {
+                    accumulatedIDs.append(conversationID)
+                }
+
+                guard metadata.nextCursor == nil,
+                      accumulatedIDs.count == metadata.manifest.totalCount
+                else {
+                    return snapshot
+                }
+
+                var authoritativeSnapshot = snapshot
+                authoritativeSnapshot.authoritativeConversationIDs = accumulatedIDs
+                authoritativeSnapshot.authoritativeConversationIDsAreComplete = true
+                return authoritativeSnapshot
+            }
+
+            mutating func recordDurablePage(
+                _ snapshot: WatchSyncSnapshot,
+                metadata: WatchSyncPageCycleMetadata,
+                outcome: WatchSyncSnapshotApplyOutcome
+            ) {
+                guard outcome.isDurable,
+                      metadata.isValid(for: snapshot),
+                      accepts(metadata)
+                else {
+                    return
+                }
+
+                if startsNewCycle(metadata) {
+                    sourceID = metadata.sourceID
+                    cycleID = metadata.cycleID
+                    conversationIDs = []
+                    conversationIDSet = []
+                }
+                for conversationID in snapshot.authoritativeConversationIDs
+                    where conversationIDSet.insert(conversationID).inserted
+                {
+                    conversationIDs.append(conversationID)
+                }
+                expectedCursor = metadata.nextCursor
+                if expectedCursor == nil {
+                    reset()
+                }
+            }
+
+            mutating func reset() {
+                sourceID = nil
+                cycleID = nil
+                expectedCursor = nil
+                conversationIDs = []
+                conversationIDSet = []
+            }
+
+            private func accepts(_ metadata: WatchSyncPageCycleMetadata) -> Bool {
+                if startsNewCycle(metadata) {
+                    return metadata.cursor == .initial
+                }
+                return metadata.cursor == expectedCursor
+            }
+
+            private func startsNewCycle(_ metadata: WatchSyncPageCycleMetadata) -> Bool {
+                sourceID != metadata.sourceID || cycleID != metadata.cycleID
+            }
+        }
+
+        private static let defaultPersistenceKey = "com.sertacozercan.ayna.watch.conversations"
+        private static let defaultMaximumCachedConversationBodies = 20
+
+        private let userDefaults: UserDefaults
+        private let persistenceKey: String
+        private let maximumCachedConversationBodies: Int
+        private let now: () -> Date
+        private let persistenceWriter: (Data) -> Bool
+        private let mutationEnqueuer: (WatchConversationMutation) -> Void
+
+        private(set) var peerID: UUID
+        private var sourceID: UUID?
+        private var lastSnapshotRevision: WatchSyncRevision = 0
+        private var committedConversations: [WatchConversation] = []
+        private var pendingMutations: [WatchConversationMutation] = []
+        private var pendingDrafts: [UUID: WatchConversationDraft] = [:]
+        private var legacyDeliveryCoverage: [UUID: WatchMutationDeliveryCoverage] = [:]
+        private var bodyRecency: [UUID: UInt64] = [:]
+        private var bodyRecencySequence: UInt64 = 0
+        private var lastAccessedConversationID: UUID?
+        private var pageCycleManifestAccumulator = PageCycleManifestAccumulator()
+
+        init(
+            userDefaults: UserDefaults = .standard,
+            persistenceKey: String = WatchConversationStore.defaultPersistenceKey,
+            maximumCachedConversationBodies: Int = WatchConversationStore.defaultMaximumCachedConversationBodies,
+            peerID: UUID? = nil,
+            now: @escaping () -> Date = Date.init,
+            persistenceWriter: ((Data) -> Bool)? = nil,
+            mutationEnqueuer: ((WatchConversationMutation) -> Void)? = nil
+        ) {
+            self.userDefaults = userDefaults
+            self.persistenceKey = persistenceKey
+            self.maximumCachedConversationBodies = max(0, maximumCachedConversationBodies)
+            self.peerID = peerID ?? UUID()
+            self.now = now
+            self.persistenceWriter = persistenceWriter ?? { data in
+                userDefaults.set(data, forKey: persistenceKey)
+                return true
+            }
+            self.mutationEnqueuer = mutationEnqueuer ?? { mutation in
+                #if os(watchOS)
+                    WatchConnectivityService.shared.enqueueMutation(mutation)
+                #else
+                    _ = mutation
+                #endif
+            }
+            initializeFromDisk()
+        }
+
+        /// Coalesced durable mutations ready for WatchConnectivity transport.
+        var pendingMutationsForSync: [WatchConversationMutation] {
+            WatchConversationMutation.coalesced(pendingMutations)
+        }
+
+        /// Loads all durable Watch sync state immediately, independent of WCSession state.
         func initializeFromDisk() {
-            loadFromDisk()
-        }
-
-        // MARK: - Persistence
-
-        /// Load conversations from UserDefaults
-        private func loadFromDisk() {
-            guard let data = UserDefaults.standard.data(forKey: persistenceKey) else {
+            guard let data = userDefaults.data(forKey: persistenceKey) else {
+                rebuildPublishedConversations()
                 DiagnosticsLogger.log(
                     .watchConnectivity,
                     level: .info,
@@ -49,13 +221,53 @@
                 return
             }
 
+            let decoder = JSONDecoder()
             do {
-                let decoded = try JSONDecoder().decode([WatchConversation].self, from: data)
-                conversations = decoded
+                if let persisted = try? decoder.decode(PersistedState.self, from: data) {
+                    sourceID = persisted.sourceID
+                    if let persistedPeerID = persisted.peerID {
+                        peerID = persistedPeerID
+                    }
+                    lastSnapshotRevision = persisted.lastSnapshotRevision
+                    committedConversations = deduplicated(persisted.conversations)
+                    pendingMutations = WatchConversationMutation.coalesced(persisted.pendingMutations)
+                    pendingDrafts = Dictionary(
+                        persisted.pendingDrafts.map { ($0.id, $0) },
+                        uniquingKeysWith: { _, new in new }
+                    )
+                    legacyDeliveryCoverage = persisted.legacyDeliveryCoverage ?? [:]
+                    bodyRecency = persisted.bodyRecency ?? [:]
+                    bodyRecencySequence = max(
+                        persisted.bodyRecencySequence ?? 0,
+                        bodyRecency.values.max() ?? 0
+                    )
+                    lastAccessedConversationID = persisted.lastAccessedConversationID
+                    recoverInterruptedDrafts()
+                } else {
+                    // Backward compatibility with the original conversations-only payload.
+                    committedConversations = try deduplicated(
+                        decoder.decode([WatchConversation].self, from: data)
+                    )
+                    lastSnapshotRevision = 0
+                    pendingMutations = []
+                    pendingDrafts = [:]
+                    legacyDeliveryCoverage = [:]
+                    bodyRecency = [:]
+                    bodyRecencySequence = 0
+                    lastAccessedConversationID = nil
+                }
+                compactLoadedBodyCache()
+                rebuildPublishedConversations()
                 DiagnosticsLogger.log(
                     .watchConnectivity,
                     level: .info,
-                    message: "⌚ Loaded \(decoded.count) conversations from disk"
+                    message: "⌚ Loaded durable Watch conversation state",
+                    metadata: [
+                        "conversations": "\(committedConversations.count)",
+                        "mutations": "\(pendingMutations.count)",
+                        "drafts": "\(pendingDrafts.count)",
+                        "snapshotRevision": "\(lastSnapshotRevision)"
+                    ]
                 )
             } catch {
                 DiagnosticsLogger.log(
@@ -67,201 +279,979 @@
             }
         }
 
-        /// Save conversations to UserDefaults
-        private func saveToDisk() {
-            // Only persist most recent conversations to save space
-            let toSave = Array(conversations.prefix(maxPersistedConversations))
-
-            do {
-                let data = try JSONEncoder().encode(toSave)
-                UserDefaults.standard.set(data, forKey: persistenceKey)
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .debug,
-                    message: "⌚ Saved \(toSave.count) conversations to disk"
-                )
-            } catch {
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .error,
-                    message: "⌚ Failed to save conversations to disk",
-                    metadata: ["error": error.localizedDescription]
-                )
-            }
-        }
-
-        /// Persist the current in-memory conversation state.
-        func persistCurrentState() {
-            saveToDisk()
-        }
-
-        /// Replace an existing conversation in-place.
+        /// Reconciles one explicit page-cycle snapshot and promotes the accumulated manifest
+        /// to authoritative only on the final durable page.
         @discardableResult
-        func replaceConversation(_ conversation: WatchConversation, persist: Bool = true) -> Bool {
-            guard let index = conversations.firstIndex(where: { $0.id == conversation.id }) else {
-                return false
-            }
-
-            conversations[index] = conversation
-            if persist {
-                saveToDisk()
-            }
-            return true
+        func applySyncSnapshot(
+            _ snapshot: WatchSyncSnapshot,
+            pageCycleMetadata: WatchSyncPageCycleMetadata
+        ) -> WatchSyncSnapshotApplyOutcome {
+            let snapshotForApplication = pageCycleManifestAccumulator.snapshotForApplication(
+                snapshot,
+                metadata: pageCycleMetadata
+            )
+            let outcome = applySyncSnapshot(snapshotForApplication)
+            pageCycleManifestAccumulator.recordDurablePage(
+                snapshot,
+                metadata: pageCycleMetadata,
+                outcome: outcome
+            )
+            return outcome
         }
 
-        /// Update conversations from WatchConnectivity sync
-        func updateConversations(_ newConversations: [WatchConversation]) {
-            // Merge with existing, preserving local state that may be ahead of iPhone
-            var updatedConversations: [WatchConversation] = []
+        func resetPageCycleManifest() {
+            pageCycleManifestAccumulator.reset()
+        }
 
-            for newConv in newConversations {
-                if let existingConv = conversations.first(where: { $0.id == newConv.id }) {
-                    var mergedConv = newConv
+        /// Reconciles a phone-authoritative snapshot under durable local mutations and drafts.
+        @discardableResult
+        func applySyncSnapshot(_ snapshot: WatchSyncSnapshot) -> WatchSyncSnapshotApplyOutcome {
+            let previousState = captureRuntimeState()
+            let baseState = WatchSyncLocalState(
+                sourceID: sourceID,
+                peerID: peerID,
+                lastSnapshotRevision: lastSnapshotRevision,
+                conversations: committedConversations,
+                pendingMutations: pendingMutations,
+                pendingDrafts: [:],
+                localDeliveryCoverage: legacyDeliveryCoverage
+            )
+            let visibleState = WatchSyncLocalState(
+                sourceID: sourceID,
+                peerID: peerID,
+                lastSnapshotRevision: lastSnapshotRevision,
+                conversations: committedConversations,
+                pendingMutations: pendingMutations,
+                pendingDrafts: pendingDrafts,
+                localDeliveryCoverage: legacyDeliveryCoverage
+            )
+            let baseReconciliation = WatchSnapshotReconciler.reconcile(snapshot, with: baseState)
+            let visibleReconciliation = WatchSnapshotReconciler.reconcile(snapshot, with: visibleState)
 
-                    // Preserve local title if iPhone still has "New Chat" but we generated one
-                    if newConv.title == "New Chat", existingConv.title != "New Chat" {
-                        mergedConv.title = existingConv.title
-                    }
-
-                    // Keep messages from the newer conversation state
-                    if existingConv.updatedAt > newConv.updatedAt {
-                        mergedConv.messages = existingConv.messages
-                        mergedConv.updatedAt = existingConv.updatedAt
-                        DiagnosticsLogger.log(
-                            .watchConnectivity,
-                            level: .debug,
-                            message: "⌚ Preserved local messages during sync (local is newer)",
-                            metadata: [
-                                "localUpdatedAt": "\(existingConv.updatedAt.timeIntervalSince1970)",
-                                "remoteUpdatedAt": "\(newConv.updatedAt.timeIntervalSince1970)"
-                            ]
-                        )
-                    }
-
-                    updatedConversations.append(mergedConv)
-                } else {
-                    updatedConversations.append(newConv)
+            switch visibleReconciliation.disposition {
+            case .applied:
+                break
+            case .ignoredStale:
+                if sourceID == snapshot.sourceID, lastSnapshotRevision == snapshot.revision {
+                    return .alreadyDurable
                 }
+                return .ignoredStale
+            case .ignoredUnsupportedSchema:
+                return .ignoredUnsupportedSchema
             }
 
-            // Add any local-only conversations (not yet synced to iPhone)
-            for localConv in conversations where !updatedConversations.contains(where: { $0.id == localConv.id }) {
-                updatedConversations.append(localConv)
+            sourceID = visibleReconciliation.state.sourceID
+            lastSnapshotRevision = visibleReconciliation.state.lastSnapshotRevision
+            committedConversations = deduplicated(baseReconciliation.state.conversations)
+            pendingMutations = visibleReconciliation.state.pendingMutations
+            recordSnapshotBodyRecency(snapshot)
+
+            pendingDrafts = visibleReconciliation.state.pendingDrafts.mapValues { draft in
+                WatchConversationDraft(
+                    conversation: canonicalized(draft.conversation),
+                    ownedMessageIDs: draft.ownedMessageIDs,
+                    deferredMutationFields: draft.deferredMutationFields
+                )
             }
-
-            // Sort by most recent
-            updatedConversations.sort { $0.updatedAt > $1.updatedAt }
-            conversations = updatedConversations
-
-            // Persist to disk
-            saveToDisk()
+            guard persistOrRestore(previousState) else { return .persistenceFailed }
+            rebuildPublishedConversations()
 
             DiagnosticsLogger.log(
                 .watchConnectivity,
                 level: .info,
-                message: "⌚ Updated local store with \(conversations.count) conversations"
+                message: "⌚ Applied Watch sync snapshot",
+                metadata: [
+                    "conversations": "\(conversations.count)",
+                    "mutations": "\(pendingMutations.count)",
+                    "drafts": "\(pendingDrafts.count)",
+                    "snapshotRevision": "\(lastSnapshotRevision)"
+                ]
             )
+            return .applied
         }
 
-        /// Get a conversation by ID
+        /// Removes all queued mutations at or below the phone-acknowledged revision.
+        @discardableResult
+        func acknowledgeWatchRevision(
+            conversationID: UUID,
+            revision: WatchSyncRevision
+        ) -> Bool {
+            let previousState = captureRuntimeState()
+            pendingMutations.removeAll {
+                $0.conversationID == conversationID && $0.revision <= revision
+            }
+            if let coverage = legacyDeliveryCoverage[conversationID] {
+                let maximumCoveredRevision = [
+                    coverage.createRevision,
+                    coverage.titleRevision,
+                    coverage.configurationRevision,
+                    coverage.messageRevisions.values.max()
+                ].compactMap(\.self).max() ?? 0
+                if revision >= maximumCoveredRevision {
+                    legacyDeliveryCoverage.removeValue(forKey: conversationID)
+                }
+            }
+            if let index = committedConversations.firstIndex(where: { $0.id == conversationID }) {
+                committedConversations[index].watchRevision = max(
+                    committedConversations[index].watchRevision,
+                    revision
+                )
+            }
+            if var draft = pendingDrafts[conversationID] {
+                draft.conversation.watchRevision = max(draft.conversation.watchRevision, revision)
+                pendingDrafts[conversationID] = draft
+            }
+            guard persistOrRestore(previousState) else { return false }
+            rebuildPublishedConversations()
+            return true
+        }
+
+        // MARK: - Conversation operations
+
         func conversation(for id: UUID) -> WatchConversation? {
-            conversations.first { $0.id == id }
-        }
-
-        /// Create a new conversation locally and sync to iPhone
-        func createConversation(title: String = "New Chat", model: String) -> WatchConversation {
-            let conversation = WatchConversation(
-                from: Conversation(title: title, model: model)
-            )
-            conversations.insert(conversation, at: 0)
-
-            // Persist to disk
-            saveToDisk()
-
-            // Sync new conversation to iPhone
-            WatchConnectivityService.shared.sendConversation(conversation)
-
+            guard let conversation = conversations.first(where: { $0.id == id }) else { return nil }
+            recordCurrentBodyAccess(for: id)
             return conversation
         }
 
-        /// Add a message to a conversation
-        func addMessage(_ message: WatchMessage, to conversationId: UUID) {
-            if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .debug,
-                    message: "⌚ addMessage: role='\(message.role)' content='\(message.content.prefix(20))...'"
+        @discardableResult
+        func createConversation(
+            title: String = "New Chat",
+            model: String,
+            resolvedSystemPrompt: String? = nil
+        ) -> WatchConversation? {
+            let previousState = captureRuntimeState()
+            let timestamp = now()
+            let conversation = WatchConversation(
+                id: UUID(),
+                title: title,
+                model: model,
+                updatedAt: timestamp,
+                createdAt: timestamp,
+                resolvedSystemPrompt: resolvedSystemPrompt,
+                watchRevision: 1
+            )
+            upsertCommitted(conversation)
+            guard queueMutation(for: conversation, fields: [.create], restoring: previousState) else {
+                return nil
+            }
+            return conversation
+        }
+
+        @discardableResult
+        func addMessage(_ message: WatchMessage, to conversationID: UUID) -> Bool {
+            guard var committed = committedConversation(for: conversationID) else { return false }
+            let previousState = captureRuntimeState()
+
+            let timestamp = now()
+            guard let revision = nextRevision(after: committed.watchRevision) else {
+                var deferred = pendingDrafts[conversationID]?.conversation ?? committed
+                deferred.messages.append(message)
+                deferred.updatedAt = timestamp
+                deferred.watchRevision = .max
+                let ownedMessageIDs = pendingDrafts[conversationID]?.ownedMessageIDs
+                    .union([message.id]) ?? [message.id]
+                return refuseMutationPreservingDraft(
+                    deferred,
+                    fields: [.messages],
+                    ownedMessageIDs: ownedMessageIDs,
+                    restoring: previousState
                 )
-                conversations[index].messages.append(message)
-                conversations[index].updatedAt = Date()
-
-                if index > 0 {
-                    conversations.move(fromOffsets: IndexSet(integer: index), toOffset: 0)
-                }
-
-                // Persist to disk
-                saveToDisk()
             }
+            committed.messages.append(message)
+            committed.updatedAt = timestamp
+            committed.watchRevision = revision
+            upsertCommitted(committed)
+
+            var mutationConversation = committed
+            if var draft = pendingDrafts[conversationID] {
+                draft.conversation.messages.append(message)
+                draft.conversation.updatedAt = timestamp
+                draft.conversation.watchRevision = committed.watchRevision
+                draft.conversation = canonicalized(draft.conversation)
+                draft.ownedMessageIDs.remove(message.id)
+                pendingDrafts[conversationID] = draft
+                mutationConversation = draft.conversation
+            }
+            return queueMutation(
+                for: mutationConversation,
+                fields: [.messages],
+                messageChanges: [message],
+                restoring: previousState
+            )
         }
 
-        /// Update the last message content (for streaming)
-        func updateLastMessage(in conversationId: UUID, content: String) {
-            if let convIndex = conversations.firstIndex(where: { $0.id == conversationId }),
-               !conversations[convIndex].messages.isEmpty
-            {
-                let lastIndex = conversations[convIndex].messages.count - 1
-                guard conversations[convIndex].messages[lastIndex].content != content else {
-                    return
-                }
-                let role = conversations[convIndex].messages[lastIndex].role
-                DiagnosticsLogger.log(
-                    .watchConnectivity,
-                    level: .debug,
-                    message: "⌚ updateLastMessage: index=\(lastIndex) role='\(role)' content='\(content.prefix(20))...'"
+        @discardableResult
+        func renameConversation(_ conversationID: UUID, newTitle: String) -> Bool {
+            guard var committed = committedConversation(for: conversationID), committed.title != newTitle else {
+                return false
+            }
+            let previousState = captureRuntimeState()
+
+            let timestamp = now()
+            guard let revision = nextRevision(after: committed.watchRevision) else {
+                var deferred = pendingDrafts[conversationID]?.conversation ?? committed
+                deferred.title = newTitle
+                deferred.updatedAt = timestamp
+                deferred.watchRevision = .max
+                return refuseMutationPreservingDraft(
+                    deferred,
+                    fields: [.title],
+                    restoring: previousState
                 )
-                conversations[convIndex].messages[lastIndex].content = content
-                saveToDisk()
             }
+            committed.title = newTitle
+            committed.updatedAt = timestamp
+            committed.watchRevision = revision
+            upsertCommitted(committed)
+
+            var mutationConversation = committed
+            if var draft = pendingDrafts[conversationID] {
+                draft.conversation.title = newTitle
+                draft.conversation.updatedAt = committed.updatedAt
+                draft.conversation.watchRevision = committed.watchRevision
+                pendingDrafts[conversationID] = draft
+                mutationConversation = draft.conversation
+            }
+            return queueMutation(
+                for: mutationConversation,
+                fields: [.title],
+                restoring: previousState
+            )
         }
 
-        /// Get the preview text for a conversation
-        func previewText(for conversation: WatchConversation) -> String {
-            if let lastMessage = conversation.messages.last {
-                let preview = lastMessage.content.prefix(50)
-                return preview.count < lastMessage.content.count ? "\(preview)..." : String(preview)
+        @discardableResult
+        func updateModel(_ model: String, for conversationID: UUID) -> Bool {
+            guard var committed = committedConversation(for: conversationID), committed.model != model else {
+                return false
             }
-            return "No messages"
+            let previousState = captureRuntimeState()
+
+            let timestamp = now()
+            guard let revision = nextRevision(after: committed.watchRevision) else {
+                var deferred = pendingDrafts[conversationID]?.conversation ?? committed
+                deferred.model = model
+                deferred.updatedAt = timestamp
+                deferred.watchRevision = .max
+                return refuseMutationPreservingDraft(
+                    deferred,
+                    fields: [.configuration],
+                    restoring: previousState
+                )
+            }
+            committed.model = model
+            committed.updatedAt = timestamp
+            committed.watchRevision = revision
+            upsertCommitted(committed)
+
+            var mutationConversation = committed
+            if var draft = pendingDrafts[conversationID] {
+                draft.conversation.model = model
+                draft.conversation.updatedAt = committed.updatedAt
+                draft.conversation.watchRevision = committed.watchRevision
+                pendingDrafts[conversationID] = draft
+                mutationConversation = draft.conversation
+            }
+            return queueMutation(
+                for: mutationConversation,
+                fields: [.configuration],
+                restoring: previousState
+            )
         }
 
-        /// Delete a conversation
-        func deleteConversation(_ conversationId: UUID) {
-            conversations.removeAll { $0.id == conversationId }
-            if selectedConversationId == conversationId {
-                selectedConversationId = nil
-            }
+        @discardableResult
+        func deleteConversation(_ conversationID: UUID) -> Bool {
+            guard var deleted = conversation(for: conversationID) else { return false }
+            let previousState = captureRuntimeState()
 
-            // Persist to disk
-            saveToDisk()
+            let committedRevision = committedConversation(for: conversationID)?.watchRevision ?? 0
+            let currentRevision = max(deleted.watchRevision, committedRevision)
+            let timestamp = now()
+            guard let revision = nextRevision(after: currentRevision) else {
+                deleted.watchRevision = .max
+                deleted.updatedAt = timestamp
+                return refuseMutationPreservingDraft(
+                    deleted,
+                    fields: [.delete],
+                    restoring: previousState
+                )
+            }
+            deleted.watchRevision = revision
+            deleted.updatedAt = timestamp
+            committedConversations.removeAll { $0.id == conversationID }
+            pendingDrafts.removeValue(forKey: conversationID)
+            guard queueMutation(for: deleted, fields: [.delete], restoring: previousState) else {
+                return false
+            }
 
             DiagnosticsLogger.log(
                 .watchConnectivity,
                 level: .info,
                 message: "⌚ Deleted conversation locally",
-                metadata: ["conversationId": conversationId.uuidString]
+                metadata: ["conversationId": conversationID.uuidString]
+            )
+            return true
+        }
+
+        // MARK: - Draft overlays
+
+        /// Persists a full local draft overlay without creating a transport mutation.
+        @discardableResult
+        func syncDraft(_ conversation: WatchConversation) -> Bool {
+            guard let committed = committedConversation(for: conversation.id),
+                  !hasPendingDelete(for: conversation.id)
+            else {
+                return false
+            }
+            let previousState = captureRuntimeState()
+
+            var draft = canonicalized(conversation)
+            draft.watchRevision = max(draft.watchRevision, committed.watchRevision)
+            draft.updatedAt = max(draft.updatedAt, now())
+            let committedMessagesByID = committed.messages.reduce(into: [UUID: WatchMessage]()) {
+                $0[$1.id] = $1
+            }
+            let newOwnedMessageIDs = Set(
+                draft.messages.lazy
+                    .filter { committedMessagesByID[$0.id] != $0 }
+                    .map(\.id)
+            )
+            let existingDraft = pendingDrafts[draft.id]
+            let ownedMessageIDs = existingDraft?.ownedMessageIDs
+                .union(newOwnedMessageIDs) ?? newOwnedMessageIDs
+            pendingDrafts[draft.id] = WatchConversationDraft(
+                conversation: draft,
+                ownedMessageIDs: ownedMessageIDs,
+                deferredMutationFields: existingDraft?.deferredMutationFields
+            )
+            guard persistOrRestore(previousState) else { return false }
+            rebuildPublishedConversations()
+            return true
+        }
+
+        /// Promotes a persisted draft to one coalesced message mutation.
+        @discardableResult
+        func finishDraft(conversationID: UUID) -> DraftPromotionOutcome {
+            guard let draft = pendingDrafts[conversationID],
+                  let committed = committedConversation(for: conversationID)
+            else {
+                return .noDraft
+            }
+            let previousState = captureRuntimeState()
+            let currentRevision = max(draft.conversation.watchRevision, committed.watchRevision)
+            guard let revision = nextRevision(after: currentRevision) else {
+                logRevisionExhaustion(conversationID: conversationID, fields: draft.deferredFields.union(.messages))
+                return .persistenceFailed
+            }
+            pendingDrafts.removeValue(forKey: conversationID)
+
+            let messageChanges = draft.conversation.messages.filter {
+                draft.ownedMessageIDs.contains($0.id)
+            }
+            guard !messageChanges.isEmpty else {
+                guard persistOrRestore(previousState) else {
+                    return .persistenceFailed
+                }
+                rebuildPublishedConversations()
+                return .discardedEmptyDraft
+            }
+
+            var finished = committed
+            finished.messages = mergeOwnedMessages(
+                remote: committed.messages,
+                ownedChanges: messageChanges
+            )
+            finished.watchRevision = revision
+            finished.updatedAt = max(draft.conversation.updatedAt, now())
+            upsertCommitted(finished)
+            guard queueMutation(
+                for: finished,
+                fields: [.messages],
+                messageChanges: messageChanges,
+                restoring: previousState
+            ) else {
+                return .persistenceFailed
+            }
+            return .promoted(finished)
+        }
+
+        /// Removes a persisted draft and restores the committed conversation.
+        @discardableResult
+        func discardDraft(conversationID: UUID) -> Bool {
+            guard pendingDrafts[conversationID] != nil else { return false }
+            let previousState = captureRuntimeState()
+            pendingDrafts.removeValue(forKey: conversationID)
+            guard persistOrRestore(previousState) else { return false }
+            rebuildPublishedConversations()
+            return true
+        }
+
+        // MARK: - Compatibility helpers
+
+        /// Compatibility path for legacy application-context payloads.
+        func updateConversations(_ newConversations: [WatchConversation]) {
+            let sourceID = lastSnapshotRevision == .max
+                ? UUID()
+                : (self.sourceID ?? WatchSyncIdentity.legacySourceID)
+            let revision = lastSnapshotRevision == .max ? 1 : lastSnapshotRevision + 1
+            applySyncSnapshot(
+                WatchSyncSnapshot(
+                    sourceID: sourceID,
+                    revision: revision,
+                    conversations: newConversations,
+                    authoritativeConversationIDs: newConversations.map(\.id),
+                    authoritativeConversationIDsAreComplete: false
+                )
             )
         }
 
-        /// Rename a conversation
-        func renameConversation(_ conversationId: UUID, newTitle: String) {
-            if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
-                conversations[index].title = newTitle
+        /// Treats direct replacement as an in-progress local draft.
+        @discardableResult
+        func replaceConversation(_ conversation: WatchConversation, persist _: Bool = true) -> Bool {
+            guard committedConversation(for: conversation.id) != nil else { return false }
+            return syncDraft(conversation)
+        }
 
-                // Persist to disk
-                saveToDisk()
-
-                // Sync title update to iPhone
-                WatchConnectivityService.shared.sendTitleUpdate(conversationId: conversationId, newTitle: newTitle)
+        /// Treats streaming content changes as draft-only state.
+        @discardableResult
+        func updateLastMessage(in conversationID: UUID, content: String) -> Bool {
+            guard var conversation = conversation(for: conversationID),
+                  let lastIndex = conversation.messages.indices.last,
+                  conversation.messages[lastIndex].content != content
+            else {
+                return false
             }
+            conversation.messages[lastIndex].content = content
+            return syncDraft(conversation)
+        }
+
+        @discardableResult
+        func persistCurrentState() -> Bool {
+            let persisted = persistState()
+            if persisted {
+                rebuildPublishedConversations()
+            }
+            return persisted
+        }
+
+        @discardableResult
+        func markLegacyComponentsDelivered(
+            _ components: [WatchLegacyEchoComponent],
+            for mutation: WatchConversationMutation
+        ) -> Bool {
+            let recordableComponents = components.filter(\.shouldRecordInStoreCoverage)
+            guard !recordableComponents.isEmpty else { return true }
+            let previousState = captureRuntimeState()
+
+            var coverage = legacyDeliveryCoverage[mutation.conversationID]
+                ?? WatchMutationDeliveryCoverage()
+            for component in recordableComponents {
+                switch component {
+                case .create:
+                    break
+                case let .title(revision):
+                    coverage.titleRevision = max(coverage.titleRevision ?? 0, revision)
+                case let .configuration(revision):
+                    coverage.configurationRevision = max(
+                        coverage.configurationRevision ?? 0,
+                        revision
+                    )
+                case let .message(messageID, revision):
+                    coverage.messageRevisions[messageID] = max(
+                        coverage.messageRevisions[messageID, default: 0],
+                        revision
+                    )
+                }
+            }
+            legacyDeliveryCoverage[mutation.conversationID] = coverage
+            guard persistOrRestore(previousState) else { return false }
+            rebuildPublishedConversations()
+            return true
+        }
+
+        func durableLegacyDeliveryCoverage(
+            for conversationID: UUID
+        ) -> WatchMutationDeliveryCoverage? {
+            legacyDeliveryCoverage[conversationID]
+        }
+
+        @discardableResult
+        func clearLegacyDeliveryCoverage() -> Bool {
+            guard !legacyDeliveryCoverage.isEmpty else { return true }
+            legacyDeliveryCoverage.removeAll()
+            let persisted = persistState()
+            rebuildPublishedConversations()
+            return persisted
+        }
+
+        func previewText(for conversation: WatchConversation) -> String {
+            guard let lastMessage = conversation.messages.last else { return "No messages" }
+            let preview = lastMessage.content.prefix(50)
+            return preview.count < lastMessage.content.count ? "\(preview)..." : String(preview)
+        }
+
+        // MARK: - Private state management
+
+        private func queueMutation(
+            for conversation: WatchConversation,
+            fields: WatchConversationMutationFields,
+            messageChanges: [WatchMessage] = [],
+            restoring previousState: RuntimeState
+        ) -> Bool {
+            let mutation = WatchConversationMutation(
+                peerID: peerID,
+                revision: conversation.watchRevision,
+                conversation: conversation,
+                fields: fields,
+                messageChanges: messageChanges
+            )
+            pendingMutations = WatchConversationMutation.coalesced(pendingMutations + [mutation])
+            guard let queued = pendingMutations.first(where: { $0.conversationID == conversation.id }) else {
+                restoreRuntimeState(previousState)
+                return false
+            }
+            guard persistOrRestore(previousState) else { return false }
+
+            rebuildPublishedConversations()
+            mutationEnqueuer(queued)
+            return true
+        }
+
+        private func captureRuntimeState() -> RuntimeState {
+            RuntimeState(
+                sourceID: sourceID,
+                peerID: peerID,
+                lastSnapshotRevision: lastSnapshotRevision,
+                committedConversations: committedConversations,
+                pendingMutations: pendingMutations,
+                pendingDrafts: pendingDrafts,
+                legacyDeliveryCoverage: legacyDeliveryCoverage,
+                bodyRecency: bodyRecency,
+                bodyRecencySequence: bodyRecencySequence,
+                lastAccessedConversationID: lastAccessedConversationID
+            )
+        }
+
+        private func restoreRuntimeState(_ state: RuntimeState) {
+            sourceID = state.sourceID
+            peerID = state.peerID
+            lastSnapshotRevision = state.lastSnapshotRevision
+            committedConversations = state.committedConversations
+            pendingMutations = state.pendingMutations
+            pendingDrafts = state.pendingDrafts
+            legacyDeliveryCoverage = state.legacyDeliveryCoverage
+            bodyRecency = state.bodyRecency
+            bodyRecencySequence = state.bodyRecencySequence
+            lastAccessedConversationID = state.lastAccessedConversationID
+        }
+
+        @discardableResult
+        private func persistOrRestore(_ previousState: RuntimeState) -> Bool {
+            guard persistState() else {
+                restoreRuntimeState(previousState)
+                return false
+            }
+            return true
+        }
+
+        @discardableResult
+        private func persistState() -> Bool {
+            let bodyCacheState = boundedBodyCacheState()
+            let state = PersistedState(
+                sourceID: sourceID,
+                peerID: peerID,
+                lastSnapshotRevision: lastSnapshotRevision,
+                conversations: bodyCacheState.conversations,
+                pendingMutations: WatchConversationMutation.coalesced(pendingMutations),
+                pendingDrafts: pendingDrafts.values.sorted {
+                    conversationSort($0.conversation, $1.conversation)
+                },
+                legacyDeliveryCoverage: legacyDeliveryCoverage,
+                bodyRecency: bodyCacheState.recency,
+                bodyRecencySequence: bodyCacheState.recencySequence,
+                lastAccessedConversationID: bodyCacheState.lastAccessedConversationID
+            )
+
+            do {
+                let data = try JSONEncoder().encode(state)
+                guard persistenceWriter(data) else {
+                    DiagnosticsLogger.log(
+                        .watchConnectivity,
+                        level: .error,
+                        message: "⌚ Watch conversation state writer rejected persistence"
+                    )
+                    return false
+                }
+                applyBodyCacheState(bodyCacheState)
+                return true
+            } catch {
+                DiagnosticsLogger.log(
+                    .watchConnectivity,
+                    level: .error,
+                    message: "⌚ Failed to persist Watch conversation state",
+                    metadata: ["error": error.localizedDescription]
+                )
+                return false
+            }
+        }
+
+        private func compactLoadedBodyCache() {
+            let bounded = boundedBodyCacheState()
+            let current = BodyCacheState(
+                conversations: committedConversations.sorted(by: conversationSort),
+                recency: bodyRecency,
+                recencySequence: bodyRecencySequence,
+                lastAccessedConversationID: lastAccessedConversationID
+            )
+            guard bounded != current else { return }
+            _ = persistState()
+        }
+
+        private func boundedBodyCacheState() -> BodyCacheState {
+            let canonicalConversations = deduplicated(committedConversations)
+            let cachedIDs = Set(canonicalConversations.map(\.id))
+            var recency = bodyRecency.filter { cachedIDs.contains($0.key) }
+            var recencySequence = max(bodyRecencySequence, recency.values.max() ?? 0)
+
+            for conversation in canonicalConversations.sorted(by: conversationSort).reversed()
+                where recency[conversation.id] == nil
+            {
+                Self.appendBodyRecency(
+                    for: conversation.id,
+                    to: &recency,
+                    sequence: &recencySequence
+                )
+            }
+
+            var protectedIDs = Set(pendingMutations.map(\.conversationID))
+            protectedIDs.formUnion(pendingDrafts.keys)
+            protectedIDs.formUnion(legacyDeliveryCoverage.keys)
+            if let selectedConversationId {
+                protectedIDs.insert(selectedConversationId)
+            }
+            if let lastAccessedConversationID {
+                protectedIDs.insert(lastAccessedConversationID)
+            }
+            protectedIDs.formIntersection(cachedIDs)
+
+            let ordinaryCapacity = max(0, maximumCachedConversationBodies - protectedIDs.count)
+            let ordinaryCandidates = canonicalConversations
+                .filter { !protectedIDs.contains($0.id) }
+                .sorted { lhs, rhs in
+                    let lhsRecency = recency[lhs.id] ?? 0
+                    let rhsRecency = recency[rhs.id] ?? 0
+                    if lhsRecency != rhsRecency {
+                        return lhsRecency > rhsRecency
+                    }
+                    return conversationSort(lhs, rhs)
+                }
+            var retainedIDs = protectedIDs
+            retainedIDs.formUnion(ordinaryCandidates.prefix(ordinaryCapacity).map(\.id))
+
+            let retainedConversations = canonicalConversations.filter { retainedIDs.contains($0.id) }
+            recency = recency.filter { retainedIDs.contains($0.key) }
+            let retainedLastAccessedID = lastAccessedConversationID.flatMap {
+                retainedIDs.contains($0) ? $0 : nil
+            }
+            return BodyCacheState(
+                conversations: retainedConversations,
+                recency: recency,
+                recencySequence: recencySequence,
+                lastAccessedConversationID: retainedLastAccessedID
+            )
+        }
+
+        private func applyBodyCacheState(_ state: BodyCacheState) {
+            committedConversations = state.conversations
+            bodyRecency = state.recency
+            bodyRecencySequence = state.recencySequence
+            lastAccessedConversationID = state.lastAccessedConversationID
+        }
+
+        private func recordSnapshotBodyRecency(_ snapshot: WatchSyncSnapshot) {
+            let cachedIDs = Set(committedConversations.map(\.id))
+            for conversation in snapshot.conversations.sorted(by: conversationSort).reversed()
+                where cachedIDs.contains(conversation.id)
+            {
+                recordBodyAccess(for: conversation.id)
+            }
+        }
+
+        private func recordBodyAccess(for conversationID: UUID, asCurrent: Bool = false) {
+            Self.appendBodyRecency(
+                for: conversationID,
+                to: &bodyRecency,
+                sequence: &bodyRecencySequence
+            )
+            if asCurrent {
+                lastAccessedConversationID = conversationID
+            }
+        }
+
+        private func recordCurrentBodyAccess(for conversationID: UUID) {
+            guard lastAccessedConversationID != conversationID else { return }
+            let previousConversationIDs = committedConversations.map(\.id)
+            recordBodyAccess(for: conversationID, asCurrent: true)
+            guard persistState(), committedConversations.map(\.id) != previousConversationIDs else { return }
+            rebuildPublishedConversations()
+        }
+
+        private static func appendBodyRecency(
+            for conversationID: UUID,
+            to recency: inout [UUID: UInt64],
+            sequence: inout UInt64
+        ) {
+            if sequence == .max {
+                normalizeBodyRecency(&recency, sequence: &sequence)
+            }
+            sequence += 1
+            recency[conversationID] = sequence
+        }
+
+        private static func normalizeBodyRecency(
+            _ recency: inout [UUID: UInt64],
+            sequence: inout UInt64
+        ) {
+            let orderedIDs = recency.keys.sorted { lhs, rhs in
+                let lhsRecency = recency[lhs] ?? 0
+                let rhsRecency = recency[rhs] ?? 0
+                if lhsRecency != rhsRecency {
+                    return lhsRecency < rhsRecency
+                }
+                return lhs.uuidString < rhs.uuidString
+            }
+            recency.removeAll(keepingCapacity: true)
+            for (offset, conversationID) in orderedIDs.enumerated() {
+                recency[conversationID] = UInt64(offset + 1)
+            }
+            sequence = UInt64(orderedIDs.count)
+        }
+
+        private func rebuildPublishedConversations() {
+            var visible = dictionaryByID(committedConversations)
+
+            for mutation in pendingMutations where mutation.fields.contains(.delete) {
+                visible.removeValue(forKey: mutation.conversationID)
+            }
+            for (id, draft) in pendingDrafts {
+                if draft.deferredFields.contains(.delete) {
+                    visible.removeValue(forKey: id)
+                } else if !hasPendingTransportDelete(for: id) {
+                    visible[id] = draft.conversation
+                }
+            }
+
+            publishConversations(visible.values.sorted(by: conversationSort))
+        }
+
+        private func publishConversations(_ conversations: [WatchConversation]) {
+            self.conversations = conversations
+            clearInvalidSelection()
+        }
+
+        private func committedConversation(for id: UUID) -> WatchConversation? {
+            committedConversations.first { $0.id == id }
+        }
+
+        private func upsertCommitted(_ conversation: WatchConversation) {
+            let canonical = canonicalized(conversation)
+            if let index = committedConversations.firstIndex(where: { $0.id == canonical.id }) {
+                committedConversations[index] = canonical
+            } else {
+                committedConversations.append(canonical)
+            }
+            committedConversations.sort(by: conversationSort)
+            recordBodyAccess(for: canonical.id)
+        }
+
+        private func hasPendingDelete(for conversationID: UUID) -> Bool {
+            hasPendingTransportDelete(for: conversationID)
+                || pendingDrafts[conversationID]?.deferredFields.contains(.delete) == true
+        }
+
+        private func hasPendingTransportDelete(for conversationID: UUID) -> Bool {
+            pendingMutations.contains {
+                $0.conversationID == conversationID && $0.fields.contains(.delete)
+            }
+        }
+
+        private func recoverInterruptedDrafts() {
+            guard !pendingDrafts.isEmpty else { return }
+            let previousState = captureRuntimeState()
+
+            for draft in Array(pendingDrafts.values) {
+                guard let committed = committedConversation(for: draft.id),
+                      !hasPendingTransportDelete(for: draft.id)
+                else {
+                    pendingDrafts.removeValue(forKey: draft.id)
+                    continue
+                }
+
+                let recoveredMessages = draft.conversation.messages.filter {
+                    draft.ownedMessageIDs.contains($0.id) && isMeaningfulDraftMessage($0)
+                }
+                let currentRevision = max(
+                    draft.conversation.watchRevision,
+                    committed.watchRevision
+                )
+                guard let revision = nextRevision(after: currentRevision) else {
+                    if recoveredMessages.isEmpty, draft.deferredFields.isEmpty {
+                        pendingDrafts.removeValue(forKey: draft.id)
+                    } else {
+                        logRevisionExhaustion(
+                            conversationID: draft.id,
+                            fields: draft.deferredFields.union(
+                                recoveredMessages.isEmpty ? [] : .messages
+                            )
+                        )
+                    }
+                    continue
+                }
+
+                pendingDrafts.removeValue(forKey: draft.id)
+                guard !recoveredMessages.isEmpty else { continue }
+
+                var recovered = committed
+                recovered.messages = mergeOwnedMessages(
+                    remote: committed.messages,
+                    ownedChanges: recoveredMessages
+                )
+                recovered.watchRevision = revision
+                recovered.updatedAt = max(draft.conversation.updatedAt, now())
+                upsertCommitted(recovered)
+                let mutation = WatchConversationMutation(
+                    peerID: peerID,
+                    revision: recovered.watchRevision,
+                    conversation: recovered,
+                    fields: [.messages],
+                    messageChanges: recoveredMessages
+                )
+                pendingMutations = WatchConversationMutation.coalesced(pendingMutations + [mutation])
+            }
+
+            _ = persistOrRestore(previousState)
+        }
+
+        private func isMeaningfulDraftMessage(_ message: WatchMessage) -> Bool {
+            !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                !(message.citations?.isEmpty ?? true) ||
+                !(message.toolCalls?.isEmpty ?? true) ||
+                message.role == Message.Role.tool.rawValue
+        }
+
+        private func mergeOwnedMessages(
+            remote: [WatchMessage],
+            ownedChanges: [WatchMessage]
+        ) -> [WatchMessage] {
+            var result: [WatchMessage] = []
+            var indexByID: [UUID: Int] = [:]
+            for message in remote {
+                if let index = indexByID[message.id] {
+                    result[index] = message
+                } else {
+                    indexByID[message.id] = result.count
+                    result.append(message)
+                }
+            }
+            for message in ownedChanges {
+                if let index = indexByID[message.id] {
+                    result[index] = message
+                } else {
+                    indexByID[message.id] = result.count
+                    result.append(message)
+                }
+            }
+            return result
+        }
+
+        private func nextRevision(after revision: WatchSyncRevision) -> WatchSyncRevision? {
+            guard revision < .max else { return nil }
+            return revision + 1
+        }
+
+        private func refuseMutationPreservingDraft(
+            _ conversation: WatchConversation,
+            fields: WatchConversationMutationFields,
+            ownedMessageIDs: Set<UUID> = [],
+            restoring previousState: RuntimeState
+        ) -> Bool {
+            let existingDraft = pendingDrafts[conversation.id]
+            pendingDrafts[conversation.id] = WatchConversationDraft(
+                conversation: canonicalized(conversation),
+                ownedMessageIDs: existingDraft?.ownedMessageIDs.union(ownedMessageIDs)
+                    ?? ownedMessageIDs,
+                deferredMutationFields: existingDraft?.deferredFields.union(fields) ?? fields
+            )
+            guard persistOrRestore(previousState) else { return false }
+            rebuildPublishedConversations()
+            logRevisionExhaustion(conversationID: conversation.id, fields: fields)
+            return false
+        }
+
+        private func logRevisionExhaustion(
+            conversationID: UUID,
+            fields: WatchConversationMutationFields
+        ) {
+            DiagnosticsLogger.log(
+                .watchConnectivity,
+                level: .error,
+                message: "⌚ Refused Watch mutation because its revision is exhausted",
+                metadata: [
+                    "conversationId": conversationID.uuidString,
+                    "fields": "\(fields.rawValue)"
+                ]
+            )
+        }
+
+        private func clearInvalidSelection() {
+            guard let selectedConversationId,
+                  !conversations.contains(where: { $0.id == selectedConversationId })
+            else {
+                return
+            }
+            self.selectedConversationId = nil
+        }
+
+        private func dictionaryByID(
+            _ source: some Sequence<WatchConversation>
+        ) -> [UUID: WatchConversation] {
+            var result: [UUID: WatchConversation] = [:]
+            for value in source {
+                let conversation = canonicalized(value)
+                if let existing = result[conversation.id] {
+                    if preferredState(conversation, over: existing) {
+                        result[conversation.id] = conversation
+                    }
+                } else {
+                    result[conversation.id] = conversation
+                }
+            }
+            return result
+        }
+
+        private func canonicalized(_ conversation: WatchConversation) -> WatchConversation {
+            WatchConversationCanonicalizer.watchConversation(conversation)
+        }
+
+        private func preferredState(
+            _ candidate: WatchConversation,
+            over existing: WatchConversation
+        ) -> Bool {
+            if candidate.watchRevision != existing.watchRevision {
+                return candidate.watchRevision > existing.watchRevision
+            }
+            return conversationSort(candidate, existing)
+        }
+
+        private func deduplicated(_ source: [WatchConversation]) -> [WatchConversation] {
+            WatchConversationCanonicalizer.watchConversations(source)
+        }
+
+        private func conversationSort(_ lhs: WatchConversation, _ rhs: WatchConversation) -> Bool {
+            if lhs.updatedAt != rhs.updatedAt {
+                return lhs.updatedAt > rhs.updatedAt
+            }
+            return lhs.id.uuidString < rhs.id.uuidString
         }
     }
 

--- a/Sources/Ayna/ViewModels/WatchConversationStore.swift
+++ b/Sources/Ayna/ViewModels/WatchConversationStore.swift
@@ -778,10 +778,11 @@
         @discardableResult
         func clearLegacyDeliveryCoverage() -> Bool {
             guard !legacyDeliveryCoverage.isEmpty else { return true }
+            let previousState = captureRuntimeState()
             legacyDeliveryCoverage.removeAll()
-            let persisted = persistState()
+            guard persistOrRestore(previousState) else { return false }
             rebuildPublishedConversations()
-            return persisted
+            return true
         }
 
         func previewText(for conversation: WatchConversation) -> String {

--- a/Sources/Ayna/ViewModels/WatchModelSelectionCoordinator.swift
+++ b/Sources/Ayna/ViewModels/WatchModelSelectionCoordinator.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+@MainActor
+enum WatchModelSelectionCoordinator {
+    nonisolated static func shouldAutoSelect(
+        availableModelCount: Int,
+        conversationID: UUID?
+    ) -> Bool {
+        availableModelCount == 1 && conversationID == nil
+    }
+
+    static func select(
+        model: String,
+        conversationID: UUID?,
+        currentConversationModel: (UUID) -> String?,
+        persistConversationModel: (String, UUID) -> Bool,
+        applyGlobalModel: (String) -> Void
+    ) -> Bool {
+        if let conversationID {
+            guard let currentModel = currentConversationModel(conversationID) else {
+                return false
+            }
+            if currentModel != model,
+               !persistConversationModel(model, conversationID)
+            {
+                return false
+            }
+        }
+
+        applyGlobalModel(model)
+        return true
+    }
+}

--- a/Sources/Ayna/Views/iOS/IOSChatView.swift
+++ b/Sources/Ayna/Views/iOS/IOSChatView.swift
@@ -121,13 +121,13 @@ struct IOSChatView: View {
                                     case let .message(message):
                                         IOSMessageView(
                                             message: message,
-                                            onRetry: message.role == .assistant ? {
+                                            onRetry: message.role == .assistant && !viewModel.isGenerating ? {
                                                 viewModel.retryMessage(beforeMessage: message)
                                             } : nil,
-                                            onSwitchModel: message.role == .assistant ? { newModel in
+                                            onSwitchModel: message.role == .assistant && !viewModel.isGenerating ? { newModel in
                                                 viewModel.switchModelAndRetry(beforeMessage: message, newModel: newModel)
                                             } : nil,
-                                            onEdit: message.role == .user ? { newContent in
+                                            onEdit: message.role == .user && !viewModel.isGenerating ? { newContent in
                                                 let edited = conversationManager.editMessage(
                                                     in: conversation,
                                                     messageId: message.id,
@@ -155,7 +155,7 @@ struct IOSChatView: View {
                                                     messageId: messageId
                                                 )
                                             },
-                                            onRetry: { message in
+                                            onRetry: viewModel.isGenerating ? nil : { message in
                                                 viewModel.retryMessage(beforeMessage: message)
                                             },
                                             defaultCandidateId: defaultCandidateId(for: responses, in: conversation)
@@ -353,6 +353,9 @@ struct IOSChatView: View {
             viewModel.configure(with: conversationManager, conversationId: conversationId)
             // Initialize selectedModels with current conversation model
             initializeSelectedModelsIfNeeded()
+        }
+        .onDisappear {
+            viewModel.cancelOwnedImageOperation()
         }
         .onChange(of: conversation?.model) { _, newModel in
             // Re-initialize if the conversation model changes and selectedModels is empty

--- a/Sources/Ayna/Views/iOS/IOSChatView.swift
+++ b/Sources/Ayna/Views/iOS/IOSChatView.swift
@@ -69,10 +69,17 @@ struct IOSChatView: View {
                 return false
             }
 
-            // Always show tool messages when they have content
+                // Web search results remain in model history but are presented as citations instead.
             if message.role == .tool {
+                    if message.toolCalls?.contains(where: { $0.toolName == WebSearchCoordinator.toolName }) == true {
+                        return false
+                    }
                 return !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             }
+
+                if message.role == .assistant, let citations = message.citations, !citations.isEmpty {
+                    return true
+                }
 
             // Don't show empty assistant messages unless we're actively generating
             if message.role == .assistant && message.content.isEmpty && message.imageData == nil && message.imagePath == nil {
@@ -190,7 +197,13 @@ struct IOSChatView: View {
                         updateDisplayableItems()
                         scrollToBottom(proxy: proxy, conversation: conversation)
                     }
+                        .onChange(of: conversation.updatedAt) {
+                            // Message content, tool metadata, citations, and response status can change
+                            // without changing the message count. Refresh copied display items for all.
+                            updateDisplayableItems()
+                        }
                     .onChange(of: conversation.messages.last?.content) {
+                            updateDisplayableItems()
                         // Only scroll during generation - use transaction to disable animations
                         // This prevents janky scrolling during rapid streaming updates
                         if viewModel.isGenerating, let lastId = conversation.messages.last?.id {
@@ -355,7 +368,7 @@ struct IOSChatView: View {
             initializeSelectedModelsIfNeeded()
         }
         .onDisappear {
-            viewModel.cancelOwnedImageOperation()
+                viewModel.cancelOwnedOperations()
         }
         .onChange(of: conversation?.model) { _, newModel in
             // Re-initialize if the conversation model changes and selectedModels is empty

--- a/Sources/Ayna/Views/iOS/IOSContentView.swift
+++ b/Sources/Ayna/Views/iOS/IOSContentView.swift
@@ -15,6 +15,8 @@ struct IOSContentView: View {
     @EnvironmentObject var conversationManager: ConversationManager
     @ObservedObject private var deepLinkManager = DeepLinkManager.shared
     @State private var columnVisibility = NavigationSplitViewVisibility.all
+    @State private var presentedAddModelRequest: AddModelRequest?
+    @State private var dismissingAddModelRequestID: UUID?
 
     var body: some View {
         ZStack {
@@ -51,40 +53,91 @@ struct IOSContentView: View {
         .alert(
             "Add Model",
             isPresented: .init(
-                get: { deepLinkManager.pendingAddModel != nil },
+                get: { presentedAddModelRequest != nil },
                 set: { newValue in
-                    // Only cancel if alert is being dismissed AND pendingAddModel is still set
-                    if !newValue, deepLinkManager.pendingAddModel != nil {
-                        deepLinkManager.cancelAddModel()
+                    guard !newValue else { return }
+                    if let requestID = dismissingAddModelRequestID {
+                        completeAddModelDismissal(requestID)
+                    } else if let request = presentedAddModelRequest {
+                        dismissingAddModelRequestID = request.id
+                        presentedAddModelRequest = nil
+                        deepLinkManager.cancelAddModel(expectedRequestID: request.id)
+                        completeAddModelDismissal(request.id)
                     }
                 }
             ),
-            presenting: deepLinkManager.pendingAddModel
-        ) { _ in
+            presenting: presentedAddModelRequest
+        ) { request in
             Button("Cancel", role: .cancel) {
-                deepLinkManager.cancelAddModel()
+                finishPresentedAddModel(request, shouldConfirm: false)
             }
             Button("Add") {
-                deepLinkManager.confirmAddModel()
+                finishPresentedAddModel(request, shouldConfirm: true)
             }
         } message: { request in
             Text("Add model '\(request.name)' (\(request.displayProvider))?\n\nOnly add models from sources you trust.")
         }
+        .onAppear {
+            if presentedAddModelRequest == nil {
+                presentedAddModelRequest = deepLinkManager.pendingAddModel
+            }
+        }
         // Process pending chat after add-model alert is dismissed (unified flow)
         .onChange(of: deepLinkManager.pendingAddModel) { oldValue, newValue in
-            // When pendingAddModel goes from some value to nil AND we have a pending chat
-            if oldValue != nil, newValue == nil, let chatRequest = deepLinkManager.pendingChat {
-                // Model was added (or cancelled), process the pending chat if model now exists
-                if let model = chatRequest.model,
-                   AIService.shared.customModels.contains(model)
-                {
-                    _ = conversationManager.startConversation(
-                        model: chatRequest.model,
-                        prompt: chatRequest.prompt,
-                        systemPrompt: chatRequest.systemPrompt
-                    )
-                }
-                deepLinkManager.clearPendingChat()
+            updatePresentedAddModel(from: oldValue, to: newValue)
+            guard oldValue != nil, newValue == nil else { return }
+
+            if let chatRequest = deepLinkManager.consumeNextReadyChat() {
+                _ = conversationManager.startConversation(
+                    model: chatRequest.model,
+                    prompt: chatRequest.prompt,
+                    systemPrompt: chatRequest.systemPrompt
+                )
+            }
+        }
+    }
+
+    private func finishPresentedAddModel(_ request: AddModelRequest, shouldConfirm: Bool) {
+        guard dismissingAddModelRequestID == nil,
+              presentedAddModelRequest?.id == request.id
+        else { return }
+
+        dismissingAddModelRequestID = request.id
+        presentedAddModelRequest = nil
+        if shouldConfirm {
+            deepLinkManager.confirmAddModel(expectedRequestID: request.id)
+        } else {
+            deepLinkManager.cancelAddModel(expectedRequestID: request.id)
+        }
+    }
+
+    private func updatePresentedAddModel(from oldValue: AddModelRequest?, to newValue: AddModelRequest?) {
+        if newValue == nil,
+           dismissingAddModelRequestID == nil,
+           presentedAddModelRequest?.id == oldValue?.id
+        {
+            dismissingAddModelRequestID = oldValue?.id
+            presentedAddModelRequest = nil
+        } else if newValue != nil,
+                  dismissingAddModelRequestID == nil,
+                  presentedAddModelRequest == nil
+        {
+            presentedAddModelRequest = newValue
+        }
+    }
+
+    private func completeAddModelDismissal(_ requestID: UUID) {
+        guard dismissingAddModelRequestID == requestID else { return }
+        presentPendingAddModelAfterDismissal(requestID)
+    }
+
+    private func presentPendingAddModelAfterDismissal(_ requestID: UUID) {
+        Task { @MainActor in
+            await Task.yield()
+            guard dismissingAddModelRequestID == requestID else { return }
+            dismissingAddModelRequestID = nil
+            if presentedAddModelRequest == nil {
+                presentedAddModelRequest = deepLinkManager.pendingAddModel
             }
         }
     }

--- a/Sources/Ayna/Views/iOS/IOSContentView.swift
+++ b/Sources/Ayna/Views/iOS/IOSContentView.swift
@@ -197,10 +197,17 @@ struct IOSNewChatView: View {
                 return false
             }
 
-            // Always show tool messages when they have content
+                // Web search results remain in model history but are presented as citations instead.
             if message.role == .tool {
+                    if message.toolCalls?.contains(where: { $0.toolName == WebSearchCoordinator.toolName }) == true {
+                        return false
+                    }
                 return !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             }
+
+                if message.role == .assistant, let citations = message.citations, !citations.isEmpty {
+                    return true
+                }
 
             // Don't show empty assistant messages unless we're actively generating
             if message.role == .assistant && message.content.isEmpty && message.imageData == nil && message.imagePath == nil {
@@ -312,7 +319,13 @@ struct IOSNewChatView: View {
                         updateDisplayableItems()
                         scrollToBottom(proxy: proxy, conversation: conversation)
                     }
+                        .onChange(of: conversation.updatedAt) {
+                            // Message content, tool metadata, citations, and response status can change
+                            // without changing the message count. Refresh copied display items for all.
+                            updateDisplayableItems()
+                        }
                     .onChange(of: conversation.messages.last?.content) {
+                            updateDisplayableItems()
                         if viewModel.isGenerating, let lastId = conversation.messages.last?.id {
                             proxy.scrollTo(lastId, anchor: .bottom)
                         }
@@ -435,7 +448,7 @@ struct IOSNewChatView: View {
             )
         }
         .onDisappear {
-            viewModel.cancelOwnedImageOperation()
+                viewModel.cancelOwnedOperations()
         }
     }
 

--- a/Sources/Ayna/Views/iOS/IOSContentView.swift
+++ b/Sources/Ayna/Views/iOS/IOSContentView.swift
@@ -27,6 +27,7 @@ struct IOSContentView: View {
                    selectedId != ConversationManager.newConversationId
                 {
                     IOSChatView(conversationId: selectedId)
+                        .id(selectedId)
                 } else {
                     IOSNewChatView()
                         .id(conversationManager.selectedConversationId)
@@ -432,6 +433,9 @@ struct IOSNewChatView: View {
                 level: .info,
                 message: "📱 IOSNewChatView appeared"
             )
+        }
+        .onDisappear {
+            viewModel.cancelOwnedImageOperation()
         }
     }
 

--- a/Sources/Ayna/Views/iOS/IOSMessageView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageView.swift
@@ -56,7 +56,9 @@ struct IOSMessageView: View {
         }
         // Pre-set hasAppeared to true for messages that are likely already in view
         // This prevents janky animations when scrolling through existing messages
-        _hasAppeared = State(initialValue: !message.content.isEmpty)
+        _hasAppeared = State(
+            initialValue: !message.content.isEmpty || !(message.citations?.isEmpty ?? true)
+        )
     }
 
     @State private var isToolExpanded = false
@@ -240,7 +242,8 @@ struct IOSMessageView: View {
                 // Show typing indicator for empty assistant messages (waiting for response)
                 // Don't show if the message has tool calls (it's waiting for tool execution)
                 if message.role == .assistant, message.content.isEmpty, message.mediaType != .image,
-                   message.toolCalls == nil || message.toolCalls?.isEmpty == true
+                   message.toolCalls == nil || message.toolCalls?.isEmpty == true,
+                   message.citations?.isEmpty ?? true
                 {
                     IOSTypingIndicatorView()
                 } else if contentBlocks.isEmpty {

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
@@ -499,13 +499,17 @@ extension MacChatView {
         // Capture necessary values for closures
         let conversationId = conversation.id
 
-        // Send to all models in parallel
-        aiService.sendToMultipleModels(
+        // Send to all models in parallel under this view's owner-specific operation.
+        let coordinator = toolChainCoordinator
+        activeAssistantMessageID = nil
+        activeMultiModelResponseGroupID = responseGroupId
+        let operationID = coordinator.beginOperation(conversationID: conversationId)
+        let request = aiService.sendToMultipleModels(
             messages: messagesToSend,
             models: models,
             temperature: temperature,
             onChunk: { model, chunk in
-                Task { @MainActor in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model],
                           let convIndex = conversationManager.conversations.firstIndex(where: {
                               $0.id == conversationId
@@ -521,7 +525,7 @@ extension MacChatView {
                 }
             },
             onModelComplete: { model in
-                Task { @MainActor in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model] else { return }
 
                     // Update response group status
@@ -542,7 +546,8 @@ extension MacChatView {
                 }
             },
             onAllComplete: {
-                Task { @MainActor in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                    guard coordinator.owns(operationID, conversationID: conversationId) else { return }
                     isGenerating = false
                     logChat("🏁 All models completed", level: .info)
 
@@ -552,10 +557,12 @@ extension MacChatView {
                     }) {
                         conversationManager.saveImmediately(conversationManager.conversations[convIndex])
                     }
+                    activeMultiModelResponseGroupID = nil
+                    _ = coordinator.finishOperation(operationID)
                 }
             },
             onError: { model, error in
-                Task { @MainActor in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model] else { return }
 
                     // Update response group status to failed
@@ -577,7 +584,7 @@ extension MacChatView {
             },
             onPendingToolCall: { model, toolId, toolName, arguments in
                 let argumentsWrapper = UncheckedSendableWrapper(arguments)
-                Task { @MainActor in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model],
                           let convIndex = conversationManager.conversations.firstIndex(where: {
                               $0.id == conversationId
@@ -610,6 +617,9 @@ extension MacChatView {
             },
             onReasoning: nil
         )
+        coordinator.onCancel(for: operationID) {
+            request.cancel()
+        }
     }
 }
 #endif

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
@@ -32,6 +32,9 @@ extension MacChatView {
     }
 
     func generateImage(prompt: String, model: String) {
+        let coordinator = imageGenerationCoordinator
+        let operationID = coordinator.beginOperation()
+
         // Create placeholder assistant message with a known ID
         let messageId = UUID()
         let placeholderMessage = Message(
@@ -43,102 +46,129 @@ extension MacChatView {
         )
         conversationManager.addMessage(to: conversation, message: placeholderMessage)
 
+        let conversationManager = conversationManager
+        let conversationID = conversation.id
+        coordinator.onCancel(for: operationID) {
+            conversationManager.removeMessage(conversationId: conversationID, messageId: messageId)
+            if let conversation = conversationManager.conversation(byId: conversationID) {
+                conversationManager.save(conversation)
+            }
+        }
+
         // Find previous image path (cheap, no disk I/O)
         let previousImagePath = findPreviousImagePath()
 
-        // Load previous image data off MainActor to avoid blocking the UI
-        Task {
-            var previousImage: Data?
-            if let path = previousImagePath {
-                previousImage = await Task.detached(priority: .userInitiated) {
-                    AttachmentStorage.shared.load(path: path)
-                }.value
+        // Own previous-image loading and the eventual transport under one logical request.
+        let task = Task { @MainActor in
+            let previousImage = await loadImageData(at: previousImagePath)
+            guard coordinator.owns(operationID), !Task.isCancelled else { return }
+
+            let onComplete: @Sendable (Data) -> Void = { imageData in
+                coordinator.schedule(for: operationID) {
+                    await handleImageGenerationSuccess(
+                        imageData: imageData,
+                        messageId: messageId,
+                        operationID: operationID
+                    )
+                }
             }
-
-            if let previousImage {
-                logChat("📝 Using image edit API with previous image context", level: .info)
-
-                aiService.editImage(
-                    prompt: prompt,
-                    sourceImage: previousImage,
-                    model: model,
-                    onComplete: { imageData in
-                        Task { @MainActor in
-                            handleImageGenerationSuccess(imageData: imageData, messageId: messageId)
-                        }
-                    },
-                    onError: { error in
-                        Task { @MainActor in
-                            handleImageGenerationError(error: error, messageId: messageId)
-                        }
-                    }
-                )
-            } else {
-                aiService.generateImage(
-                    prompt: prompt,
-                    model: model,
-                    onComplete: { imageData in
-                        Task { @MainActor in
-                            handleImageGenerationSuccess(imageData: imageData, messageId: messageId)
-                        }
-                    },
-                    onError: { error in
-                        Task { @MainActor in
-                            handleImageGenerationError(error: error, messageId: messageId)
-                        }
-                    }
-                )
-            }
-        }
-    }
-
-    func handleImageGenerationSuccess(imageData: Data, messageId: UUID) {
-        // Save image to disk off MainActor to avoid blocking the UI
-        Task {
-            let imagePath = await Task.detached(priority: .userInitiated) {
-                try? AttachmentStorage.shared.save(data: imageData, extension: "png")
-            }.value
-
-            if imagePath == nil {
-                logChat("❌ Failed to save generated image to disk", level: .error)
-            }
-
-            // Update the placeholder message with actual image using the proper method
-            conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
-                message.content = ""
-                if let path = imagePath {
-                    message.imagePath = path
-                    message.imageData = nil // Don't store raw data if saved to disk
-                } else {
-                    // Fallback to storing in message if save failed
-                    message.imageData = imageData
-                    message.imagePath = nil
+            let onError: @Sendable (Error) -> Void = { error in
+                coordinator.schedule(for: operationID) {
+                    handleImageGenerationError(
+                        error: error,
+                        messageId: messageId,
+                        operationID: operationID
+                    )
                 }
             }
 
-            isGenerating = false
+            let request: AIImageRequest?
+            if let previousImage {
+                logChat("📝 Using image edit API with previous image context", level: .info)
+                request = aiService.editImage(
+                    prompt: prompt,
+                    sourceImage: previousImage,
+                    model: model,
+                    onComplete: onComplete,
+                    onError: onError
+                )
+            } else {
+                request = aiService.generateImage(
+                    prompt: prompt,
+                    model: model,
+                    onComplete: onComplete,
+                    onError: onError
+                )
+            }
+            coordinator.track(request, for: operationID)
         }
+        coordinator.track(task, for: operationID)
     }
 
-    func handleImageGenerationError(error: Error, messageId: UUID) {
+    private func handleImageGenerationSuccess(
+        imageData: Data,
+        messageId: UUID,
+        operationID: ImageGenerationCoordinator.OperationID
+    ) async {
+        let imagePath = await saveImageData(imageData)
+        guard imageGenerationCoordinator.owns(operationID), !Task.isCancelled else {
+            await deleteImageData(at: imagePath)
+            return
+        }
+
+        if imagePath == nil {
+            logChat("❌ Failed to save generated image to disk", level: .error)
+        }
+
+        let messageUpdated = conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
+            message.content = ""
+            if let path = imagePath {
+                message.imagePath = path
+                message.imageData = nil
+            } else {
+                message.imageData = imageData
+                message.imagePath = nil
+            }
+        }
+        guard messageUpdated else {
+            await deleteImageData(at: imagePath)
+            _ = imageGenerationCoordinator.finishOperation(operationID)
+            isGenerating = false
+            return
+        }
+
+        guard imageGenerationCoordinator.finishOperation(operationID) else { return }
+        isGenerating = false
+    }
+
+    private func handleImageGenerationError(
+        error: Error,
+        messageId: UUID,
+        operationID: ImageGenerationCoordinator.OperationID
+    ) {
+        guard imageGenerationCoordinator.finishOperation(operationID) else { return }
+
         isGenerating = false
         errorMessage = ErrorPresenter.userMessage(for: error)
         errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
 
         // Remove the empty assistant placeholder message since we show error in banner
-        if let index = conversationManager.conversations.firstIndex(where: {
-            $0.id == conversation.id
-        }) {
-            if let messageIndex = conversationManager.conversations[index].messages.firstIndex(where: {
-                $0.id == messageId
-            }) {
-                conversationManager.conversations[index].messages.remove(at: messageIndex)
-            }
+        conversationManager.removeMessage(conversationId: conversation.id, messageId: messageId)
+        if let conversation = conversationManager.conversation(byId: conversation.id) {
+            conversationManager.save(conversation)
         }
     }
 
     /// Generates images from multiple models in parallel for comparison
     func generateMultiModelImages(prompt: String, models: [String]) {
+        let coordinator = imageGenerationCoordinator
+        let operationID = coordinator.beginOperation()
+        guard !models.isEmpty else {
+            _ = coordinator.finishOperation(operationID)
+            isGenerating = false
+            return
+        }
+
         // Find previous image path (cheap, no disk I/O)
         let previousImagePath = findPreviousImagePath()
 
@@ -183,37 +213,42 @@ extension MacChatView {
             conversationManager.conversations[index].responseGroups.append(responseGroup)
         }
 
-        let messageIdsByModel = messageIds
+        registerImageBatchCancellation(
+            coordinator: coordinator,
+            operationID: operationID,
+            responseGroupID: responseGroupId,
+            messageIDs: Array(messageIds.values)
+        )
 
-        // Track completion state with actor-isolated counter
+        let messageIdsByModel = messageIds
         let counter = MainActorCompletionCounter(total: models.count)
 
-        // Load previous image off MainActor, then dispatch parallel generations
-        Task {
-            var previousImage: Data?
-            if let path = previousImagePath {
-                previousImage = await Task.detached(priority: .userInitiated) {
-                    AttachmentStorage.shared.load(path: path)
-                }.value
-            }
+        // Own previous-image loading and every child transport under one batch operation.
+        let task = Task { @MainActor in
+            let previousImage = await loadImageData(at: previousImagePath)
+            guard coordinator.owns(operationID), !Task.isCancelled else { return }
 
             if previousImage != nil {
                 logChat("📝 Using image edit API with previous image context for multi-model", level: .info)
             }
 
-            // Generate/edit images in parallel
             for model in models {
                 guard let messageId = messageIdsByModel[model] else { continue }
 
                 let onComplete: @Sendable (Data) -> Void = { imageData in
-                    Task { @MainActor in
-                        // Save image to disk off MainActor
-                        let imagePath = await Task.detached(priority: .userInitiated) {
-                            try? AttachmentStorage.shared.save(data: imageData, extension: "png")
-                        }.value
+                    coordinator.schedule(for: operationID) {
+                        let imagePath = await saveImageData(imageData)
+                        guard coordinator.owns(operationID), !Task.isCancelled else {
+                            await deleteImageData(at: imagePath)
+                            return
+                        }
 
-                        // Update the placeholder message with actual image
-                        conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
+                        updateImageResponseStatus(
+                            responseGroupId: responseGroupId,
+                            messageId: messageId,
+                            status: .completed
+                        )
+                        let messageUpdated = conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
                             message.content = ""
                             if let path = imagePath {
                                 message.imagePath = path
@@ -223,61 +258,62 @@ extension MacChatView {
                                 message.imagePath = nil
                             }
                         }
-
-                        // Update response group status
-                        if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }),
-                           let groupIndex = conversationManager.conversations[convIndex].responseGroups.firstIndex(where: { $0.id == responseGroupId }),
-                           let entryIndex = conversationManager.conversations[convIndex].responseGroups[groupIndex].responses.firstIndex(where: { $0.id == messageId })
-                        {
-                            conversationManager.conversations[convIndex].responseGroups[groupIndex].responses[entryIndex].status = .completed
+                        guard messageUpdated else {
+                            await handleMissingImageMessage(
+                                imagePath: imagePath,
+                                responseGroupID: responseGroupId,
+                                messageID: messageId,
+                                counter: counter,
+                                coordinator: coordinator,
+                                operationID: operationID
+                            )
+                            return
                         }
 
                         counter.increment()
-                        if counter.isComplete {
-                            isGenerating = false
-                        }
+                        finishImageBatchIfComplete(
+                            counter: counter,
+                            coordinator: coordinator,
+                            operationID: operationID
+                        )
                     }
                 }
 
                 let onError: @Sendable (Error) -> Void = { error in
-                    Task { @MainActor in
+                    coordinator.schedule(for: operationID) {
                         logChat(
                             "❌ Image generation failed for \(model): \(error.localizedDescription)",
                             level: .error,
                             metadata: ["model": model]
                         )
 
-                        // Update response group status to failed
-                        if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }),
-                           let groupIndex = conversationManager.conversations[convIndex].responseGroups.firstIndex(where: { $0.id == responseGroupId }),
-                           let entryIndex = conversationManager.conversations[convIndex].responseGroups[groupIndex].responses.firstIndex(where: { $0.id == messageId })
-                        {
-                            conversationManager.conversations[convIndex].responseGroups[groupIndex].responses[entryIndex].status = .failed
-                        }
-
-                        // Update message with error
+                        updateImageResponseStatus(
+                            responseGroupId: responseGroupId,
+                            messageId: messageId,
+                            status: .failed
+                        )
                         conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
                             message.content = "Image generation failed: \(error.localizedDescription)"
                         }
 
                         counter.increment()
-                        if counter.isComplete {
-                            isGenerating = false
-                        }
+                        finishImageBatchIfComplete(
+                            counter: counter,
+                            coordinator: coordinator,
+                            operationID: operationID
+                        )
                     }
                 }
 
-                if let sourceImage = previousImage {
-                    // Use image editing API
+                let request: AIImageRequest? = if let previousImage {
                     aiService.editImage(
                         prompt: prompt,
-                        sourceImage: sourceImage,
+                        sourceImage: previousImage,
                         model: model,
                         onComplete: onComplete,
                         onError: onError
                     )
                 } else {
-                    // Use image generation API
                     aiService.generateImage(
                         prompt: prompt,
                         model: model,
@@ -285,8 +321,126 @@ extension MacChatView {
                         onError: onError
                     )
                 }
+                coordinator.track(request, for: operationID)
             }
         }
+        coordinator.track(task, for: operationID)
+    }
+
+    private func handleMissingImageMessage(
+        imagePath: String?,
+        responseGroupID: UUID,
+        messageID: UUID,
+        counter: MainActorCompletionCounter,
+        coordinator: ImageGenerationCoordinator,
+        operationID: ImageGenerationCoordinator.OperationID
+    ) async {
+        await deleteImageData(at: imagePath)
+        updateImageResponseStatus(
+            responseGroupId: responseGroupID,
+            messageId: messageID,
+            status: .failed
+        )
+        counter.increment()
+        finishImageBatchIfComplete(
+            counter: counter,
+            coordinator: coordinator,
+            operationID: operationID
+        )
+    }
+
+    private func finishImageBatchIfComplete(
+        counter: MainActorCompletionCounter,
+        coordinator: ImageGenerationCoordinator,
+        operationID: ImageGenerationCoordinator.OperationID
+    ) {
+        guard counter.isComplete, coordinator.finishOperation(operationID) else { return }
+        if let conversation = conversationManager.conversation(byId: conversation.id) {
+            conversationManager.save(conversation)
+        }
+        isGenerating = false
+    }
+
+    private func registerImageBatchCancellation(
+        coordinator: ImageGenerationCoordinator,
+        operationID: ImageGenerationCoordinator.OperationID,
+        responseGroupID: UUID,
+        messageIDs: [UUID]
+    ) {
+        let conversationManager = conversationManager
+        let conversationID = conversation.id
+        coordinator.onCancel(for: operationID) {
+            guard let conversation = conversationManager.conversation(byId: conversationID),
+                  let responseGroup = conversation.getResponseGroup(responseGroupID)
+            else {
+                return
+            }
+            let pendingMessageIDs = ImageGenerationCoordinator.pendingMessageIDs(
+                in: responseGroup,
+                candidates: messageIDs
+            )
+            for messageID in pendingMessageIDs {
+                conversationManager.updateMessage(conversationId: conversationID, messageId: messageID) { message in
+                    message.content = "Image generation stopped"
+                }
+                conversationManager.updateResponseGroupStatus(
+                    conversationId: conversationID,
+                    responseGroupId: responseGroupID,
+                    messageId: messageID,
+                    status: .failed
+                )
+            }
+            if let conversation = conversationManager.conversation(byId: conversationID) {
+                conversationManager.save(conversation)
+            }
+        }
+    }
+
+    private func updateImageResponseStatus(
+        responseGroupId: UUID,
+        messageId: UUID,
+        status: ResponseGroup.ResponseStatus
+    ) {
+        guard let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }),
+              let groupIndex = conversationManager.conversations[conversationIndex].responseGroups.firstIndex(where: {
+                  $0.id == responseGroupId
+              }),
+              let entryIndex = conversationManager.conversations[conversationIndex].responseGroups[groupIndex]
+              .responses.firstIndex(where: { $0.id == messageId })
+        else {
+            return
+        }
+        conversationManager.conversations[conversationIndex].responseGroups[groupIndex].responses[entryIndex].status = status
+    }
+
+    private func loadImageData(at path: String?) async -> Data? {
+        guard let path else { return nil }
+        let task = Task.detached(priority: .userInitiated) {
+            AttachmentStorage.shared.load(path: path)
+        }
+        return await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    private func saveImageData(_ imageData: Data) async -> String? {
+        let task = Task.detached(priority: .userInitiated) {
+            try? AttachmentStorage.shared.save(data: imageData, extension: "png")
+        }
+        return await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    private func deleteImageData(at path: String?) async {
+        guard let path else { return }
+        await Task.detached(priority: .utility) {
+            AttachmentStorage.shared.delete(path: path)
+        }.value
     }
 
     // MARK: - Multi-Model Message Sending

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
@@ -141,7 +141,8 @@ extension MacChatView {
             model: updatedConversation.model,
             temperature: updatedConversation.temperature,
             tools: tools,
-            isInitialRequest: true
+            isInitialRequest: true,
+            assistantMessageID: assistantMessage.id
         )
     }
 
@@ -192,7 +193,8 @@ extension MacChatView {
             model: model,
             temperature: updatedConversation.temperature,
             tools: tools,
-            isInitialRequest: true
+            isInitialRequest: true,
+            assistantMessageID: assistantMessage.id
         )
     }
 

--- a/Sources/Ayna/Views/macOS/Chat/MacNewChatView+Lifecycle.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacNewChatView+Lifecycle.swift
@@ -1,0 +1,59 @@
+#if os(macOS)
+    //
+    //  MacNewChatView+Lifecycle.swift
+    //  ayna
+    //
+    //  Cancellation finalization for the macOS new-chat flow.
+    //
+
+    import SwiftUI
+
+    extension MacNewChatView {
+        func cancelOwnedGenerationForLifecycle() {
+            cancelSendPreparation()
+            toolChainCoordinator.cancelCurrentOperation {
+                finalizePersistedTextGeneration()
+            }
+            imageGenerationCoordinator.cancelCurrentOperation()
+            activeAssistantMessageID = nil
+            activeMultiModelResponseGroupID = nil
+            isGenerating = false
+            currentToolName = nil
+            toolCallDepth = 0
+        }
+
+        func abortOwnedTextGeneration(
+            operationID: ToolChainCoordinator.OperationID,
+            conversationID: UUID
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationID) else { return }
+            finalizePersistedTextGeneration()
+            toolChainCoordinator.cancelCurrentOperation()
+            activeAssistantMessageID = nil
+            activeMultiModelResponseGroupID = nil
+            isGenerating = false
+            currentToolName = nil
+            toolCallDepth = 0
+        }
+
+        func finalizePersistedTextGeneration() {
+            let assistantMessageID = activeAssistantMessageID
+            let responseGroupID = activeMultiModelResponseGroupID
+            guard assistantMessageID != nil || responseGroupID != nil,
+                  let conversationID = currentConversationId,
+                  let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversationID })
+            else {
+                activeMultiModelResponseGroupID = nil
+                return
+            }
+
+            ChatGenerationFinalizer.finalize(
+                conversation: &conversationManager.conversations[conversationIndex],
+                activeAssistantMessageID: assistantMessageID,
+                activeResponseGroupID: responseGroupID
+            )
+            conversationManager.saveImmediately(conversationManager.conversations[conversationIndex])
+            activeMultiModelResponseGroupID = nil
+        }
+    }
+#endif

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -44,6 +44,7 @@ struct MacChatView: View {
     @State private var currentToolName: String?
     @State private var isComposerFocused = true
     @State private var toolChainTimeoutTask: Task<Void, Never>?
+    @State var imageGenerationCoordinator = ImageGenerationCoordinator()
     @State private var showingSystemPromptSheet = false
 
     // Multi-model support (unified selection - 1 model = single, 2+ = multi)
@@ -357,6 +358,12 @@ struct MacChatView: View {
             isComposerFocused = true
             checkAndProcessPendingPrompt()
         }
+        .onDisappear {
+            if imageGenerationCoordinator.hasActiveOperation {
+                imageGenerationCoordinator.cancelCurrentOperation()
+                isGenerating = false
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .sendPendingMessage)) { notification in
             // Handle Work with Apps: auto-send message when conversation is created with context
             guard let conversationId = notification.userInfo?["conversationId"] as? UUID,
@@ -667,7 +674,10 @@ struct MacChatView: View {
         if isGenerating {
             // Stop generation immediately
             logChat("🛑 Stop button clicked, cancelling...", level: .info)
-            AIService.shared.cancelCurrentRequest()
+            let cancelledImageOperation = imageGenerationCoordinator.cancelCurrentOperation()
+            if !cancelledImageOperation {
+                AIService.shared.cancelCurrentRequest(includeImageRequests: false)
+            }
 
             // Flush any pending chunks before stopping
             batchUpdateTask?.cancel()

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 #if os(macOS)
 //
 //  MacChatView.swift
@@ -16,6 +17,11 @@ import SwiftUI
 
 // swiftlint:disable:next type_body_length
 struct MacChatView: View {
+    private struct PendingAutoSendClaim {
+        let conversationID: UUID
+        let prompt: String
+    }
+
     let conversation: Conversation
 
     init(conversation: Conversation) {
@@ -44,6 +50,13 @@ struct MacChatView: View {
     @State private var currentToolName: String?
     @State private var isComposerFocused = true
     @State private var toolChainTimeoutTask: Task<Void, Never>?
+        @State private var sendPreparationTask: Task<Void, Never>?
+        @State private var sendPreparationID: UUID?
+        @State private var pendingAutoSendClaim: PendingAutoSendClaim?
+        @State var activeAssistantMessageID: UUID?
+        @State var activeMultiModelResponseGroupID: UUID?
+        @State var toolChainCoordinator = ToolChainCoordinator()
+        @State private var toolCallRequestRoundCoordinator = ToolCallRequestRoundCoordinator<ToolExecutionResult>()
     @State var imageGenerationCoordinator = ImageGenerationCoordinator()
     @State private var showingSystemPromptSheet = false
 
@@ -111,7 +124,11 @@ struct MacChatView: View {
 
             // Always show tool messages when they have content (tool replies are the "first" assistant response)
             if message.role == .tool {
-                return !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    let isWebSearchResult = message.toolCalls?.contains(where: {
+                        $0.toolName == WebSearchCoordinator.toolName
+                    }) == true
+                    return !isWebSearchResult &&
+                        !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             }
 
             // Always show assistant messages that have citations (from web search)
@@ -298,7 +315,7 @@ struct MacChatView: View {
                     isToolSectionExpanded: $isToolSectionExpanded,
                     isGenerating: isGenerating,
                     composerModelLabel: composerModelLabel,
-                    onSendMessage: { Task { await sendMessage() } },
+                        onSendMessage: { beginSendMessage() },
                     onAttachFile: attachFile,
                     onShowAppContentPicker: { showAppContentPicker = true },
                     onToggleModelSelection: toggleModelSelection,
@@ -359,10 +376,7 @@ struct MacChatView: View {
             checkAndProcessPendingPrompt()
         }
         .onDisappear {
-            if imageGenerationCoordinator.hasActiveOperation {
-                imageGenerationCoordinator.cancelCurrentOperation()
-                isGenerating = false
-            }
+                cancelOwnedGenerationForLifecycle()
         }
         .onReceive(NotificationCenter.default.publisher(for: .sendPendingMessage)) { notification in
             // Handle Work with Apps: auto-send message when conversation is created with context
@@ -385,7 +399,8 @@ struct MacChatView: View {
 
     /// Check for and process a pending auto-send prompt from deep link.
     private func checkAndProcessPendingPrompt() {
-        guard let index = getConversationIndex(),
+        guard pendingAutoSendClaim == nil,
+              let index = getConversationIndex(),
               let prompt = conversationManager.conversations[index].pendingAutoSendPrompt,
               !prompt.isEmpty
         else {
@@ -399,28 +414,30 @@ struct MacChatView: View {
             metadata: ["promptLength": "\(prompt.count)"]
         )
 
-        // Clear the pending prompt to prevent re-sending
+        // Clear and persist the prompt while this view owns the claim. Lifecycle cancellation
+        // restores it until the user message is actually committed.
         conversationManager.conversations[index].pendingAutoSendPrompt = nil
+        conversationManager.saveImmediately(conversationManager.conversations[index])
+        pendingAutoSendClaim = PendingAutoSendClaim(
+            conversationID: conversationManager.conversations[index].id,
+            prompt: prompt
+        )
 
-        // Set the message text and send
+        // Set the message text and send after the view has had one layout turn.
         messageText = prompt
-        // Use a small delay to ensure the view is fully loaded
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(100))
-            await sendMessage()
-        }
+        beginSendMessage(delay: .milliseconds(100))
     }
 
     /// Sends the last user message in the conversation (used for Work with Apps)
     private func sendPendingUserMessage() {
-        guard let lastUserMessage = currentConversation.messages.last(where: { $0.role == .user }) else {
+            guard currentConversation.messages.contains(where: { $0.role == .user }) else {
             return
         }
 
         isGenerating = true
 
         // Build messages for API using the same pattern as sendMessage
-        var messagesToSend = currentConversation.messages
+            var messagesToSend = currentConversation.getEffectiveHistory()
         if let systemPrompt = buildFullSystemPrompt(for: currentConversation) {
             let systemMessage = Message(role: .system, content: systemPrompt)
             messagesToSend.insert(systemMessage, at: 0)
@@ -439,7 +456,8 @@ struct MacChatView: View {
             model: currentConversation.model,
             temperature: currentConversation.temperature,
             tools: tools,
-            isInitialRequest: true
+                isInitialRequest: true,
+                assistantMessageID: assistantMessage.id
         )
     }
 
@@ -654,7 +672,7 @@ struct MacChatView: View {
 
         // Set message text and send
         messageText = message
-        Task { await sendMessage() }
+            beginSendMessage()
     }
 
     /// Dismiss the current error without retrying
@@ -664,58 +682,104 @@ struct MacChatView: View {
         errorRecoverySuggestion = nil
     }
 
-    // MARK: - Message Sending
-
-    // This method coordinates attachment handling, MCP tool availability, streaming setup, and state
-    // resets. Breaking it apart right now would require plumbing a large amount of shared state, so
-    // we defer that refactor and explicitly allow the longer body.
-    // swiftlint:disable:next function_body_length
-    private func sendMessage() async {
-        if isGenerating {
-            // Stop generation immediately
-            logChat("🛑 Stop button clicked, cancelling...", level: .info)
-            let cancelledImageOperation = imageGenerationCoordinator.cancelCurrentOperation()
-            if !cancelledImageOperation {
-                AIService.shared.cancelCurrentRequest(includeImageRequests: false)
+        private func cancelOwnedGenerationForLifecycle() {
+            sendPreparationTask?.cancel()
+            sendPreparationTask = nil
+            sendPreparationID = nil
+            restorePendingAutoSendClaimIfNeeded()
+            toolChainCoordinator.cancelCurrentOperation {
+                finalizePersistedTextGeneration()
             }
-
-            // Flush any pending chunks before stopping
-            batchUpdateTask?.cancel()
-            if !pendingChunks.isEmpty {
-                let remainingChunks = pendingChunks.joined()
-                pendingChunks.removeAll()
-
-                if let index = conversationManager.conversations.firstIndex(where: {
-                    $0.id == conversation.id
-                }),
-                    var lastMessage = conversationManager.conversations[index].messages.last,
-                    lastMessage.role == .assistant
-                {
-                    lastMessage.content += remainingChunks
-                    conversationManager.conversations[index].messages[
-                        conversationManager.conversations[index].messages.count - 1
-                    ] = lastMessage
-                    logChat(
-                        "💾 Flushed \(remainingChunks.count) chars before cancellation",
-                        level: .info,
-                        metadata: ["chunkLength": "\(remainingChunks.count)"]
-                    )
-                }
-            }
-
-            // Save conversations immediately to persist partial message
-            if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }) {
-                conversationManager.saveImmediately(conversationManager.conversations[index])
-                logChat("💾 Saved conversation after cancellation", level: .info)
-            } else {
-                logChat("⚠️ Could not find conversation to save after cancellation", level: .error)
-            }
-
+            imageGenerationCoordinator.cancelCurrentOperation()
+            toolChainTimeoutTask?.cancel()
+            toolChainTimeoutTask = nil
+            activeAssistantMessageID = nil
+            activeMultiModelResponseGroupID = nil
             isGenerating = false
             currentToolName = nil
             toolCallDepth = 0
+            }
+
+        private func finalizePersistedTextGeneration() {
+            batchUpdateTask?.cancel()
+            batchUpdateTask = nil
+            let pendingText = pendingChunks.joined()
+                pendingChunks.removeAll()
+
+            let assistantMessageID = activeAssistantMessageID
+            let responseGroupID = activeMultiModelResponseGroupID
+            guard assistantMessageID != nil || responseGroupID != nil || !pendingText.isEmpty,
+                  let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id })
+            else {
+                activeMultiModelResponseGroupID = nil
+                return
+            }
+
+            let result = ChatGenerationFinalizer.finalize(
+                conversation: &conversationManager.conversations[conversationIndex],
+                activeAssistantMessageID: assistantMessageID,
+                pendingText: pendingText,
+                activeResponseGroupID: responseGroupID
+            )
+            conversationManager.saveImmediately(conversationManager.conversations[conversationIndex])
+            activeMultiModelResponseGroupID = nil
+
+            if result.appendedCharacterCount > 0 {
+                    logChat(
+                    "💾 Flushed \(result.appendedCharacterCount) chars before cancellation",
+                        level: .info,
+                    metadata: ["chunkLength": "\(result.appendedCharacterCount)"]
+                    )
+                }
+                logChat("💾 Saved conversation after cancellation", level: .info)
+            }
+
+        private func abortOwnedTextGeneration(
+            operationID: ToolChainCoordinator.OperationID,
+            conversationID: UUID
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationID) else { return }
+            finalizePersistedTextGeneration()
             toolChainTimeoutTask?.cancel()
             toolChainTimeoutTask = nil
+            toolChainCoordinator.cancelCurrentOperation()
+            activeAssistantMessageID = nil
+            activeMultiModelResponseGroupID = nil
+            isGenerating = false
+            currentToolName = nil
+            toolCallDepth = 0
+        }
+
+        private func armToolChainTimeout(
+            operationID: ToolChainCoordinator.OperationID,
+            assistantMessageID: UUID,
+            conversationID: UUID
+        ) {
+            toolChainTimeoutTask?.cancel()
+            let coordinator = toolChainCoordinator
+            let timeoutTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(60))
+                guard !Task.isCancelled,
+                      coordinator.owns(operationID, conversationID: conversationID),
+                      activeAssistantMessageID == assistantMessageID
+                else {
+                    return
+                }
+
+                logChat("⏰ Tool execution timeout after 60s, cancelling owned work", level: .error)
+                abortOwnedTextGeneration(operationID: operationID, conversationID: conversationID)
+                errorMessage = "Tool execution timed out after 60 seconds"
+            }
+            toolChainTimeoutTask = timeoutTask
+            coordinator.track(timeoutTask, for: operationID)
+        }
+
+        // MARK: - Message Sending
+
+        private func beginSendMessage(delay: Duration? = nil) {
+            if isGenerating || sendPreparationTask != nil {
+                logChat("🛑 Stop button clicked, cancelling...", level: .info)
+                cancelOwnedGenerationForLifecycle()
             logChat("✅ isGenerating set to FALSE after stop", level: .info)
             isComposerFocused = true
             return
@@ -725,6 +789,78 @@ struct MacChatView: View {
             isComposerFocused = true
             return
         }
+
+            let preparationID = UUID()
+            sendPreparationID = preparationID
+            isGenerating = true
+            let task = Task { @MainActor in
+                if let delay {
+                    try? await Task.sleep(for: delay)
+                }
+                guard !Task.isCancelled, sendPreparationID == preparationID else { return }
+                await sendMessage(preparationID: preparationID)
+            }
+            sendPreparationTask = task
+        }
+
+        private func discardStoredAttachments(in message: Message) {
+            for attachment in message.attachments ?? [] {
+                if let localPath = attachment.localPath {
+                    AttachmentStorage.shared.delete(path: localPath)
+                }
+            }
+        }
+
+        private func restorePendingAutoSendClaimIfNeeded() {
+            guard let claim = pendingAutoSendClaim else { return }
+            defer { pendingAutoSendClaim = nil }
+            guard messageText == claim.prompt,
+                  let index = conversationManager.conversations.firstIndex(where: { $0.id == claim.conversationID })
+            else {
+                return
+            }
+
+            if conversationManager.conversations[index].pendingAutoSendPrompt == nil {
+                conversationManager.conversations[index].pendingAutoSendPrompt = claim.prompt
+                conversationManager.saveImmediately(conversationManager.conversations[index])
+            }
+            messageText = ""
+        }
+
+        private func isSameAppContent(_ lhs: AppContent?, _ rhs: AppContent?) -> Bool {
+            switch (lhs, rhs) {
+            case (nil, nil):
+                true
+            case let (lhs?, rhs?):
+                lhs.appName == rhs.appName &&
+                    lhs.bundleIdentifier == rhs.bundleIdentifier &&
+                    lhs.windowTitle == rhs.windowTitle &&
+                    lhs.content == rhs.content &&
+                    lhs.contentType == rhs.contentType &&
+                    lhs.isTruncated == rhs.isTruncated &&
+                    lhs.originalLength == rhs.originalLength
+            default:
+                false
+            }
+        }
+
+        // This method coordinates attachment handling, MCP tool availability, streaming setup, and state
+        // resets. Breaking it apart right now would require plumbing a large amount of shared state, so
+        // we defer that refactor and explicitly allow the longer body.
+        // swiftlint:disable:next function_body_length
+        private func sendMessage(preparationID: UUID) async {
+            var handedOff = false
+            defer {
+                if sendPreparationID == preparationID {
+                    sendPreparationTask = nil
+                    sendPreparationID = nil
+                    if !handedOff {
+                        isGenerating = false
+                    }
+                }
+            }
+
+            guard sendPreparationID == preparationID, !Task.isCancelled else { return }
 
         // Auto-select response if we are continuing from a multi-model state without selection
         autoSelectResponseIfNeeded()
@@ -736,6 +872,10 @@ struct MacChatView: View {
         }
 
         ensureConversationModelMatchesSelection(activeModel)
+            let promptText = messageText
+            let filesToSend = attachedFiles
+            let appContentToSend = attachedAppContent
+            let selectedModelsToSend = selectedModels
         logChat(
             "🎯 Sending message with model \(activeModel)",
             level: .info,
@@ -744,45 +884,52 @@ struct MacChatView: View {
 
         // Build user message using ChatMessageBuilder
         let userMessage = await ChatMessageBuilder.createUserMessage(
-            text: messageText,
-            appContent: attachedAppContent,
-            fileURLs: attachedFiles,
+                text: promptText,
+                appContent: appContentToSend,
+                fileURLs: filesToSend,
             saveToStorage: true
         )
+            guard sendPreparationID == preparationID, !Task.isCancelled else {
+                discardStoredAttachments(in: userMessage)
+                return
+            }
 
-        if attachedAppContent != nil {
+            if appContentToSend != nil {
             logChat(
                 "📎 Including app content in message",
                 level: .info,
                 metadata: [
-                    "appName": attachedAppContent?.appName ?? "",
-                    "contentType": attachedAppContent?.contentType.displayName ?? "",
-                    "contentLength": "\(attachedAppContent?.content.count ?? 0)"
+                        "appName": appContentToSend?.appName ?? "",
+                        "contentType": appContentToSend?.contentType.displayName ?? "",
+                        "contentLength": "\(appContentToSend?.content.count ?? 0)"
                 ]
             )
         }
 
-        logChat(
-            "📨 Creating message with \(userMessage.attachments?.count ?? 0) attachments",
+            logChat(
+                "📨 Creating message with \(userMessage.attachments?.count ?? 0) attachments",
             level: .info,
             metadata: ["attachmentCount": "\(userMessage.attachments?.count ?? 0)"]
-        )
-        conversationManager.addMessage(to: conversation, message: userMessage)
+            )
+            pendingAutoSendClaim = nil
+            conversationManager.addMessage(to: conversation, message: userMessage)
 
         // Process memory commands (e.g., "remember that I prefer dark mode")
         if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: userMessage.content) {
             logChat("💾 Memory command processed: \(memoryResponse)", level: .info)
         }
 
-        let promptText = messageText
+            if messageText == promptText {
         messageText = ""
+            }
         isComposerFocused = true
-        attachedFiles = [] // Clear attached files after sending
-        attachedAppContent = nil // Clear app content after sending
+            attachedFiles.removeAll { filesToSend.contains($0) }
+            if isSameAppContent(attachedAppContent, appContentToSend) {
+                attachedAppContent = nil
+            }
         errorMessage = nil
         errorRecoverySuggestion = nil
         failedMessage = promptText // Store for retry in case of failure
-        isGenerating = true
         logChat("🔄 isGenerating set to TRUE", level: .info)
 
         // Get updated messages after adding user message
@@ -798,9 +945,10 @@ struct MacChatView: View {
         let modelCapability = aiService.getModelCapability(activeModel)
 
         if modelCapability == .imageGeneration {
+                handedOff = true
             // Image generation flow - handle multi-model image gen
-            if selectedModels.count >= 2 {
-                generateMultiModelImages(prompt: promptText, models: Array(selectedModels))
+                if selectedModelsToSend.count >= 2 {
+                    generateMultiModelImages(prompt: promptText, models: Array(selectedModelsToSend))
             } else {
                 generateImage(prompt: promptText, model: activeModel)
             }
@@ -808,16 +956,17 @@ struct MacChatView: View {
         }
 
         // Check if multi-model mode is enabled (2+ models selected)
-        if selectedModels.count >= 2 {
+            if selectedModelsToSend.count >= 2 {
+                handedOff = true
             sendMultiModelMessage(
                 userMessageId: userMessage.id,
-                models: Array(selectedModels),
+                    models: Array(selectedModelsToSend),
                 temperature: updatedConversation.temperature
             )
             return
         }
 
-        let currentMessages = updatedConversation.messages
+            let currentMessages = updatedConversation.getEffectiveHistory()
 
         // Prepend system prompt if configured
         var messagesToSend = currentMessages
@@ -890,31 +1039,17 @@ struct MacChatView: View {
         // Reset tool call depth for new user messages
         toolCallDepth = 0
 
-        // Start timeout watchdog for tool chain (60 seconds max)
-        toolChainTimeoutTask?.cancel()
-        toolChainTimeoutTask = Task { @MainActor in
-            try? await Task.sleep(for: .seconds(60))
-            guard !Task.isCancelled else { return }
-            if toolCallDepth > 0 {
-                logChat("⏰ Tool chain timeout after 60s, resetting state", level: .error)
-                toolCallDepth = 0
-                currentToolName = nil
-                if isGenerating {
-                    isGenerating = false
-                    errorMessage = "Tool execution timed out after 60 seconds"
-                }
-            }
-        }
-
         // Auto-select response if we are continuing from a multi-model state without selection
         autoSelectResponseIfNeeded()
 
+            handedOff = true
         sendMessageWithToolSupport(
             messages: messagesToSend,
             model: activeModel,
             temperature: updatedConversation.temperature,
             tools: tools,
-            isInitialRequest: true
+            isInitialRequest: true,
+            assistantMessageID: assistantMessage.id
         )
     }
 
@@ -925,374 +1060,370 @@ struct MacChatView: View {
         model: String,
         temperature: Double,
         tools: [[String: Any]]?,
-        isInitialRequest _: Bool
+        isInitialRequest _: Bool,
+        assistantMessageID requestedAssistantMessageID: UUID? = nil,
+        operationID existingOperationID: ToolChainCoordinator.OperationID? = nil
     ) {
         let maxToolCallDepth = AgentSettingsStore.shared.settings.maxToolChainDepth
         let mcpManager = MCPServerManager.shared
         let toolsWrapper = UncheckedSendableWrapper(tools)
-
         let conversationId = conversation.id
+        let coordinator = toolChainCoordinator
+        let requestRounds = toolCallRequestRoundCoordinator
+            let operationID: ToolChainCoordinator.OperationID
+            guard let assistantMessageID = requestedAssistantMessageID
+                ?? conversationManager.conversation(byId: conversationId)?.messages.last(where: { $0.role == .assistant })?.id
+            else {
+                isGenerating = false
+                return
+            }
+            activeAssistantMessageID = assistantMessageID
 
-        aiService.sendMessage(
+            if let existingOperationID {
+                operationID = existingOperationID
+            } else {
+                activeMultiModelResponseGroupID = nil
+                batchUpdateTask?.cancel()
+                batchUpdateTask = nil
+                pendingChunks.removeAll()
+                toolCallDepth = 0
+                operationID = coordinator.beginOperation(conversationID: conversationId)
+            }
+
+            guard coordinator.owns(operationID, conversationID: conversationId),
+                  let requestRoundID = requestRounds.beginRequestRound(
+                      for: operationID,
+                      coordinatedBy: coordinator
+                  )
+            else {
+                return
+            }
+
+            let request = aiService.sendMessage(
             messages: messages,
             model: model,
             temperature: temperature,
             tools: tools,
-            conversationId: conversation.id,
+                conversationId: conversationId,
             onChunk: { chunk in
-                Task { @MainActor in
-                    // Batch chunks for better performance during streaming
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard activeAssistantMessageID == assistantMessageID else { return }
                     pendingChunks.append(chunk)
-
-                    // Cancel existing batch task and create new one
                     batchUpdateTask?.cancel()
-                    batchUpdateTask = Task { @MainActor in
-                        // Wait for batch window (100ms for smoother updates with large text)
-                        try? await Task.sleep(for: .milliseconds(100))
-                        guard !Task.isCancelled else { return }
 
-                        // Process all pending chunks at once
+                        let batchTask = Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(100))
+                            guard !Task.isCancelled,
+                                  coordinator.owns(operationID, conversationID: conversationId),
+                                  activeAssistantMessageID == assistantMessageID
+                            else {
+                                return
+                            }
+
                         let chunksToProcess = pendingChunks
                         pendingChunks.removeAll()
-
                         guard !chunksToProcess.isEmpty else { return }
 
                         let combinedChunk = chunksToProcess.joined()
-
-                        // Always update the conversation data, but only update UI state if we're viewing this conversation
-                        guard let index = getConversationIndex() else {
+                            guard conversationManager.appendToMessage(
+                                conversationId: conversationId,
+                                messageId: assistantMessageID,
+                                chunk: combinedChunk
+                            ) else {
                             logChat(
-                                "⚠️ Conversation \(conversation.id) no longer exists, ignoring chunk",
-                                level: .info
+                                    "⚠️ Assistant message no longer exists, ignoring chunk",
+                                    level: .info,
+                                    metadata: ["messageId": assistantMessageID.uuidString]
                             )
                             return
                         }
-
-                        // Update the message content regardless of which conversation is active
-                        var lastMessage = conversationManager.conversations[index].messages.last
-                        if lastMessage?.role == .assistant {
-                            lastMessage?.content += combinedChunk
-                            conversationManager.conversations[index].messages[
-                                conversationManager.conversations[index].messages.count - 1
-                            ] = lastMessage!
+                            if let conversation = conversationManager.conversation(byId: conversationId) {
+                                conversationManager.save(conversation)
                         }
-
-                        // Persist during streaming so content isn't lost on quit
-                        conversationManager.save(conversationManager.conversations[index])
-
-                        // Only update UI state if we're currently viewing this conversation
-                        if conversationManager.conversations[index].id == conversationId {
-                            // Clear tool execution indicator when we start receiving actual content
-                            if currentToolName != nil {
                                 currentToolName = nil
                             }
-                        }
-                    }
+                        batchUpdateTask = batchTask
+                        coordinator.track(batchTask, for: operationID)
                 }
             },
             onComplete: {
-                Task { @MainActor in
-                    // Flush any pending chunks immediately
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard activeAssistantMessageID == assistantMessageID else { return }
                     batchUpdateTask?.cancel()
+                        batchUpdateTask = nil
+
                     if !pendingChunks.isEmpty {
                         let remainingChunks = pendingChunks.joined()
                         pendingChunks.removeAll()
-
-                        if let index = conversationManager.conversations.firstIndex(where: {
-                            $0.id == conversation.id
-                        }),
-                            var lastMessage = conversationManager.conversations[index].messages.last,
-                            lastMessage.role == .assistant
-                        {
-                            lastMessage.content += remainingChunks
-                            conversationManager.conversations[index].messages[
-                                conversationManager.conversations[index].messages.count - 1
-                            ] = lastMessage
-                        }
-                    }
-
-                    // Always save conversations immediately on completion
-                    if let index = conversationManager.conversations.firstIndex(where: {
-                        $0.id == conversation.id
-                    }) {
-                        conversationManager.saveImmediately(conversationManager.conversations[index])
-                    }
-
-                    // Only update UI state if we're viewing this conversation
-                    guard let currentIndex = conversationManager.conversations.firstIndex(where: {
-                        $0.id == conversationId
-                    }) else {
-                        isGenerating = false
-                        logChat(
-                            "✅ onComplete for conversation \(conversationId) (background)",
-                            level: .info
-                        )
-                        return
-                    }
-
-                    guard conversationManager.conversations[currentIndex].id == conversationId else {
-                        isGenerating = false
-                        logChat(
-                            "✅ onComplete for conversation \(conversationId) (background)",
-                            level: .info
-                        )
-                        return
-                    }
-
-                    // Only clear state if no tool call is pending
-                    // If currentToolName is set, a tool call was requested and will execute
-                    // The tool execution will manage the state from there
-                    if currentToolName == nil {
-                        logChat("✅ onComplete: isGenerating set to FALSE (no tool calls pending)", level: .info)
-                        isGenerating = false
-                        failedMessage = nil // Clear failed message on success
-                        toolChainTimeoutTask?.cancel()
-                        toolChainTimeoutTask = nil
-                    } else {
-                        logChat(
-                            "⏳ onComplete: Keeping isGenerating TRUE (tool call pending: \(currentToolName ?? "unknown"))",
-                            level: .info,
-                            metadata: ["toolName": currentToolName ?? "unknown"]
+                            conversationManager.appendToMessage(
+                                conversationId: conversationId,
+                                messageId: assistantMessageID,
+                                chunk: remainingChunks
                         )
                     }
+                        if let conversation = conversationManager.conversation(byId: conversationId) {
+                            conversationManager.saveImmediately(conversation)
+                    }
+
+                        let resolution = requestRounds.providerDidComplete(
+                            operationID: operationID,
+                            requestRoundID: requestRoundID
+                        )
+                        handleToolRoundResolution(
+                            resolution,
+                            operationID: operationID,
+                            sourceAssistantMessageID: assistantMessageID,
+                            conversationID: conversationId,
+                            model: model,
+                            temperature: temperature,
+                            tools: toolsWrapper.value
+                        )
                 }
             },
             onError: { error in
-                Task { @MainActor in
-                    // Clean up batching
-                    batchUpdateTask?.cancel()
-                    pendingChunks.removeAll()
-
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard activeAssistantMessageID == assistantMessageID else { return }
+                        guard coordinator.owns(operationID, conversationID: conversationId) else { return }
+                        abortOwnedTextGeneration(operationID: operationID, conversationID: conversationId)
+                        if !(error is CancellationError) {
                     logChat(
                         "❌ Stream error",
                         level: .error,
                         metadata: ["error": error.localizedDescription]
                     )
-
-                    // Remove the empty assistant placeholder message since we show error in banner
-                    if let index = conversationManager.conversations.firstIndex(where: {
-                        $0.id == conversation.id
-                    }) {
-                        let lastIndex = conversationManager.conversations[index].messages.count - 1
-                        if lastIndex >= 0,
-                           conversationManager.conversations[index].messages[lastIndex].role == .assistant,
-                           conversationManager.conversations[index].messages[lastIndex].content.isEmpty
-                        {
-                            conversationManager.conversations[index].messages.remove(at: lastIndex)
-                        }
-                    }
-
-                    // Only update UI state if we're viewing this conversation
-                    guard conversationManager.conversations.firstIndex(where: {
-                        $0.id == conversationId
-                    }) != nil else {
-                        isGenerating = false
-                        let safeMessage = ErrorPresenter.userMessage(for: error)
-                        logChat(
-                            "❌ onError for conversation \(conversationId) (background): \(safeMessage)",
-                            level: .error,
-                            metadata: ["error": safeMessage]
-                        )
-                        return
-                    }
-
-                    isGenerating = false
-                    currentToolName = nil
-                    toolCallDepth = 0
-                    toolChainTimeoutTask?.cancel()
-                    toolChainTimeoutTask = nil
                     errorMessage = ErrorPresenter.userMessage(for: error)
                     errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
                 }
+                    }
             },
             onToolCallRequested: { toolCallId, toolName, arguments in
                 let argumentsWrapper = UncheckedSendableWrapper(arguments)
-                let toolNameCopy = toolName
-                Task { @MainActor in
-                    // Set currentToolName first thing to prevent race condition with onComplete
-                    // checking if tool call is pending. The stream may send [DONE] immediately
-                    // after finish_reason: "tool_calls".
-                    currentToolName = toolNameCopy
-                    let arguments = argumentsWrapper.value
-                    // Validate conversation still exists
-                    guard conversationManager.conversations.contains(where: { $0.id == conversation.id }) else {
-                        logChat(
-                            "⚠️ Tool call requested for conversation \(conversation.id) but conversation no longer exists, ignoring",
-                            level: .default
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard activeAssistantMessageID == assistantMessageID,
+                              let token = requestRounds.registerTool(
+                                  for: operationID,
+                                  requestRoundID: requestRoundID
                         )
-                        currentToolName = nil // Clear since we're not processing
+                        else {
                         return
                     }
 
-                    // Tool call was requested by the LLM
-                    logChat(
-                        "🔧 Tool call requested: \(toolName) for conversation \(conversation.id)",
-                        level: .info,
-                        metadata: ["toolName": toolName]
-                    )
-
-                    // Check depth limit
+                        if token.registrationIndex == 0 {
                     guard toolCallDepth < maxToolCallDepth else {
                         logChat("⚠️ Max tool call depth reached, stopping", level: .error)
-                        isGenerating = false
-                        currentToolName = nil
+                                abortOwnedTextGeneration(operationID: operationID, conversationID: conversationId)
+                                errorMessage = "Tool call limit reached. Please try again."
                         return
                     }
-
                     toolCallDepth += 1
+                            armToolChainTimeout(
+                                operationID: operationID,
+                                assistantMessageID: assistantMessageID,
+                                conversationID: conversationId
+                            )
+                        }
 
-                    // Store the tool call in the last assistant message
-                    if let index = conversationManager.conversations.firstIndex(where: {
-                        $0.id == conversation.id
-                    }),
-                        var lastMessage = conversationManager.conversations[index].messages.last,
-                        lastMessage.role == .assistant
-                    {
-                        // Convert arguments to AnyCodable
-                        let toolCall = ToolCallHandler.createToolCall(
+                        currentToolName = toolName
+                        let arguments = argumentsWrapper.value
+                        let anyCodableArguments = arguments.reduce(into: [String: AnyCodable]()) { result, pair in
+                            result[pair.key] = AnyCodable(pair.value)
+                        }
+                        let toolCall = MCPToolCall(
                             id: toolCallId,
                             toolName: toolName,
-                            arguments: arguments
+                            arguments: anyCodableArguments
                         )
-                        var existingToolCalls = lastMessage.toolCalls ?? []
-                        existingToolCalls.append(toolCall)
-                        lastMessage.toolCalls = existingToolCalls
-                        conversationManager.conversations[index].messages[
-                            conversationManager.conversations[index].messages.count - 1
-                        ] = lastMessage
-                        conversationManager.save(conversationManager.conversations[index])
+                        conversationManager.updateMessage(
+                            conversationId: conversationId,
+                            messageId: assistantMessageID
+                        ) { message in
+                            var calls = message.toolCalls ?? []
+                            if !calls.contains(where: { $0.id == toolCallId }) {
+                                calls.append(toolCall)
+                            }
+                            message.toolCalls = calls
+                        }
+                        if let conversation = conversationManager.conversation(byId: conversationId) {
+                            conversationManager.save(conversation)
                     }
 
-                    // Execute the tool asynchronously
-                    Task {
-                        do {
-                            logChat(
-                                "⚙️ Executing tool: \(toolName)",
-                                level: .info,
-                                metadata: ["toolName": toolName]
-                            )
-
-                            // Route to appropriate tool handler
-                            let result: String
-                            var citations: [CitationReference]?
-
-                            if aiService.isBuiltInTool(toolName) {
-                                // Built-in tool (e.g., web_search, agentic tools) - get citations
-                                let (toolResult, toolCitations) = await aiService.executeBuiltInToolWithCitations(
-                                    name: toolName,
-                                    arguments: argumentsWrapper.value,
-                                    conversationId: conversation.id
-                                )
-                                result = toolResult
-                                citations = toolCitations
-                            } else {
-                                // MCP tool
-                                result = try await mcpManager.executeTool(name: toolName, arguments: argumentsWrapper.value)
+                        coordinator.schedule(for: operationID, conversationID: conversationId) {
+                            guard coordinator.owns(operationID, conversationID: conversationId),
+                                  activeAssistantMessageID == assistantMessageID,
+                                  !Task.isCancelled
+                            else {
+                                return
                             }
 
-                            logChat(
-                                "✅ Tool result received (\(result.count) chars)",
-                                level: .info,
-                                metadata: ["resultLength": "\(result.count)"]
-                            )
+                            let result: ToolExecutionResult
+                            do {
+                                logChat(
+                                    "⚙️ Executing tool: \(toolName)",
+                                    level: .info,
+                                    metadata: ["toolName": toolName]
+                                )
 
-                            // For web_search, skip creating a visible tool message
-                            let isWebSearch = ToolCallHandler.isWebSearchTool(toolName)
-
-                            // Create a tool message with the result
-                            await MainActor.run {
-                                if !isWebSearch {
-                                    // For non-web-search tools, create the tool message
-                                    let toolMessage = ToolCallHandler.createToolMessage(
-                                        toolCallId: toolCallId,
-                                        toolName: toolName,
+                                let output: String
+                                let citations: [CitationReference]?
+                                if aiService.isBuiltInTool(toolName) {
+                                    (output, citations) = await aiService.executeBuiltInToolWithCitations(
+                                        name: toolName,
                                         arguments: argumentsWrapper.value,
-                                        result: result
+                                        conversationId: conversationId
                                     )
-                                    conversationManager.addMessage(to: conversation, message: toolMessage)
+                                } else {
+                                    output = try await mcpManager.executeTool(
+                                        name: toolName,
+                                        arguments: argumentsWrapper.value
+                                    )
+                                    citations = nil
                                 }
-
-                                // Get updated conversation with tool result
-                                guard
-                                    let updatedConv = conversationManager.conversations.first(where: {
-                                        $0.id == conversation.id
-                                    })
-                                else {
-                                    // Only update UI if viewing this conversation
-                                    if conversationManager.conversations.contains(where: { $0.id == conversationId }) {
-                                        isGenerating = false
-                                        currentToolName = nil
-                                        toolCallDepth = 0
-                                        toolChainTimeoutTask?.cancel()
-                                        toolChainTimeoutTask = nil
-                                    }
-                                    return
-                                }
-
-                                // Continue conversation with tool result
-                                // Add a new empty assistant message for the model's response
-                                let continuationAssistantMessage = ToolCallHandler.createContinuationMessage(
-                                    model: model,
-                                    citations: isWebSearch ? citations : nil
-                                )
-                                conversationManager.addMessage(to: updatedConv, message: continuationAssistantMessage)
-
-                                // Get the conversation again with the new assistant message
-                                guard
-                                    let convWithAssistant = conversationManager.conversations.first(where: {
-                                        $0.id == conversation.id
-                                    })
+                                guard coordinator.owns(operationID, conversationID: conversationId),
+                                      activeAssistantMessageID == assistantMessageID,
+                                      !Task.isCancelled
                                 else {
                                     return
                                 }
-
-                                // Build messages for API using ToolCallHandler
-                                let continuationMessages = ToolCallHandler.buildContinuationMessages(
-                                    conversationMessages: convWithAssistant.messages,
-                                    toolCallId: toolCallId,
+                                result = ToolExecutionResult(
+                                    callID: toolCallId,
                                     toolName: toolName,
-                                    arguments: argumentsWrapper.value,
-                                    result: result,
-                                    isWebSearch: isWebSearch,
-                                    systemPrompt: buildFullSystemPrompt(for: convWithAssistant)
+                                    arguments: anyCodableArguments,
+                                    output: output,
+                                    citations: citations ?? []
                                 )
-
-                                // Clear tool name since tool execution is complete
-                                // The continuation is now a regular API call
-                                currentToolName = nil
-
-                                sendMessageWithToolSupport(
-                                    messages: continuationMessages,
-                                    model: model,
-                                    temperature: temperature,
-                                    tools: toolsWrapper.value,
-                                    isInitialRequest: false
+                            } catch is CancellationError {
+                                return
+                            } catch {
+                                guard coordinator.owns(operationID, conversationID: conversationId),
+                                      activeAssistantMessageID == assistantMessageID,
+                                      !Task.isCancelled
+                                else {
+                                    return
+                                }
+                                logChat(
+                                    "❌ Tool execution failed: \(error.localizedDescription)",
+                                    level: .error,
+                                    metadata: ["toolName": toolName, "error": error.localizedDescription]
+                                )
+                                result = ToolExecutionResult(
+                                    callID: toolCallId,
+                                    toolName: toolName,
+                                    arguments: anyCodableArguments,
+                                    output: "ERROR: \(error.localizedDescription)"
                                 )
                             }
-                        } catch {
-                            logChat(
-                                "❌ Tool execution failed: \(error.localizedDescription)",
-                                level: .error,
-                                metadata: ["error": error.localizedDescription]
+
+                            let resolution = requestRounds.toolDidComplete(token, result: result)
+                            handleToolRoundResolution(
+                                resolution,
+                                operationID: operationID,
+                                sourceAssistantMessageID: assistantMessageID,
+                                conversationID: conversationId,
+                                model: model,
+                                temperature: temperature,
+                                tools: toolsWrapper.value
                             )
-                            await MainActor.run {
-                                isGenerating = false
-                                currentToolName = nil
-                                toolCallDepth = 0
-                                toolChainTimeoutTask?.cancel()
-                                toolChainTimeoutTask = nil
-                                errorMessage = "Tool execution failed: \(error.localizedDescription)"
-                            }
                         }
                     }
                 }
+            )
+            coordinator.track(request, for: operationID)
+        }
+
+        private func handleToolRoundResolution(
+            _ resolution: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Resolution,
+            operationID: ToolChainCoordinator.OperationID,
+            sourceAssistantMessageID: UUID,
+            conversationID: UUID,
+            model: String,
+            temperature: Double,
+            tools: [[String: Any]]?
+        ) {
+            switch resolution {
+            case .pending:
+                return
+            case .ignored:
+                return
+            case .responseCompleted:
+                toolChainTimeoutTask?.cancel()
+                toolChainTimeoutTask = nil
+                guard toolChainCoordinator.finishOperation(operationID) else { return }
+                activeAssistantMessageID = nil
+                currentToolName = nil
+                toolCallDepth = 0
+                isGenerating = false
+                failedMessage = nil
+            case let .launchContinuation(continuation):
+                toolChainTimeoutTask?.cancel()
+                toolChainTimeoutTask = nil
+                launchToolContinuation(
+                    continuation,
+                    operationID: operationID,
+                    sourceAssistantMessageID: sourceAssistantMessageID,
+                    conversationID: conversationID,
+                    model: model,
+                    temperature: temperature,
+                    tools: tools
+                )
             }
-        )
+        }
+
+        private func launchToolContinuation(
+            _ continuation: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Continuation,
+            operationID: ToolChainCoordinator.OperationID,
+            sourceAssistantMessageID: UUID,
+            conversationID: UUID,
+            model: String,
+            temperature: Double,
+            tools: [[String: Any]]?
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationID),
+                  continuation.operationID == operationID,
+                  activeAssistantMessageID == sourceAssistantMessageID,
+                  let conversation = conversationManager.conversation(byId: conversationID)
+            else {
+                return
+            }
+
+            let results = continuation.toolResults.map(\.result)
+            for result in results {
+                conversationManager.addMessage(to: conversation, message: result.makeMessage())
+            }
+
+            let citations = ToolExecutionResult.combinedCitations(from: results)
+            let continuationMessage = ToolCallHandler.createContinuationMessage(
+                model: model,
+                citations: citations.isEmpty ? nil : citations
+            )
+            conversationManager.addMessage(to: conversation, message: continuationMessage)
+
+            guard let conversationWithAssistant = conversationManager.conversation(byId: conversationID),
+                  toolChainCoordinator.owns(operationID, conversationID: conversationID)
+            else {
+                return
+            }
+
+            var history = conversationWithAssistant
+            history.messages.removeAll { $0.id == continuationMessage.id }
+            var continuationMessages = history.getEffectiveHistory()
+            if let systemPrompt = buildFullSystemPrompt(for: conversationWithAssistant) {
+                continuationMessages.insert(Message(role: .system, content: systemPrompt), at: 0)
+            }
+
+            currentToolName = nil
+            sendMessageWithToolSupport(
+                messages: continuationMessages,
+                model: model,
+                temperature: temperature,
+                tools: tools,
+                isInitialRequest: false,
+                assistantMessageID: continuationMessage.id,
+                operationID: operationID
+            )
+        }
     }
 
-}
-
-// MARK: - Pending Approvals Section View
+    // MARK: - Pending Approvals Section View
 
 /// Helper view for pending approvals.
 /// Reads directly from PermissionService (@Observable) so SwiftUI tracks changes automatically.

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -1098,6 +1098,7 @@ struct MacChatView: View {
             else {
                 return
             }
+            let toolCallAdmissionGate = ToolCallRequestAdmissionGate()
 
             let request = aiService.sendMessage(
             messages: messages,
@@ -1196,7 +1197,7 @@ struct MacChatView: View {
                 }
                     }
             },
-            onToolCallRequested: { toolCallId, toolName, arguments in
+            onToolCallRequested: toolCallAdmissionGate.admittedCallback { toolCallId, toolName, arguments in
                 let argumentsWrapper = UncheckedSendableWrapper(arguments)
                     coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                         guard activeAssistantMessageID == assistantMessageID,

--- a/Sources/Ayna/Views/macOS/MacContentView.swift
+++ b/Sources/Ayna/Views/macOS/MacContentView.swift
@@ -19,6 +19,8 @@ extension Notification.Name {
 struct MacContentView: View {
     @EnvironmentObject var conversationManager: ConversationManager
     @ObservedObject private var deepLinkManager = DeepLinkManager.shared
+    @State private var presentedAddModelRequest: AddModelRequest?
+    @State private var dismissingAddModelRequestID: UUID?
 
     var body: some View {
         ZStack {
@@ -89,34 +91,88 @@ struct MacContentView: View {
         }
         // Add model confirmation sheet
         .sheet(isPresented: .init(
-            get: { deepLinkManager.pendingAddModel != nil },
+            get: { presentedAddModelRequest != nil },
             set: { newValue in
-                // Only cancel if the sheet is being dismissed AND pendingAddModel is still set
-                // (i.e., user dismissed without clicking Add - confirmAddModel already clears it)
-                if !newValue, deepLinkManager.pendingAddModel != nil {
-                    deepLinkManager.cancelAddModel()
+                guard !newValue else { return }
+                if let requestID = dismissingAddModelRequestID {
+                    completeAddModelDismissal(requestID)
+                } else if let request = presentedAddModelRequest {
+                    dismissingAddModelRequestID = request.id
+                    presentedAddModelRequest = nil
+                    deepLinkManager.cancelAddModel(expectedRequestID: request.id)
+                    completeAddModelDismissal(request.id)
                 }
             }
         )) {
-            if let request = deepLinkManager.pendingAddModel {
-                AddModelConfirmationSheet(request: request)
+            if let request = presentedAddModelRequest {
+                AddModelConfirmationSheet(
+                    request: request,
+                    onCancel: { finishPresentedAddModel(request, shouldConfirm: false) },
+                    onConfirm: { finishPresentedAddModel(request, shouldConfirm: true) }
+                )
+            }
+        }
+        .onAppear {
+            if presentedAddModelRequest == nil {
+                presentedAddModelRequest = deepLinkManager.pendingAddModel
             }
         }
         // Process pending chat after add-model sheet is dismissed (unified flow)
         .onChange(of: deepLinkManager.pendingAddModel) { oldValue, newValue in
-            // When pendingAddModel goes from some value to nil AND we have a pending chat
-            if oldValue != nil, newValue == nil, let chatRequest = deepLinkManager.pendingChat {
-                // Model was added (or cancelled), process the pending chat if model now exists
-                if let model = chatRequest.model,
-                   AIService.shared.customModels.contains(model)
-                {
-                    _ = conversationManager.startConversation(
-                        model: chatRequest.model,
-                        prompt: chatRequest.prompt,
-                        systemPrompt: chatRequest.systemPrompt
-                    )
-                }
-                deepLinkManager.clearPendingChat()
+            updatePresentedAddModel(from: oldValue, to: newValue)
+            guard oldValue != nil, newValue == nil else { return }
+
+            if let chatRequest = deepLinkManager.consumeNextReadyChat() {
+                _ = conversationManager.startConversation(
+                    model: chatRequest.model,
+                    prompt: chatRequest.prompt,
+                    systemPrompt: chatRequest.systemPrompt
+                )
+            }
+        }
+    }
+
+    private func finishPresentedAddModel(_ request: AddModelRequest, shouldConfirm: Bool) {
+        guard dismissingAddModelRequestID == nil,
+              presentedAddModelRequest?.id == request.id
+        else { return }
+
+        dismissingAddModelRequestID = request.id
+        presentedAddModelRequest = nil
+        if shouldConfirm {
+            deepLinkManager.confirmAddModel(expectedRequestID: request.id)
+        } else {
+            deepLinkManager.cancelAddModel(expectedRequestID: request.id)
+        }
+    }
+
+    private func updatePresentedAddModel(from oldValue: AddModelRequest?, to newValue: AddModelRequest?) {
+        if newValue == nil,
+           dismissingAddModelRequestID == nil,
+           presentedAddModelRequest?.id == oldValue?.id
+        {
+            dismissingAddModelRequestID = oldValue?.id
+            presentedAddModelRequest = nil
+        } else if newValue != nil,
+                  dismissingAddModelRequestID == nil,
+                  presentedAddModelRequest == nil
+        {
+            presentedAddModelRequest = newValue
+        }
+    }
+
+    private func completeAddModelDismissal(_ requestID: UUID) {
+        guard dismissingAddModelRequestID == requestID else { return }
+        presentPendingAddModelAfterDismissal(requestID)
+    }
+
+    private func presentPendingAddModelAfterDismissal(_ requestID: UUID) {
+        Task { @MainActor in
+            await Task.yield()
+            guard dismissingAddModelRequestID == requestID else { return }
+            dismissingAddModelRequestID = nil
+            if presentedAddModelRequest == nil {
+                presentedAddModelRequest = deepLinkManager.pendingAddModel
             }
         }
     }
@@ -126,7 +182,8 @@ struct MacContentView: View {
 
 private struct AddModelConfirmationSheet: View {
     let request: AddModelRequest
-    @ObservedObject private var deepLinkManager = DeepLinkManager.shared
+    let onCancel: () -> Void
+    let onConfirm: () -> Void
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -176,13 +233,13 @@ private struct AddModelConfirmationSheet: View {
             // Actions
             HStack(spacing: 16) {
                 Button("Cancel") {
-                    deepLinkManager.cancelAddModel()
+                    onCancel()
                     dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Button("Add Model") {
-                    deepLinkManager.confirmAddModel()
+                    onConfirm()
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)

--- a/Sources/Ayna/Views/macOS/MacMessageView.swift
+++ b/Sources/Ayna/Views/macOS/MacMessageView.swift
@@ -471,10 +471,13 @@ struct MacMessageView: View {
 
         // Check if message has meaningful reasoning content
         let hasReasoning = message.reasoning.map { !$0.isEmpty } ?? false
+        let hasCitations = !(message.citations?.isEmpty ?? true)
 
         // Show typing indicator for empty assistant messages (waiting for response)
         // But not if we have reasoning content (model is thinking)
-        if message.role == .assistant, message.content.isEmpty, message.mediaType != .image, !hasReasoning {
+        if message.role == .assistant, message.content.isEmpty, message.mediaType != .image,
+           !hasReasoning, !hasCitations
+        {
             TypingIndicatorView()
         }
 

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 #if os(macOS)
 //
 //  MacNewChatView.swift
@@ -20,12 +21,18 @@ struct MacNewChatView: View {
     @State var isGenerating = false
     @State var currentConversationId: UUID?
     @State private var selectedModel = AIService.shared.selectedModel
-    @State private var toolCallDepth = 0
-    @State private var currentToolName: String?
+        @State var toolCallDepth = 0
+        @State var currentToolName: String?
+        @State var activeAssistantMessageID: UUID?
+        @State var activeMultiModelResponseGroupID: UUID?
     @State private var showModelSelector = false
     @State private var selectedModels: Set<String> = []
     @State private var isToolSectionExpanded = false
-    @State private var imageGenerationCoordinator = ImageGenerationCoordinator()
+        @State var toolChainCoordinator = ToolChainCoordinator()
+        @State private var toolCallRequestRoundCoordinator = ToolCallRequestRoundCoordinator<ToolExecutionResult>()
+        @State var imageGenerationCoordinator = ImageGenerationCoordinator()
+        @State private var sendPreparationTask: Task<Void, Never>?
+        @State private var sendPreparationID: UUID?
 
     @State var errorMessage: String?
     @State var errorRecoverySuggestion: String?
@@ -73,7 +80,15 @@ struct MacNewChatView: View {
             }
 
             if message.role == .tool {
-                return !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    let isWebSearchResult = message.toolCalls?.contains(where: {
+                        $0.toolName == WebSearchCoordinator.toolName
+                    }) == true
+                    return !isWebSearchResult &&
+                        !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                }
+
+                if message.role == .assistant, let citations = message.citations, !citations.isEmpty {
+                    return true
             }
 
             if message.role == .assistant && message.content.isEmpty && message.imageData == nil {
@@ -196,7 +211,7 @@ struct MacNewChatView: View {
                                                             in: conversation,
                                                             messageId: message.id,
                                                             newContent: newContent
-                                                        )
+                                                    )
                                                         if edited {
                                                             sendMessageForConversation(conversation, model: conversation.model)
                                                         }
@@ -274,9 +289,7 @@ struct MacNewChatView: View {
             syncSelectedModelState()
         }
         .onDisappear {
-            if imageGenerationCoordinator.cancelCurrentOperation() {
-                isGenerating = false
-            }
+                cancelOwnedGenerationForLifecycle()
         }
         .onChange(of: currentConversation?.model ?? "") { _, _ in
             syncSelectedModelState()
@@ -315,7 +328,7 @@ struct MacNewChatView: View {
             composerModelLabel: composerModelLabel,
             textEditorIdentifier: TestIdentifiers.NewChatComposer.textEditor,
             sendButtonIdentifier: TestIdentifiers.NewChatComposer.sendButton,
-            onSendMessage: { Task { await sendMessage() } },
+                onSendMessage: { beginSendMessage() },
             onAttachFile: attachFile,
             onShowAppContentPicker: { showAppContentPicker = true },
             onToggleModelSelection: toggleModelSelection,
@@ -460,16 +473,10 @@ struct MacNewChatView: View {
 
     // MARK: - Send Message
 
-    private func sendMessage() async {
-        dismissError()
-        if isGenerating {
-            // Stop generation immediately
+        private func beginSendMessage() {
+            if isGenerating || sendPreparationTask != nil {
             logNewChat("🛑 Stop button clicked in NewChatView, cancelling...", level: .info)
-            let cancelledImageOperation = imageGenerationCoordinator.cancelCurrentOperation()
-            if !cancelledImageOperation {
-                AIService.shared.cancelCurrentRequest(includeImageRequests: false)
-            }
-            isGenerating = false
+                cancelOwnedGenerationForLifecycle()
             logNewChat("✅ isGenerating set to FALSE after stop", level: .info)
             isComposerFocused = true
             return
@@ -479,6 +486,37 @@ struct MacNewChatView: View {
             isComposerFocused = true
             return
         }
+
+            let preparationID = UUID()
+            sendPreparationID = preparationID
+            isGenerating = true
+            let task = Task { @MainActor in
+                guard !Task.isCancelled, sendPreparationID == preparationID else { return }
+                await sendMessage(preparationID: preparationID)
+            }
+            sendPreparationTask = task
+        }
+
+        func cancelSendPreparation() {
+            sendPreparationTask?.cancel()
+            sendPreparationTask = nil
+            sendPreparationID = nil
+        }
+
+        private func sendMessage(preparationID: UUID) async {
+            var handedOff = false
+            defer {
+                if sendPreparationID == preparationID {
+                    sendPreparationTask = nil
+                    sendPreparationID = nil
+                    if !handedOff {
+                    isGenerating = false
+                    }
+                }
+            }
+
+            dismissError()
+            guard sendPreparationID == preparationID, !Task.isCancelled else { return }
 
         guard let activeModel = resolveModelForSending() else {
             logNewChat("⚠️ Cannot send message: no model selected", level: .error)
@@ -493,6 +531,17 @@ struct MacNewChatView: View {
 
         let textToSend = messageText
         let filesToSend = attachedFiles
+            let appContentToSend = attachedAppContent
+
+            // Attachment construction is the only suspension in send preparation. Do it before
+            // mutating conversation state, then recheck lifecycle ownership before committing.
+            let userMessage = await ChatMessageBuilder.createUserMessage(
+                text: textToSend,
+                appContent: appContentToSend,
+                fileURLs: filesToSend,
+                saveToStorage: false
+            )
+            guard sendPreparationID == preparationID, !Task.isCancelled else { return }
 
         // Get or create the conversation
         let conversation: Conversation
@@ -530,22 +579,14 @@ struct MacNewChatView: View {
         updatedConversation.multiModelEnabled = selectedModels.count > 1
         conversationManager.updateConversation(updatedConversation)
 
-        // Build user message using ChatMessageBuilder
-        let userMessage = await ChatMessageBuilder.createUserMessage(
-            text: textToSend,
-            appContent: attachedAppContent,
-            fileURLs: filesToSend,
-            saveToStorage: false
-        )
-
-        if attachedAppContent != nil {
+            if appContentToSend != nil {
             logNewChat(
                 "📎 Including app content in message",
                 level: .info,
                 metadata: [
-                    "appName": attachedAppContent?.appName ?? "",
-                    "contentType": attachedAppContent?.contentType.displayName ?? "",
-                    "contentLength": "\(attachedAppContent?.content.count ?? 0)"
+                        "appName": appContentToSend?.appName ?? "",
+                        "contentType": appContentToSend?.contentType.displayName ?? "",
+                        "contentLength": "\(appContentToSend?.content.count ?? 0)"
                 ]
             )
         }
@@ -569,8 +610,8 @@ struct MacNewChatView: View {
         // Check if we're in image generation mode (any selected model is image gen means all are)
         let modelCapability = aiService.getModelCapability(activeModel)
         if modelCapability == .imageGeneration {
+                handedOff = true
             // Image generation flow - handle multi-model image gen
-            isGenerating = true
             if selectedModels.count > 1 {
                 generateMultiModelImages(prompt: textToSend, models: Array(selectedModels), conversation: conversation)
             } else {
@@ -581,13 +622,14 @@ struct MacNewChatView: View {
 
         // Send the message immediately (no delay needed)
         if selectedModels.count > 1 {
-            isGenerating = true
+                handedOff = true
             sendMultiModelMessage(
                 userMessageId: userMessage.id,
                 models: Array(selectedModels),
                 temperature: conversation.temperature
             )
         } else {
+                handedOff = true
             sendMessageForConversation(conversation, model: activeModel)
         }
     }
@@ -629,7 +671,8 @@ struct MacNewChatView: View {
             messages: currentMessages,
             model: activeModel,
             temperature: updatedConversation.temperature,
-            tools: tools
+                tools: tools,
+                assistantMessageID: assistantMessage.id
         )
     }
 
@@ -820,7 +863,7 @@ struct MacNewChatView: View {
             }
             let onError: @Sendable (Error) -> Void = { error in
                 coordinator.schedule(for: operationID) {
-                    logNewChat(
+                logNewChat(
                         "❌ Image generation failed for \(model): \(error.localizedDescription)",
                         level: .error,
                         metadata: ["model": model]
@@ -956,13 +999,17 @@ struct MacNewChatView: View {
             messagesToSend.insert(systemMessage, at: 0)
         }
 
-        // Send to all models in parallel
-        aiService.sendToMultipleModels(
+            // Send to all models in parallel under this view's owner-specific operation.
+            let coordinator = toolChainCoordinator
+            activeAssistantMessageID = nil
+            activeMultiModelResponseGroupID = responseGroupId
+            let operationID = coordinator.beginOperation(conversationID: conversationId)
+            let request = aiService.sendToMultipleModels(
             messages: messagesToSend,
             models: models,
             temperature: temperature,
             onChunk: { model, chunk in
-                Task { @MainActor in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model],
                           let convIndex = conversationManager.conversations.firstIndex(where: {
                               $0.id == conversationId
@@ -978,15 +1025,21 @@ struct MacNewChatView: View {
                 }
             },
             onModelComplete: { model in
-                Task { @MainActor in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model] else { return }
 
-                    updateResponseGroupViaGroup(conversationId: conversationId, responseGroupId: responseGroupId, messageId: messageId, status: .completed)
+                        updateResponseGroupViaGroup(
+                            conversationId: conversationId,
+                            responseGroupId: responseGroupId,
+                            messageId: messageId,
+                            status: .completed
+                        )
                     logNewChat("✅ Model completed in multi-model", level: .info, metadata: ["model": model])
                 }
             },
             onAllComplete: {
-                Task { @MainActor in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard coordinator.owns(operationID, conversationID: conversationId) else { return }
                     isGenerating = false
                     logNewChat("🏁 All models completed", level: .info)
 
@@ -996,17 +1049,28 @@ struct MacNewChatView: View {
                     }) {
                         conversationManager.saveImmediately(conversationManager.conversations[convIndex])
                     }
+                        activeMultiModelResponseGroupID = nil
+                        guard coordinator.finishOperation(operationID) else { return }
 
                     // Switch to chat view
                     selectedConversationId = conversationId
                 }
             },
             onError: { model, error in
-                Task { @MainActor in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model] else { return }
 
-                    updateResponseGroupViaGroup(conversationId: conversationId, responseGroupId: responseGroupId, messageId: messageId, status: .failed)
-                    logNewChat("❌ Model failed in multi-model", level: .error, metadata: ["model": model, "error": error.localizedDescription])
+                        updateResponseGroupViaGroup(
+                            conversationId: conversationId,
+                            responseGroupId: responseGroupId,
+                            messageId: messageId,
+                            status: .failed
+                        )
+                        logNewChat(
+                            "❌ Model failed in multi-model",
+                            level: .error,
+                            metadata: ["model": model, "error": error.localizedDescription]
+                        )
 
                     if errorMessage == nil {
                         let safeMessage = ErrorPresenter.userMessage(for: error)
@@ -1017,6 +1081,9 @@ struct MacNewChatView: View {
                 }
             }
         )
+            coordinator.onCancel(for: operationID) {
+                request.cancel()
+            }
     }
 
     // swiftlint:disable:next function_body_length
@@ -1025,75 +1092,95 @@ struct MacNewChatView: View {
         messages: [Message],
         model: String,
         temperature: Double,
-        tools: [[String: Any]]?
+        tools: [[String: Any]]?,
+        assistantMessageID requestedAssistantMessageID: UUID? = nil,
+        operationID existingOperationID: ToolChainCoordinator.OperationID? = nil
     ) {
         let maxToolCallDepth = AgentSettingsStore.shared.settings.maxToolChainDepth
         let conversationId = conversation.id
         let mcpManager = MCPServerManager.shared
         let toolsWrapper = UncheckedSendableWrapper(tools)
+        let coordinator = toolChainCoordinator
+        let requestRounds = toolCallRequestRoundCoordinator
+        let operationID: ToolChainCoordinator.OperationID
+            guard let assistantMessageID = requestedAssistantMessageID
+                ?? conversationManager.conversation(byId: conversationId)?.messages.last(where: { $0.role == .assistant })?.id
+            else {
+                isGenerating = false
+                return
+            }
+            activeAssistantMessageID = assistantMessageID
 
-        aiService.sendMessage(
+            if let existingOperationID {
+                operationID = existingOperationID
+            } else {
+                activeMultiModelResponseGroupID = nil
+                toolCallDepth = 0
+                operationID = coordinator.beginOperation(conversationID: conversationId)
+            }
+
+            guard coordinator.owns(operationID, conversationID: conversationId),
+                  let requestRoundID = requestRounds.beginRequestRound(
+                      for: operationID,
+                      coordinatedBy: coordinator
+                  )
+            else {
+                return
+            }
+
+            let request = aiService.sendMessage(
             messages: messages,
             model: model,
             temperature: temperature,
             tools: tools,
-            conversationId: conversation.id,
+                conversationId: conversationId,
             onChunk: { chunk in
-                Task { @MainActor in
-                    guard let index = conversationManager.conversations
-                        .firstIndex(where: { $0.id == conversationId })
-                    else {
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard activeAssistantMessageID == assistantMessageID else { return }
+                        guard conversationManager.appendToMessage(
+                            conversationId: conversationId,
+                            messageId: assistantMessageID,
+                            chunk: chunk
+                        ) else {
                         logNewChat(
-                            "⚠️ Conversation \(conversationId) no longer exists, ignoring chunk",
-                            level: .info,
-                            metadata: ["conversationId": conversationId.uuidString]
+                                "⚠️ Assistant message no longer exists, ignoring chunk",
+                        level: .info,
+                                metadata: ["messageId": assistantMessageID.uuidString]
                         )
                         return
                     }
-
-                    if var lastMessage = conversationManager.conversations[index].messages.last,
-                       lastMessage.role == .assistant
-                    {
-                        lastMessage.content += chunk
-                        conversationManager.conversations[index].messages[
-                            conversationManager.conversations[index].messages.count - 1
-                        ] = lastMessage
+                        if let conversation = conversationManager.conversation(byId: conversationId) {
+                            conversationManager.save(conversation)
                     }
-
-                    // Persist during streaming so content isn't lost on quit
-                    conversationManager.save(conversationManager.conversations[index])
-
-                    if currentToolName != nil {
-                        currentToolName = nil
+                    currentToolName = nil
                     }
-                }
             },
             onComplete: {
-                Task { @MainActor in
-                    // Save immediately on completion
-                    if let index = conversationManager.conversations
-                        .firstIndex(where: { $0.id == conversationId })
-                    {
-                        conversationManager.saveImmediately(conversationManager.conversations[index])
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard activeAssistantMessageID == assistantMessageID else { return }
+                        if let conversation = conversationManager.conversation(byId: conversationId) {
+                            conversationManager.saveImmediately(conversation)
                     }
-
-                    if currentToolName == nil {
-                        currentToolName = nil
-                        isGenerating = false
-                        logNewChat(
-                            "✅ Initial message finished streaming, switching to ChatView",
-                            level: .info,
-                            metadata: ["conversationId": conversationId.uuidString]
+                        let resolution = requestRounds.providerDidComplete(
+                            operationID: operationID,
+                            requestRoundID: requestRoundID
                         )
-                        selectedConversationId = conversationId
-                    }
+                        handleNewChatToolRoundResolution(
+                            resolution,
+                            operationID: operationID,
+                            sourceAssistantMessageID: assistantMessageID,
+                            conversationID: conversationId,
+                            model: model,
+                            temperature: temperature,
+                            tools: toolsWrapper.value
+                        )
                 }
             },
             onError: { error in
-                Task { @MainActor in
-                    isGenerating = false
-                    currentToolName = nil
-                    toolCallDepth = 0
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard activeAssistantMessageID == assistantMessageID else { return }
+                        guard coordinator.owns(operationID, conversationID: conversationId) else { return }
+                        abortOwnedTextGeneration(operationID: operationID, conversationID: conversationId)
                     logNewChat(
                         "❌ Error sending initial message: \(error.localizedDescription)",
                         level: .error,
@@ -1102,196 +1189,234 @@ struct MacNewChatView: View {
                             "error": error.localizedDescription
                         ]
                     )
-
+                        if !(error is CancellationError) {
                     presentError(error)
                 }
+                    }
             },
             onToolCallRequested: { toolCallId, toolName, arguments in
                 let argumentsWrapper = UncheckedSendableWrapper(arguments)
-                let toolNameCopy = toolName
-                Task { @MainActor in
-                    // Set currentToolName first thing to prevent race condition with onComplete
-                    currentToolName = toolNameCopy
-                    let arguments = argumentsWrapper.value
-                    guard conversationManager.conversations.contains(where: { $0.id == conversationId }) else {
-                        logNewChat(
-                            "⚠️ Tool call requested but conversation \(conversationId) no longer exists",
-                            level: .error
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard activeAssistantMessageID == assistantMessageID,
+                              let token = requestRounds.registerTool(
+                                  for: operationID,
+                                  requestRoundID: requestRoundID
                         )
-                        currentToolName = nil // Clear since we're not processing
+                        else {
                         return
                     }
-                    logNewChat(
-                        "🔧 Tool call requested: \(toolName)",
-                        level: .info,
-                        metadata: ["toolName": toolName]
-                    )
 
+                        if token.registrationIndex == 0 {
                     guard toolCallDepth < maxToolCallDepth else {
                         logNewChat("⚠️ Max tool call depth reached in NewChatView", level: .error)
-                        isGenerating = false
-                        currentToolName = nil
+                                abortOwnedTextGeneration(operationID: operationID, conversationID: conversationId)
                         errorMessage = "Too many tool calls"
                         errorRecoverySuggestion = "Try again, or disable tools in Settings"
                         shouldOfferOpenSettings = true
                         return
                     }
-
                     toolCallDepth += 1
+                        }
 
-                    if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
-                       var lastMessage = conversationManager.conversations[index].messages.last,
-                       lastMessage.role == .assistant
-                    {
-                        let toolCall = ToolCallHandler.createToolCall(
+                        currentToolName = toolName
+                        let arguments = argumentsWrapper.value
+                        let anyCodableArguments = arguments.reduce(into: [String: AnyCodable]()) { result, pair in
+                            result[pair.key] = AnyCodable(pair.value)
+                        }
+                        let toolCall = MCPToolCall(
                             id: toolCallId,
                             toolName: toolName,
-                            arguments: arguments
+                            arguments: anyCodableArguments
                         )
-                        lastMessage.toolCalls = [toolCall]
-                        conversationManager.conversations[index].messages[
-                            conversationManager.conversations[index].messages.count - 1
-                        ] = lastMessage
-                        conversationManager.save(conversationManager.conversations[index])
+                        conversationManager.updateMessage(
+                            conversationId: conversationId,
+                            messageId: assistantMessageID
+                        ) { message in
+                            var calls = message.toolCalls ?? []
+                            if !calls.contains(where: { $0.id == toolCallId }) {
+                                calls.append(toolCall)
+                            }
+                            message.toolCalls = calls
+                        }
+                        if let conversation = conversationManager.conversation(byId: conversationId) {
+                            conversationManager.save(conversation)
                     }
 
-                    Task {
-                        do {
-                            logNewChat(
-                                "⚙️ Executing tool: \(toolName)",
-                                level: .info,
-                                metadata: ["toolName": toolName]
-                            )
+                        coordinator.schedule(for: operationID, conversationID: conversationId) {
+                            guard coordinator.owns(operationID, conversationID: conversationId),
+                                  activeAssistantMessageID == assistantMessageID,
+                                  !Task.isCancelled
+                            else {
+                                return
+                            }
 
-                            // Route to appropriate tool handler
-                            let result: String
-                            var citations: [CitationReference]?
-
+                            let result: ToolExecutionResult
+                            do {
+                                let output: String
+                                let citations: [CitationReference]?
                             if aiService.isBuiltInTool(toolName) {
-                                // Built-in tool (e.g., web_search, agentic tools) - get citations
-                                let (toolResult, toolCitations) = await aiService
-                                    .executeBuiltInToolWithCitations(
+                                    (output, citations) = await aiService.executeBuiltInToolWithCitations(
                                         name: toolName,
                                         arguments: argumentsWrapper.value,
-                                        conversationId: conversation.id
+                                        conversationId: conversationId
                                     )
-                                result = toolResult
-                                citations = toolCitations
                             } else {
-                                // MCP tool
-                                result = try await mcpManager.executeTool(
+                                    output = try await mcpManager.executeTool(
                                     name: toolName,
                                     arguments: argumentsWrapper.value
                                 )
+                                    citations = nil
                             }
-
-                            // For web_search, skip creating a visible tool message
-                            let isWebSearch = ToolCallHandler.isWebSearchTool(toolName)
-
-                            await MainActor.run {
-                                if !isWebSearch {
-                                    // For non-web-search tools, create the tool message
-                                    let toolMessage = ToolCallHandler.createToolMessage(
-                                        toolCallId: toolCallId,
-                                        toolName: toolName,
-                                        arguments: argumentsWrapper.value,
-                                        result: result
-                                    )
-                                    conversationManager.addMessage(to: conversation, message: toolMessage)
-                                }
-
-                                guard let updatedConversation = conversationManager.conversations
-                                    .first(where: { $0.id == conversationId })
+                                guard coordinator.owns(operationID, conversationID: conversationId),
+                                      activeAssistantMessageID == assistantMessageID,
+                                      !Task.isCancelled
                                 else {
-                                    currentToolName = nil
-                                    isGenerating = false
-                                    selectedConversationId = conversationId
                                     return
                                 }
-
-                                // For web_search, attach citations to the new assistant message
-                                let newAssistantMessage = ToolCallHandler.createContinuationMessage(
-                                    model: model,
-                                    citations: isWebSearch ? citations : nil
-                                )
-                                conversationManager.addMessage(
-                                    to: updatedConversation,
-                                    message: newAssistantMessage
-                                )
-
-                                // Re-fetch conversation AFTER adding the new assistant message
-                                guard let convWithAssistant = conversationManager.conversations
-                                    .first(where: { $0.id == conversationId })
-                                else {
-                                    currentToolName = nil
-                                    isGenerating = false
-                                    selectedConversationId = conversationId
-                                    return
-                                }
-
-                                currentToolName = "Analyzing \(toolName) results"
-
-                                logNewChat(
-                                    "🔄 Sending follow-up request with tool output",
-                                    level: .info,
-                                    metadata: [
-                                        "conversationId": conversationId.uuidString,
-                                        "toolName": toolName
-                                    ]
-                                )
-
-                                // Build messages for API using ToolCallHandler
-                                let messagesForAPI = ToolCallHandler.buildContinuationMessages(
-                                    conversationMessages: convWithAssistant.messages,
-                                    toolCallId: toolCallId,
+                                result = ToolExecutionResult(
+                                    callID: toolCallId,
                                     toolName: toolName,
-                                    arguments: argumentsWrapper.value,
-                                    result: result,
-                                    isWebSearch: isWebSearch,
-                                    systemPrompt: nil // MacNewChatView doesn't add system prompts here
+                                    arguments: anyCodableArguments,
+                                    output: output,
+                                    citations: citations ?? []
                                 )
-
-                                // Clear tool name since tool execution is complete
-                                // The continuation is now a regular API call
-                                currentToolName = nil
-
-                                sendMessageWithToolSupport(
-                                    conversation: conversation,
-                                    messages: messagesForAPI,
-                                    model: model,
-                                    temperature: temperature,
-                                    tools: toolsWrapper.value
-                                )
-                            }
-                        } catch {
-                            await MainActor.run {
+                            } catch is CancellationError {
+                                return
+                            } catch {
+                                guard coordinator.owns(operationID, conversationID: conversationId),
+                                      activeAssistantMessageID == assistantMessageID,
+                                      !Task.isCancelled
+                                else {
+                                    return
+                                }
                                 logNewChat(
                                     "❌ Tool execution failed: \(error.localizedDescription)",
                                     level: .error,
                                     metadata: ["toolName": toolName, "error": error.localizedDescription]
                                 )
-                                isGenerating = false
-                                currentToolName = nil
-                                presentError(error)
+                                result = ToolExecutionResult(
+                                    callID: toolCallId,
+                                    toolName: toolName,
+                                    arguments: anyCodableArguments,
+                                    output: "ERROR: \(error.localizedDescription)"
+                                )
                             }
+
+                            let resolution = requestRounds.toolDidComplete(token, result: result)
+                            handleNewChatToolRoundResolution(
+                                resolution,
+                                operationID: operationID,
+                                sourceAssistantMessageID: assistantMessageID,
+                                conversationID: conversationId,
+                                    model: model,
+                                    temperature: temperature,
+                                    tools: toolsWrapper.value
+                                )
+                            }
+                    }
+                },
+                onReasoning: { reasoning in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard activeAssistantMessageID == assistantMessageID else { return }
+                        conversationManager.updateMessage(
+                            conversationId: conversationId,
+                            messageId: assistantMessageID
+                        ) { message in
+                            message.reasoning = (message.reasoning ?? "") + reasoning
                         }
                     }
                 }
-            },
-            onReasoning: { reasoning in
-                Task { @MainActor in
-                    if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
-                       var lastMessage = conversationManager.conversations[index].messages.last,
-                       lastMessage.role == .assistant
-                    {
-                        let currentReasoning = lastMessage.reasoning ?? ""
-                        lastMessage.reasoning = currentReasoning + reasoning
-                        conversationManager.conversations[index].messages[
-                            conversationManager.conversations[index].messages.count - 1
-                        ] = lastMessage
-                    }
-                }
+                                )
+            coordinator.track(request, for: operationID)
+                            }
+
+        private func handleNewChatToolRoundResolution(
+            _ resolution: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Resolution,
+            operationID: ToolChainCoordinator.OperationID,
+            sourceAssistantMessageID: UUID,
+            conversationID: UUID,
+            model: String,
+            temperature: Double,
+            tools: [[String: Any]]?
+        ) {
+            switch resolution {
+            case .pending, .ignored:
+                return
+            case .responseCompleted:
+                guard toolChainCoordinator.finishOperation(operationID) else { return }
+                activeAssistantMessageID = nil
+                    currentToolName = nil
+                toolCallDepth = 0
+                    isGenerating = false
+                    logNewChat(
+                    "✅ Initial message finished streaming, switching to ChatView",
+                        level: .info,
+                    metadata: ["conversationId": conversationID.uuidString]
+                    )
+                selectedConversationId = conversationID
+            case let .launchContinuation(continuation):
+                launchNewChatToolContinuation(
+                    continuation,
+                    operationID: operationID,
+                    sourceAssistantMessageID: sourceAssistantMessageID,
+                    conversationID: conversationID,
+                    model: model,
+                    temperature: temperature,
+                    tools: tools
+                )
             }
+        }
+
+        private func launchNewChatToolContinuation(
+            _ continuation: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Continuation,
+            operationID: ToolChainCoordinator.OperationID,
+            sourceAssistantMessageID: UUID,
+            conversationID: UUID,
+            model: String,
+            temperature: Double,
+            tools: [[String: Any]]?
+        ) {
+            guard toolChainCoordinator.owns(operationID, conversationID: conversationID),
+                  continuation.operationID == operationID,
+                  activeAssistantMessageID == sourceAssistantMessageID,
+                  let conversation = conversationManager.conversation(byId: conversationID)
+            else {
+                return
+                }
+
+            let results = continuation.toolResults.map(\.result)
+            for result in results {
+                conversationManager.addMessage(to: conversation, message: result.makeMessage())
+                    }
+
+            let citations = ToolExecutionResult.combinedCitations(from: results)
+            var continuationMessage = Message(role: .assistant, content: "", model: model)
+            if !citations.isEmpty {
+                continuationMessage.citations = citations
+                }
+            conversationManager.addMessage(to: conversation, message: continuationMessage)
+
+            guard let conversationWithAssistant = conversationManager.conversation(byId: conversationID),
+                  toolChainCoordinator.owns(operationID, conversationID: conversationID)
+            else {
+                return
+            }
+
+            var history = conversationWithAssistant
+            history.messages.removeAll { $0.id == continuationMessage.id }
+            var continuationMessages = history.getEffectiveHistory()
+            if let systemPrompt = conversationManager.effectiveSystemPrompt(for: conversationWithAssistant) {
+                continuationMessages.insert(Message(role: .system, content: systemPrompt), at: 0)
+            }
+            currentToolName = nil
+            sendMessageWithToolSupport(
+                conversation: conversationWithAssistant,
+                messages: continuationMessages,
+                model: model,
+                temperature: temperature,
+                tools: tools,
+                assistantMessageID: continuationMessage.id,
+                operationID: operationID
         )
     }
 

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -25,6 +25,7 @@ struct MacNewChatView: View {
     @State private var showModelSelector = false
     @State private var selectedModels: Set<String> = []
     @State private var isToolSectionExpanded = false
+    @State private var imageGenerationCoordinator = ImageGenerationCoordinator()
 
     @State var errorMessage: String?
     @State var errorRecoverySuggestion: String?
@@ -272,6 +273,11 @@ struct MacNewChatView: View {
         .onAppear {
             syncSelectedModelState()
         }
+        .onDisappear {
+            if imageGenerationCoordinator.cancelCurrentOperation() {
+                isGenerating = false
+            }
+        }
         .onChange(of: currentConversation?.model ?? "") { _, _ in
             syncSelectedModelState()
         }
@@ -434,24 +440,22 @@ struct MacNewChatView: View {
         }
     }
 
-    func saveImageAndUpdateMessage(imageData: Data, conversation: Conversation, messageId: UUID) {
-        // Save image to disk off MainActor to avoid blocking the UI
-        Task {
-            let imagePath = await Task.detached(priority: .userInitiated) {
-                try? AttachmentStorage.shared.save(data: imageData, extension: "png")
-            }.value
-
-            if imagePath == nil {
-                logNewChat("❌ Failed to save generated image to disk", level: .error)
-            }
-
-            conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
-                message.content = ""
-                if let path = imagePath { message.imagePath = path; message.imageData = nil } else {
-                    message.imageData = imageData; message.imagePath = nil
-                }
-            }
+    private func saveImageData(_ imageData: Data) async -> String? {
+        let task = Task.detached(priority: .userInitiated) {
+            try? AttachmentStorage.shared.save(data: imageData, extension: "png")
         }
+        return await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    private func deleteImageData(at path: String?) async {
+        guard let path else { return }
+        await Task.detached(priority: .utility) {
+            AttachmentStorage.shared.delete(path: path)
+        }.value
     }
 
     // MARK: - Send Message
@@ -461,7 +465,10 @@ struct MacNewChatView: View {
         if isGenerating {
             // Stop generation immediately
             logNewChat("🛑 Stop button clicked in NewChatView, cancelling...", level: .info)
-            AIService.shared.cancelCurrentRequest()
+            let cancelledImageOperation = imageGenerationCoordinator.cancelCurrentOperation()
+            if !cancelledImageOperation {
+                AIService.shared.cancelCurrentRequest(includeImageRequests: false)
+            }
             isGenerating = false
             logNewChat("✅ isGenerating set to FALSE after stop", level: .info)
             isComposerFocused = true
@@ -629,7 +636,9 @@ struct MacNewChatView: View {
     // MARK: - Image Generation
 
     private func generateImage(prompt: String, model: String, conversation: Conversation) {
-        // Create placeholder assistant message with a known ID
+        let coordinator = imageGenerationCoordinator
+        let operationID = coordinator.beginOperation()
+
         let messageId = UUID()
         let placeholderMessage = Message(
             id: messageId,
@@ -640,51 +649,84 @@ struct MacNewChatView: View {
         )
         conversationManager.addMessage(to: conversation, message: placeholderMessage)
 
-        aiService.generateImage(
-            prompt: prompt,
-            model: model,
-            onComplete: { imageData in
-                Task { @MainActor in
-                    saveImageAndUpdateMessage(imageData: imageData, conversation: conversation, messageId: messageId)
-                    isGenerating = false
-                    selectedConversationId = conversation.id
-                }
-            },
-            onError: { error in
-                Task { @MainActor in
-                    isGenerating = false
-                    logNewChat(
-                        "❌ Image generation failed: \(error.localizedDescription)",
-                        level: .error,
-                        metadata: ["model": model]
-                    )
-                    presentError(error)
+        let conversationManager = conversationManager
+        coordinator.onCancel(for: operationID) {
+            conversationManager.removeMessage(conversationId: conversation.id, messageId: messageId)
+            if let currentConversation = conversationManager.conversation(byId: conversation.id) {
+                conversationManager.save(currentConversation)
+            }
+        }
 
-                    // Remove the empty assistant placeholder message since we show error in banner
-                    if let index = conversationManager.conversations.firstIndex(where: {
-                        $0.id == conversation.id
-                    }) {
-                        let lastIndex = conversationManager.conversations[index].messages.count - 1
-                        if lastIndex >= 0,
-                           conversationManager.conversations[index].messages[lastIndex].role == .assistant,
-                           conversationManager.conversations[index].messages[lastIndex].content.isEmpty
-                        {
-                            conversationManager.conversations[index].messages.remove(at: lastIndex)
-                        }
+        let onComplete: @Sendable (Data) -> Void = { imageData in
+            coordinator.schedule(for: operationID) {
+                let imagePath = await saveImageData(imageData)
+                guard coordinator.owns(operationID), !Task.isCancelled else {
+                    await deleteImageData(at: imagePath)
+                    return
+                }
+
+                let messageUpdated = conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
+                    message.content = ""
+                    if let imagePath {
+                        message.imagePath = imagePath
+                        message.imageData = nil
+                    } else {
+                        message.imageData = imageData
+                        message.imagePath = nil
                     }
                 }
+                guard messageUpdated else {
+                    await deleteImageData(at: imagePath)
+                    _ = coordinator.finishOperation(operationID)
+                    isGenerating = false
+                    return
+                }
+
+                guard coordinator.finishOperation(operationID) else { return }
+                isGenerating = false
+                selectedConversationId = conversation.id
             }
+        }
+        let onError: @Sendable (Error) -> Void = { error in
+            coordinator.schedule(for: operationID) {
+                guard coordinator.finishOperation(operationID) else { return }
+                isGenerating = false
+                logNewChat(
+                    "❌ Image generation failed: \(error.localizedDescription)",
+                    level: .error,
+                    metadata: ["model": model]
+                )
+                presentError(error)
+                conversationManager.removeMessage(conversationId: conversation.id, messageId: messageId)
+                if let currentConversation = conversationManager.conversation(byId: conversation.id) {
+                    conversationManager.save(currentConversation)
+                }
+            }
+        }
+
+        let request = aiService.generateImage(
+            prompt: prompt,
+            model: model,
+            onComplete: onComplete,
+            onError: onError
         )
+        coordinator.track(request, for: operationID)
     }
 
     /// Generates images from multiple models in parallel for comparison
     private func generateMultiModelImages(prompt: String, models: [String], conversation: Conversation) {
-        // Create a response group for the multi-model comparison
+        let coordinator = imageGenerationCoordinator
+        let operationID = coordinator.beginOperation()
+        guard !models.isEmpty else {
+            _ = coordinator.finishOperation(operationID)
+            isGenerating = false
+            return
+        }
+
         let responseGroupId = UUID()
         var responseEntries: [ResponseGroup.ResponseEntry] = []
         var messageIds: [String: UUID] = [:]
 
-        // Create placeholder messages for each model
         for model in models {
             let messageId = UUID()
             messageIds[model] = messageId
@@ -698,7 +740,6 @@ struct MacNewChatView: View {
                 mediaType: .image
             )
             conversationManager.addMessage(to: conversation, message: placeholderMessage)
-
             responseEntries.append(ResponseGroup.ResponseEntry(
                 id: messageId,
                 modelName: model,
@@ -706,62 +747,160 @@ struct MacNewChatView: View {
             ))
         }
 
-        // Create response group
         let responseGroup = ResponseGroup(
             id: responseGroupId,
             userMessageId: conversation.messages.last(where: { $0.role == .user })?.id ?? UUID(),
             responses: responseEntries
         )
-
-        // Add response group to conversation
         if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }) {
             conversationManager.conversations[index].responseGroups.append(responseGroup)
         }
 
-        let messageIdsByModel = messageIds
+        registerNewChatImageBatchCancellation(
+            coordinator: coordinator,
+            operationID: operationID,
+            conversationID: conversation.id,
+            responseGroupID: responseGroupId,
+            messageIDs: Array(messageIds.values)
+        )
 
-        // Track completion state with actor-isolated counter
         let counter = MainActorCompletionCounter(total: models.count)
-
-        // Generate images in parallel
         for model in models {
-            guard let messageId = messageIdsByModel[model] else { continue }
+            guard let messageId = messageIds[model] else { continue }
 
-            aiService.generateImage(
+            let onComplete: @Sendable (Data) -> Void = { imageData in
+                coordinator.schedule(for: operationID) {
+                    let imagePath = await saveImageData(imageData)
+                    guard coordinator.owns(operationID), !Task.isCancelled else {
+                        await deleteImageData(at: imagePath)
+                        return
+                    }
+
+                    updateResponseGroupStatus(
+                        conversationId: conversation.id,
+                        responseGroupId: responseGroupId,
+                        messageId: messageId,
+                        status: .completed
+                    )
+                    let messageUpdated = conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
+                        message.content = ""
+                        if let imagePath {
+                            message.imagePath = imagePath
+                            message.imageData = nil
+                        } else {
+                            message.imageData = imageData
+                            message.imagePath = nil
+                        }
+                    }
+                    guard messageUpdated else {
+                        await deleteImageData(at: imagePath)
+                        updateResponseGroupStatus(
+                            conversationId: conversation.id,
+                            responseGroupId: responseGroupId,
+                            messageId: messageId,
+                            status: .failed
+                        )
+                        counter.increment()
+                        finishNewChatImageBatchIfComplete(
+                            counter: counter,
+                            coordinator: coordinator,
+                            operationID: operationID,
+                            conversationID: conversation.id
+                        )
+                        return
+                    }
+                    counter.increment()
+                    finishNewChatImageBatchIfComplete(
+                        counter: counter,
+                        coordinator: coordinator,
+                        operationID: operationID,
+                        conversationID: conversation.id
+                    )
+                }
+            }
+            let onError: @Sendable (Error) -> Void = { error in
+                coordinator.schedule(for: operationID) {
+                    logNewChat(
+                        "❌ Image generation failed for \(model): \(error.localizedDescription)",
+                        level: .error,
+                        metadata: ["model": model]
+                    )
+                    updateResponseGroupStatus(
+                        conversationId: conversation.id,
+                        responseGroupId: responseGroupId,
+                        messageId: messageId,
+                        status: .failed
+                    )
+                    conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
+                        message.content = "Image generation failed: \(error.localizedDescription)"
+                    }
+                    counter.increment()
+                    finishNewChatImageBatchIfComplete(
+                        counter: counter,
+                        coordinator: coordinator,
+                        operationID: operationID,
+                        conversationID: conversation.id
+                    )
+                }
+            }
+
+            let request = aiService.generateImage(
                 prompt: prompt,
                 model: model,
-                onComplete: { imageData in
-                    Task { @MainActor in
-                        saveImageAndUpdateMessage(imageData: imageData, conversation: conversation, messageId: messageId)
-                        updateResponseGroupStatus(conversationId: conversation.id, responseGroupId: responseGroupId, messageId: messageId, status: .completed)
-                        counter.increment()
-                        if counter.isComplete { isGenerating = false; selectedConversationId = conversation.id }
-                    }
-                },
-                onError: { error in
-                    Task { @MainActor in
-                        logNewChat(
-                            "❌ Image generation failed for \(model): \(error.localizedDescription)",
-                            level: .error,
-                            metadata: ["model": model]
-                        )
-
-                        updateResponseGroupStatus(conversationId: conversation.id, responseGroupId: responseGroupId, messageId: messageId, status: .failed)
-
-                        // Update message with error
-                        conversationManager.updateMessage(in: conversation, messageId: messageId) { message in
-                            message.content = "Image generation failed: \(error.localizedDescription)"
-                        }
-
-                        counter.increment()
-                        if counter.isComplete {
-                            isGenerating = false
-                            selectedConversationId = conversation.id
-                        }
-                    }
-                }
+                onComplete: onComplete,
+                onError: onError
             )
+            coordinator.track(request, for: operationID)
         }
+    }
+
+    private func registerNewChatImageBatchCancellation(
+        coordinator: ImageGenerationCoordinator,
+        operationID: ImageGenerationCoordinator.OperationID,
+        conversationID: UUID,
+        responseGroupID: UUID,
+        messageIDs: [UUID]
+    ) {
+        let conversationManager = conversationManager
+        coordinator.onCancel(for: operationID) {
+            guard let conversation = conversationManager.conversation(byId: conversationID),
+                  let responseGroup = conversation.getResponseGroup(responseGroupID)
+            else {
+                return
+            }
+            let pendingMessageIDs = ImageGenerationCoordinator.pendingMessageIDs(
+                in: responseGroup,
+                candidates: messageIDs
+            )
+            for messageID in pendingMessageIDs {
+                conversationManager.updateMessage(conversationId: conversationID, messageId: messageID) { message in
+                    message.content = "Image generation stopped"
+                }
+                conversationManager.updateResponseGroupStatus(
+                    conversationId: conversationID,
+                    responseGroupId: responseGroupID,
+                    messageId: messageID,
+                    status: .failed
+                )
+            }
+            if let currentConversation = conversationManager.conversation(byId: conversationID) {
+                conversationManager.save(currentConversation)
+            }
+        }
+    }
+
+    private func finishNewChatImageBatchIfComplete(
+        counter: MainActorCompletionCounter,
+        coordinator: ImageGenerationCoordinator,
+        operationID: ImageGenerationCoordinator.OperationID,
+        conversationID: UUID
+    ) {
+        guard counter.isComplete, coordinator.finishOperation(operationID) else { return }
+        if let conversation = conversationManager.conversation(byId: conversationID) {
+            conversationManager.save(conversation)
+        }
+        isGenerating = false
+        selectedConversationId = conversationID
     }
 
     private func sendMultiModelMessage(

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -1127,6 +1127,7 @@ struct MacNewChatView: View {
             else {
                 return
             }
+            let toolCallAdmissionGate = ToolCallRequestAdmissionGate()
 
             let request = aiService.sendMessage(
             messages: messages,
@@ -1194,7 +1195,7 @@ struct MacNewChatView: View {
                 }
                     }
             },
-            onToolCallRequested: { toolCallId, toolName, arguments in
+            onToolCallRequested: toolCallAdmissionGate.admittedCallback { toolCallId, toolName, arguments in
                 let argumentsWrapper = UncheckedSendableWrapper(arguments)
                     coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                         guard activeAssistantMessageID == assistantMessageID,

--- a/Sources/Ayna/Views/macOS/MacSidebarView.swift
+++ b/Sources/Ayna/Views/macOS/MacSidebarView.swift
@@ -187,6 +187,12 @@ struct MacSidebarView: View {
             selectedConversationId = nil
             selectedConversations.removeAll()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .conversationDeleteRolledBack)) { notification in
+            guard let id = notification.userInfo?["conversationId"] as? UUID,
+                  conversationManager.selectedConversationId == id
+            else { return }
+            selectedConversations.insert(id)
+        }
     }
 
     private func startNewConversation() {

--- a/Sources/Ayna/Views/watchOS/WatchChatView.swift
+++ b/Sources/Ayna/Views/watchOS/WatchChatView.swift
@@ -28,8 +28,16 @@
                     LazyVStack(spacing: 12) {
                         if let conversation = conversationStore.conversation(for: conversationId) {
                             ForEach(conversation.messages) { message in
-                                // Don't show empty assistant messages (placeholder during streaming)
-                                if !message.content.isEmpty || message.role.lowercased() == "user" {
+                                let isWebSearchToolResult = message.role.lowercased() == "tool" &&
+                                    message.toolCalls?.contains(where: {
+                                        $0.toolName == WebSearchCoordinator.toolName
+                                    }) == true
+                                // Keep web-search output in provider history but present citations instead.
+                                if !isWebSearchToolResult && (
+                                    !message.content.isEmpty ||
+                                        message.role.lowercased() == "user" ||
+                                        !(message.citations?.isEmpty ?? true)
+                                ) {
                                     WatchMessageView(message: message)
                                         .id(message.id)
                                         .accessibilityIdentifier(TestIdentifiers.Watch.chatMessageRow(for: message.id))
@@ -96,6 +104,9 @@
             }
             .onAppear {
                 viewModel.setConversation(conversationId)
+            }
+            .onDisappear {
+                viewModel.cancelOwnedRequest()
             }
             .userActivity(handoffActivityType) { activity in
                 // Set up Handoff activity for this conversation

--- a/Sources/Ayna/Views/watchOS/WatchChatView.swift
+++ b/Sources/Ayna/Views/watchOS/WatchChatView.swift
@@ -1,232 +1,231 @@
 #if os(watchOS)
 //
-//  WatchChatView.swift
-//  Ayna Watch App
+    //  WatchChatView.swift
+    //  Ayna Watch App
 //
-//  Created on 11/29/25.
+    //  Created on 11/29/25.
 //
 
-#if os(watchOS)
+    #if os(watchOS)
 
-    import SwiftUI
+        import SwiftUI
 
-    /// Activity type for Handoff
-    private let handoffActivityType = "com.sertacozercan.ayna.conversation"
+        /// Activity type for Handoff
+        private let handoffActivityType = "com.sertacozercan.ayna.conversation"
 
-    /// Chat view for Watch showing messages and input
-    /// Mimics iMessage style with bubbles and bottom composer bar
-    struct WatchChatView: View {
-        let conversationId: UUID
-        @ObservedObject var viewModel: WatchChatViewModel
-        @EnvironmentObject var conversationStore: WatchConversationStore
+        /// Chat view for Watch showing messages and input
+        /// Mimics iMessage style with bubbles and bottom composer bar
+        struct WatchChatView: View {
+            let conversationId: UUID
+            @ObservedObject var viewModel: WatchChatViewModel
+            @EnvironmentObject var conversationStore: WatchConversationStore
 
-        @State private var messageText = ""
+            @State private var messageText = ""
 
-        var body: some View {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(spacing: 12) {
-                        if let conversation = conversationStore.conversation(for: conversationId) {
-                            ForEach(conversation.messages) { message in
-                                let isWebSearchToolResult = message.role.lowercased() == "tool" &&
-                                    message.toolCalls?.contains(where: {
-                                        $0.toolName == WebSearchCoordinator.toolName
-                                    }) == true
-                                // Keep web-search output in provider history but present citations instead.
-                                if !isWebSearchToolResult && (
-                                    !message.content.isEmpty ||
-                                        message.role.lowercased() == "user" ||
-                                        !(message.citations?.isEmpty ?? true)
-                                ) {
-                                    WatchMessageView(message: message)
-                                        .id(message.id)
-                                        .accessibilityIdentifier(TestIdentifiers.Watch.chatMessageRow(for: message.id))
+            var body: some View {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 12) {
+                            if let conversation = conversationStore.conversation(for: conversationId) {
+                                ForEach(conversation.messages) { message in
+                                    let isWebSearchToolResult = message.role.lowercased() == "tool" &&
+                                        message.toolCalls?.contains(where: {
+                                            $0.toolName == WebSearchCoordinator.toolName
+                                        }) == true
+                                    // Keep web-search output in provider history but present citations instead.
+                                    if !isWebSearchToolResult,
+                                       !message.content.isEmpty ||
+                                       message.role.lowercased() == "user" ||
+                                       !(message.citations?.isEmpty ?? true)
+                                    {
+                                        WatchMessageView(message: message)
+                                            .id(message.id)
+                                            .accessibilityIdentifier(TestIdentifiers.Watch.chatMessageRow(for: message.id))
+                                    }
+                                }
+
+                                // Typing indicator only when waiting for response (not during streaming)
+                                if viewModel.isLoading, !viewModel.isStreaming {
+                                    if let toolName = viewModel.currentToolName {
+                                        toolIndicator(toolName)
+                                            .id("tool")
+                                    } else {
+                                        typingIndicator
+                                            .id("typing")
+                                    }
                                 }
                             }
 
-                            // Typing indicator only when waiting for response (not during streaming)
-                            if viewModel.isLoading, !viewModel.isStreaming {
-                                if let toolName = viewModel.currentToolName {
-                                    toolIndicator(toolName)
-                                        .id("tool")
-                                } else {
-                                    typingIndicator
-                                        .id("typing")
-                                }
-                            }
-
-                            // Error message with retry if any
+                            // Keep preparation errors visible even if a phone tombstone removed
+                            // the conversation while this view was still on screen.
                             if let error = viewModel.errorMessage {
                                 errorView(error)
                             }
+
+                            // Spacer to separate messages from composer
+                            Spacer()
+                                .frame(height: 20)
+
+                            // Composer at bottom of scroll content
+                            composerBar
+                                .id("composer")
                         }
-
-                        // Spacer to separate messages from composer
-                        Spacer()
-                            .frame(height: 20)
-
-                        // Composer at bottom of scroll content
-                        composerBar
-                            .id("composer")
+                        .padding(.horizontal, 4)
                     }
-                    .padding(.horizontal, 4)
-                }
-                .accessibilityIdentifier(TestIdentifiers.Watch.chatMessagesList)
-                .onChange(of: conversationStore.conversation(for: conversationId)?.messages.count) { _, _ in
-                    // Scroll to bottom when new message arrives
-                    withAnimation {
-                        if viewModel.isLoading, !viewModel.isStreaming {
-                            // Waiting for response - scroll to typing indicator
-                            if viewModel.currentToolName != nil {
-                                proxy.scrollTo("tool", anchor: .bottom)
-                            } else {
-                                proxy.scrollTo("typing", anchor: .bottom)
+                    .accessibilityIdentifier(TestIdentifiers.Watch.chatMessagesList)
+                    .onChange(of: conversationStore.conversation(for: conversationId)?.messages.count) { _, _ in
+                        // Scroll to bottom when new message arrives
+                        withAnimation {
+                            if viewModel.isLoading, !viewModel.isStreaming {
+                                // Waiting for response - scroll to typing indicator
+                                if viewModel.currentToolName != nil {
+                                    proxy.scrollTo("tool", anchor: .bottom)
+                                } else {
+                                    proxy.scrollTo("typing", anchor: .bottom)
+                                }
+                            } else if let lastId = conversationStore.conversation(for: conversationId)?.messages.last?.id {
+                                // Streaming or idle - scroll to last message
+                                proxy.scrollTo(lastId, anchor: .bottom)
                             }
-                        } else if let lastId = conversationStore.conversation(for: conversationId)?.messages.last?.id {
-                            // Streaming or idle - scroll to last message
-                            proxy.scrollTo(lastId, anchor: .bottom)
                         }
                     }
+                    .defaultScrollAnchor(.bottom)
                 }
-                .defaultScrollAnchor(.bottom)
-            }
-            .navigationTitle(conversationTitle)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    NavigationLink {
-                        WatchModelSelectionView()
-                    } label: {
-                        Image(systemName: "cpu")
-                    }
-                    .accessibilityIdentifier(TestIdentifiers.Watch.modelSelectorButton)
-                }
-            }
-            .onAppear {
-                viewModel.setConversation(conversationId)
-            }
-            .onDisappear {
-                viewModel.cancelOwnedRequest()
-            }
-            .userActivity(handoffActivityType) { activity in
-                // Set up Handoff activity for this conversation
-                activity.isEligibleForHandoff = true
-                activity.title = conversationTitle
-                activity.userInfo = ["conversationId": conversationId.uuidString]
-                activity.needsSave = true
-            }
-        }
-
-        private var conversationTitle: String {
-            conversationStore.conversation(for: conversationId)?.title ?? "Chat"
-        }
-
-        /// iMessage-style composer bar
-        private var composerBar: some View {
-            HStack(spacing: 6) {
-                if viewModel.isLoading {
-                    // Stop button when generating
-                    Button {
-                        viewModel.cancelRequest()
-                    } label: {
-                        HStack {
-                            Image(systemName: "stop.fill")
-                            Text("Stop")
+                .navigationTitle(conversationTitle)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        NavigationLink {
+                            WatchModelSelectionView(conversationId: conversationId)
+                        } label: {
+                            Image(systemName: "cpu")
                         }
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 4)
-                        .background(Color.red)
-                        .clipShape(Capsule())
+                        .accessibilityIdentifier(TestIdentifiers.Watch.modelSelectorButton)
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier(TestIdentifiers.Watch.chatStopButton)
-                } else {
-                    // Text field - tapping triggers dictation on watchOS
-                    TextField("Ask anything", text: $messageText)
-                        .font(.system(size: 13))
-                        .frame(height: 28)
-                        .submitLabel(.send)
-                        .onSubmit {
-                            sendMessage()
-                        }
-                        .accessibilityIdentifier(TestIdentifiers.Watch.chatComposerTextField)
+                }
+                .onAppear {
+                    viewModel.setConversation(conversationId)
+                }
+                .userActivity(handoffActivityType) { activity in
+                    // Set up Handoff activity for this conversation
+                    activity.isEligibleForHandoff = true
+                    activity.title = conversationTitle
+                    activity.userInfo = ["conversationId": conversationId.uuidString]
+                    activity.needsSave = true
                 }
             }
-            .padding(.top, 4)
+
+            private var conversationTitle: String {
+                conversationStore.conversation(for: conversationId)?.title ?? "Chat"
+            }
+
+            /// iMessage-style composer bar
+            private var composerBar: some View {
+                HStack(spacing: 6) {
+                    if viewModel.isLoading {
+                        // Stop button when generating
+                        Button {
+                            viewModel.cancelRequest()
+                        } label: {
+                            HStack {
+                                Image(systemName: "stop.fill")
+                                Text("Stop")
+                            }
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 4)
+                            .background(Color.red)
+                            .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier(TestIdentifiers.Watch.chatStopButton)
+                    } else {
+                        // Text field - tapping triggers dictation on watchOS
+                        TextField("Ask anything", text: $messageText)
+                            .font(.system(size: 13))
+                            .frame(height: 28)
+                            .submitLabel(.send)
+                            .onSubmit {
+                                sendMessage()
+                            }
+                            .accessibilityIdentifier(TestIdentifiers.Watch.chatComposerTextField)
+                    }
+                }
+                .padding(.top, 4)
+            }
+
+            private func sendMessage() {
+                let trimmed = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return }
+                if viewModel.sendMessage(trimmed).consumedInput {
+                    messageText = ""
+                }
+            }
+
+            private var typingIndicator: some View {
+                HStack(spacing: 4) {
+                    ForEach(0 ..< 3, id: \.self) { index in
+                        Circle()
+                            .fill(Color.secondary)
+                            .frame(width: 6, height: 6)
+                            .opacity(0.5)
+                            .animation(
+                                .easeInOut(duration: 0.5)
+                                    .repeatForever()
+                                    .delay(Double(index) * 0.15),
+                                value: viewModel.isLoading
+                            )
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color(white: 0.2))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityIdentifier(TestIdentifiers.Watch.chatTypingIndicator)
+            }
+
+            private func toolIndicator(_: String) -> some View {
+                HStack(spacing: 6) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.blue)
+                    Text("Searching...")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color.blue.opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            private func errorView(_ message: String) -> some View {
+                ErrorBannerView(
+                    message: message,
+                    recoverySuggestion: nil, // watchOS errors don't typically have recovery suggestions
+                    onRetry: viewModel.failedMessage != nil ? { viewModel.retryFailedMessage() } : nil,
+                    onDismiss: { viewModel.dismissError() },
+                    identifierPrefix: "watch.chat.error"
+                )
+            }
         }
 
-        private func sendMessage() {
-            let trimmed = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return }
-            viewModel.sendMessage(trimmed)
-            messageText = ""
-        }
-
-        private var typingIndicator: some View {
-            HStack(spacing: 4) {
-                ForEach(0 ..< 3, id: \.self) { index in
-                    Circle()
-                        .fill(Color.secondary)
-                        .frame(width: 6, height: 6)
-                        .opacity(0.5)
-                        .animation(
-                            .easeInOut(duration: 0.5)
-                                .repeatForever()
-                                .delay(Double(index) * 0.15),
-                            value: viewModel.isLoading
+        #if DEBUG
+            struct WatchChatView_Previews: PreviewProvider {
+                static var previews: some View {
+                    NavigationStack {
+                        WatchChatView(
+                            conversationId: UUID(),
+                            viewModel: WatchChatViewModel()
                         )
+                        .environmentObject(WatchConversationStore.shared)
+                    }
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(Color(white: 0.2))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityIdentifier(TestIdentifiers.Watch.chatTypingIndicator)
-        }
+        #endif
 
-        private func toolIndicator(_: String) -> some View {
-            HStack(spacing: 6) {
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.blue)
-                Text("Searching...")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(Color.blue.opacity(0.15))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-
-        private func errorView(_ message: String) -> some View {
-            ErrorBannerView(
-                message: message,
-                recoverySuggestion: nil, // watchOS errors don't typically have recovery suggestions
-                onRetry: viewModel.failedMessage != nil ? { viewModel.retryFailedMessage() } : nil,
-                onDismiss: { viewModel.dismissError() },
-                identifierPrefix: "watch.chat.error"
-            )
-        }
-    }
-
-    #if DEBUG
-        struct WatchChatView_Previews: PreviewProvider {
-            static var previews: some View {
-                NavigationStack {
-                    WatchChatView(
-                        conversationId: UUID(),
-                        viewModel: WatchChatViewModel()
-                    )
-                    .environmentObject(WatchConversationStore.shared)
-                }
-            }
-        }
     #endif
-
-#endif
 #endif

--- a/Sources/Ayna/Views/watchOS/WatchMessageView.swift
+++ b/Sources/Ayna/Views/watchOS/WatchMessageView.swift
@@ -8,6 +8,7 @@
 
 #if os(watchOS)
 
+    import Foundation
     import SwiftUI
 
     // MARK: - Design System Integration
@@ -44,10 +45,30 @@
                         Spacer(minLength: Spacing.Component.bubbleMinWidth - 20)
                     }
 
-                    // Message content
+                    // Message content and web-search sources.
+                    VStack(alignment: .leading, spacing: Spacing.xxs) {
+                        if !message.content.isEmpty {
                     Text(renderedContent)
                         .font(Typography.body)
                         .foregroundStyle(isUser ? Theme.userBubbleText : .primary)
+                        }
+
+                        if let citations = message.citations, !citations.isEmpty {
+                            ForEach(Array(citations.enumerated()), id: \.offset) { _, citation in
+                                if let url = URL(string: citation.url) {
+                                    Link(destination: url) {
+                                        Label(citation.title, systemImage: "link")
+                                            .font(Typography.micro)
+                                            .lineLimit(2)
+                                    }
+                                } else {
+                                    Text(citation.title)
+                                        .font(Typography.micro)
+                                        .lineLimit(2)
+                                }
+                            }
+                        }
+                    }
                         .padding(.horizontal, Spacing.bubblePaddingH)
                         .padding(.vertical, Spacing.bubblePaddingV)
                         .background(bubbleBackground)

--- a/Sources/Ayna/Views/watchOS/WatchModelSelectionView.swift
+++ b/Sources/Ayna/Views/watchOS/WatchModelSelectionView.swift
@@ -1,73 +1,116 @@
 #if os(watchOS)
 //
-//  WatchModelSelectionView.swift
-//  Ayna Watch App
+    //  WatchModelSelectionView.swift
+    //  Ayna Watch App
 //
-//  Created on 11/29/25.
+    //  Created on 11/29/25.
 //
 
-#if os(watchOS)
+    #if os(watchOS)
 
-    import SwiftUI
+        import SwiftUI
 
-    struct WatchModelSelectionView: View {
-        @Environment(\.dismiss) private var dismiss
-        @EnvironmentObject var connectivityService: WatchConnectivityService
-        @ObservedObject private var aiService = AIService.shared
+        struct WatchModelSelectionView: View {
+            let conversationId: UUID?
 
-        /// Filter models to only show those usable on watchOS
-        private var watchUsableModels: [String] {
-            connectivityService.availableModels.filter { model in
-                // Filter out Apple Intelligence - it can't run on watchOS
-                let provider = aiService.modelProviders[model]
-                return provider != .appleIntelligence
+            @Environment(\.dismiss) private var dismiss
+            @EnvironmentObject var connectivityService: WatchConnectivityService
+            @EnvironmentObject var conversationStore: WatchConversationStore
+            @ObservedObject private var aiService = AIService.shared
+            @State private var showsSelectionError = false
+
+            init(conversationId: UUID? = nil) {
+                self.conversationId = conversationId
             }
-        }
 
-        /// Check if a model should show as selected
-        private func isModelSelected(_ model: String) -> Bool {
-            // If only one model, it's always selected
-            if watchUsableModels.count == 1 {
-                return true
+            /// Filter models to only show those usable on watchOS
+            private var watchUsableModels: [String] {
+                connectivityService.availableModels.filter { model in
+                    // Filter out Apple Intelligence - it can't run on watchOS
+                    let provider = aiService.modelProviders[model]
+                    return provider != .appleIntelligence
+                }
             }
-            return model == connectivityService.selectedModel
-        }
 
-        var body: some View {
-            List {
-                if watchUsableModels.isEmpty {
-                    Text("No models available. Sync with iPhone.")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(watchUsableModels, id: \.self) { model in
-                        Button {
-                            connectivityService.selectedModel = model
-                            aiService.selectedModel = model
-                            dismiss()
-                        } label: {
-                            HStack {
-                                Text(model)
-                                    .font(.body)
-                                Spacer()
-                                if isModelSelected(model) {
-                                    Image(systemName: "checkmark")
-                                        .foregroundStyle(.blue)
+            /// Check if a model should show as selected
+            private func isModelSelected(_ model: String) -> Bool {
+                if let conversationId,
+                   let conversation = conversationStore.conversation(for: conversationId)
+                {
+                    return conversation.model == model
+                }
+
+                // If only one model, it's always selected
+                if watchUsableModels.count == 1 {
+                    return true
+                }
+                return model == connectivityService.selectedModel
+            }
+
+            var body: some View {
+                List {
+                    if watchUsableModels.isEmpty {
+                        Text("No models available. Sync with iPhone.")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(watchUsableModels, id: \.self) { model in
+                            Button {
+                                if selectModel(model) {
+                                    dismiss()
+                                } else {
+                                    showsSelectionError = true
+                                }
+                            } label: {
+                                HStack {
+                                    Text(model)
+                                        .font(.body)
+                                    Spacer()
+                                    if isModelSelected(model) {
+                                        Image(systemName: "checkmark")
+                                            .foregroundStyle(.blue)
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-            .navigationTitle("Models")
-            .onAppear {
-                // Auto-select if only one model available
-                if watchUsableModels.count == 1, let onlyModel = watchUsableModels.first {
-                    connectivityService.selectedModel = onlyModel
-                    aiService.selectedModel = onlyModel
+                .navigationTitle("Models")
+                .onAppear {
+                    // Auto-select if only one model available
+                    if WatchModelSelectionCoordinator.shouldAutoSelect(
+                        availableModelCount: watchUsableModels.count,
+                        conversationID: conversationId
+                    ),
+                        let onlyModel = watchUsableModels.first,
+                        !selectModel(onlyModel)
+                    {
+                        showsSelectionError = true
+                    }
+                }
+                .alert("Couldn't Change Model", isPresented: $showsSelectionError) {
+                    Button("OK", role: .cancel) {}
+                } message: {
+                    Text("The model selection could not be saved. Please try again.")
                 }
             }
-        }
-    }
 
-#endif
+            private func selectModel(_ model: String) -> Bool {
+                WatchModelSelectionCoordinator.select(
+                    model: model,
+                    conversationID: conversationId,
+                    currentConversationModel: { conversationID in
+                        conversationStore.conversation(for: conversationID)?.model
+                    },
+                    persistConversationModel: { model, conversationID in
+                        conversationStore.updateModel(model, for: conversationID)
+                    },
+                    applyGlobalModel: { model in
+                        connectivityService.selectedModel = model
+                        aiService.selectedModel = model
+                    }
+                )
+            }
+        }
+
+    #endif
 #endif

--- a/Sources/Ayna/Views/watchOS/WatchNewChatView.swift
+++ b/Sources/Ayna/Views/watchOS/WatchNewChatView.swift
@@ -62,6 +62,7 @@
                     .padding(.horizontal, 4)
                 }
                 .defaultScrollAnchor(.bottom)
+                .accessibilityIdentifier(TestIdentifiers.Watch.newChatView)
             }
 
             private var composerBar: some View {

--- a/Sources/Ayna/Views/watchOS/WatchNewChatView.swift
+++ b/Sources/Ayna/Views/watchOS/WatchNewChatView.swift
@@ -1,87 +1,95 @@
 #if os(watchOS)
 //
-//  WatchNewChatView.swift
-//  Ayna Watch App
+    //  WatchNewChatView.swift
+    //  Ayna Watch App
 //
-//  Created on 11/30/25.
+    //  Created on 11/30/25.
 //
 
-#if os(watchOS)
+    #if os(watchOS)
 
-    import SwiftUI
+        import SwiftUI
 
-    /// New chat view that doesn't create a conversation until user sends a message
-    struct WatchNewChatView: View {
-        @Environment(\.dismiss) private var dismiss
-        @ObservedObject var viewModel: WatchChatViewModel
-        @EnvironmentObject var conversationStore: WatchConversationStore
+        /// New chat view that doesn't create a conversation until user sends a message
+        struct WatchNewChatView: View {
+            @Environment(\.dismiss) private var dismiss
+            @ObservedObject var viewModel: WatchChatViewModel
+            @EnvironmentObject var conversationStore: WatchConversationStore
 
-        @State private var messageText = ""
-        @State private var createdConversationId: UUID?
+            @State private var messageText = ""
+            @State private var createdConversationId: UUID?
 
-        var body: some View {
-            Group {
-                if let conversationId = createdConversationId {
-                    // Once conversation is created, show the regular chat view
-                    WatchChatView(conversationId: conversationId, viewModel: viewModel)
-                } else {
-                    // Show empty state with just the composer
-                    newChatContent
-                }
-            }
-            .navigationTitle("New Chat")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    NavigationLink {
-                        WatchModelSelectionView()
-                    } label: {
-                        Image(systemName: "cpu")
+            var body: some View {
+                Group {
+                    if let conversationId = createdConversationId {
+                        // Once conversation is created, show the regular chat view
+                        WatchChatView(conversationId: conversationId, viewModel: viewModel)
+                    } else {
+                        // Show empty state with just the composer
+                        newChatContent
                     }
-                    .accessibilityIdentifier(TestIdentifiers.Watch.modelSelectorButton)
+                }
+                .navigationTitle("New Chat")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        NavigationLink {
+                            WatchModelSelectionView()
+                        } label: {
+                            Image(systemName: "cpu")
+                        }
+                        .accessibilityIdentifier(TestIdentifiers.Watch.modelSelectorButton)
+                    }
+                }
+            }
+
+            private var newChatContent: some View {
+                ScrollView {
+                    VStack(spacing: 12) {
+                        Spacer()
+                            .frame(height: 40)
+
+                        // Composer
+                        composerBar
+
+                        if let error = viewModel.errorMessage {
+                            Text(error)
+                                .font(.caption2)
+                                .foregroundStyle(.red)
+                                .multilineTextAlignment(.center)
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                }
+                .defaultScrollAnchor(.bottom)
+            }
+
+            private var composerBar: some View {
+                TextField("Ask anything", text: $messageText)
+                    .font(.system(size: 13))
+                    .frame(height: 28)
+                    .submitLabel(.send)
+                    .onSubmit {
+                        sendFirstMessage()
+                    }
+                    .accessibilityIdentifier(TestIdentifiers.Watch.newChatComposerTextField)
+            }
+
+            private func sendFirstMessage() {
+                let trimmed = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return }
+
+                // Create the conversation only now
+                guard let newId = viewModel.createNewConversation() else { return }
+                createdConversationId = newId
+                conversationStore.selectedConversationId = newId
+
+                // Send the message
+                if viewModel.sendMessage(trimmed).consumedInput {
+                    messageText = ""
                 }
             }
         }
 
-        private var newChatContent: some View {
-            ScrollView {
-                VStack(spacing: 12) {
-                    Spacer()
-                        .frame(height: 40)
-
-                    // Composer
-                    composerBar
-                }
-                .padding(.horizontal, 4)
-            }
-            .defaultScrollAnchor(.bottom)
-        }
-
-        private var composerBar: some View {
-            TextField("Ask anything", text: $messageText)
-                .font(.system(size: 13))
-                .frame(height: 28)
-                .submitLabel(.send)
-                .onSubmit {
-                    sendFirstMessage()
-                }
-                .accessibilityIdentifier(TestIdentifiers.Watch.newChatComposerTextField)
-        }
-
-        private func sendFirstMessage() {
-            let trimmed = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return }
-
-            // Create the conversation only now
-            let newId = viewModel.createNewConversation()
-            createdConversationId = newId
-            conversationStore.selectedConversationId = newId
-
-            // Send the message
-            viewModel.sendMessage(trimmed)
-            messageText = ""
-        }
-    }
-
-#endif
+    #endif
 #endif

--- a/Tests/AynaIOSUITests/IOSSmokeUITests.swift
+++ b/Tests/AynaIOSUITests/IOSSmokeUITests.swift
@@ -176,3 +176,24 @@ final class IOSSmokeUITests: IOSUITestCase {
         XCTAssertTrue(hasEmptyState, "Empty state or welcome view should be visible after navigating to new chat")
     }
 }
+
+/// Deep-link lifecycle coverage that does not depend on compact split-view navigation.
+@MainActor
+final class IOSDeepLinkUITests: IOSUITestCase {
+    func testUnifiedChatShowsModelConfirmationAndCanCancel() throws {
+        let url = try XCTUnwrap(
+            URL(string: "ayna://chat?model=ui-deeplink-model&provider=openai&prompt=Should%20not%20send")
+        )
+
+        app.open(url)
+
+        let addModelAlert = app.alerts["Add Model"]
+        let alertAppeared = addModelAlert.waitForExistence(timeout: UITestTimeout.normal)
+        XCTAssertTrue(alertAppeared, "Unified chat should require add-model confirmation")
+
+        addModelAlert.buttons["Cancel"].tap()
+
+        let alertDisappeared = addModelAlert.waitForNonExistence(timeout: UITestTimeout.normal)
+        XCTAssertTrue(alertDisappeared, "Cancelling should dismiss model confirmation")
+    }
+}

--- a/Tests/AynaTests/AIServiceAppleIntelligenceTests.swift
+++ b/Tests/AynaTests/AIServiceAppleIntelligenceTests.swift
@@ -1,0 +1,861 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+#if !os(watchOS)
+    extension AIServiceTests {
+        @Test("Apple foreground replacement suppresses stale callbacks", .timeLimit(.minutes(1)))
+        func appleForegroundReplacementSuppressesStaleCallbacks() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let models = ["apple-first", "apple-second"]
+            configureAppleModels(models, on: service)
+            let firstChunks = FlightTestBox<[String]>([])
+            let firstCompletions = FlightTestBox(0)
+            let secondChunks = FlightTestBox<[String]>([])
+            let secondCompleted = FlightTestSignal()
+
+            service.sendMessage(
+                messages: [Message(role: .user, content: "First")],
+                model: models[0],
+                onChunk: { chunk in firstChunks.update { $0.append(chunk) } },
+                onComplete: { firstCompletions.update { $0 += 1 } },
+                onError: { _ in }
+            )
+            let first = try #require(await appleService.request(at: 0))
+
+            service.sendMessage(
+                messages: [Message(role: .user, content: "Second")],
+                model: models[1],
+                onChunk: { chunk in secondChunks.update { $0.append(chunk) } },
+                onComplete: { secondCompleted.signal() },
+                onError: { error in Issue.record("Unexpected error: \(error)") }
+            )
+            let second = try #require(await appleService.request(at: 1))
+            #expect(await first.cancelled.wait(timeout: .seconds(1)))
+
+            first.emitChunk("stale")
+            first.complete()
+            second.emitChunk("fresh")
+            second.complete()
+
+            #expect(await secondCompleted.wait(timeout: .seconds(1)))
+            #expect(firstChunks.value.isEmpty)
+            #expect(firstCompletions.value == 0)
+            #expect(secondChunks.value == ["fresh"])
+        }
+
+        @Test("Stale Apple cleanup preserves the replacement cancellation handle", .timeLimit(.minutes(1)))
+        func staleAppleCleanupPreservesReplacementCancellationHandle() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let models = ["apple-first", "apple-second"]
+            configureAppleModels(models, on: service)
+            let replacementChunks = FlightTestBox<[String]>([])
+            let replacementCompletions = FlightTestBox(0)
+
+            service.sendMessage(
+                messages: [Message(role: .user, content: "First")],
+                model: models[0],
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let first = try #require(await appleService.request(at: 0))
+
+            service.sendMessage(
+                messages: [Message(role: .user, content: "Second")],
+                model: models[1],
+                onChunk: { chunk in replacementChunks.update { $0.append(chunk) } },
+                onComplete: { replacementCompletions.update { $0 += 1 } },
+                onError: { _ in }
+            )
+            let second = try #require(await appleService.request(at: 1))
+            #expect(await first.cancelled.wait(timeout: .seconds(1)))
+
+            await Task.yield()
+            service.cancelCurrentRequest(includeImageRequests: false)
+            #expect(await second.cancelled.wait(timeout: .seconds(1)))
+            second.emitChunk("late")
+            second.complete()
+            #expect(appleService.clearedSessionIDs.filter { $0.hasPrefix("default:") }.count == 2)
+            #expect(replacementChunks.value.isEmpty)
+            #expect(replacementCompletions.value == 0)
+        }
+
+        @Test("Apple non-stream chunk reentrancy cannot complete a replaced request", .timeLimit(.minutes(1)))
+        func appleNonStreamChunkReentrancyCannotCompleteReplacedRequest() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let models = ["apple-first", "apple-second"]
+            configureAppleModels(models, on: service)
+            let firstCompletions = FlightTestBox(0)
+            let secondCompletions = FlightTestSignal()
+
+            service.sendMessage(
+                messages: [Message(role: .user, content: "First")],
+                model: models[0],
+                stream: false,
+                onChunk: { _ in
+                    MainActor.assumeIsolated {
+                        service.sendMessage(
+                            messages: [Message(role: .user, content: "Second")],
+                            model: models[1],
+                            stream: false,
+                            onChunk: { _ in },
+                            onComplete: { secondCompletions.signal() },
+                            onError: { error in Issue.record("Unexpected error: \(error)") }
+                        )
+                    }
+                },
+                onComplete: { firstCompletions.update { $0 += 1 } },
+                onError: { error in Issue.record("Unexpected error: \(error)") }
+            )
+            let first = try #require(await appleService.request(at: 0))
+            first.complete(response: "first response")
+
+            let second = try #require(await appleService.request(at: 1))
+            #expect(await first.cancelled.wait(timeout: .seconds(1)))
+            second.complete(response: "second response")
+
+            #expect(await secondCompletions.wait(timeout: .seconds(1)))
+            #expect(firstCompletions.value == 0)
+        }
+
+        @Test("Apple foreground and per-model flights remain independent", .timeLimit(.minutes(1)))
+        func appleForegroundAndPerModelFlightsRemainIndependent() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let foregroundModel = "apple-foreground"
+            let batchModel = "apple-batch"
+            configureAppleModels([foregroundModel, batchModel], on: service)
+            let batchComplete = FlightTestSignal()
+
+            service.sendMessage(
+                messages: [Message(role: .user, content: "Foreground")],
+                model: foregroundModel,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let foreground = try #require(await appleService.request(sessionIDPrefix: "default:"))
+
+            service.sendToMultipleModels(
+                messages: [Message(role: .user, content: "Batch")],
+                models: [batchModel],
+                onChunk: { _, _ in },
+                onModelComplete: { _ in },
+                onAllComplete: { batchComplete.signal() },
+                onError: { _, error in Issue.record("Unexpected error: \(error)") }
+            )
+            let batch = try #require(await appleService.request(sessionIDPrefix: "multi:default:\(batchModel):"))
+            batch.complete()
+
+            #expect(await batchComplete.wait(timeout: .seconds(2)))
+            #expect(!foreground.cancelled.isSignaled)
+
+            service.cancelCurrentRequest(includeImageRequests: false)
+            #expect(await foreground.cancelled.wait(timeout: .seconds(1)))
+        }
+
+        @Test("Apple foreground requests rebuild the full conversation transcript", .timeLimit(.minutes(1)))
+        func appleForegroundRequestsRebuildFullConversationTranscript() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-context"
+            configureAppleModels([model], on: service)
+            let toolCall = MCPToolCall(
+                id: "call-1",
+                toolName: "lookup",
+                arguments: ["query": AnyCodable("weather")]
+            )
+            var assistantToolCall = Message(role: .assistant, content: "")
+            assistantToolCall.toolCalls = [toolCall]
+            var toolOutput = Message(role: .tool, content: "Sunny")
+            toolOutput.toolCalls = [toolCall]
+            let messages = [
+                Message(role: .user, content: "    Earlier question\n"),
+                Message(role: .assistant, content: "Earlier answer"),
+                assistantToolCall,
+                toolOutput,
+                Message(role: .user, content: "Latest question"),
+            ]
+            let expectedHistory = [
+                AppleIntelligenceHistoryEntry(role: .user, content: "    Earlier question\n"),
+                AppleIntelligenceHistoryEntry(role: .assistant, content: "Earlier answer"),
+                AppleIntelligenceHistoryEntry(
+                    role: .assistant,
+                    content: "",
+                    toolCalls: [
+                        AppleIntelligenceToolCall(
+                            id: "call-1",
+                            name: "lookup",
+                            argumentsJSON: #"{"query":"weather"}"#
+                        ),
+                    ]
+                ),
+                AppleIntelligenceHistoryEntry(
+                    role: .tool,
+                    content: "Sunny",
+                    toolName: "lookup",
+                    toolCallID: "call-1"
+                ),
+            ]
+
+            service.sendMessage(
+                messages: messages,
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let first = try #require(await appleService.request(at: 0))
+            #expect(first.prompt == "Latest question")
+            #expect(first.history == expectedHistory)
+            service.cancelCurrentRequest(includeImageRequests: false)
+            #expect(await first.cancelled.wait(timeout: .seconds(1)))
+
+            service.sendMessage(
+                messages: messages,
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let second = try #require(await appleService.request(at: 1))
+            #expect(second.prompt == "Latest question")
+            #expect(second.history == expectedHistory)
+            #expect(second.conversationID != first.conversationID)
+            second.complete()
+        }
+
+        @Test("Apple tool continuation preserves matched calls and drops orphaned calls", .timeLimit(.minutes(1)))
+        func appleToolContinuationPreservesMatchedCallsAndDropsOrphans() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-tool-context"
+            configureAppleModels([model], on: service)
+
+            let matchedCall = MCPToolCall(
+                id: "matched",
+                toolName: "lookup",
+                arguments: ["query": AnyCodable("weather")]
+            )
+            let orphanedCall = MCPToolCall(
+                id: "orphaned",
+                toolName: "unused",
+                arguments: [:]
+            )
+            let emptyOutputCall = MCPToolCall(
+                id: "empty-output",
+                toolName: "noop",
+                arguments: [:]
+            )
+            var assistantCall = Message(role: .assistant, content: "")
+            assistantCall.toolCalls = [matchedCall]
+            var toolOutput = Message(role: .tool, content: "Sunny")
+            toolOutput.toolCalls = [matchedCall]
+            var orphanedAssistantCall = Message(role: .assistant, content: "")
+            orphanedAssistantCall.toolCalls = [orphanedCall]
+            var emptyOutputAssistantCall = Message(role: .assistant, content: "")
+            emptyOutputAssistantCall.toolCalls = [emptyOutputCall]
+            var emptyToolOutput = Message(role: .tool, content: "")
+            emptyToolOutput.toolCalls = [emptyOutputCall]
+
+            service.sendMessage(
+                messages: [
+                    Message(role: .user, content: "What is the weather?"),
+                    assistantCall,
+                    toolOutput,
+                    emptyOutputAssistantCall,
+                    emptyToolOutput,
+                    orphanedAssistantCall,
+                ],
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let request = try #require(await appleService.request(at: 0))
+
+            #expect(request.prompt == "Continue the conversation using the completed context above.")
+            #expect(request.history == [
+                AppleIntelligenceHistoryEntry(role: .user, content: "What is the weather?"),
+                AppleIntelligenceHistoryEntry(
+                    role: .assistant,
+                    content: "",
+                    toolCalls: [
+                        AppleIntelligenceToolCall(
+                            id: "matched",
+                            name: "lookup",
+                            argumentsJSON: #"{"query":"weather"}"#
+                        ),
+                    ]
+                ),
+                AppleIntelligenceHistoryEntry(
+                    role: .tool,
+                    content: "Sunny",
+                    toolName: "lookup",
+                    toolCallID: "matched"
+                ),
+                AppleIntelligenceHistoryEntry(
+                    role: .assistant,
+                    content: "",
+                    toolCalls: [
+                        AppleIntelligenceToolCall(
+                            id: "empty-output",
+                            name: "noop",
+                            argumentsJSON: "{}"
+                        ),
+                    ]
+                ),
+                AppleIntelligenceHistoryEntry(
+                    role: .tool,
+                    content: "(empty tool output)",
+                    toolName: "noop",
+                    toolCallID: "empty-output"
+                ),
+            ])
+            request.complete()
+        }
+
+        @Test("Apple tool matching pairs reused IDs with the nearest preceding call")
+        func appleToolMatchingPairsReusedIDsWithNearestPrecedingCall() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-reused-tool-id"
+            configureAppleModels([model], on: service)
+
+            let firstCall = MCPToolCall(id: "reused", toolName: "first", arguments: [:])
+            let secondCall = MCPToolCall(id: "reused", toolName: "second", arguments: [:])
+            var orphanedAssistant = Message(role: .assistant, content: "")
+            orphanedAssistant.toolCalls = [firstCall]
+            var matchedAssistant = Message(role: .assistant, content: "")
+            matchedAssistant.toolCalls = [secondCall]
+            var matchedOutput = Message(role: .tool, content: "second result")
+            matchedOutput.toolCalls = [secondCall]
+
+            service.sendMessage(
+                messages: [
+                    Message(role: .user, content: "First question"),
+                    orphanedAssistant,
+                    Message(role: .user, content: "Second question"),
+                    matchedAssistant,
+                    matchedOutput,
+                    Message(role: .user, content: "Latest"),
+                ],
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let request = try #require(await appleService.request(at: 0))
+
+            #expect(request.history == [
+                AppleIntelligenceHistoryEntry(role: .user, content: "First question"),
+                AppleIntelligenceHistoryEntry(role: .user, content: "Second question"),
+                AppleIntelligenceHistoryEntry(
+                    role: .assistant,
+                    content: "",
+                    toolCalls: [
+                        AppleIntelligenceToolCall(
+                            id: "reused#1",
+                            name: "second",
+                            argumentsJSON: "{}"
+                        ),
+                    ]
+                ),
+                AppleIntelligenceHistoryEntry(
+                    role: .tool,
+                    content: "second result",
+                    toolName: "second",
+                    toolCallID: "reused#1"
+                ),
+            ])
+            request.complete()
+        }
+
+        @Test("Apple context budgeting keeps the newest complete history")
+        func appleContextBudgetingKeepsNewestCompleteHistory() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            appleService.contextSize = 200
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-budget"
+            configureAppleModels([model], on: service)
+            let oldContent = String(repeating: "o", count: 100)
+            let recentUser = String(repeating: "u", count: 20)
+            let recentAssistant = String(repeating: "a", count: 20)
+
+            service.sendMessage(
+                messages: [
+                    Message(role: .user, content: oldContent),
+                    Message(role: .assistant, content: oldContent),
+                    Message(role: .user, content: recentUser),
+                    Message(role: .assistant, content: recentAssistant),
+                    Message(role: .user, content: "Latest"),
+                ],
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let request = try #require(await appleService.request(at: 0))
+
+            #expect(request.prompt == "Latest")
+            #expect(request.history == [
+                AppleIntelligenceHistoryEntry(role: .user, content: recentUser),
+                AppleIntelligenceHistoryEntry(role: .assistant, content: recentAssistant),
+            ])
+            request.complete()
+        }
+
+        @Test("Apple context budgeting accounts for many small transcript entries")
+        func appleContextBudgetingAccountsForManySmallTranscriptEntries() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            appleService.contextSize = 200
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-small-turns"
+            configureAppleModels([model], on: service)
+            var messages: [Message] = []
+            for index in 0 ..< 20 {
+                messages.append(Message(role: .user, content: "u\(index)"))
+                messages.append(Message(role: .assistant, content: "a\(index)"))
+            }
+            messages.append(Message(role: .user, content: "Latest"))
+
+            service.sendMessage(
+                messages: messages,
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let request = try #require(await appleService.request(at: 0))
+
+            #expect(request.history.count == 6)
+            #expect(request.history.first?.content == "u17")
+            #expect(request.history.last?.content == "a19")
+            request.complete()
+        }
+
+        @Test("Apple exact token counting trims additional oldest turns")
+        func appleExactTokenCountingTrimsAdditionalOldestTurns() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            appleService.contextSize = 200
+            appleService.tokenCountHandler = { request in
+                20 + request.history.count * 50
+            }
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-exact-budget"
+            configureAppleModels([model], on: service)
+
+            service.sendMessage(
+                messages: [
+                    Message(role: .user, content: "Old question"),
+                    Message(role: .assistant, content: "Old answer"),
+                    Message(role: .user, content: "Recent question"),
+                    Message(role: .assistant, content: "Recent answer"),
+                    Message(role: .user, content: "Latest"),
+                ],
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let request = try #require(await appleService.request(at: 0))
+
+            #expect(request.history == [
+                AppleIntelligenceHistoryEntry(role: .user, content: "Recent question"),
+                AppleIntelligenceHistoryEntry(role: .assistant, content: "Recent answer"),
+            ])
+            request.complete()
+        }
+
+        @Test("Apple exact token counting can admit content rejected by fallback estimate")
+        func appleExactTokenCountingCanAdmitFallbackRejectedContent() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            appleService.contextSize = 100
+            appleService.tokenCountHandler = { _ in 20 }
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-exact-admission"
+            configureAppleModels([model], on: service)
+            let errors = FlightTestBox<[String]>([])
+
+            service.sendMessage(
+                messages: [Message(role: .user, content: String(repeating: "x", count: 200))],
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { error in errors.update { $0.append(error.localizedDescription) } }
+            )
+            let request = try #require(await appleService.request(at: 0))
+
+            #expect(request.prompt.count == 200)
+            #expect(errors.value.isEmpty)
+            request.complete()
+        }
+
+        @Test("Apple context budgeting never splits parallel tool outputs")
+        func appleContextBudgetingNeverSplitsParallelToolOutputs() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            appleService.contextSize = 220
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-parallel-tools"
+            configureAppleModels([model], on: service)
+
+            let firstCall = MCPToolCall(id: "first", toolName: "first", arguments: [:])
+            let secondCall = MCPToolCall(id: "second", toolName: "second", arguments: [:])
+            var assistantCalls = Message(role: .assistant, content: "")
+            assistantCalls.toolCalls = [firstCall, secondCall]
+            var firstOutput = Message(role: .tool, content: String(repeating: "a", count: 20))
+            firstOutput.toolCalls = [firstCall]
+            var secondOutput = Message(role: .tool, content: String(repeating: "b", count: 20))
+            secondOutput.toolCalls = [secondCall]
+
+            let errorReceived = FlightTestBox<[String]>([])
+            service.sendMessage(
+                messages: [
+                    Message(role: .user, content: "Run both tools"),
+                    assistantCalls,
+                    firstOutput,
+                    secondOutput,
+                ],
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { error in errorReceived.update { $0.append(error.localizedDescription) } }
+            )
+
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(1))
+            while errorReceived.value.isEmpty, clock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            #expect(errorReceived.value == ["Apple Intelligence context is too large to continue safely"])
+            #expect(appleService.requests.isEmpty)
+        }
+
+        @Test("Apple context budgeting rejects oversized fixed prompt content")
+        func appleContextBudgetingRejectsOversizedFixedPromptContent() async {
+            let appleService = FlightTestAppleIntelligenceService()
+            appleService.contextSize = 100
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-oversized-prompt"
+            configureAppleModels([model], on: service)
+            let errors = FlightTestBox<[String]>([])
+
+            service.sendMessage(
+                messages: [Message(role: .user, content: String(repeating: "x", count: 200))],
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { error in errors.update { $0.append(error.localizedDescription) } }
+            )
+
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(1))
+            while errors.value.isEmpty, clock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            #expect(errors.value == ["Apple Intelligence context is too large to continue safely"])
+            #expect(appleService.requests.isEmpty)
+        }
+
+        @Test("Oversized Apple replacement cancels the previous foreground request")
+        func oversizedAppleReplacementCancelsPreviousForegroundRequest() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-oversized-replacement"
+            configureAppleModels([model], on: service)
+
+            service.sendMessage(
+                messages: [Message(role: .user, content: "First")],
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let first = try #require(await appleService.request(at: 0))
+
+            appleService.contextSize = 100
+            let errors = FlightTestBox<[String]>([])
+            service.sendMessage(
+                messages: [Message(role: .user, content: String(repeating: "x", count: 200))],
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { error in errors.update { $0.append(error.localizedDescription) } }
+            )
+
+            #expect(await first.cancelled.wait(timeout: .seconds(1)))
+            #expect(errors.value == ["Apple Intelligence context is too large to continue safely"])
+            #expect(appleService.requests.count == 1)
+            #expect(appleService.clearedSessionIDs.contains(first.conversationID))
+        }
+
+        @Test("Apple history excludes explicitly unselected response alternatives")
+        func appleHistoryExcludesExplicitlyUnselectedResponseAlternatives() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-selected-history"
+            configureAppleModels([model], on: service)
+            let groupID = UUID()
+
+            service.sendMessage(
+                messages: [
+                    Message(role: .user, content: "Earlier"),
+                    Message(
+                        role: .assistant,
+                        content: "Chosen answer",
+                        responseGroupId: groupID,
+                        isSelectedResponse: true
+                    ),
+                    Message(
+                        role: .assistant,
+                        content: "Rejected answer",
+                        responseGroupId: groupID,
+                        isSelectedResponse: false
+                    ),
+                    Message(role: .user, content: "Latest"),
+                ],
+                model: model,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let request = try #require(await appleService.request(at: 0))
+
+            #expect(request.history == [
+                AppleIntelligenceHistoryEntry(role: .user, content: "Earlier"),
+                AppleIntelligenceHistoryEntry(role: .assistant, content: "Chosen answer"),
+            ])
+            request.complete()
+        }
+
+        @Test("Two Apple model aliases complete independently", .timeLimit(.minutes(1)))
+        func twoAppleModelAliasesCompleteIndependently() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let models = ["apple-a", "apple-b"]
+            configureAppleModels(models, on: service)
+            let modelCompletions = FlightTestBox<Set<String>>([])
+            let errors = FlightTestBox<[String]>([])
+            let allComplete = FlightTestSignal()
+
+            service.sendToMultipleModels(
+                messages: [Message(role: .user, content: "Compare")],
+                models: models,
+                onChunk: { _, _ in },
+                onModelComplete: { model in modelCompletions.update { $0.insert(model) } },
+                onAllComplete: { allComplete.signal() },
+                onError: { model, error in errors.update { $0.append("\(model):\(error.localizedDescription)") } }
+            )
+
+            let first = try #require(await appleService.request(sessionIDPrefix: "multi:default:\(models[0]):"))
+            let second = try #require(await appleService.request(sessionIDPrefix: "multi:default:\(models[1]):"))
+            #expect(!first.cancelled.isSignaled)
+            #expect(!second.cancelled.isSignaled)
+
+            first.complete()
+            #expect(!second.cancelled.isSignaled)
+            second.complete()
+
+            #expect(await allComplete.wait(timeout: .seconds(2)))
+            #expect(modelCompletions.value == Set(models))
+            #expect(errors.value.isEmpty)
+            #expect(Set(appleService.clearedSessionIDs) == Set([
+                first.conversationID,
+                second.conversationID,
+            ]))
+        }
+
+        @Test("Replacing an Apple batch cancels its old child", .timeLimit(.minutes(1)))
+        func replacingAppleBatchCancelsOldChild() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let oldModel = "apple-old"
+            let newModel = "apple-new"
+            configureAppleModels([oldModel, newModel], on: service)
+            let oldChunks = FlightTestBox<[String]>([])
+            let oldCompletions = FlightTestBox(0)
+            let oldAllComplete = FlightTestBox(false)
+            let newAllComplete = FlightTestSignal()
+
+            service.sendToMultipleModels(
+                messages: [Message(role: .user, content: "Old")],
+                models: [oldModel],
+                onChunk: { _, chunk in oldChunks.update { $0.append(chunk) } },
+                onModelComplete: { _ in oldCompletions.update { $0 += 1 } },
+                onAllComplete: { oldAllComplete.value = true },
+                onError: { _, _ in }
+            )
+            let oldRequest = try #require(await appleService.request(sessionIDPrefix: "multi:default:\(oldModel):"))
+
+            service.sendToMultipleModels(
+                messages: [Message(role: .user, content: "New")],
+                models: [newModel],
+                onChunk: { _, _ in },
+                onModelComplete: { _ in },
+                onAllComplete: { newAllComplete.signal() },
+                onError: { _, error in Issue.record("Unexpected error: \(error)") }
+            )
+            let newRequest = try #require(await appleService.request(sessionIDPrefix: "multi:default:\(newModel):"))
+            #expect(await oldRequest.cancelled.wait(timeout: .seconds(1)))
+
+            oldRequest.emitChunk("stale")
+            oldRequest.complete()
+            newRequest.complete()
+
+            #expect(await newAllComplete.wait(timeout: .seconds(2)))
+            #expect(oldChunks.value.isEmpty)
+            #expect(oldCompletions.value == 0)
+            #expect(!oldAllComplete.value)
+        }
+
+        @Test("Global cancellation stops foreground and all Apple batch children", .timeLimit(.minutes(1)))
+        func globalCancellationStopsForegroundAndAllAppleBatchChildren() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let models = ["apple-foreground", "apple-a", "apple-b"]
+            configureAppleModels(models, on: service)
+
+            service.sendMessage(
+                messages: [Message(role: .user, content: "Foreground")],
+                model: models[0],
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in }
+            )
+            let foreground = try #require(await appleService.request(sessionIDPrefix: "default:"))
+
+            service.sendToMultipleModels(
+                messages: [Message(role: .user, content: "Batch")],
+                models: Array(models.dropFirst()),
+                onChunk: { _, _ in },
+                onModelComplete: { _ in },
+                onAllComplete: {},
+                onError: { _, _ in }
+            )
+            let firstBatch = try #require(await appleService.request(sessionIDPrefix: "multi:default:\(models[1]):"))
+            let secondBatch = try #require(await appleService.request(sessionIDPrefix: "multi:default:\(models[2]):"))
+
+            service.cancelCurrentRequest(includeImageRequests: false)
+
+            #expect(await foreground.cancelled.wait(timeout: .seconds(1)))
+            #expect(await firstBatch.cancelled.wait(timeout: .seconds(1)))
+            #expect(await secondBatch.cancelled.wait(timeout: .seconds(1)))
+            #expect(Set(appleService.clearedSessionIDs) == Set([
+                foreground.conversationID,
+                firstBatch.conversationID,
+                secondBatch.conversationID,
+            ]))
+        }
+
+        @Test("Apple request return without callback terminates the batch", .timeLimit(.minutes(1)))
+        func appleRequestReturnWithoutCallbackTerminatesBatch() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-no-terminal"
+            configureAppleModels([model], on: service)
+            let errors = FlightTestBox<[String]>([])
+            let allComplete = FlightTestSignal()
+
+            service.sendToMultipleModels(
+                messages: [Message(role: .user, content: "Return")],
+                models: [model],
+                onChunk: { _, _ in },
+                onModelComplete: { _ in },
+                onAllComplete: { allComplete.signal() },
+                onError: { _, error in errors.update { $0.append(error.localizedDescription) } }
+            )
+            let request = try #require(await appleService.request(at: 0))
+            request.returnWithoutTerminal()
+
+            #expect(await allComplete.wait(timeout: .seconds(2)))
+            #expect(errors.value == ["Apple Intelligence request ended without a terminal callback"])
+        }
+
+        @Test("Injected unavailable Apple service terminates a batch", .timeLimit(.minutes(1)))
+        func injectedUnavailableAppleServiceTerminatesBatch() async {
+            let appleService = FlightTestAppleIntelligenceService()
+            appleService.isAvailable = false
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-unavailable"
+            configureAppleModels([model], on: service)
+            let errors = FlightTestBox<[String]>([])
+            let allComplete = FlightTestSignal()
+
+            service.sendToMultipleModels(
+                messages: [Message(role: .user, content: "Unavailable")],
+                models: [model],
+                onChunk: { _, _ in },
+                onModelComplete: { _ in },
+                onAllComplete: { allComplete.signal() },
+                onError: { _, error in errors.update { $0.append(error.localizedDescription) } }
+            )
+
+            #expect(await allComplete.wait(timeout: .seconds(2)))
+            #expect(errors.value == [appleService.unavailableDescription])
+            #expect(appleService.requests.isEmpty)
+        }
+
+        private func configureAppleModels(_ models: [String], on service: AIService) {
+            service.customModels = models
+            service.selectedModel = models[0]
+            for model in models {
+                service.modelProviders[model] = .appleIntelligence
+            }
+        }
+    }
+#endif
+
+#if !os(watchOS)
+    @Suite("Apple Intelligence Retry Gate Tests", .tags(.async))
+    @MainActor
+    struct AppleIntelligenceRetryGateTests {
+        @Test("Cancellation during retry delay prevents another attempt")
+        func cancellationDuringRetryDelayPreventsAnotherAttempt() async {
+            let delayStarted = FlightTestSignal()
+            let releaseDelay = FlightTestSignal()
+            let result = FlightTestBox(true)
+            var clearCount = 0
+
+            let task = Task { @MainActor in
+                result.value = await AppleIntelligenceRetryGate.prepare(
+                    clearSession: { clearCount += 1 },
+                    delay: {
+                        delayStarted.signal()
+                        await releaseDelay.wait()
+                    }
+                )
+            }
+            await delayStarted.wait()
+            task.cancel()
+            releaseDelay.signal()
+            await task.value
+
+            #expect(!result.value)
+            #expect(clearCount == 1)
+        }
+
+        @Test("Pre-cancelled retry does not clear the session or start delay")
+        func preCancelledRetryDoesNotClearSessionOrStartDelay() async {
+            let delayStarted = FlightTestSignal()
+            var clearCount = 0
+
+            let result = await Task { @MainActor in
+                withUnsafeCurrentTask { currentTask in
+                    currentTask?.cancel()
+                }
+                return await AppleIntelligenceRetryGate.prepare(
+                    clearSession: { clearCount += 1 },
+                    delay: { delayStarted.signal() }
+                )
+            }.value
+
+            #expect(!result)
+            #expect(clearCount == 0)
+            #expect(!delayStarted.isSignaled)
+        }
+    }
+#endif

--- a/Tests/AynaTests/AIServiceAppleIntelligenceTests.swift
+++ b/Tests/AynaTests/AIServiceAppleIntelligenceTests.swift
@@ -98,7 +98,7 @@ import Testing
                 stream: false,
                 onChunk: { _ in
                     MainActor.assumeIsolated {
-                        service.sendMessage(
+                        _ = service.sendMessage(
                             messages: [Message(role: .user, content: "Second")],
                             model: models[1],
                             stream: false,

--- a/Tests/AynaTests/AIServiceFlightTestSupport.swift
+++ b/Tests/AynaTests/AIServiceFlightTestSupport.swift
@@ -104,6 +104,15 @@ final class FlightTestURLProtocolServer: @unchecked Sendable {
         }
     }
 
+    func waitForRequestCount(_ count: Int, timeout: Duration = .seconds(2)) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while requestCount < count, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return requestCount >= count
+    }
+
     var requestCount: Int {
         lock.lock()
         defer { lock.unlock() }

--- a/Tests/AynaTests/AIServiceFlightTestSupport.swift
+++ b/Tests/AynaTests/AIServiceFlightTestSupport.swift
@@ -1,0 +1,318 @@
+@testable import Ayna
+import Foundation
+
+final class FlightTestSignal: @unchecked Sendable {
+    private let lock = NSLock()
+    private var signaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    var isSignaled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return signaled
+    }
+
+    func signal() {
+        lock.lock()
+        guard !signaled else {
+            lock.unlock()
+            return
+        }
+        signaled = true
+        let pending = waiters
+        waiters.removeAll()
+        lock.unlock()
+        pending.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if signaled {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                waiters.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    func wait(timeout: Duration) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !isSignaled, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return isSignaled
+    }
+}
+
+final class FlightTestBox<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: Value
+
+    init(_ value: Value) {
+        storedValue = value
+    }
+
+    var value: Value {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedValue
+        }
+        set {
+            lock.lock()
+            storedValue = newValue
+            lock.unlock()
+        }
+    }
+
+    func update(_ body: (inout Value) -> Void) {
+        lock.lock()
+        body(&storedValue)
+        lock.unlock()
+    }
+}
+
+final class FlightTestURLProtocolServer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var exchanges: [FlightTestURLProtocolExchange] = []
+    private var waiters: [Int: [CheckedContinuation<FlightTestURLProtocolExchange, Never>]] = [:]
+
+    fileprivate func record(_ exchange: FlightTestURLProtocolExchange) {
+        lock.lock()
+        exchanges.append(exchange)
+        let index = exchanges.count - 1
+        let pending = waiters.removeValue(forKey: index) ?? []
+        lock.unlock()
+        pending.forEach { $0.resume(returning: exchange) }
+    }
+
+    func exchange(at index: Int) async -> FlightTestURLProtocolExchange {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if exchanges.indices.contains(index) {
+                let exchange = exchanges[index]
+                lock.unlock()
+                continuation.resume(returning: exchange)
+            } else {
+                waiters[index, default: []].append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    var requestCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return exchanges.count
+    }
+}
+
+final class FlightTestURLProtocolExchange: @unchecked Sendable {
+    private struct State {
+        var sentResponse = false
+        var finished = false
+        var stopped = false
+    }
+
+    let request: URLRequest
+
+    private weak var protocolInstance: FlightTestURLProtocol?
+    private let lock = NSLock()
+    private var state = State()
+
+    fileprivate init(request: URLRequest, protocolInstance: FlightTestURLProtocol) {
+        self.request = request
+        self.protocolInstance = protocolInstance
+    }
+
+    var isStopped: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return state.stopped
+    }
+
+    func sendResponse(statusCode: Int, headers: [String: String] = [:]) {
+        lock.lock()
+        guard !state.stopped, !state.finished, !state.sentResponse else {
+            lock.unlock()
+            return
+        }
+        state.sentResponse = true
+        lock.unlock()
+
+        guard let protocolInstance,
+              let response = HTTPURLResponse(
+                  url: request.url!,
+                  statusCode: statusCode,
+                  httpVersion: nil,
+                  headerFields: headers
+              )
+        else {
+            return
+        }
+        protocolInstance.client?.urlProtocol(protocolInstance, didReceive: response, cacheStoragePolicy: .notAllowed)
+    }
+
+    func send(_ data: Data) {
+        lock.lock()
+        let canSend = state.sentResponse && !state.stopped && !state.finished
+        lock.unlock()
+        guard canSend, let protocolInstance else { return }
+        protocolInstance.client?.urlProtocol(protocolInstance, didLoad: data)
+    }
+
+    func finish() {
+        lock.lock()
+        guard state.sentResponse, !state.stopped, !state.finished else {
+            lock.unlock()
+            return
+        }
+        state.finished = true
+        lock.unlock()
+        guard let protocolInstance else { return }
+        protocolInstance.client?.urlProtocolDidFinishLoading(protocolInstance)
+    }
+
+    func fail(_ error: Error) {
+        lock.lock()
+        guard !state.stopped, !state.finished else {
+            lock.unlock()
+            return
+        }
+        state.finished = true
+        lock.unlock()
+        guard let protocolInstance else { return }
+        protocolInstance.client?.urlProtocol(protocolInstance, didFailWithError: error)
+    }
+
+    func waitUntilStopped(timeout: Duration = .seconds(2)) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !isStopped, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return isStopped
+    }
+
+    fileprivate func markStopped() {
+        lock.lock()
+        state.stopped = true
+        lock.unlock()
+    }
+}
+
+final class FlightTestURLProtocol: URLProtocol, @unchecked Sendable {
+    private static let serverLock = NSLock()
+    private nonisolated(unsafe) static var server: FlightTestURLProtocolServer?
+
+    private let exchangeLock = NSLock()
+    private var exchange: FlightTestURLProtocolExchange?
+
+    static func install(server: FlightTestURLProtocolServer) {
+        serverLock.lock()
+        self.server = server
+        serverLock.unlock()
+    }
+
+    static func reset() {
+        serverLock.lock()
+        server = nil
+        serverLock.unlock()
+    }
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.serverLock.lock()
+        let server = Self.server
+        Self.serverLock.unlock()
+        guard let server else {
+            client?.urlProtocol(
+                self,
+                didFailWithError: NSError(
+                    domain: "FlightTestURLProtocol",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Server not installed"]
+                )
+            )
+            return
+        }
+
+        let recordedExchange = FlightTestURLProtocolExchange(request: request, protocolInstance: self)
+        exchangeLock.lock()
+        exchange = recordedExchange
+        exchangeLock.unlock()
+        server.record(recordedExchange)
+    }
+
+    override func stopLoading() {
+        exchangeLock.lock()
+        let exchange = exchange
+        exchangeLock.unlock()
+        exchange?.markStopped()
+    }
+}
+
+@MainActor
+final class FlightTestAnthropicProvider: AIProviderProtocol, @unchecked Sendable {
+    let providerType: AIProvider = .anthropic
+    let requiresAPIKey = true
+
+    private var callbacks: AIProviderStreamCallbacks?
+    private(set) var isCancelled = false
+
+    func sendMessage(
+        messages _: [Message],
+        config _: AIProviderRequestConfig,
+        stream _: Bool,
+        tools _: [[String: Any]]?,
+        callbacks: AIProviderStreamCallbacks
+    ) {
+        self.callbacks = callbacks
+    }
+
+    func cancelRequest() {
+        isCancelled = true
+    }
+
+    func emitChunk(_ chunk: String) {
+        callbacks?.onChunk(chunk)
+    }
+
+    func emitReasoning(_ reasoning: String) {
+        callbacks?.onReasoning?(reasoning)
+    }
+
+    func emitToolRequest(name: String) {
+        callbacks?.onToolCallRequested?("tool-id", name, [:])
+    }
+
+    func complete() {
+        callbacks?.onComplete()
+    }
+
+    func fail(_ error: Error) {
+        callbacks?.onError(error)
+    }
+}
+
+@MainActor
+final class FlightTestAnthropicProviderFactory {
+    private(set) var providers: [FlightTestAnthropicProvider] = []
+
+    func makeProvider() -> FlightTestAnthropicProvider {
+        let provider = FlightTestAnthropicProvider()
+        providers.append(provider)
+        return provider
+    }
+}

--- a/Tests/AynaTests/AIServiceFlightTestSupport.swift
+++ b/Tests/AynaTests/AIServiceFlightTestSupport.swift
@@ -1,5 +1,6 @@
 @testable import Ayna
 import Foundation
+import os
 
 final class FlightTestSignal: @unchecked Sendable {
     private let lock = NSLock()
@@ -325,3 +326,176 @@ final class FlightTestAnthropicProviderFactory {
         return provider
     }
 }
+
+#if !os(watchOS)
+    @MainActor
+    final class FlightTestAppleIntelligenceService: AppleIntelligenceServing {
+        var isAvailable = true
+        var contextSize = 4096
+        var tokenCountHandler: ((AppleIntelligenceRequest) -> Int?)?
+        var unavailableDescription = "Unavailable for testing"
+        private(set) var requests: [FlightTestAppleRequest] = []
+        private(set) var clearedSessionIDs: [String] = []
+
+        func availabilityDescription() -> String {
+            unavailableDescription
+        }
+
+        func clearSession(conversationId: String) {
+            clearedSessionIDs.append(conversationId)
+        }
+
+        func tokenCount(for request: AppleIntelligenceRequest) async -> Int? {
+            tokenCountHandler?(request)
+        }
+
+        func streamResponse(
+            request: AppleIntelligenceRequest,
+            onChunk: @escaping @MainActor @Sendable (String) -> Void,
+            onComplete: @escaping @MainActor @Sendable () -> Void,
+            onError: @escaping @MainActor @Sendable (Error) -> Void
+        ) async {
+            let request = FlightTestAppleRequest(
+                conversationID: request.conversationID,
+                prompt: request.prompt,
+                history: request.history,
+                onChunk: onChunk,
+                onComplete: { _ in onComplete() },
+                onError: onError
+            )
+            requests.append(request)
+            await request.waitForTerminalOrCancellation()
+        }
+
+        func generateResponse(
+            request: AppleIntelligenceRequest,
+            onComplete: @escaping @MainActor @Sendable (String) -> Void,
+            onError: @escaping @MainActor @Sendable (Error) -> Void
+        ) async {
+            let request = FlightTestAppleRequest(
+                conversationID: request.conversationID,
+                prompt: request.prompt,
+                history: request.history,
+                onChunk: { _ in },
+                onComplete: { response in onComplete(response ?? "") },
+                onError: onError
+            )
+            requests.append(request)
+            await request.waitForTerminalOrCancellation()
+        }
+
+        func request(at index: Int, timeout: Duration = .seconds(2)) async -> FlightTestAppleRequest? {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while requests.count <= index, clock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            return requests.indices.contains(index) ? requests[index] : nil
+        }
+
+        func request(sessionIDPrefix: String, timeout: Duration = .seconds(2)) async -> FlightTestAppleRequest? {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                if let request = requests.first(where: { $0.conversationID.hasPrefix(sessionIDPrefix) }) {
+                    return request
+                }
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            return requests.first(where: { $0.conversationID.hasPrefix(sessionIDPrefix) })
+        }
+    }
+
+    final class FlightTestAppleRequest: @unchecked Sendable {
+        private enum WaitState {
+            case pending
+            case waiting(CheckedContinuation<Void, Never>)
+            case finished
+        }
+
+        let conversationID: String
+        let prompt: String
+        let history: [AppleIntelligenceHistoryEntry]
+        let cancelled = FlightTestSignal()
+
+        private let waitState = OSAllocatedUnfairLock(initialState: WaitState.pending)
+        private let onChunk: @MainActor @Sendable (String) -> Void
+        private let onComplete: @MainActor @Sendable (String?) -> Void
+        private let onError: @MainActor @Sendable (Error) -> Void
+
+        init(
+            conversationID: String,
+            prompt: String,
+            history: [AppleIntelligenceHistoryEntry],
+            onChunk: @escaping @MainActor @Sendable (String) -> Void,
+            onComplete: @escaping @MainActor @Sendable (String?) -> Void,
+            onError: @escaping @MainActor @Sendable (Error) -> Void
+        ) {
+            self.conversationID = conversationID
+            self.prompt = prompt
+            self.history = history
+            self.onChunk = onChunk
+            self.onComplete = onComplete
+            self.onError = onError
+        }
+
+        func waitForTerminalOrCancellation() async {
+            await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    let shouldResume = waitState.withLock { state -> Bool in
+                        guard case .pending = state else { return true }
+                        state = .waiting(continuation)
+                        return false
+                    }
+                    if shouldResume {
+                        continuation.resume()
+                    }
+                }
+            } onCancel: {
+                self.cancel()
+            }
+        }
+
+        @MainActor
+        func emitChunk(_ chunk: String) {
+            onChunk(chunk)
+        }
+
+        @MainActor
+        func complete(response: String? = nil) {
+            onComplete(response)
+            finishWait()
+        }
+
+        @MainActor
+        func fail(_ error: Error) {
+            onError(error)
+            finishWait()
+        }
+
+        func returnWithoutTerminal() {
+            finishWait()
+        }
+
+        private func cancel() {
+            cancelled.signal()
+            finishWait()
+        }
+
+        private func finishWait() {
+            let continuation = waitState.withLock { state -> CheckedContinuation<Void, Never>? in
+                switch state {
+                case .pending:
+                    state = .finished
+                    return nil
+                case let .waiting(continuation):
+                    state = .finished
+                    return continuation
+                case .finished:
+                    return nil
+                }
+            }
+            continuation?.resume()
+        }
+    }
+#endif

--- a/Tests/AynaTests/AIServiceImageOwnershipTests.swift
+++ b/Tests/AynaTests/AIServiceImageOwnershipTests.swift
@@ -1,0 +1,452 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+extension AIServiceTests {
+    @Test("Cancelling the current request stops image generation and suppresses callbacks", .timeLimit(.minutes(1)))
+    func cancellingCurrentRequestStopsImageGenerationAndSuppressesCallbacks() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-cancel.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let callbackReceived = FlightTestSignal()
+        service.generateImage(
+            prompt: "a glass sphere",
+            model: "image-model",
+            onComplete: { _ in callbackReceived.signal() },
+            onError: { _ in callbackReceived.signal() }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        service.cancelCurrentRequest()
+        let requestStopped = await exchange.waitUntilStopped(timeout: .milliseconds(250))
+
+        exchange.sendResponse(statusCode: 200)
+        exchange.send(Data(#"{"data":[{"b64_json":"aW1hZ2U="}]}"#.utf8))
+        exchange.finish()
+        let callbackWasDelivered = await callbackReceived.wait(timeout: .milliseconds(100))
+
+        #expect(requestStopped)
+        #expect(!callbackWasDelivered)
+    }
+
+    @Test("Cancelling the current request stops image editing and suppresses callbacks", .timeLimit(.minutes(1)))
+    func cancellingCurrentRequestStopsImageEditingAndSuppressesCallbacks() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-edit-cancel.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let callbackReceived = FlightTestSignal()
+        service.editImage(
+            prompt: "make it blue",
+            sourceImage: Data("source".utf8),
+            model: "image-model",
+            onComplete: { _ in callbackReceived.signal() },
+            onError: { _ in callbackReceived.signal() }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        service.cancelCurrentRequest()
+        let requestStopped = await exchange.waitUntilStopped(timeout: .milliseconds(250))
+
+        exchange.sendResponse(statusCode: 200)
+        exchange.send(Data(#"{"data":[{"b64_json":"aW1hZ2U="}]}"#.utf8))
+        exchange.finish()
+        let callbackWasDelivered = await callbackReceived.wait(timeout: .milliseconds(100))
+
+        #expect(requestStopped)
+        #expect(!callbackWasDelivered)
+    }
+
+    @Test("Cancelling image generation during retry backoff prevents a retry", .timeLimit(.minutes(1)))
+    func cancellingImageGenerationDuringRetryBackoffPreventsRetry() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let retryStarted = FlightTestSignal()
+        let releaseRetry = FlightTestSignal()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            retryDelay: { _, _ in
+                retryStarted.signal()
+                await releaseRetry.wait()
+            }
+        )
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-retry.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let callbackReceived = FlightTestSignal()
+        service.generateImage(
+            prompt: "a glass sphere",
+            model: "image-model",
+            onComplete: { _ in callbackReceived.signal() },
+            onError: { _ in callbackReceived.signal() }
+        )
+
+        let firstExchange = await server.exchange(at: 0)
+        firstExchange.fail(URLError(.networkConnectionLost))
+        await retryStarted.wait()
+
+        service.cancelCurrentRequest()
+        releaseRetry.signal()
+
+        let retryStartedAfterCancellation = await server.waitForRequestCount(2, timeout: .milliseconds(150))
+        let callbackWasDelivered = await callbackReceived.wait(timeout: .milliseconds(100))
+        #expect(!retryStartedAfterCancellation)
+        #expect(!callbackWasDelivered)
+    }
+
+    @Test("Cancelling image generation stops a fallback image download", .timeLimit(.minutes(1)))
+    func cancellingImageGenerationStopsFallbackImageDownload() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-fallback.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let callbackReceived = FlightTestSignal()
+        service.generateImage(
+            prompt: "a glass sphere",
+            model: "image-model",
+            onComplete: { _ in callbackReceived.signal() },
+            onError: { _ in callbackReceived.signal() }
+        )
+
+        let generationExchange = await server.exchange(at: 0)
+        generationExchange.sendResponse(statusCode: 200)
+        generationExchange.send(Data(#"{"data":[{"url":"https://cdn.example.com/generated.png"}]}"#.utf8))
+        generationExchange.finish()
+
+        let downloadExchange = await server.exchange(at: 1)
+        service.cancelCurrentRequest()
+        let downloadStopped = await downloadExchange.waitUntilStopped(timeout: .milliseconds(250))
+
+        downloadExchange.sendResponse(statusCode: 200)
+        downloadExchange.send(Data("image".utf8))
+        downloadExchange.finish()
+        let callbackWasDelivered = await callbackReceived.wait(timeout: .milliseconds(100))
+
+        #expect(downloadStopped)
+        #expect(!callbackWasDelivered)
+    }
+
+    @Test("A failed fallback image download reports an error instead of completing", .timeLimit(.minutes(1)))
+    func failedFallbackImageDownloadReportsErrorInsteadOfCompleting() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-fallback-error.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let completionReceived = FlightTestSignal()
+        let errorReceived = FlightTestSignal()
+        service.generateImage(
+            prompt: "a glass sphere",
+            model: "image-model",
+            onComplete: { _ in completionReceived.signal() },
+            onError: { _ in errorReceived.signal() }
+        )
+
+        let generationExchange = await server.exchange(at: 0)
+        generationExchange.sendResponse(statusCode: 200)
+        generationExchange.send(Data(#"{"data":[{"url":"https://cdn.example.com/missing.png"}]}"#.utf8))
+        generationExchange.finish()
+
+        let downloadExchange = await server.exchange(at: 1)
+        downloadExchange.sendResponse(statusCode: 404)
+        downloadExchange.send(Data("not an image".utf8))
+        downloadExchange.finish()
+
+        #expect(await errorReceived.wait(timeout: .seconds(1)))
+        #expect(!completionReceived.isSignaled)
+    }
+
+    @Test("A successful fallback response with non-image data reports an error", .timeLimit(.minutes(1)))
+    func successfulFallbackResponseWithNonImageDataReportsError() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-fallback-html.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let completionReceived = FlightTestSignal()
+        let errorReceived = FlightTestSignal()
+        service.generateImage(
+            prompt: "a glass sphere",
+            model: "image-model",
+            onComplete: { _ in completionReceived.signal() },
+            onError: { _ in errorReceived.signal() }
+        )
+
+        let generationExchange = await server.exchange(at: 0)
+        generationExchange.sendResponse(statusCode: 200)
+        generationExchange.send(Data(#"{"data":[{"url":"https://cdn.example.com/not-image.png"}]}"#.utf8))
+        generationExchange.finish()
+
+        let downloadExchange = await server.exchange(at: 1)
+        downloadExchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/html"])
+        downloadExchange.send(Data("<html>error</html>".utf8))
+        downloadExchange.finish()
+
+        #expect(await errorReceived.wait(timeout: .seconds(1)))
+        #expect(!completionReceived.isSignaled)
+    }
+
+    @Test("A transient fallback download failure retries under the same owner", .timeLimit(.minutes(1)))
+    func transientFallbackDownloadFailureRetriesUnderSameOwner() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let retryStarted = FlightTestSignal()
+        let releaseRetry = FlightTestSignal()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            retryDelay: { _, _ in
+                retryStarted.signal()
+                await releaseRetry.wait()
+            }
+        )
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-fallback-retry.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let completionReceived = FlightTestSignal()
+        let errorReceived = FlightTestSignal()
+        service.generateImage(
+            prompt: "a glass sphere",
+            model: "image-model",
+            onComplete: { _ in completionReceived.signal() },
+            onError: { _ in errorReceived.signal() }
+        )
+
+        let generationExchange = await server.exchange(at: 0)
+        generationExchange.sendResponse(statusCode: 200)
+        generationExchange.send(Data(#"{"data":[{"url":"https://cdn.example.com/transient.png"}]}"#.utf8))
+        generationExchange.finish()
+
+        let failedDownload = await server.exchange(at: 1)
+        failedDownload.sendResponse(statusCode: 503)
+        failedDownload.send(Data("temporarily unavailable".utf8))
+        failedDownload.finish()
+        await retryStarted.wait()
+
+        releaseRetry.signal()
+        let retriedDownload = await server.exchange(at: 2)
+        retriedDownload.sendResponse(statusCode: 200)
+        retriedDownload.send(Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]))
+        retriedDownload.finish()
+
+        #expect(await completionReceived.wait(timeout: .seconds(1)))
+        #expect(!errorReceived.isSignaled)
+    }
+
+    @Test("An active fallback download cancellation terminates with an error", .timeLimit(.minutes(1)))
+    func activeFallbackDownloadCancellationTerminatesWithError() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-fallback-cancelled.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let completionReceived = FlightTestSignal()
+        let errorReceived = FlightTestSignal()
+        service.generateImage(
+            prompt: "a glass sphere",
+            model: "image-model",
+            onComplete: { _ in completionReceived.signal() },
+            onError: { _ in errorReceived.signal() }
+        )
+
+        let generationExchange = await server.exchange(at: 0)
+        generationExchange.sendResponse(statusCode: 200)
+        generationExchange.send(Data(#"{"data":[{"url":"https://cdn.example.com/cancelled.png"}]}"#.utf8))
+        generationExchange.finish()
+
+        let downloadExchange = await server.exchange(at: 1)
+        downloadExchange.fail(URLError(.cancelled))
+
+        #expect(await errorReceived.wait(timeout: .seconds(1)))
+        #expect(!completionReceived.isSignaled)
+    }
+
+    @Test("Cancelling one image request preserves a peer request", .timeLimit(.minutes(1)))
+    func cancellingOneImageRequestPreservesPeerRequest() async throws {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-peer.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let firstCallback = FlightTestSignal()
+        let secondCallback = FlightTestSignal()
+        let firstRequestCandidate = service.generateImage(
+            prompt: "first",
+            model: "image-model",
+            onComplete: { _ in firstCallback.signal() },
+            onError: { _ in firstCallback.signal() }
+        )
+        let firstRequest = try #require(firstRequestCandidate)
+        service.generateImage(
+            prompt: "second",
+            model: "image-model",
+            onComplete: { _ in secondCallback.signal() },
+            onError: { _ in secondCallback.signal() }
+        )
+
+        let firstExchange = await server.exchange(at: 0)
+        let secondExchange = await server.exchange(at: 1)
+        firstRequest.cancel()
+
+        let firstStopped = await firstExchange.waitUntilStopped(timeout: .milliseconds(250))
+        #expect(firstStopped)
+        #expect(!secondExchange.isStopped)
+
+        secondExchange.sendResponse(statusCode: 200)
+        secondExchange.send(Data(#"{"data":[{"b64_json":"aW1hZ2U="}]}"#.utf8))
+        secondExchange.finish()
+
+        let secondCompleted = await secondCallback.wait(timeout: .seconds(1))
+        let firstCompleted = await firstCallback.wait(timeout: .milliseconds(100))
+        #expect(secondCompleted)
+        #expect(!firstCompleted)
+    }
+
+    @Test("Cancelling non-image work preserves an image owned by another view", .timeLimit(.minutes(1)))
+    func cancellingNonImageWorkPreservesImageOwnedByAnotherView() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-peer-stop.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let completionReceived = FlightTestSignal()
+        service.generateImage(
+            prompt: "peer image",
+            model: "image-model",
+            onComplete: { _ in completionReceived.signal() },
+            onError: { _ in }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        service.cancelCurrentRequest(includeImageRequests: false)
+        #expect(!exchange.isStopped)
+
+        exchange.sendResponse(statusCode: 200)
+        exchange.send(Data(#"{"data":[{"b64_json":"aW1hZ2U="}]}"#.utf8))
+        exchange.finish()
+        #expect(await completionReceived.wait(timeout: .seconds(1)))
+    }
+
+    @Test("Replacing a logical image batch cancels every old child and preserves new children", .timeLimit(.minutes(1)))
+    func replacingLogicalImageBatchCancelsOldChildrenAndPreservesNewChildren() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        service.customModels = ["image-model"]
+        service.selectedModel = "image-model"
+        service.modelProviders["image-model"] = .openai
+        service.modelAPIKeys["image-model"] = "sk-unit-test"
+        service.modelEndpoints["image-model"] = "https://image-batch-replacement.example.com"
+        service.modelEndpointTypes["image-model"] = .imageGeneration
+
+        let coordinator = ImageGenerationCoordinator()
+        let oldOperationID = coordinator.beginOperation()
+        for prompt in ["old-one", "old-two"] {
+            let request = service.generateImage(
+                prompt: prompt,
+                model: "image-model",
+                onComplete: { _ in },
+                onError: { _ in }
+            )
+            coordinator.track(request, for: oldOperationID)
+        }
+        let firstOldExchange = await server.exchange(at: 0)
+        let secondOldExchange = await server.exchange(at: 1)
+
+        let newOperationID = coordinator.beginOperation()
+        for prompt in ["new-one", "new-two"] {
+            let request = service.generateImage(
+                prompt: prompt,
+                model: "image-model",
+                onComplete: { _ in },
+                onError: { _ in }
+            )
+            coordinator.track(request, for: newOperationID)
+        }
+        let firstNewExchange = await server.exchange(at: 2)
+        let secondNewExchange = await server.exchange(at: 3)
+
+        #expect(await firstOldExchange.waitUntilStopped(timeout: .milliseconds(250)))
+        #expect(await secondOldExchange.waitUntilStopped(timeout: .milliseconds(250)))
+        #expect(!firstNewExchange.isStopped)
+        #expect(!secondNewExchange.isStopped)
+        #expect(coordinator.owns(newOperationID))
+
+        coordinator.cancelCurrentOperation()
+        #expect(await firstNewExchange.waitUntilStopped(timeout: .milliseconds(250)))
+        #expect(await secondNewExchange.waitUntilStopped(timeout: .milliseconds(250)))
+    }
+}

--- a/Tests/AynaTests/AIServiceMultiModelTests.swift
+++ b/Tests/AynaTests/AIServiceMultiModelTests.swift
@@ -50,6 +50,109 @@ extension AIServiceTests {
         #expect(allComplete.value)
     }
 
+    @Test("Cancelling an owned batch stops its child and suppresses callbacks", .timeLimit(.minutes(1)))
+    func cancellingOwnedBatchStopsChildAndSuppressesCallbacks() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let model = "owned-batch"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-unit-test"
+
+        let callbackReceived = FlightTestSignal()
+        let batch = service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Cancel batch")],
+            models: [model],
+            onChunk: { _, _ in callbackReceived.signal() },
+            onModelComplete: { _ in callbackReceived.signal() },
+            onAllComplete: { callbackReceived.signal() },
+            onError: { _, _ in callbackReceived.signal() }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+        batch.cancel()
+
+        #expect(await exchange.waitUntilStopped(timeout: .seconds(1)))
+        exchange.send(Data("data: {\"choices\":[{\"delta\":{\"content\":\"late\"}}]}\n\n".utf8))
+        exchange.finish()
+        #expect(await !(callbackReceived.wait(timeout: .milliseconds(100))))
+    }
+
+    @Test("A stale batch handle cannot cancel its replacement or a foreground request", .timeLimit(.minutes(1)))
+    func staleBatchHandleCannotCancelReplacementOrForeground() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let models = ["stale-batch", "replacement-batch", "foreground"]
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .openai
+            service.modelAPIKeys[model] = "sk-unit-test"
+        }
+
+        let staleCallbacks = FlightTestSignal()
+        let staleBatch = service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Stale")],
+            models: [models[0]],
+            onChunk: { _, _ in staleCallbacks.signal() },
+            onModelComplete: { _ in staleCallbacks.signal() },
+            onAllComplete: { staleCallbacks.signal() },
+            onError: { _, _ in staleCallbacks.signal() }
+        )
+        let staleExchange = await server.exchange(at: 0)
+        staleExchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+
+        let replacementComplete = FlightTestSignal()
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Replacement")],
+            models: [models[1]],
+            onChunk: { _, _ in },
+            onModelComplete: { _ in },
+            onAllComplete: { replacementComplete.signal() },
+            onError: { _, error in Issue.record("Unexpected replacement error: \(error)") }
+        )
+        let replacementExchange = await server.exchange(at: 1)
+        replacementExchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+        #expect(await staleExchange.waitUntilStopped(timeout: .seconds(1)))
+
+        let foregroundChunk = FlightTestBox("")
+        let foregroundComplete = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Foreground")],
+            model: models[2],
+            onChunk: { foregroundChunk.value += $0 },
+            onComplete: { foregroundComplete.signal() },
+            onError: { error in Issue.record("Unexpected foreground error: \(error)") }
+        )
+        let foregroundExchange = await server.exchange(at: 2)
+        foregroundExchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+
+        staleBatch.cancel()
+        #expect(!replacementExchange.isStopped)
+        #expect(!foregroundExchange.isStopped)
+
+        replacementExchange.send(Data("data: [DONE]\n\n".utf8))
+        replacementExchange.finish()
+        foregroundExchange.send(
+            Data("data: {\"choices\":[{\"delta\":{\"content\":\"foreground\"}}]}\n\n".utf8)
+        )
+        foregroundExchange.send(Data("data: [DONE]\n\n".utf8))
+        foregroundExchange.finish()
+
+        #expect(await replacementComplete.wait(timeout: .seconds(1)))
+        #expect(await foregroundComplete.wait(timeout: .seconds(1)))
+        #expect(foregroundChunk.value == "foreground")
+        #expect(await !(staleCallbacks.wait(timeout: .milliseconds(100))))
+    }
+
     @Test("A replacement batch drops delayed callbacks from the cancelled batch", .timeLimit(.minutes(1)))
     func replacementBatchDropsDelayedCallbacksFromCancelledBatch() async {
         let staleResponseWaiting = FlightTestSignal()
@@ -166,7 +269,7 @@ extension AIServiceTests {
             service.modelAPIKeys[model] = token
         }
 
-        service.sendToMultipleModels(
+        let staleBatch = service.sendToMultipleModels(
             messages: [Message(role: .user, content: "Stale batch")],
             models: staleModels,
             onChunk: { _, _ in },
@@ -189,7 +292,7 @@ extension AIServiceTests {
         }
 
         if trigger == .stopThenReplace {
-            service.cancelCurrentRequest()
+            staleBatch.cancel()
         }
         service.sendToMultipleModels(
             messages: [Message(role: .user, content: "Replacement")],

--- a/Tests/AynaTests/AIServiceMultiModelTests.swift
+++ b/Tests/AynaTests/AIServiceMultiModelTests.swift
@@ -1,0 +1,445 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+// swiftformat:disable swiftTestingTestCaseNames
+
+extension AIServiceTests {
+    @Test("An empty model list reports an error and completes the batch")
+    func emptyModelListReportsErrorAndCompletesBatch() {
+        let service = AIService()
+        let errors = FlightTestBox<[String]>([])
+        let allComplete = FlightTestBox(false)
+
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Empty")],
+            models: [],
+            onChunk: { _, _ in },
+            onModelComplete: { _ in },
+            onAllComplete: { allComplete.value = true },
+            onError: { model, error in
+                errors.update { $0.append("\(model):\(error.localizedDescription)") }
+            }
+        )
+
+        #expect(errors.value == [":Please add or select a model in Settings"])
+        #expect(allComplete.value)
+    }
+
+    @Test("Duplicate normalized models fail before launching a batch")
+    func duplicateNormalizedModelsFailBeforeLaunchingBatch() {
+        let service = AIService()
+        let errors = FlightTestBox<[String]>([])
+        let allComplete = FlightTestBox(false)
+
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Duplicate")],
+            models: ["gpt-4o", " gpt-4o "],
+            onChunk: { _, _ in },
+            onModelComplete: { _ in },
+            onAllComplete: { allComplete.value = true },
+            onError: { model, error in
+                errors.update { $0.append("\(model):\(error.localizedDescription)") }
+            }
+        )
+
+        #expect(errors.value == [
+            "gpt-4o:Duplicate model in multi-model request: gpt-4o",
+            " gpt-4o :Duplicate model in multi-model request: gpt-4o"
+        ])
+        #expect(allComplete.value)
+    }
+
+    @Test("A replacement batch drops delayed callbacks from the cancelled batch", .timeLimit(.minutes(1)))
+    func replacementBatchDropsDelayedCallbacksFromCancelledBatch() async {
+        let staleResponseWaiting = FlightTestSignal()
+        let releaseStaleResponse = FlightTestSignal()
+        let staleCallbackRejected = FlightTestSignal()
+        let responseSimulator: AIServiceResponseSimulator = { messages, callbacks in
+            let content = messages.last(where: { $0.role == .user })?.content ?? "Mock response"
+            if content == "Stale" {
+                Task { @MainActor in
+                    staleResponseWaiting.signal()
+                    await releaseStaleResponse.wait()
+                    callbacks.onChunk("UI Test Response: Stale")
+                    callbacks.onComplete()
+                }
+            } else {
+                callbacks.onChunk("UI Test Response: \(content)")
+                callbacks.onComplete()
+            }
+        }
+        let service = AIService(
+            requestFlightObserver: RequestFlightObserver { checkpoint, ownsFlight in
+                if checkpoint == .multiModelCallback, !ownsFlight {
+                    staleCallbackRejected.signal()
+                }
+            },
+            responseSimulator: responseSimulator
+        )
+        let models = ["stale-ui-model", "replacement-ui-model"]
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .openai
+            service.modelAPIKeys[model] = "ui-test-key"
+        }
+
+        let staleChunks = FlightTestBox<[String]>([])
+        let staleModelCompletions = FlightTestBox(0)
+        let staleErrors = FlightTestBox(0)
+        let staleAllComplete = FlightTestBox(false)
+        let replacementChunks = FlightTestBox<[String]>([])
+        let replacementAllComplete = FlightTestSignal()
+
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Stale")],
+            models: [models[0]],
+            onChunk: { _, chunk in staleChunks.update { $0.append(chunk) } },
+            onModelComplete: { _ in staleModelCompletions.update { $0 += 1 } },
+            onAllComplete: { staleAllComplete.value = true },
+            onError: { _, _ in staleErrors.update { $0 += 1 } }
+        )
+
+        let staleResponseIsHeld = await staleResponseWaiting.wait(timeout: .seconds(2))
+        #expect(staleResponseIsHeld)
+        guard staleResponseIsHeld else {
+            releaseStaleResponse.signal()
+            service.cancelCurrentRequest()
+            return
+        }
+
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Replacement")],
+            models: [models[1]],
+            onChunk: { _, chunk in replacementChunks.update { $0.append(chunk) } },
+            onModelComplete: { _ in },
+            onAllComplete: { replacementAllComplete.signal() },
+            onError: { _, error in Issue.record("Unexpected replacement error: \(error)") }
+        )
+
+        let replacementCompleted = await replacementAllComplete.wait(timeout: .seconds(2))
+        releaseStaleResponse.signal()
+        let rejectedStaleCallback = await staleCallbackRejected.wait(timeout: .seconds(2))
+        service.cancelCurrentRequest()
+
+        #expect(replacementCompleted)
+        #expect(rejectedStaleCallback)
+        #expect(replacementChunks.value == ["UI Test Response: Replacement"])
+        #expect(staleChunks.value.isEmpty)
+        #expect(staleModelCompletions.value == 0)
+        #expect(staleErrors.value == 0)
+        #expect(!staleAllComplete.value)
+    }
+
+    @Test(
+        "Cancelling a batch fences queued same-token GitHub models",
+        .timeLimit(.minutes(1)),
+        arguments: MultiModelBatchReplacementTrigger.allCases
+    )
+    func cancellingBatchFencesQueuedSameTokenGitHubModels(
+        trigger: MultiModelBatchReplacementTrigger
+    ) async throws {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let permitQueued = FlightTestSignal()
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            requestFlightObserver: RequestFlightObserver { checkpoint, _ in
+                if checkpoint == .multiModelPermitQueued {
+                    permitQueued.signal()
+                }
+            }
+        )
+        let staleModels = ["github-stale-a", "github-stale-b"]
+        let replacementModel = "github-replacement"
+        let token = "github-token-\(UUID().uuidString)"
+        let models = staleModels + [replacementModel]
+        let staleAllComplete = FlightTestBox(false)
+        let replacementAllComplete = FlightTestSignal()
+        service.customModels = models
+        service.selectedModel = staleModels[0]
+        for model in models {
+            service.modelProviders[model] = .githubModels
+            service.modelAPIKeys[model] = token
+        }
+
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Stale batch")],
+            models: staleModels,
+            onChunk: { _, _ in },
+            onModelComplete: { _ in },
+            onAllComplete: { staleAllComplete.value = true },
+            onError: { _, _ in }
+        )
+        let firstRequestStarted = await server.waitForRequestCount(1)
+        #expect(firstRequestStarted)
+        guard firstRequestStarted else {
+            service.cancelCurrentRequest()
+            return
+        }
+        _ = await server.exchange(at: 0)
+        let queuedBeforeCancellation = await permitQueued.wait(timeout: .seconds(2))
+        #expect(queuedBeforeCancellation)
+        guard queuedBeforeCancellation else {
+            service.cancelCurrentRequest()
+            return
+        }
+
+        if trigger == .stopThenReplace {
+            service.cancelCurrentRequest()
+        }
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Replacement")],
+            models: [replacementModel],
+            onChunk: { _, _ in },
+            onModelComplete: { _ in },
+            onAllComplete: { replacementAllComplete.signal() },
+            onError: { _, _ in }
+        )
+
+        let replacementStarted = await server.waitForRequestCount(2)
+        #expect(replacementStarted)
+        guard replacementStarted else {
+            service.cancelCurrentRequest()
+            return
+        }
+
+        let next = await server.exchange(at: 1)
+        let startedModel = try requestModel(from: next.request)
+
+        next.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+        next.send(Data("data: [DONE]\n\n".utf8))
+        next.finish()
+        let replacementCompleted = await replacementAllComplete.wait(timeout: .seconds(2))
+        service.cancelCurrentRequest()
+
+        #expect(startedModel == replacementModel)
+        #expect(replacementCompleted)
+        #expect(!staleAllComplete.value)
+        #expect(server.requestCount == 2)
+    }
+
+    @Test(
+        "A queued model rejects configuration changes before launch",
+        .timeLimit(.minutes(1)),
+        arguments: MultiModelQueuedMutation.allCases
+    )
+    func queuedModelRejectsConfigurationChangesBeforeLaunch(
+        mutation: MultiModelQueuedMutation
+    ) async throws {
+        GitHubOAuthService.shared.signOut()
+        defer { GitHubOAuthService.shared.signOut() }
+
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let permitQueued = FlightTestSignal()
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            requestFlightObserver: RequestFlightObserver { checkpoint, _ in
+                if checkpoint == .multiModelPermitQueued {
+                    permitQueued.signal()
+                }
+            }
+        )
+        let models = ["config-a", "config-b"]
+        let token = "config-token-\(UUID().uuidString)"
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .githubModels
+            service.modelAPIKeys[model] = token
+        }
+
+        let errors = FlightTestBox<[String]>([])
+        let allComplete = FlightTestSignal()
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Configuration")],
+            models: models,
+            onChunk: { _, _ in },
+            onModelComplete: { _ in },
+            onAllComplete: { allComplete.signal() },
+            onError: { model, error in
+                errors.update { $0.append("\(model):\(error.localizedDescription)") }
+            }
+        )
+
+        let firstRequestStarted = await server.waitForRequestCount(1)
+        let queuedBeforeMutation = await permitQueued.wait(timeout: .seconds(2))
+        #expect(firstRequestStarted)
+        #expect(queuedBeforeMutation)
+        guard firstRequestStarted, queuedBeforeMutation else {
+            service.cancelCurrentRequest()
+            return
+        }
+
+        let first = await server.exchange(at: 0)
+        let startedModel = try requestModel(from: first.request)
+        let queuedModel = try #require(models.first(where: { $0 != startedModel }))
+        switch mutation {
+        case .provider:
+            service.modelProviders[queuedModel] = .openai
+        case .credential:
+            service.modelAPIKeys[queuedModel] = "replacement-token"
+        case .oauthPreference:
+            let tokenInfo = GitHubTokenInfo(
+                accessToken: "oauth-token",
+                refreshToken: nil,
+                expiresAt: Date().addingTimeInterval(3600),
+                scope: "models:read"
+            )
+            try GitHubOAuthService.keychain.setData(
+                JSONEncoder().encode(tokenInfo),
+                for: "github_token_info"
+            )
+            GitHubOAuthService.shared.isAuthenticated = true
+        }
+
+        first.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+        first.send(Data("data: [DONE]\n\n".utf8))
+        first.finish()
+        let didComplete = await allComplete.wait(timeout: .seconds(2))
+        service.cancelCurrentRequest()
+
+        #expect(didComplete)
+        #expect(server.requestCount == 1)
+        #expect(errors.value == [
+            "\(queuedModel):Model configuration changed while the request was queued. Please retry."
+        ])
+    }
+
+    @Test("A near-expiry OAuth token without a refresh token remains valid")
+    func nearExpiryOAuthTokenWithoutRefreshTokenRemainsValid() throws {
+        let storage = InMemoryKeychainStorage()
+        GitHubOAuthService.keychain = storage
+        let accessToken = "near-expiry-token"
+        let tokenInfo = GitHubTokenInfo(
+            accessToken: accessToken,
+            refreshToken: nil,
+            expiresAt: Date().addingTimeInterval(60),
+            scope: "models:read"
+        )
+        try storage.setData(JSONEncoder().encode(tokenInfo), for: "github_token_info")
+        let oauth = GitHubOAuthService()
+
+        #expect(oauth.isCurrentAccessTokenValid(accessToken))
+    }
+
+    @Test("A missing prepared GitHub credential never launches a request", .timeLimit(.minutes(1)))
+    func missingPreparedGitHubCredentialNeverLaunchesRequest() async {
+        GitHubOAuthService.shared.signOut()
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let model = "github-missing-key"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .githubModels
+        service.modelAPIKeys[model] = ""
+        let errors = FlightTestBox<[String]>([])
+        let allComplete = FlightTestSignal()
+
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "No key")],
+            models: [model],
+            onChunk: { _, _ in },
+            onModelComplete: { _ in },
+            onAllComplete: { allComplete.signal() },
+            onError: { _, error in errors.update { $0.append(error.localizedDescription) } }
+        )
+
+        let didComplete = await allComplete.wait(timeout: .seconds(2))
+        service.cancelCurrentRequest()
+
+        #expect(didComplete)
+        #expect(errors.value == ["GitHub Models API key not configured"])
+        #expect(server.requestCount == 0)
+    }
+
+    @Test("Prepared API key is the exact credential sent", .timeLimit(.minutes(1)))
+    func preparedAPIKeyIsTheExactCredentialSent() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        service.customModels = ["prepared-model"]
+        service.selectedModel = "prepared-model"
+        service.modelProviders["prepared-model"] = .openai
+        service.modelAPIKeys["prepared-model"] = "configured-key"
+        let completed = FlightTestSignal()
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Hello")],
+            model: "prepared-model",
+            stream: false,
+            onChunk: { _ in },
+            onComplete: { completed.signal() },
+            onError: { error in Issue.record("Unexpected error: \(error)") },
+            preparedAPIKey: "prepared-key"
+        )
+
+        let requestStarted = await server.waitForRequestCount(1)
+        #expect(requestStarted)
+        guard requestStarted else {
+            service.cancelCurrentRequest()
+            return
+        }
+        let exchange = await server.exchange(at: 0)
+        let authorization = exchange.request.value(forHTTPHeaderField: "Authorization")
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        exchange.send(Data("{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}".utf8))
+        exchange.finish()
+        let didComplete = await completed.wait(timeout: .seconds(2))
+        service.cancelCurrentRequest()
+
+        #expect(authorization == "Bearer prepared-key")
+        #expect(didComplete)
+    }
+
+    private func requestModel(from request: URLRequest) throws -> String {
+        var body = request.httpBody
+        if body == nil, let stream = request.httpBodyStream {
+            stream.open()
+            var streamedBody = Data()
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1024)
+            defer { buffer.deallocate() }
+            while stream.hasBytesAvailable {
+                let count = stream.read(buffer, maxLength: 1024)
+                guard count > 0 else { break }
+                streamedBody.append(buffer, count: count)
+            }
+            stream.close()
+            body = streamedBody
+        }
+
+        let requestBody = try #require(body)
+        let object = try #require(JSONSerialization.jsonObject(with: requestBody) as? [String: Any])
+        return try #require(object["model"] as? String)
+    }
+}
+
+enum MultiModelQueuedMutation: String, CaseIterable, Sendable, CustomTestStringConvertible {
+    case provider
+    case credential
+    case oauthPreference
+
+    var testDescription: String {
+        rawValue
+    }
+}
+
+enum MultiModelBatchReplacementTrigger: String, CaseIterable, Sendable, CustomTestStringConvertible {
+    case stopThenReplace
+    case replaceDirectly
+
+    var testDescription: String {
+        rawValue
+    }
+}

--- a/Tests/AynaTests/AIServiceTests.swift
+++ b/Tests/AynaTests/AIServiceTests.swift
@@ -2,6 +2,7 @@
 import Foundation
 import Testing
 
+// swiftlint:disable type_body_length
 @Suite("AIService Tests", .tags(.networking, .async), .serialized)
 @MainActor
 struct AIServiceTests {
@@ -30,6 +31,437 @@ struct AIServiceTests {
         service.customModels = ["gpt-4o"]
         service.selectedModel = "gpt-4o"
         return service
+    }
+
+    @Test("Request flights reject stale cleanup")
+    func requestFlightsRejectStaleCleanup() {
+        var flight = RequestFlight<String>()
+        let firstID = RequestFlightID()
+        let secondID = RequestFlightID()
+
+        #expect(flight.install("first", id: firstID) == nil)
+        #expect(flight.install("second", id: secondID) == "first")
+        let staleClearSucceeded = flight.clear(ifOwnedBy: firstID)
+        #expect(!staleClearSucceeded)
+        #expect(flight.owns(secondID))
+    }
+
+    @Test("Taking a request flight detaches its owner and handle")
+    func takingRequestFlightDetachesOwnerAndHandle() {
+        var flight = RequestFlight<String>()
+        let flightID = RequestFlightID()
+        flight.install("handle", id: flightID)
+
+        let handle = flight.take()
+
+        #expect(handle == "handle")
+        #expect(!flight.isActive)
+        #expect(!flight.owns(flightID))
+    }
+
+    @Test("Stale stream cleanup preserves the replacement cancellation handle", .timeLimit(.minutes(1)))
+    func staleStreamCleanupPreservesReplacementCancellationHandle() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let staleCleanupProcessed = FlightTestSignal()
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            requestFlightObserver: RequestFlightObserver { checkpoint, ownsFlight in
+                if checkpoint == .streamCancellation, !ownsFlight {
+                    staleCleanupProcessed.signal()
+                }
+            }
+        )
+        let models = ["stream-first", "stream-second"]
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .openai
+            service.modelAPIKeys[model] = "sk-unit-test"
+        }
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "First")],
+            model: models[0],
+            stream: true,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+        let first = await server.exchange(at: 0)
+        first.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Second")],
+            model: models[1],
+            stream: true,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+        let second = await server.exchange(at: 1)
+        second.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+
+        let firstStopped = await first.waitUntilStopped()
+        let staleCleanupObserved = await staleCleanupProcessed.wait(timeout: .seconds(2))
+        #expect(firstStopped)
+        #expect(staleCleanupObserved)
+
+        service.cancelCurrentRequest()
+        let replacementStopped = await second.waitUntilStopped()
+        #expect(replacementStopped)
+    }
+
+    @Test("URLSession cancellation uses stream cancellation cleanup", .timeLimit(.minutes(1)))
+    func urlSessionCancellationUsesStreamCancellationCleanup() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let cancellationProcessed = FlightTestSignal()
+        let clearedOwnedFlight = FlightTestBox<Bool?>(nil)
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            requestFlightObserver: RequestFlightObserver { checkpoint, ownsFlight in
+                if checkpoint == .streamCancellation {
+                    clearedOwnedFlight.value = ownsFlight
+                    cancellationProcessed.signal()
+                }
+            }
+        )
+        let model = "cancelled-stream"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-unit-test"
+        let errors = FlightTestBox(0)
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Cancel")],
+            model: model,
+            stream: true,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in errors.value += 1 }
+        )
+        let exchange = await server.exchange(at: 0)
+        exchange.fail(URLError(.cancelled))
+
+        let observedCancellation = await cancellationProcessed.wait(timeout: .seconds(2))
+        #expect(observedCancellation)
+        #expect(clearedOwnedFlight.value == true)
+        #expect(errors.value == 0)
+    }
+
+    @Test("Stream tool result is discarded after ownership changes", .timeLimit(.minutes(1)))
+    func streamToolResultIsDiscardedAfterOwnershipChanges() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let toolStarted = FlightTestSignal()
+        let releaseTool = FlightTestSignal()
+        let staleParserStopped = FlightTestSignal()
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            requestFlightObserver: RequestFlightObserver { checkpoint, ownsFlight in
+                if checkpoint == .streamCancellation, !ownsFlight {
+                    staleParserStopped.signal()
+                }
+            }
+        )
+        let models = ["tool-stream", "tool-replacement"]
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .openai
+            service.modelAPIKeys[model] = "sk-unit-test"
+        }
+        let staleChunks = FlightTestBox("")
+        let staleCompleted = FlightTestBox(false)
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Tool")],
+            model: models[0],
+            stream: true,
+            onChunk: { staleChunks.value += $0 },
+            onComplete: { staleCompleted.value = true },
+            onError: { _ in },
+            onToolCall: { _, _, _ in
+                toolStarted.signal()
+                await releaseTool.wait()
+                return "stale tool result"
+            }
+        )
+        let first = await server.exchange(at: 0)
+        first.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+        first.send(Data(
+            #"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-1","function":{"name":"test_tool","arguments":"{}"}}]}}]}"#.utf8
+        ))
+        first.send(Data("\n".utf8))
+        first.send(Data(#"data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#.utf8))
+        first.send(Data("\n".utf8))
+        let didStartTool = await toolStarted.wait(timeout: .seconds(2))
+        #expect(didStartTool)
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Replacement")],
+            model: models[1],
+            stream: true,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+        let replacement = await server.exchange(at: 1)
+        replacement.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+
+        releaseTool.signal()
+        let stoppedStaleParser = await staleParserStopped.wait(timeout: .seconds(2))
+        #expect(stoppedStaleParser)
+        #expect(staleChunks.value.isEmpty)
+        #expect(!staleCompleted.value)
+
+        service.cancelCurrentRequest()
+        let replacementStopped = await replacement.waitUntilStopped()
+        #expect(replacementStopped)
+    }
+
+    @Test("Per-model multi stream terminal leaves the foreground stream owned", .timeLimit(.minutes(1)))
+    func perModelMultiStreamTerminalLeavesForegroundStreamOwned() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let models = ["foreground-stream", "multi-stream"]
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .openai
+            service.modelAPIKeys[model] = "sk-unit-test"
+        }
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Foreground")],
+            model: models[0],
+            stream: true,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+        let foreground = await server.exchange(at: 0)
+        foreground.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+
+        let multiCompleted = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Multi")],
+            model: models[1],
+            stream: true,
+            isMultiModelRequest: true,
+            onChunk: { _ in },
+            onComplete: { multiCompleted.signal() },
+            onError: { _ in }
+        )
+        let multi = await server.exchange(at: 1)
+        multi.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+        multi.send(Data("data: [DONE]\n\n".utf8))
+        multi.finish()
+
+        let didComplete = await multiCompleted.wait(timeout: .seconds(2))
+        #expect(didComplete)
+
+        service.cancelCurrentRequest()
+        let foregroundStopped = await foreground.waitUntilStopped()
+        #expect(foregroundStopped)
+    }
+
+    @Test("Stream retry rechecks ownership after waiting", .timeLimit(.minutes(1)))
+    func streamRetryRechecksOwnershipAfterWaiting() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let retryStarted = FlightTestSignal()
+        let releaseRetry = FlightTestSignal()
+        let staleRetryRejected = FlightTestSignal()
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            retryDelay: { _, _ in
+                retryStarted.signal()
+                await releaseRetry.wait()
+            },
+            requestFlightObserver: RequestFlightObserver { checkpoint, ownsFlight in
+                if checkpoint == .streamRetry, !ownsFlight {
+                    staleRetryRejected.signal()
+                }
+            }
+        )
+        let models = ["retry-first", "retry-replacement"]
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .openai
+            service.modelAPIKeys[model] = "sk-unit-test"
+        }
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "First")],
+            model: models[0],
+            stream: true,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+        let first = await server.exchange(at: 0)
+        first.fail(URLError(.networkConnectionLost))
+        let didStartRetry = await retryStarted.wait(timeout: .seconds(2))
+        #expect(didStartRetry)
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Replacement")],
+            model: models[1],
+            stream: true,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+        let replacement = await server.exchange(at: 1)
+        replacement.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+
+        releaseRetry.signal()
+        let rejectedStaleRetry = await staleRetryRejected.wait(timeout: .seconds(2))
+        #expect(rejectedStaleRetry)
+        #expect(server.requestCount == 2)
+
+        service.cancelCurrentRequest()
+        let replacementStopped = await replacement.waitUntilStopped()
+        #expect(replacementStopped)
+    }
+
+    @Test(
+        "Stale data completion is suppressed and preserves the replacement handle",
+        arguments: DataFlightVariant.allCases
+    )
+    func staleDataCompletionIsSuppressed(variant: DataFlightVariant) async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let staleCallbackProcessed = FlightTestSignal()
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            requestFlightObserver: RequestFlightObserver { checkpoint, ownsFlight in
+                if checkpoint == .dataCallback, !ownsFlight {
+                    staleCallbackProcessed.signal()
+                }
+            }
+        )
+        let model = variant.model
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-unit-test"
+        service.modelEndpointTypes[model] = variant.endpointType
+
+        let staleChunks = FlightTestBox("")
+        let staleCompleted = FlightTestBox(false)
+        service.sendMessage(
+            messages: [Message(role: .user, content: "First")],
+            model: model,
+            stream: false,
+            onChunk: { staleChunks.value += $0 },
+            onComplete: { staleCompleted.value = true },
+            onError: { _ in }
+        )
+        let first = await server.exchange(at: 0)
+        first.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        first.send(variant.responseData)
+        first.finish()
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Replacement")],
+            model: model,
+            stream: false,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+        let replacement = await server.exchange(at: 1)
+
+        let rejectedStaleCallback = await staleCallbackProcessed.wait(timeout: .seconds(2))
+        #expect(rejectedStaleCallback)
+        #expect(staleChunks.value.isEmpty)
+        #expect(!staleCompleted.value)
+
+        service.cancelCurrentRequest()
+        let replacementStopped = await replacement.waitUntilStopped()
+        #expect(replacementStopped)
+    }
+
+    @Test(
+        "Data retry rechecks ownership after waiting",
+        arguments: DataFlightVariant.allCases
+    )
+    func dataRetryRechecksOwnershipAfterWaiting(variant: DataFlightVariant) async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let retryStarted = FlightTestSignal()
+        let releaseRetry = FlightTestSignal()
+        let staleRetryRejected = FlightTestSignal()
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            retryDelay: { _, _ in
+                retryStarted.signal()
+                await releaseRetry.wait()
+            },
+            requestFlightObserver: RequestFlightObserver { checkpoint, ownsFlight in
+                if checkpoint == .dataRetry, !ownsFlight {
+                    staleRetryRejected.signal()
+                }
+            }
+        )
+        let model = variant.model
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-unit-test"
+        service.modelEndpointTypes[model] = variant.endpointType
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "First")],
+            model: model,
+            stream: false,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+        let first = await server.exchange(at: 0)
+        first.fail(URLError(.networkConnectionLost))
+        let didStartRetry = await retryStarted.wait(timeout: .seconds(2))
+        #expect(didStartRetry)
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Replacement")],
+            model: model,
+            stream: false,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+        let replacement = await server.exchange(at: 1)
+
+        releaseRetry.signal()
+        let rejectedStaleRetry = await staleRetryRejected.wait(timeout: .seconds(2))
+        #expect(rejectedStaleRetry)
+        #expect(server.requestCount == 2)
+
+        service.cancelCurrentRequest()
+        let replacementStopped = await replacement.waitUntilStopped()
+        #expect(replacementStopped)
     }
 
     @Test("Send message without API key throws error", .timeLimit(.minutes(1)))
@@ -254,6 +686,134 @@ struct AIServiceTests {
 
         oauth.clearRetryAfter(forAccessToken: "token-A")
         #expect(oauth.retryAfterDate(forAccessToken: "token-A") == nil)
+    }
+
+    @Test("Stale Anthropic callbacks cannot clear or deliver into a replacement", .timeLimit(.minutes(1)))
+    func staleAnthropicCallbacksCannotClearOrDeliverIntoReplacement() async throws {
+        let factory = FlightTestAnthropicProviderFactory()
+        let staleTerminalProcessed = FlightTestSignal()
+        let service = AIService(
+            anthropicProviderFactory: { _ in factory.makeProvider() },
+            requestFlightObserver: RequestFlightObserver { checkpoint, ownsFlight in
+                if checkpoint == .anthropicTerminal, !ownsFlight {
+                    staleTerminalProcessed.signal()
+                }
+            }
+        )
+        let model = "claude-flight"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .anthropic
+        service.modelAPIKeys[model] = "sk-ant-unit-test"
+
+        let staleChunks = FlightTestBox("")
+        let staleReasoning = FlightTestBox("")
+        let staleTools = FlightTestBox([String]())
+        let staleCompleted = FlightTestBox(false)
+        let staleErrors = FlightTestBox(0)
+        service.sendMessage(
+            messages: [Message(role: .user, content: "First")],
+            model: model,
+            stream: true,
+            onChunk: { staleChunks.value += $0 },
+            onComplete: { staleCompleted.value = true },
+            onError: { _ in staleErrors.value += 1 },
+            onToolCallRequested: { _, name, _ in staleTools.update { $0.append(name) } },
+            onReasoning: { staleReasoning.value += $0 }
+        )
+
+        let currentChunk = FlightTestBox("")
+        let currentChunkReceived = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Replacement")],
+            model: model,
+            stream: true,
+            onChunk: {
+                currentChunk.value += $0
+                currentChunkReceived.signal()
+            },
+            onComplete: {},
+            onError: { _ in }
+        )
+
+        #expect(factory.providers.count == 2)
+        let stale = try #require(factory.providers.first)
+        let current = try #require(factory.providers.last)
+        stale.emitChunk("stale chunk")
+        stale.emitReasoning("stale reasoning")
+        stale.emitToolRequest(name: "stale_tool")
+        stale.complete()
+        stale.fail(URLError(.badServerResponse))
+
+        let rejectedStaleTerminal = await staleTerminalProcessed.wait(timeout: .seconds(2))
+        #expect(rejectedStaleTerminal)
+        current.emitChunk("current chunk")
+        let deliveredCurrentChunk = await currentChunkReceived.wait(timeout: .seconds(2))
+        #expect(deliveredCurrentChunk)
+        #expect(staleChunks.value.isEmpty)
+        #expect(staleReasoning.value.isEmpty)
+        #expect(staleTools.value.isEmpty)
+        #expect(!staleCompleted.value)
+        #expect(staleErrors.value == 0)
+        #expect(currentChunk.value == "current chunk")
+
+        service.cancelCurrentRequest()
+        #expect(current.isCancelled)
+    }
+
+    @Test("Anthropic foreground and per-model multi handles remain independent", .timeLimit(.minutes(1)))
+    func anthropicForegroundAndPerModelMultiHandlesRemainIndependent() async {
+        let factory = FlightTestAnthropicProviderFactory()
+        let service = AIService(anthropicProviderFactory: { _ in factory.makeProvider() })
+        let models = ["claude-foreground", "claude-multi-a", "claude-multi-b"]
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .anthropic
+            service.modelAPIKeys[model] = "sk-ant-unit-test"
+        }
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Foreground")],
+            model: models[0],
+            stream: true,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+
+        let firstMultiCompleted = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Multi A")],
+            model: models[1],
+            stream: true,
+            isMultiModelRequest: true,
+            onChunk: { _ in },
+            onComplete: { firstMultiCompleted.signal() },
+            onError: { _ in }
+        )
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Multi B")],
+            model: models[2],
+            stream: true,
+            isMultiModelRequest: true,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { _ in }
+        )
+
+        #expect(factory.providers.count == 3)
+        let foreground = factory.providers[0]
+        let completedMulti = factory.providers[1]
+        let activeMulti = factory.providers[2]
+        completedMulti.complete()
+        let didCompleteMulti = await firstMultiCompleted.wait(timeout: .seconds(2))
+        #expect(didCompleteMulti)
+
+        service.cancelCurrentRequest()
+        #expect(foreground.isCancelled)
+        #expect(activeMulti.isCancelled)
+        #expect(!completedMulti.isCancelled)
     }
 
     // MARK: - Anthropic Integration Tests
@@ -579,7 +1139,44 @@ struct AIServiceTests {
         #expect(request.url?.absoluteString == "https://proxy.example.com/v1/images/generations")
         #expect(imageData.value == Data("image".utf8))
     }
+}
 
+// swiftlint:enable type_body_length
+
+enum DataFlightVariant: String, CaseIterable, Sendable, CustomTestStringConvertible {
+    case chatCompletions
+    case responses
+
+    var model: String {
+        switch self {
+        case .chatCompletions:
+            "data-chat"
+        case .responses:
+            "data-responses"
+        }
+    }
+
+    var endpointType: APIEndpointType {
+        switch self {
+        case .chatCompletions:
+            .chatCompletions
+        case .responses:
+            .responses
+        }
+    }
+
+    var responseData: Data {
+        switch self {
+        case .chatCompletions:
+            Data("{\"choices\":[{\"message\":{\"content\":\"stale\"}}]}".utf8)
+        case .responses:
+            Data("{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"stale\"}]}]}".utf8)
+        }
+    }
+
+    var testDescription: String {
+        rawValue
+    }
 }
 
 private final class MockURLProtocol: URLProtocol, @unchecked Sendable {

--- a/Tests/AynaTests/AIServiceTextOwnershipTests.swift
+++ b/Tests/AynaTests/AIServiceTextOwnershipTests.swift
@@ -1,0 +1,504 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+// swiftformat:disable swiftTestingTestCaseNames
+
+extension AIServiceTests {
+    @Test("A lone short streaming chunk is delivered before the terminal event", .timeLimit(.minutes(1)))
+    func loneShortStreamingChunkDeliveredBeforeTerminalEvent() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let model = "short-stream-chunk"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-unit-test"
+
+        let received = FlightTestBox("")
+        let chunkDelivered = FlightTestSignal()
+        let request = service.sendMessage(
+            messages: [Message(role: .user, content: "Stream")],
+            model: model,
+            stream: true,
+            onChunk: {
+                received.value += $0
+                chunkDelivered.signal()
+            },
+            onComplete: {},
+            onError: { error in Issue.record("Unexpected error: \(error)") }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+        exchange.send(Data("data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n".utf8))
+
+        #expect(await chunkDelivered.wait(timeout: .seconds(1)))
+        #expect(received.value == "x")
+
+        request.cancel()
+        #expect(await exchange.waitUntilStopped(timeout: .seconds(1)))
+    }
+
+    @Test("A final SSE record without a newline is delivered", .timeLimit(.minutes(1)))
+    func finalSSERecordWithoutNewlineIsDelivered() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let model = "unterminated-final-sse"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-unit-test"
+
+        let received = FlightTestBox("")
+        let completed = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Stream")],
+            model: model,
+            stream: true,
+            onChunk: { received.value += $0 },
+            onComplete: { completed.signal() },
+            onError: { error in Issue.record("Unexpected error: \(error)") }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+        exchange.send(Data("data: {\"choices\":[{\"delta\":{\"content\":\"tail\"}}]}".utf8))
+        exchange.finish()
+
+        #expect(await completed.wait(timeout: .seconds(1)))
+        #expect(received.value == "tail")
+    }
+
+    @Test("Cancelling an owned streaming request stops callbacks", .timeLimit(.minutes(1)))
+    func cancellingOwnedStreamingRequestStopsCallbacks() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let model = "owned-stream"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-unit-test"
+
+        let callbackReceived = FlightTestSignal()
+        let request = service.sendMessage(
+            messages: [Message(role: .user, content: "Cancel me")],
+            model: model,
+            stream: true,
+            onChunk: { _ in callbackReceived.signal() },
+            onComplete: { callbackReceived.signal() },
+            onError: { _ in callbackReceived.signal() }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+        request.cancel()
+
+        #expect(await exchange.waitUntilStopped(timeout: .seconds(1)))
+        exchange.send(Data("data: {\"choices\":[{\"delta\":{\"content\":\"late\"}}]}\n\n".utf8))
+        exchange.finish()
+        #expect(await !(callbackReceived.wait(timeout: .milliseconds(100))))
+    }
+
+    @Test("A stale streaming handle cannot cancel its replacement", .timeLimit(.minutes(1)))
+    func staleStreamingHandleCannotCancelReplacement() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let models = ["stale-stream", "replacement-stream"]
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .openai
+            service.modelAPIKeys[model] = "sk-unit-test"
+        }
+
+        let staleCallbacks = FlightTestSignal()
+        let staleRequest = service.sendMessage(
+            messages: [Message(role: .user, content: "Stale")],
+            model: models[0],
+            stream: true,
+            onChunk: { _ in staleCallbacks.signal() },
+            onComplete: { staleCallbacks.signal() },
+            onError: { _ in staleCallbacks.signal() }
+        )
+        let staleExchange = await server.exchange(at: 0)
+        staleExchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+
+        let replacementChunk = FlightTestBox("")
+        let replacementComplete = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Replacement")],
+            model: models[1],
+            stream: true,
+            onChunk: { replacementChunk.value += $0 },
+            onComplete: { replacementComplete.signal() },
+            onError: { _ in }
+        )
+        let replacementExchange = await server.exchange(at: 1)
+        replacementExchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+
+        #expect(await staleExchange.waitUntilStopped(timeout: .seconds(1)))
+        staleRequest.cancel()
+        #expect(!replacementExchange.isStopped)
+
+        replacementExchange.send(
+            Data("data: {\"choices\":[{\"delta\":{\"content\":\"replacement\"}}]}\n\n".utf8)
+        )
+        replacementExchange.send(Data("data: [DONE]\n\n".utf8))
+        replacementExchange.finish()
+
+        #expect(await replacementComplete.wait(timeout: .seconds(1)))
+        #expect(replacementChunk.value == "replacement")
+        #expect(await !(staleCallbacks.wait(timeout: .milliseconds(100))))
+    }
+
+    @Test("Synchronous simulator replacement fences stale and late callbacks")
+    func synchronousSimulatorReplacementFencesStaleAndLateCallbacks() throws {
+        let replacementCallbacks = FlightTestBox<AIServiceResponseSimulationCallbacks?>(nil)
+        let service = AIService(responseSimulator: { messages, callbacks in
+            let content = messages.last(where: { $0.role == .user })?.content
+            if content == "First" {
+                callbacks.onChunk("first")
+                callbacks.onComplete()
+                callbacks.onChunk("late-first")
+            } else {
+                replacementCallbacks.value = callbacks
+            }
+        })
+
+        let firstChunks = FlightTestBox<[String]>([])
+        let firstCompleted = FlightTestBox(false)
+        let replacementChunks = FlightTestBox<[String]>([])
+        let replacementCompleted = FlightTestBox(false)
+
+        let staleRequest = service.sendMessage(
+            messages: [Message(role: .user, content: "First")],
+            model: "simulator-model",
+            onChunk: { chunk in
+                firstChunks.update { $0.append(chunk) }
+                _ = MainActor.assumeIsolated {
+                    service.sendMessage(
+                        messages: [Message(role: .user, content: "Replacement")],
+                        model: "simulator-model",
+                        onChunk: { chunk in replacementChunks.update { $0.append(chunk) } },
+                        onComplete: { replacementCompleted.value = true },
+                        onError: { _ in }
+                    )
+                }
+            },
+            onComplete: { firstCompleted.value = true },
+            onError: { _ in }
+        )
+
+        staleRequest.cancel()
+        let callbacks = try #require(replacementCallbacks.value)
+        callbacks.onChunk("replacement")
+        callbacks.onComplete()
+
+        #expect(firstChunks.value == ["first"])
+        #expect(!firstCompleted.value)
+        #expect(replacementChunks.value == ["replacement"])
+        #expect(replacementCompleted.value)
+    }
+
+    @Test("Cancelling an owned Responses API request suppresses callbacks", .timeLimit(.minutes(1)))
+    func cancellingOwnedResponsesAPIRequestSuppressesCallbacks() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let model = "owned-responses"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-unit-test"
+        service.modelEndpointTypes[model] = .responses
+
+        let callbackReceived = FlightTestSignal()
+        let request = service.sendMessage(
+            messages: [Message(role: .user, content: "Cancel responses")],
+            model: model,
+            onChunk: { _ in callbackReceived.signal() },
+            onComplete: { callbackReceived.signal() },
+            onError: { _ in callbackReceived.signal() }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        request.cancel()
+        #expect(await exchange.waitUntilStopped(timeout: .seconds(1)))
+
+        exchange.sendResponse(statusCode: 200)
+        exchange.send(Data(#"{"output":[{"type":"message","content":[{"type":"output_text","text":"late"}]}]}"#.utf8))
+        exchange.finish()
+        #expect(await !(callbackReceived.wait(timeout: .milliseconds(100))))
+    }
+
+    @Test("The original handle owns a non-stream retry", .timeLimit(.minutes(1)))
+    func originalHandleOwnsNonStreamRetry() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let retryStarted = FlightTestSignal()
+        let releaseRetry = FlightTestSignal()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(
+            urlSession: URLSession(configuration: config),
+            retryDelay: { _, _ in
+                retryStarted.signal()
+                await releaseRetry.wait()
+            }
+        )
+        let model = "owned-retry"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-unit-test"
+
+        let callbackReceived = FlightTestSignal()
+        let request = service.sendMessage(
+            messages: [Message(role: .user, content: "Retry")],
+            model: model,
+            stream: false,
+            onChunk: { _ in callbackReceived.signal() },
+            onComplete: { callbackReceived.signal() },
+            onError: { _ in callbackReceived.signal() }
+        )
+
+        let firstExchange = await server.exchange(at: 0)
+        firstExchange.fail(URLError(.networkConnectionLost))
+        await retryStarted.wait()
+        releaseRetry.signal()
+
+        let retryExchange = await server.exchange(at: 1)
+        request.cancel()
+        #expect(await retryExchange.waitUntilStopped(timeout: .seconds(1)))
+        #expect(await !(callbackReceived.wait(timeout: .milliseconds(100))))
+    }
+
+    @Test("Cancelling a non-stream request cancels and fences legacy tool execution", .timeLimit(.minutes(1)))
+    func cancellingNonStreamRequestCancelsAndFencesLegacyToolExecution() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let model = "owned-nonstream-tool"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-unit-test"
+
+        let toolStarted = FlightTestSignal()
+        let releaseTool = FlightTestSignal()
+        let toolReturned = FlightTestSignal()
+        let toolWasCancelled = FlightTestBox(false)
+        let callbackReceived = FlightTestSignal()
+        let request = service.sendMessage(
+            messages: [Message(role: .user, content: "Run tool")],
+            model: model,
+            stream: false,
+            onChunk: { _ in callbackReceived.signal() },
+            onComplete: { callbackReceived.signal() },
+            onError: { _ in callbackReceived.signal() },
+            onToolCall: { _, _, _ in
+                toolStarted.signal()
+                await releaseTool.wait()
+                toolWasCancelled.value = Task.isCancelled
+                toolReturned.signal()
+                return "late tool result"
+            }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        exchange.send(legacyToolCallResponseData)
+        exchange.finish()
+        #expect(await toolStarted.wait(timeout: .seconds(1)))
+
+        request.cancel()
+        releaseTool.signal()
+
+        #expect(await toolReturned.wait(timeout: .seconds(1)))
+        #expect(toolWasCancelled.value)
+        #expect(await !(callbackReceived.wait(timeout: .milliseconds(100))))
+    }
+
+    @Test("Replacing a non-stream tool request cancels and fences stale callbacks", .timeLimit(.minutes(1)))
+    func replacingNonStreamToolRequestCancelsAndFencesStaleCallbacks() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: config))
+        let models = ["stale-nonstream-tool", "replacement-nonstream"]
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .openai
+            service.modelAPIKeys[model] = "sk-unit-test"
+        }
+
+        let toolStarted = FlightTestSignal()
+        let releaseTool = FlightTestSignal()
+        let toolReturned = FlightTestSignal()
+        let toolWasCancelled = FlightTestBox(false)
+        let staleChunks = FlightTestBox<[String]>([])
+        let staleCompleted = FlightTestBox(false)
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Stale tool")],
+            model: models[0],
+            stream: false,
+            onChunk: { chunk in staleChunks.update { $0.append(chunk) } },
+            onComplete: { staleCompleted.value = true },
+            onError: { _ in },
+            onToolCall: { _, _, _ in
+                toolStarted.signal()
+                await releaseTool.wait()
+                toolWasCancelled.value = Task.isCancelled
+                toolReturned.signal()
+                return "stale tool result"
+            }
+        )
+
+        let staleExchange = await server.exchange(at: 0)
+        staleExchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        staleExchange.send(legacyToolCallResponseData)
+        staleExchange.finish()
+        #expect(await toolStarted.wait(timeout: .seconds(1)))
+
+        let replacementChunks = FlightTestBox<[String]>([])
+        let replacementComplete = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Replacement")],
+            model: models[1],
+            stream: false,
+            onChunk: { chunk in replacementChunks.update { $0.append(chunk) } },
+            onComplete: { replacementComplete.signal() },
+            onError: { error in Issue.record("Unexpected replacement error: \(error)") }
+        )
+        let replacementExchange = await server.exchange(at: 1)
+        replacementExchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        replacementExchange.send(Data("{\"choices\":[{\"message\":{\"content\":\"replacement\"}}]}".utf8))
+        replacementExchange.finish()
+
+        #expect(await replacementComplete.wait(timeout: .seconds(1)))
+        releaseTool.signal()
+        #expect(await toolReturned.wait(timeout: .seconds(1)))
+        #expect(toolWasCancelled.value)
+        #expect(staleChunks.value.isEmpty)
+        #expect(!staleCompleted.value)
+        #expect(replacementChunks.value == ["replacement"])
+    }
+
+    @Test("Anthropic handles cancel and fence only their owned request", .timeLimit(.minutes(1)))
+    func anthropicHandlesCancelAndFenceOnlyOwnedRequest() async throws {
+        let factory = FlightTestAnthropicProviderFactory()
+        let service = AIService(anthropicProviderFactory: { _ in factory.makeProvider() })
+        let model = "owned-anthropic"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .anthropic
+        service.modelAPIKeys[model] = "sk-ant-unit-test"
+
+        let staleCallbacks = FlightTestSignal()
+        let staleRequest = service.sendMessage(
+            messages: [Message(role: .user, content: "First")],
+            model: model,
+            onChunk: { _ in staleCallbacks.signal() },
+            onComplete: { staleCallbacks.signal() },
+            onError: { _ in staleCallbacks.signal() }
+        )
+        let staleProvider = try #require(factory.providers.first)
+
+        staleRequest.cancel()
+        #expect(staleProvider.isCancelled)
+        staleProvider.emitChunk("late")
+        staleProvider.complete()
+        #expect(await !(staleCallbacks.wait(timeout: .milliseconds(100))))
+
+        let replacementChunk = FlightTestBox("")
+        let replacementComplete = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Replacement")],
+            model: model,
+            onChunk: { replacementChunk.value += $0 },
+            onComplete: { replacementComplete.signal() },
+            onError: { _ in }
+        )
+        let replacementProvider = try #require(factory.providers.last)
+
+        staleRequest.cancel()
+        #expect(!replacementProvider.isCancelled)
+        replacementProvider.emitChunk("replacement")
+        replacementProvider.complete()
+
+        #expect(await replacementComplete.wait(timeout: .seconds(1)))
+        #expect(replacementChunk.value == "replacement")
+    }
+
+    #if !os(watchOS)
+        @Test("Apple Intelligence handles cancel and fence only their owned request", .timeLimit(.minutes(1)))
+        func appleIntelligenceHandlesCancelAndFenceOnlyOwnedRequest() async throws {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "owned-apple"
+            service.customModels = [model]
+            service.selectedModel = model
+            service.modelProviders[model] = .appleIntelligence
+
+            let staleCallbacks = FlightTestSignal()
+            let staleRequest = service.sendMessage(
+                messages: [Message(role: .user, content: "First")],
+                model: model,
+                onChunk: { _ in staleCallbacks.signal() },
+                onComplete: { staleCallbacks.signal() },
+                onError: { _ in staleCallbacks.signal() }
+            )
+            let staleAppleRequest = try #require(await appleService.request(at: 0))
+
+            staleRequest.cancel()
+            #expect(await staleAppleRequest.cancelled.wait(timeout: .seconds(1)))
+            staleAppleRequest.emitChunk("late")
+            staleAppleRequest.complete()
+            #expect(await !(staleCallbacks.wait(timeout: .milliseconds(100))))
+
+            let replacementChunk = FlightTestBox("")
+            let replacementComplete = FlightTestSignal()
+            service.sendMessage(
+                messages: [Message(role: .user, content: "Replacement")],
+                model: model,
+                onChunk: { replacementChunk.value += $0 },
+                onComplete: { replacementComplete.signal() },
+                onError: { _ in }
+            )
+            let replacementAppleRequest = try #require(await appleService.request(at: 1))
+
+            staleRequest.cancel()
+            #expect(!replacementAppleRequest.cancelled.isSignaled)
+            replacementAppleRequest.emitChunk("replacement")
+            replacementAppleRequest.complete()
+
+            #expect(await replacementComplete.wait(timeout: .seconds(1)))
+            #expect(replacementChunk.value == "replacement")
+        }
+    #endif
+
+    private var legacyToolCallResponseData: Data {
+        Data(
+            #"{"choices":[{"message":{"tool_calls":[{"id":"tool-call","function":{"name":"test_tool","arguments":"{}"}}]}}]}"#.utf8
+        )
+    }
+}

--- a/Tests/AynaTests/AIServiceTextOwnershipTests.swift
+++ b/Tests/AynaTests/AIServiceTextOwnershipTests.swift
@@ -213,6 +213,33 @@ extension AIServiceTests {
         #expect(replacementCompleted.value)
     }
 
+    @Test("Detached simulator callbacks hop safely to the main actor")
+    func detachedSimulatorCallbacksHopSafelyToMainActor() async throws {
+        let capturedCallbacks = FlightTestBox<AIServiceResponseSimulationCallbacks?>(nil)
+        let service = AIService(responseSimulator: { _, callbacks in
+            capturedCallbacks.value = callbacks
+        })
+        let chunks = FlightTestBox<[String]>([])
+        let completed = FlightTestSignal()
+
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Detached")],
+            model: "simulator-model",
+            onChunk: { chunk in chunks.update { $0.append(chunk) } },
+            onComplete: { completed.signal() },
+            onError: { error in Issue.record("Unexpected error: \(error)") }
+        )
+
+        let callbacks = try #require(capturedCallbacks.value)
+        await Task.detached {
+            await callbacks.onChunk("detached")
+            await callbacks.onComplete()
+        }.value
+
+        #expect(chunks.value == ["detached"])
+        #expect(await completed.wait(timeout: .seconds(1)))
+    }
+
     @Test("Cancelling an owned Responses API request suppresses callbacks", .timeLimit(.minutes(1)))
     func cancellingOwnedResponsesAPIRequestSuppressesCallbacks() async {
         let server = FlightTestURLProtocolServer()

--- a/Tests/AynaTests/AccessibilityServiceTests.swift
+++ b/Tests/AynaTests/AccessibilityServiceTests.swift
@@ -19,6 +19,88 @@
             service = AccessibilityService.shared
         }
 
+        // MARK: - Window Identity Tests
+
+        @Test("Window identity preserves PID and index at signed PID edges")
+        func windowIdentityPreservesPIDAndIndexAtSignedPIDEdges() {
+            let maximumPID: pid_t = .max
+            let minimumPID: pid_t = .min
+
+            let maximumFirst = AccessibilityService.WindowIdentity(
+                processIdentifier: maximumPID,
+                enumerationIndex: 0
+            )
+            let maximumFirstCopy = AccessibilityService.WindowIdentity(
+                processIdentifier: maximumPID,
+                enumerationIndex: 0
+            )
+            let maximumSecond = AccessibilityService.WindowIdentity(
+                processIdentifier: maximumPID,
+                enumerationIndex: 1
+            )
+            let minimumFirst = AccessibilityService.WindowIdentity(
+                processIdentifier: minimumPID,
+                enumerationIndex: 0
+            )
+
+            #expect(maximumFirst.processIdentifier == maximumPID)
+            #expect(maximumFirst.enumerationIndex == 0)
+            #expect(maximumFirst == maximumFirstCopy)
+            #expect(maximumFirst != maximumSecond)
+            #expect(maximumFirst != minimumFirst)
+            #expect(Set([maximumFirst, maximumFirstCopy, maximumSecond, minimumFirst]).count == 3)
+        }
+
+        @Test("Window info equality and hashing use window identity")
+        func windowInfoEqualityAndHashingUseWindowIdentity() {
+            let processIdentifier: pid_t = .max
+            let firstIdentity = AccessibilityService.WindowIdentity(
+                processIdentifier: processIdentifier,
+                enumerationIndex: 17
+            )
+            let firstIdentityCopy = AccessibilityService.WindowIdentity(
+                processIdentifier: processIdentifier,
+                enumerationIndex: 17
+            )
+            let secondIdentity = AccessibilityService.WindowIdentity(
+                processIdentifier: processIdentifier,
+                enumerationIndex: 18
+            )
+            let element = AXUIElementCreateApplication(0)
+
+            let first = AccessibilityService.WindowInfo(
+                id: firstIdentity,
+                title: "First",
+                appPID: processIdentifier,
+                appName: "Example",
+                appIcon: nil,
+                bundleIdentifier: "com.example.first",
+                axElement: element
+            )
+            let equivalent = AccessibilityService.WindowInfo(
+                id: firstIdentityCopy,
+                title: "Equivalent",
+                appPID: processIdentifier,
+                appName: "Renamed Example",
+                appIcon: nil,
+                bundleIdentifier: "com.example.equivalent",
+                axElement: element
+            )
+            let distinct = AccessibilityService.WindowInfo(
+                id: secondIdentity,
+                title: "First",
+                appPID: processIdentifier,
+                appName: "Example",
+                appIcon: nil,
+                bundleIdentifier: "com.example.first",
+                axElement: element
+            )
+
+            #expect(first == equivalent)
+            #expect(first != distinct)
+            #expect(Set([first, equivalent, distinct]).count == 2)
+        }
+
         // MARK: - Permission Tests
 
         @Test("Check permission does not prompt when false")

--- a/Tests/AynaTests/AnthropicRequestBuilderTests.swift
+++ b/Tests/AynaTests/AnthropicRequestBuilderTests.swift
@@ -126,6 +126,32 @@ struct AnthropicRequestBuilderTests {
         #expect(anthropicMessages[0]["role"] as? String == "assistant")
     }
 
+    @Test("Serialized request omits empty assistant placeholders")
+    func serializedRequestOmitsEmptyAssistantPlaceholders() throws {
+        let url = try #require(URL(string: "https://api.anthropic.com/v1/messages"))
+        let request = try AnthropicRequestBuilder.createMessagesRequest(
+            url: url,
+            messages: [
+                Message(role: .user, content: "Question"),
+                Message(
+                    role: .assistant,
+                    content: "",
+                    responseGroupId: UUID(),
+                    isSelectedResponse: false
+                ),
+            ],
+            config: AnthropicRequestConfig(model: "claude-sonnet-4-20250514", apiKey: "test-key"),
+            stream: false,
+            tools: nil
+        )
+        let bodyData = try #require(request.httpBody)
+        let bodyObject = try JSONSerialization.jsonObject(with: bodyData)
+        let body = try #require(bodyObject as? [String: Any])
+        let messages = try #require(body["messages"] as? [[String: Any]])
+        #expect(messages.count == 1)
+        #expect(messages[0]["role"] as? String == "user")
+    }
+
     // MARK: - max_tokens Tests
 
     @Test("Default max_tokens is 4096")

--- a/Tests/AynaTests/AnyCodableTests.swift
+++ b/Tests/AynaTests/AnyCodableTests.swift
@@ -54,6 +54,91 @@ struct AnyCodableTests {
     }
 
     @Test
+    func `ordinary fractional numbers continue decoding as Double`() throws {
+        for expected in [0.1, 2.5, 1e-20] {
+            let encoded = Data(String(expected).utf8)
+            let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+
+            #expect(decoded.value is Double)
+            #expect(decoded.value as? Double == expected)
+        }
+    }
+
+    @Test
+    func `UInt64 max remains exact after decode and re-encode`() throws {
+        let expected = String(UInt64.max)
+        let encoded = try JSONEncoder().encode(AnyCodable(NSNumber(value: UInt64.max)))
+
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+        let reencoded = try JSONEncoder().encode(decoded)
+
+        #expect(String(bytes: encoded, encoding: .utf8) == expected)
+        #expect(Mirror(reflecting: decoded.value).displayStyle == .class)
+        #expect((decoded.value as? NSNumber)?.stringValue == expected)
+        #expect(reencoded == encoded)
+    }
+
+    @Test
+    func `high-precision decimal remains exact after decode and re-encode`() throws {
+        let expected = "1234567890.123456789012345678"
+        let number = NSDecimalNumber(string: expected)
+        let encoded = try JSONEncoder().encode(AnyCodable(number))
+
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+        let reencoded = try JSONEncoder().encode(decoded)
+
+        #expect(String(bytes: encoded, encoding: .utf8) == expected)
+        #expect(Mirror(reflecting: decoded.value).displayStyle == .class)
+        #expect((decoded.value as? NSDecimalNumber)?.stringValue == expected)
+        #expect(reencoded == encoded)
+    }
+
+    @Test
+    func `large and high-precision decoded numbers compare exactly`() throws {
+        let unsignedMax = try JSONDecoder().decode(
+            AnyCodable.self,
+            from: Data(String(UInt64.max).utf8)
+        )
+        let unsignedPredecessor = try JSONDecoder().decode(
+            AnyCodable.self,
+            from: Data(String(UInt64.max - 1).utf8)
+        )
+        let decimal = try JSONDecoder().decode(
+            AnyCodable.self,
+            from: Data("1234567890.123456789012345678".utf8)
+        )
+        let adjacentDecimal = try JSONDecoder().decode(
+            AnyCodable.self,
+            from: Data("1234567890.123456789012345679".utf8)
+        )
+
+        #expect(unsignedMax == unsignedMax)
+        #expect(unsignedMax != unsignedPredecessor)
+        #expect(decimal == decimal)
+        #expect(decimal != adjacentDecimal)
+        #expect(AnyCodable(NSNumber(value: 1)) != AnyCodable(NSNumber(value: true)))
+    }
+
+    @Test
+    func `nested decoded numbers use exact equality`() throws {
+        let first = try JSONDecoder().decode(
+            AnyCodable.self,
+            from: Data(#"{"values":[18446744073709551615,1234567890.123456789012345678]}"#.utf8)
+        )
+        let same = try JSONDecoder().decode(
+            AnyCodable.self,
+            from: Data(#"{"values":[18446744073709551615,1234567890.123456789012345678]}"#.utf8)
+        )
+        let different = try JSONDecoder().decode(
+            AnyCodable.self,
+            from: Data(#"{"values":[18446744073709551614,1234567890.123456789012345679]}"#.utf8)
+        )
+
+        #expect(first == same)
+        #expect(first != different)
+    }
+
+    @Test
     func `native Swift numeric types preserve null fallback`() throws {
         let values: [Any] = [Float(1.5), Int8(1), CGFloat(1.5)]
 

--- a/Tests/AynaTests/AnyCodableTests.swift
+++ b/Tests/AynaTests/AnyCodableTests.swift
@@ -1,0 +1,121 @@
+//
+//  AnyCodableTests.swift
+//  AynaTests
+//
+//  Focused regression tests for NSNumber encoding.
+//
+
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("AnyCodable Tests", .tags(.fast))
+struct AnyCodableTests {
+    @Test
+    func `JSONSerialization integers re-encode as numbers`() throws {
+        let data = Data(#"{"line":1,"offset":0,"count":2}"#.utf8)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let wrapped = object.mapValues(AnyCodable.init)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        let encoded = try encoder.encode(wrapped)
+        let encodedString = try #require(String(bytes: encoded, encoding: .utf8))
+
+        #expect(encodedString == #"{"count":2,"line":1,"offset":0}"#)
+    }
+
+    @Test
+    func `JSONSerialization booleans remain booleans`() throws {
+        let data = Data(#"{"enabled":true,"disabled":false}"#.utf8)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let wrapped = object.mapValues(AnyCodable.init)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        let encoded = try encoder.encode(wrapped)
+        let encodedString = try #require(String(bytes: encoded, encoding: .utf8))
+
+        #expect(encodedString == #"{"disabled":false,"enabled":true}"#)
+    }
+
+    @Test
+    func `high-precision NSDecimalNumber encodes losslessly`() throws {
+        let number = NSDecimalNumber(string: "1234567890.123456789012345678")
+
+        let encoded = try JSONEncoder().encode(AnyCodable(number))
+        let decoded = try JSONDecoder().decode(Decimal.self, from: encoded)
+
+        #expect(decoded == number.decimalValue)
+    }
+
+    @Test
+    func `native Swift numeric types preserve null fallback`() throws {
+        let values: [Any] = [Float(1.5), Int8(1), CGFloat(1.5)]
+
+        for value in values {
+            let encoded = try JSONEncoder().encode(AnyCodable(value))
+            #expect(String(bytes: encoded, encoding: .utf8) == "null")
+        }
+    }
+
+    @Test
+    func `signed Foundation integers use full Int64 range`() throws {
+        let cases: [(number: NSNumber, expected: String)] = [
+            (NSNumber(value: Int64(-2_147_483_649)), "-2147483649"),
+            (NSNumber(value: Int64.min), String(Int64.min))
+        ]
+
+        for testCase in cases {
+            let encoded = try JSONEncoder().encode(AnyCodable(testCase.number))
+            #expect(String(bytes: encoded, encoding: .utf8) == testCase.expected)
+        }
+    }
+
+    @Test
+    func `large unsigned Foundation integers remain exact numbers`() throws {
+        for expected in [UInt64(1) << 63, UInt64.max] {
+            let encoded = try JSONEncoder().encode(AnyCodable(NSNumber(value: expected)))
+            #expect(String(bytes: encoded, encoding: .utf8) == String(expected))
+        }
+    }
+
+    @Test
+    func `finite class-backed floating NSNumber values encode as numbers`() throws {
+        let float = Float(1.5)
+        let double = Double(2.25)
+        let cgFloat = CGFloat(3.5)
+        let cases: [(number: NSNumber, expected: Double)] = [
+            (NSNumber(value: float), Double(float)),
+            (NSNumber(value: double), double),
+            (NSNumber(value: cgFloat), Double(cgFloat))
+        ]
+
+        for testCase in cases {
+            #expect(Mirror(reflecting: testCase.number).displayStyle == .class)
+
+            let encoded = try JSONEncoder().encode(AnyCodable(testCase.number))
+            let decoded = try JSONDecoder().decode(Double.self, from: encoded)
+
+            #expect(decoded == testCase.expected)
+        }
+    }
+
+    @Test
+    func `nonfinite Foundation numbers preserve null fallback`() throws {
+        let values: [NSNumber] = [
+            NSDecimalNumber.notANumber,
+            NSNumber(value: Double.nan),
+            NSNumber(value: Double.infinity)
+        ]
+
+        for value in values {
+            let encoded = try JSONEncoder().encode(AnyCodable(value))
+            #expect(String(bytes: encoded, encoding: .utf8) == "null")
+        }
+    }
+}

--- a/Tests/AynaTests/BuiltinToolServiceTests.swift
+++ b/Tests/AynaTests/BuiltinToolServiceTests.swift
@@ -6,7 +6,9 @@
 //
 
 #if os(macOS)
+    // swiftlint:disable identifier_name
     @testable import Ayna
+    import Darwin
     import Foundation
     import Testing
 
@@ -18,8 +20,8 @@
         @Suite("Tool Name Detection")
         @MainActor
         struct ToolNameDetectionTests {
-            @Test("Identifies builtin file tools")
-            func identifiesFileTools() {
+            @Test
+            func `Identifies builtin file tools`() {
                 #expect(BuiltinToolService.isBuiltinTool("read_file"))
                 #expect(BuiltinToolService.isBuiltinTool("write_file"))
                 #expect(BuiltinToolService.isBuiltinTool("edit_file"))
@@ -27,13 +29,13 @@
                 #expect(BuiltinToolService.isBuiltinTool("search_files"))
             }
 
-            @Test("Identifies run_command as builtin")
-            func identifiesRunCommand() {
+            @Test
+            func `Identifies run_command as builtin`() {
                 #expect(BuiltinToolService.isBuiltinTool("run_command"))
             }
 
-            @Test("Does not identify non-builtin tools")
-            func doesNotIdentifyNonBuiltin() {
+            @Test
+            func `Does not identify non-builtin tools`() {
                 #expect(!BuiltinToolService.isBuiltinTool("custom_tool"))
                 #expect(!BuiltinToolService.isBuiltinTool("mcp_tool"))
                 #expect(!BuiltinToolService.isBuiltinTool(""))
@@ -45,8 +47,8 @@
         @Suite("Tool Definitions")
         @MainActor
         struct ToolDefinitionTests {
-            @Test("All tool definitions have required fields")
-            func allDefinitionsHaveRequiredFields() {
+            @Test
+            func `All tool definitions have required fields`() {
                 let permissionService = PermissionService()
                 let sut = BuiltinToolService(permissionService: permissionService)
                 let definitions = sut.allToolDefinitions()
@@ -67,8 +69,8 @@
                 }
             }
 
-            @Test("Tool definitions include all expected tools")
-            func definitionsIncludeExpectedTools() {
+            @Test
+            func `Tool definitions include all expected tools`() {
                 let permissionService = PermissionService()
                 let sut = BuiltinToolService(permissionService: permissionService)
                 let definitions = sut.allToolDefinitions()
@@ -87,8 +89,8 @@
                 #expect(toolNames.contains("web_fetch"))
             }
 
-            @Test("Tool count is 7")
-            func toolCountIs7() {
+            @Test
+            func `Tool count is 7`() {
                 let permissionService = PermissionService()
                 let sut = BuiltinToolService(permissionService: permissionService)
                 let definitions = sut.allToolDefinitions()
@@ -102,16 +104,16 @@
         @Suite("Service Configuration")
         @MainActor
         struct ServiceConfigurationTests {
-            @Test("Default timeout is 30 seconds")
-            func defaultTimeout() {
+            @Test
+            func `Default timeout is 30 seconds`() {
                 let permissionService = PermissionService()
                 let sut = BuiltinToolService(permissionService: permissionService)
 
                 #expect(sut.commandTimeoutSeconds == 30)
             }
 
-            @Test("Timeout is configurable")
-            func timeoutConfigurable() {
+            @Test
+            func `Timeout is configurable`() {
                 let permissionService = PermissionService()
                 let sut = BuiltinToolService(permissionService: permissionService)
 
@@ -119,16 +121,16 @@
                 #expect(sut.commandTimeoutSeconds == 60)
             }
 
-            @Test("Default max read size is 10MB")
-            func defaultMaxReadSize() {
+            @Test
+            func `Default max read size is 10MB`() {
                 let permissionService = PermissionService()
                 let sut = BuiltinToolService(permissionService: permissionService)
 
                 #expect(sut.maxReadSize == 10 * 1024 * 1024)
             }
 
-            @Test("Service can be disabled")
-            func serviceCanBeDisabled() {
+            @Test
+            func `Service can be disabled`() {
                 let permissionService = PermissionService()
                 let sut = BuiltinToolService(permissionService: permissionService)
 
@@ -138,8 +140,8 @@
                 #expect(!sut.isEnabled)
             }
 
-            @Test("Project root is stored")
-            func projectRootStored() {
+            @Test
+            func `Project root is stored`() {
                 let permissionService = PermissionService()
                 let projectRoot = URL(fileURLWithPath: "/tmp/test-project")
                 let sut = BuiltinToolService(
@@ -150,8 +152,8 @@
                 #expect(sut.projectRoot == projectRoot)
             }
 
-            @Test("Project root is nil by default")
-            func projectRootNilByDefault() {
+            @Test
+            func `Project root is nil by default`() {
                 let permissionService = PermissionService()
                 let sut = BuiltinToolService(permissionService: permissionService)
 
@@ -163,8 +165,8 @@
 
         @Suite("Tool Name Constants")
         struct ToolNameConstantsTests {
-            @Test("Tool names are correct")
-            func toolNamesCorrect() {
+            @Test
+            func `Tool names are correct`() {
                 #expect(BuiltinToolService.ToolName.readFile == "read_file")
                 #expect(BuiltinToolService.ToolName.writeFile == "write_file")
                 #expect(BuiltinToolService.ToolName.editFile == "edit_file")
@@ -174,5 +176,281 @@
                 #expect(BuiltinToolService.ToolName.webFetch == "web_fetch")
             }
         }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `Cancellation before result delivery wins atomically`() async throws {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("BuiltinToolCompletion-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+            let command = "echo complete"
+            let completionReached = FlightTestSignal()
+            let releaseCompletion = FlightTestSignal()
+            let permissionService = PermissionService()
+            permissionService.recordSessionApproval(
+                tool: BuiltinToolService.ToolName.runCommand,
+                details: command
+            )
+            let service = BuiltinToolService(
+                permissionService: permissionService,
+                projectRoot: directory,
+                processCompletionGate: {
+                    completionReached.signal()
+                    await releaseCompletion.wait()
+                }
+            )
+
+            let task = Task {
+                try await service.runCommand(
+                    command: command,
+                    workingDirectory: directory.path,
+                    conversationId: UUID()
+                )
+            }
+            #expect(await completionReached.wait(timeout: .seconds(1)))
+            task.cancel()
+            releaseCompletion.signal()
+
+            do {
+                _ = try await task.value
+                Issue.record("Expected cancellation to win before result delivery")
+            } catch is CancellationError {
+                // Expected.
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `Cancellation before process startup prevents command execution`() async throws {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("BuiltinToolCancellation-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+            let marker = directory.appendingPathComponent("executed.txt")
+            let command = "echo executed > '\(marker.path)'"
+            let gateStarted = FlightTestSignal()
+            let releaseGate = FlightTestSignal()
+            let permissionService = PermissionService()
+            permissionService.recordSessionApproval(
+                tool: BuiltinToolService.ToolName.runCommand,
+                details: command
+            )
+            let service = BuiltinToolService(
+                permissionService: permissionService,
+                projectRoot: directory,
+                processStartGate: {
+                    gateStarted.signal()
+                    await releaseGate.wait()
+                }
+            )
+
+            let task = Task {
+                try await service.runCommand(
+                    command: command,
+                    workingDirectory: directory.path,
+                    conversationId: UUID()
+                )
+            }
+            #expect(await gateStarted.wait(timeout: .seconds(1)))
+            task.cancel()
+            releaseGate.signal()
+
+            do {
+                _ = try await task.value
+                Issue.record("Expected command startup to be cancelled")
+            } catch is CancellationError {
+                // Expected.
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+            #expect(!FileManager.default.fileExists(atPath: marker.path))
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `Cancellation after approval neither grants permission nor starts the command`() async throws {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("BuiltinToolApprovalCancellation-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+            let marker = directory.appendingPathComponent("executed.txt")
+            let command = "echo executed > '\(marker.path)'"
+            let gateStarted = FlightTestSignal()
+            let releaseGate = FlightTestSignal()
+            let permissionService = PermissionService()
+            let service = BuiltinToolService(
+                permissionService: permissionService,
+                projectRoot: directory,
+                processStartGate: {
+                    gateStarted.signal()
+                    await releaseGate.wait()
+                }
+            )
+
+            let task = Task {
+                try await service.runCommand(
+                    command: command,
+                    workingDirectory: directory.path,
+                    conversationId: UUID()
+                )
+            }
+
+            let clock = ContinuousClock()
+            let approvalDeadline = clock.now.advanced(by: .seconds(1))
+            while permissionService.pendingApprovals.isEmpty, clock.now < approvalDeadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            let approvalID = try #require(permissionService.pendingApprovals.first?.id)
+            permissionService.approve(approvalID, rememberForSession: false)
+            #expect(await gateStarted.wait(timeout: .seconds(1)))
+
+            task.cancel()
+            releaseGate.signal()
+
+            do {
+                _ = try await task.value
+                Issue.record("Expected cancellation before process startup")
+            } catch is CancellationError {
+                // Expected.
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+
+            #expect(!FileManager.default.fileExists(atPath: marker.path))
+            #expect(permissionService.checkPermission(
+                tool: BuiltinToolService.ToolName.runCommand,
+                details: command,
+                defaultLevel: .askOnce
+            ) == .askOnce)
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `Cancellation force-kills a command that ignores SIGTERM`() async throws {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("BuiltinToolForceKill-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+
+            let pidFile = directory.appendingPathComponent("command.pid")
+            let command = "echo $$ > '\(pidFile.path)'; trap '' TERM; while :; do :; done"
+            let permissionService = PermissionService()
+            permissionService.recordSessionApproval(
+                tool: BuiltinToolService.ToolName.runCommand,
+                details: command
+            )
+            let service = BuiltinToolService(
+                permissionService: permissionService,
+                projectRoot: directory
+            )
+            service.commandTimeoutSeconds = 30
+
+            let commandTask = Task {
+                try await service.runCommand(
+                    command: command,
+                    workingDirectory: directory.path,
+                    conversationId: UUID()
+                )
+            }
+
+            let clock = ContinuousClock()
+            let startDeadline = clock.now.advanced(by: .seconds(2))
+            while !FileManager.default.fileExists(atPath: pidFile.path), clock.now < startDeadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            let pidText = try String(contentsOf: pidFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let processIdentifier = try #require(pid_t(pidText))
+
+            let outcome = FlightTestBox<String?>(nil)
+            let finished = FlightTestSignal()
+            let waiter = Task {
+                defer { finished.signal() }
+                do {
+                    _ = try await commandTask.value
+                    outcome.value = "completed"
+                } catch is CancellationError {
+                    outcome.value = "cancelled"
+                } catch {
+                    outcome.value = "error: \(error.localizedDescription)"
+                }
+            }
+
+            commandTask.cancel()
+            let completedPromptly = await finished.wait(timeout: .seconds(2))
+            if !completedPromptly {
+                // Keep the pre-fix regression deterministic instead of leaking the child process.
+                _ = Darwin.kill(processIdentifier, SIGKILL)
+            }
+            _ = await waiter.result
+
+            #expect(completedPromptly)
+            #expect(outcome.value == "cancelled")
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `Background descendants cannot retain command pipes or survive completion`() async throws {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("BuiltinToolDescendant-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+
+            let pidFile = directory.appendingPathComponent("child.pid")
+            let command = "sleep 60 & child=$!; echo $child > '\(pidFile.path)'; echo done"
+            let permissionService = PermissionService()
+            permissionService.recordSessionApproval(
+                tool: BuiltinToolService.ToolName.runCommand,
+                details: command
+            )
+            let service = BuiltinToolService(
+                permissionService: permissionService,
+                projectRoot: directory
+            )
+
+            let outcome = FlightTestBox<Result<CommandResult, Error>?>(nil)
+            let finished = FlightTestSignal()
+            let task = Task {
+                defer { finished.signal() }
+                do {
+                    outcome.value = try await .success(service.runCommand(
+                        command: command,
+                        workingDirectory: directory.path,
+                        conversationId: UUID()
+                    ))
+                } catch {
+                    outcome.value = .failure(error)
+                }
+            }
+
+            let clock = ContinuousClock()
+            let pidDeadline = clock.now.advanced(by: .seconds(1))
+            while !FileManager.default.fileExists(atPath: pidFile.path), clock.now < pidDeadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            let childPIDText = try String(contentsOf: pidFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let childPID = try #require(pid_t(childPIDText))
+
+            let completedPromptly = await finished.wait(timeout: .seconds(2))
+            if !completedPromptly {
+                // Deterministic cleanup for the pre-fix behavior, where the pipe drain blocks.
+                _ = Darwin.kill(childPID, SIGKILL)
+            }
+            _ = await task.result
+
+            #expect(completedPromptly)
+            if case let .success(result) = outcome.value {
+                #expect(result.stdout.contains("done"))
+            } else {
+                Issue.record("Expected successful command completion, got \(String(describing: outcome.value))")
+            }
+
+            let exitDeadline = clock.now.advanced(by: .seconds(1))
+            while Darwin.kill(childPID, 0) == 0, clock.now < exitDeadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            #expect(Darwin.kill(childPID, 0) == -1 && errno == ESRCH)
+        }
     }
+    // swiftlint:enable identifier_name
 #endif

--- a/Tests/AynaTests/BuiltinToolServiceTests.swift
+++ b/Tests/AynaTests/BuiltinToolServiceTests.swift
@@ -389,6 +389,82 @@
         }
 
         @Test(.timeLimit(.minutes(1)))
+        func `Delayed escalation cannot signal a PID reused after cancellation reaps the child`() async throws {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("BuiltinToolPIDReuse-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+
+            let pidFile = directory.appendingPathComponent("command.pid")
+            let releaseFile = directory.appendingPathComponent("release-command")
+            let command = "echo $$ > '\(pidFile.path)'; trap '' TERM; "
+                + "while [ ! -f '\(releaseFile.path)' ]; do sleep 0.01; done"
+            let completionReached = FlightTestSignal()
+            let releaseCompletion = FlightTestSignal()
+            let releaseEscalation = FlightTestSignal()
+            let simulatePIDReuse = FlightTestBox(false)
+            let staleSignalAttempts = FlightTestBox<[Int32]>([])
+            let permissionService = PermissionService()
+            permissionService.recordSessionApproval(
+                tool: BuiltinToolService.ToolName.runCommand,
+                details: command
+            )
+            let service = BuiltinToolService(
+                permissionService: permissionService,
+                projectRoot: directory,
+                processCompletionGate: {
+                    simulatePIDReuse.value = true
+                    completionReached.signal()
+                    await releaseCompletion.wait()
+                },
+                processEscalationGate: {
+                    await releaseEscalation.wait()
+                },
+                subprocessSignal: { processIdentifier, signal in
+                    if simulatePIDReuse.value {
+                        staleSignalAttempts.update { $0.append(signal) }
+                        return 0
+                    }
+                    return Darwin.kill(processIdentifier, signal)
+                }
+            )
+
+            let commandTask = Task {
+                try await service.runCommand(
+                    command: command,
+                    workingDirectory: directory.path,
+                    conversationId: UUID()
+                )
+            }
+
+            let clock = ContinuousClock()
+            let startDeadline = clock.now.advanced(by: .seconds(2))
+            while !FileManager.default.fileExists(atPath: pidFile.path), clock.now < startDeadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            _ = try String(contentsOf: pidFile, encoding: .utf8)
+
+            commandTask.cancel()
+            try Data().write(to: releaseFile)
+            let childWasReaped = await completionReached.wait(timeout: .seconds(2))
+            #expect(childWasReaped)
+
+            releaseEscalation.signal()
+            try? await Task.sleep(for: .milliseconds(100))
+            #expect(staleSignalAttempts.value.isEmpty)
+
+            releaseCompletion.signal()
+            do {
+                _ = try await commandTask.value
+                Issue.record("Expected cancellation after child reap")
+            } catch is CancellationError {
+                // Expected.
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+
+        @Test(.timeLimit(.minutes(1)))
         func `Background descendants cannot retain command pipes or survive completion`() async throws {
             let directory = FileManager.default.temporaryDirectory
                 .appendingPathComponent("BuiltinToolDescendant-\(UUID().uuidString)")

--- a/Tests/AynaTests/ChatGenerationFinalizerTests.swift
+++ b/Tests/AynaTests/ChatGenerationFinalizerTests.swift
@@ -1,0 +1,119 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Chat Generation Finalizer Tests")
+struct ChatGenerationFinalizerTests {
+    @Test
+    func `cancellation flushes pending text and preserves the partial response`() {
+        let assistantID = UUID()
+        var conversation = Conversation(messages: [
+            Message(id: assistantID, role: .assistant, content: "partial")
+        ])
+
+        let result = ChatGenerationFinalizer.finalize(
+            conversation: &conversation,
+            activeAssistantMessageID: assistantID,
+            pendingText: " response",
+            activeResponseGroupID: nil
+        )
+
+        #expect(result.appendedCharacterCount == 9)
+        #expect(result.removedAssistantMessageID == nil)
+        #expect(conversation.messages.first?.content == "partial response")
+    }
+
+    @Test
+    func `cancellation removes only the empty active text placeholder`() {
+        let unrelatedID = UUID()
+        let activeID = UUID()
+        var conversation = Conversation(messages: [
+            Message(id: unrelatedID, role: .assistant, content: ""),
+            Message(id: activeID, role: .assistant, content: "")
+        ])
+
+        let result = ChatGenerationFinalizer.finalize(
+            conversation: &conversation,
+            activeAssistantMessageID: activeID,
+            activeResponseGroupID: nil
+        )
+
+        #expect(result.removedAssistantMessageID == activeID)
+        #expect(conversation.messages.map(\.id) == [unrelatedID])
+    }
+
+    @Test
+    func `cancellation terminalizes active multi-model entries without deleting responses`() {
+        let groupID = UUID()
+        let partialID = UUID()
+        let emptyID = UUID()
+        let completedID = UUID()
+        let userID = UUID()
+        var conversation = Conversation(
+            messages: [
+                Message(id: partialID, role: .assistant, content: "partial", responseGroupId: groupID),
+                Message(id: emptyID, role: .assistant, content: "", responseGroupId: groupID),
+                Message(id: completedID, role: .assistant, content: "done", responseGroupId: groupID)
+            ],
+            responseGroups: [
+                ResponseGroup(
+                    id: groupID,
+                    userMessageId: userID,
+                    responses: [
+                        .init(id: partialID, modelName: "one", status: .streaming),
+                        .init(id: emptyID, modelName: "two", status: .streaming),
+                        .init(id: completedID, modelName: "three", status: .completed)
+                    ]
+                )
+            ]
+        )
+
+        let result = ChatGenerationFinalizer.finalize(
+            conversation: &conversation,
+            activeAssistantMessageID: nil,
+            activeResponseGroupID: groupID
+        )
+
+        #expect(result.terminalizedResponseCount == 2)
+        #expect(conversation.messages.map(\.id) == [partialID, emptyID, completedID])
+        #expect(conversation.responseGroups[0].responses.map(\.status) == [.failed, .failed, .completed])
+    }
+
+    @Test
+    func `reasoning-only assistant output is preserved`() {
+        let assistantID = UUID()
+        var conversation = Conversation(messages: [
+            Message(id: assistantID, role: .assistant, content: "", reasoning: "thinking")
+        ])
+
+        ChatGenerationFinalizer.finalize(
+            conversation: &conversation,
+            activeAssistantMessageID: assistantID,
+            activeResponseGroupID: nil
+        )
+
+        #expect(conversation.messages.map(\.id) == [assistantID])
+    }
+    @Test("Citation-only assistant output is preserved")
+    func preservesCitationOnlyOutput() {
+        let assistantID = UUID()
+        var conversation = Conversation(messages: [
+            Message(
+                id: assistantID,
+                role: .assistant,
+                content: "",
+                citations: [CitationReference(number: 1, title: "Source", url: "https://example.com")]
+            )
+        ])
+
+        ChatGenerationFinalizer.finalize(
+            conversation: &conversation,
+            activeAssistantMessageID: assistantID,
+            activeResponseGroupID: nil
+        )
+
+        #expect(conversation.messages.map(\.id) == [assistantID])
+        #expect(conversation.messages.first?.citations?.first?.title == "Source")
+    }
+
+}

--- a/Tests/AynaTests/ChatGenerationFinalizerTests.swift
+++ b/Tests/AynaTests/ChatGenerationFinalizerTests.swift
@@ -80,6 +80,40 @@ struct ChatGenerationFinalizerTests {
     }
 
     @Test
+    func `cancelled partial multi-model response remains in effective history`() {
+        let groupID = UUID()
+        let user = Message(role: .user, content: "Question")
+        let partial = Message(
+            role: .assistant,
+            content: "Saved partial answer",
+            model: "model-a",
+            responseGroupId: groupID
+        )
+        var conversation = Conversation(
+            messages: [user, partial],
+            model: "model-a",
+            responseGroups: [
+                ResponseGroup(
+                    id: groupID,
+                    userMessageId: user.id,
+                    responses: [
+                        .init(id: partial.id, modelName: "model-a", status: .streaming)
+                    ]
+                )
+            ]
+        )
+
+        ChatGenerationFinalizer.finalize(
+            conversation: &conversation,
+            activeAssistantMessageID: partial.id,
+            activeResponseGroupID: groupID
+        )
+
+        #expect(conversation.responseGroups[0].responses[0].status == .failed)
+        #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, partial.id])
+    }
+
+    @Test
     func `reasoning-only assistant output is preserved`() {
         let assistantID = UUID()
         var conversation = Conversation(messages: [
@@ -94,8 +128,66 @@ struct ChatGenerationFinalizerTests {
 
         #expect(conversation.messages.map(\.id) == [assistantID])
     }
-    @Test("Citation-only assistant output is preserved")
-    func preservesCitationOnlyOutput() {
+
+    @Test
+    func `tool-call-only assistant output is preserved`() {
+        let assistantID = UUID()
+        var conversation = Conversation(messages: [
+            Message(
+                id: assistantID,
+                role: .assistant,
+                content: "",
+                toolCalls: [
+                    MCPToolCall(
+                        id: "call-1",
+                        toolName: "write_file",
+                        arguments: [:]
+                    )
+                ]
+            )
+        ])
+
+        ChatGenerationFinalizer.finalize(
+            conversation: &conversation,
+            activeAssistantMessageID: assistantID,
+            activeResponseGroupID: nil
+        )
+
+        #expect(conversation.messages.map(\.id) == [assistantID])
+        #expect(conversation.messages.first?.toolCalls?.first?.id == "call-1")
+    }
+
+    @Test
+    func `attachment-only assistant output is preserved`() {
+        let assistantID = UUID()
+        var conversation = Conversation(messages: [
+            Message(
+                id: assistantID,
+                role: .assistant,
+                content: "",
+                attachments: [
+                    Message.FileAttachment(
+                        fileName: "result.txt",
+                        mimeType: "text/plain",
+                        data: Data("result".utf8),
+                        localPath: nil
+                    )
+                ]
+            )
+        ])
+
+        ChatGenerationFinalizer.finalize(
+            conversation: &conversation,
+            activeAssistantMessageID: assistantID,
+            activeResponseGroupID: nil
+        )
+
+        #expect(conversation.messages.map(\.id) == [assistantID])
+        #expect(conversation.messages.first?.attachments?.first?.fileName == "result.txt")
+    }
+
+    @Test
+    func `citation-only assistant output is preserved`() {
         let assistantID = UUID()
         var conversation = Conversation(messages: [
             Message(
@@ -115,5 +207,4 @@ struct ChatGenerationFinalizerTests {
         #expect(conversation.messages.map(\.id) == [assistantID])
         #expect(conversation.messages.first?.citations?.first?.title == "Source")
     }
-
 }

--- a/Tests/AynaTests/ConversationCodableTests.swift
+++ b/Tests/AynaTests/ConversationCodableTests.swift
@@ -1,0 +1,125 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Conversation Codable Tests", .tags(.fast))
+struct ConversationCodableTests {
+    @Test
+    func `legacy nonempty system prompt decodes as custom`() throws {
+        let data = legacyConversationData(
+            systemPromptMember: ",\n    \"systemPrompt\": \"Answer concisely.\""
+        )
+
+        let conversation = try JSONDecoder().decode(Conversation.self, from: data)
+
+        #expect(conversation.systemPromptMode == .custom("Answer concisely."))
+        #expect(conversation.temperature == 0.25)
+    }
+
+    @Test(
+        arguments: LegacyInheritingSystemPrompt.allCases
+    )
+    func `legacy absent, null, or empty system prompt decodes as inherit global`(_ legacyPrompt: LegacyInheritingSystemPrompt) throws {
+        let data = legacyConversationData(systemPromptMember: legacyPrompt.jsonMember)
+
+        let conversation = try JSONDecoder().decode(Conversation.self, from: data)
+
+        #expect(conversation.systemPromptMode == .inheritGlobal)
+        #expect(conversation.temperature == 0.25)
+    }
+
+    @Test
+    func `current schema round-trips`() throws {
+        let id = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let original = Conversation(
+            id: id,
+            title: "Current schema",
+            messages: [],
+            createdAt: Date(timeIntervalSinceReferenceDate: 1000),
+            updatedAt: Date(timeIntervalSinceReferenceDate: 2000),
+            model: "gpt-5",
+            systemPromptMode: .disabled,
+            temperature: 0.5,
+            multiModelEnabled: true,
+            activeModels: ["gpt-5", "claude-sonnet-4"],
+            responseGroups: []
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Conversation.self, from: data)
+
+        #expect(decoded == original)
+    }
+
+    @Test
+    func `current system prompt mode takes precedence over legacy prompt`() throws {
+        let systemPromptMember = """
+        ,
+            "systemPrompt": "Legacy prompt",
+            "systemPromptMode": {"type": "disabled"}
+        """
+        let data = legacyConversationData(systemPromptMember: systemPromptMember)
+
+        let conversation = try JSONDecoder().decode(Conversation.self, from: data)
+
+        #expect(conversation.systemPromptMode == .disabled)
+    }
+
+    @Test
+    func `malformed current system prompt mode does not fall back to legacy prompt`() {
+        let systemPromptMember = """
+        ,
+            "systemPrompt": "Valid legacy prompt",
+            "systemPromptMode": null
+        """
+        let data = legacyConversationData(systemPromptMember: systemPromptMember)
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(Conversation.self, from: data)
+        }
+    }
+}
+
+enum LegacyInheritingSystemPrompt: CaseIterable, CustomTestStringConvertible, Sendable {
+    case absent
+    case null
+    case empty
+
+    var jsonMember: String {
+        switch self {
+        case .absent:
+            ""
+        case .null:
+            ",\n    \"systemPrompt\": null"
+        case .empty:
+            ",\n    \"systemPrompt\": \"\""
+        }
+    }
+
+    var testDescription: String {
+        switch self {
+        case .absent:
+            "absent"
+        case .null:
+            "null"
+        case .empty:
+            "empty"
+        }
+    }
+}
+
+private func legacyConversationData(systemPromptMember: String) -> Data {
+    Data(
+        """
+        {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "title": "Legacy conversation",
+            "messages": [],
+            "createdAt": 1000,
+            "updatedAt": 2000,
+            "model": "gpt-4o"\(systemPromptMember),
+            "temperature": 0.25
+        }
+        """.utf8
+    )
+}

--- a/Tests/AynaTests/ConversationEffectiveHistoryTests.swift
+++ b/Tests/AynaTests/ConversationEffectiveHistoryTests.swift
@@ -4,8 +4,8 @@ import Testing
 
 @Suite("Conversation Effective History Tests", .tags(.fast))
 struct ConversationEffectiveHistoryTests {
-    @Test("Selected response linearizes a group and excludes every other status")
-    func selectedResponseLinearizesGroup() {
+    @Test
+    func `selected response linearizes a group and excludes every other status`() {
         let groupID = UUID()
         let user = Message(role: .user, content: "Question")
         let failed = Message(id: UUID(), role: .assistant, content: "Failure text", responseGroupId: groupID)
@@ -34,8 +34,8 @@ struct ConversationEffectiveHistoryTests {
         #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, selected.id, nextUser.id])
     }
 
-    @Test("Fallback uses response entry order and skips incomplete or empty responses")
-    func deterministicCompletedNonemptyFallback() {
+    @Test
+    func `fallback uses response entry order and skips incomplete or empty responses`() {
         let groupID = UUID()
         let user = Message(role: .user, content: "Question")
         let laterCompleted = Message(
@@ -81,8 +81,81 @@ struct ConversationEffectiveHistoryTests {
         #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, preferredCompleted.id])
     }
 
-    @Test("Unselected groups prefer the conversation model shown as the UI default")
-    func unselectedGroupPrefersConversationModel() {
+    @Test
+    func `failed partial response is the final fallback for an otherwise unsuccessful group`() {
+        let groupID = UUID()
+        let user = Message(role: .user, content: "Question")
+        let emptyDefault = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "",
+            responseGroupId: groupID
+        )
+        let partialFallback = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "Saved partial answer",
+            responseGroupId: groupID
+        )
+        let streaming = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "Still in flight",
+            responseGroupId: groupID
+        )
+        let group = ResponseGroup(
+            id: groupID,
+            userMessageId: user.id,
+            responses: [
+                .init(id: emptyDefault.id, modelName: "model-a", status: .failed),
+                .init(id: partialFallback.id, modelName: "model-b", status: .failed),
+                .init(id: streaming.id, modelName: "model-c", status: .streaming),
+            ]
+        )
+        let conversation = Conversation(
+            messages: [user, emptyDefault, partialFallback, streaming],
+            model: "model-a",
+            responseGroups: [group]
+        )
+
+        #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, partialFallback.id])
+    }
+
+    @Test
+    func `failed fallback prefers the conversation model`() {
+        let groupID = UUID()
+        let user = Message(role: .user, content: "Question")
+        let firstFailure = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "First saved partial",
+            responseGroupId: groupID
+        )
+        let defaultFailure = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "Default model partial",
+            responseGroupId: groupID
+        )
+        let group = ResponseGroup(
+            id: groupID,
+            userMessageId: user.id,
+            responses: [
+                .init(id: firstFailure.id, modelName: "model-b", status: .failed),
+                .init(id: defaultFailure.id, modelName: "model-a", status: .failed),
+            ]
+        )
+        let conversation = Conversation(
+            messages: [user, firstFailure, defaultFailure],
+            model: "model-a",
+            responseGroups: [group]
+        )
+
+        #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, defaultFailure.id])
+    }
+
+    @Test
+    func `unselected groups prefer the conversation model shown as the UI default`() {
         let groupID = UUID()
         let user = Message(role: .user, content: "Question")
         let arbitraryFirst = Message(
@@ -116,8 +189,8 @@ struct ConversationEffectiveHistoryTests {
         #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, displayedDefault.id])
     }
 
-    @Test("Meaningful metadata survives history filtering while empty assistants do not")
-    func meaningfulMetadataSurvives() {
+    @Test
+    func `meaningful metadata survives history filtering while empty assistants do not`() {
         let groupID = UUID()
         let user = Message(role: .user, content: "Question")
         let emptyPlaceholder = Message(role: .assistant, content: "", mediaType: .image)

--- a/Tests/AynaTests/ConversationEffectiveHistoryTests.swift
+++ b/Tests/AynaTests/ConversationEffectiveHistoryTests.swift
@@ -1,0 +1,152 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Conversation Effective History Tests", .tags(.fast))
+struct ConversationEffectiveHistoryTests {
+    @Test("Selected response linearizes a group and excludes every other status")
+    func selectedResponseLinearizesGroup() {
+        let groupID = UUID()
+        let user = Message(role: .user, content: "Question")
+        let failed = Message(id: UUID(), role: .assistant, content: "Failure text", responseGroupId: groupID)
+        let streaming = Message(id: UUID(), role: .assistant, content: "Partial text", responseGroupId: groupID)
+        let completed = Message(id: UUID(), role: .assistant, content: "Completed fallback", responseGroupId: groupID)
+        let selected = Message(id: UUID(), role: .assistant, content: "Chosen answer", responseGroupId: groupID)
+        let unselected = Message(id: UUID(), role: .assistant, content: "Other answer", responseGroupId: groupID)
+        let nextUser = Message(role: .user, content: "Follow-up")
+        let group = ResponseGroup(
+            id: groupID,
+            userMessageId: user.id,
+            responses: [
+                .init(id: failed.id, modelName: "failed", status: .failed),
+                .init(id: streaming.id, modelName: "streaming", status: .streaming),
+                .init(id: completed.id, modelName: "completed", status: .completed),
+                .init(id: selected.id, modelName: "selected", status: .selected),
+                .init(id: unselected.id, modelName: "unselected", status: .completed),
+            ],
+            selectedResponseId: selected.id
+        )
+        let conversation = Conversation(
+            messages: [user, failed, streaming, completed, selected, unselected, nextUser],
+            responseGroups: [group]
+        )
+
+        #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, selected.id, nextUser.id])
+    }
+
+    @Test("Fallback uses response entry order and skips incomplete or empty responses")
+    func deterministicCompletedNonemptyFallback() {
+        let groupID = UUID()
+        let user = Message(role: .user, content: "Question")
+        let laterCompleted = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "Later in response metadata",
+            responseGroupId: groupID
+        )
+        let emptySelected = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "",
+            responseGroupId: groupID
+        )
+        let preferredCompleted = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "Preferred deterministic fallback",
+            responseGroupId: groupID
+        )
+        let partial = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "Streaming partial",
+            responseGroupId: groupID
+        )
+        let group = ResponseGroup(
+            id: groupID,
+            userMessageId: user.id,
+            responses: [
+                .init(id: emptySelected.id, modelName: "selected-empty", status: .selected),
+                .init(id: partial.id, modelName: "partial", status: .streaming),
+                .init(id: preferredCompleted.id, modelName: "preferred", status: .completed),
+                .init(id: laterCompleted.id, modelName: "later", status: .completed),
+            ],
+            selectedResponseId: emptySelected.id
+        )
+        let conversation = Conversation(
+            messages: [user, laterCompleted, emptySelected, preferredCompleted, partial],
+            responseGroups: [group]
+        )
+
+        #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, preferredCompleted.id])
+    }
+
+    @Test("Unselected groups prefer the conversation model shown as the UI default")
+    func unselectedGroupPrefersConversationModel() {
+        let groupID = UUID()
+        let user = Message(role: .user, content: "Question")
+        let arbitraryFirst = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "First set entry",
+            model: "model-b",
+            responseGroupId: groupID
+        )
+        let displayedDefault = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "Displayed default",
+            model: "model-a",
+            responseGroupId: groupID
+        )
+        let group = ResponseGroup(
+            id: groupID,
+            userMessageId: user.id,
+            responses: [
+                .init(id: arbitraryFirst.id, modelName: "model-b", status: .completed),
+                .init(id: displayedDefault.id, modelName: "model-a", status: .completed),
+            ]
+        )
+        let conversation = Conversation(
+            messages: [user, arbitraryFirst, displayedDefault],
+            model: "model-a",
+            responseGroups: [group]
+        )
+
+        #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, displayedDefault.id])
+    }
+
+    @Test("Meaningful metadata survives history filtering while empty assistants do not")
+    func meaningfulMetadataSurvives() {
+        let groupID = UUID()
+        let user = Message(role: .user, content: "Question")
+        let emptyPlaceholder = Message(role: .assistant, content: "", mediaType: .image)
+        let reasoning = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "",
+            responseGroupId: groupID,
+            reasoning: "Completed reasoning"
+        )
+        let text = Message(
+            id: UUID(),
+            role: .assistant,
+            content: "Text fallback",
+            responseGroupId: groupID
+        )
+        let group = ResponseGroup(
+            id: groupID,
+            userMessageId: user.id,
+            responses: [
+                .init(id: reasoning.id, modelName: "reasoning", status: .completed),
+                .init(id: text.id, modelName: "text", status: .completed),
+            ]
+        )
+        let conversation = Conversation(
+            messages: [user, emptyPlaceholder, reasoning, text],
+            responseGroups: [group]
+        )
+
+        #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, reasoning.id])
+    }
+}

--- a/Tests/AynaTests/ConversationManagerTests.swift
+++ b/Tests/AynaTests/ConversationManagerTests.swift
@@ -55,6 +55,28 @@ struct ConversationManagerTests {
         #expect(manager.conversations.first?.messages.first?.content == "Ping")
     }
 
+    @Test("Update message reports whether the target still exists")
+    @MainActor
+    func updateMessageReportsWhetherTargetExists() throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let manager = makeManager(directory: directory)
+        manager.createNewConversation()
+        let conversation = try #require(manager.conversations.first)
+        let message = Message(role: .assistant, content: "Pending")
+        manager.addMessage(to: conversation, message: message)
+
+        let updated = manager.updateMessage(in: conversation, messageId: message.id) { target in
+            target.content = "Completed"
+        }
+        let missing = manager.updateMessage(in: conversation, messageId: UUID()) { target in
+            target.content = "Unexpected"
+        }
+
+        #expect(updated)
+        #expect(!missing)
+        #expect(manager.conversations.first?.messages.first?.content == "Completed")
+    }
+
     @Test("Clear all conversations empties encrypted store")
     @MainActor
     func clearAllConversationsEmptiesEncryptedStore() async throws {
@@ -127,6 +149,55 @@ struct ConversationManagerTests {
         await clearRepair.started.wait()
         await clearRepair.releaseGate.open()
         await clearManager.flushPendingSaves()
+    }
+
+    @Test("Failed delete restores image placeholders as stopped")
+    @MainActor
+    func failedDeleteRestoresImagePlaceholdersAsStopped() async throws {
+        let model = AIService.shared.selectedModel
+        let userMessage = Message(role: .user, content: "Draw a sphere")
+        let responseGroupID = UUID()
+        let placeholder = Message(
+            role: .assistant,
+            content: "",
+            model: model,
+            responseGroupId: responseGroupID,
+            mediaType: .image
+        )
+        let responseGroup = ResponseGroup(
+            id: responseGroupID,
+            userMessageId: userMessage.id,
+            responses: [
+                .init(id: placeholder.id, modelName: model, status: .streaming),
+            ]
+        )
+        let conversation = Conversation(
+            title: "Interrupted image",
+            messages: [userMessage, placeholder],
+            model: model,
+            responseGroups: [responseGroup]
+        )
+        let store = ScriptedConversationStore(conversations: [conversation])
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+        let deleteGate = await store.enqueue(.delete(conversation.id), outcome: .fail, blocked: true)
+        let repairGate = await store.enqueue(.save(conversation.id, nil), blocked: true)
+
+        let target = try #require(manager.conversations.first)
+        let rollback = try #require(manager.deleteConversation(target))
+        await deleteGate.started.wait()
+        await deleteGate.releaseGate.open()
+        await rollback.value
+
+        let restored = try #require(manager.conversation(byId: conversation.id))
+        let restoredMessage = try #require(restored.messages.first(where: { $0.id == placeholder.id }))
+        let restoredGroup = try #require(restored.getResponseGroup(responseGroupID))
+        #expect(restoredMessage.content == "Image generation stopped")
+        #expect(restoredGroup.responses.first?.status == .failed)
+
+        await repairGate.started.wait()
+        await repairGate.releaseGate.open()
+        await manager.flushPendingSaves()
     }
 
     @Test("Failed clear does not override a newer new-chat selection")

--- a/Tests/AynaTests/ConversationManagerTests.swift
+++ b/Tests/AynaTests/ConversationManagerTests.swift
@@ -1,8 +1,11 @@
+// swiftlint:disable file_length
 @testable import Ayna
 import Foundation
 import Testing
 
+// swiftlint:disable identifier_name
 @Suite("ConversationManager Tests", .tags(.viewModel, .persistence), .serialized)
+// swiftlint:disable:next type_body_length
 struct ConversationManagerTests {
     private var defaults: UserDefaults
 
@@ -24,9 +27,9 @@ struct ConversationManagerTests {
         return ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
     }
 
-    @Test("Create new conversation uses selected model")
+    @Test
     @MainActor
-    func createNewConversationUsesSelectedModel() throws {
+    func `Create new conversation uses selected model`() throws {
         AIService.keychain = InMemoryKeychainStorage()
         let directory = try TestHelpers.makeTemporaryDirectory()
         let expectedModel = "unit-test-model"
@@ -39,9 +42,9 @@ struct ConversationManagerTests {
         #expect(manager.conversations.first?.model == expectedModel)
     }
 
-    @Test("Add message appends and updates timestamp")
+    @Test
     @MainActor
-    func addMessageAppendsAndUpdatesTimestamp() throws {
+    func `Add message appends and updates timestamp`() throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
 
         let manager = makeManager(directory: directory)
@@ -55,9 +58,9 @@ struct ConversationManagerTests {
         #expect(manager.conversations.first?.messages.first?.content == "Ping")
     }
 
-    @Test("Update message reports whether the target still exists")
+    @Test
     @MainActor
-    func updateMessageReportsWhetherTargetExists() throws {
+    func `Update message reports whether the target still exists`() throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let manager = makeManager(directory: directory)
         manager.createNewConversation()
@@ -77,9 +80,9 @@ struct ConversationManagerTests {
         #expect(manager.conversations.first?.messages.first?.content == "Completed")
     }
 
-    @Test("Appending streamed content advances the conversation revision")
+    @Test
     @MainActor
-    func appendStreamedContentAdvancesConversationRevision() async throws {
+    func `Appending streamed content advances the conversation revision`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let manager = makeManager(directory: directory)
         manager.createNewConversation()
@@ -100,15 +103,16 @@ struct ConversationManagerTests {
         #expect(manager.conversations.first?.updatedAt ?? .distantPast > previousUpdate)
     }
 
-    @Test("Clear all conversations empties encrypted store")
+    @Test
     @MainActor
-    func clearAllConversationsEmptiesEncryptedStore() async throws {
+    func `Clear all conversations empties encrypted store`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let keychain = InMemoryKeychainStorage()
         let store = TestHelpers.makeTestStore(directory: directory, keychain: keychain)
 
         let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
         _ = await manager.loadingTask?.value
+        #expect(manager.isConversationStateAuthoritative)
         manager.conversations = [TestHelpers.sampleConversation()]
         try await store.save(manager.conversations)
 
@@ -120,9 +124,230 @@ struct ConversationManagerTests {
         #expect(try await store.loadConversations().isEmpty)
     }
 
-    @Test("Failed delete and clear roll back optimistic UI without losing newer state")
+    @Test
     @MainActor
-    func persistenceFailuresRollBackOptimisticUI() async throws {
+    func `Failed initial load does not mark empty memory as authoritative`() async {
+        let store = ScriptedConversationStore()
+        _ = await store.enqueue(.load, outcome: .fail)
+        let manager = ConversationManager(store: store, loadRetryBaseDelay: .seconds(30))
+
+        _ = await manager.loadingTask?.value
+
+        #expect(manager.conversations.isEmpty)
+        #expect(!manager.isConversationStateAuthoritative)
+    }
+
+    @Test
+    @MainActor
+    func `Unreadable encrypted record does not publish a partial authoritative load`() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let store = TestHelpers.makeTestStore(directory: directory)
+        let readable = TestHelpers.sampleConversation(title: "Readable")
+        let unreadable = TestHelpers.sampleConversation(title: "Unreadable")
+        try await store.save(readable)
+        try await store.save(unreadable)
+        try Data("corrupt encrypted record".utf8).write(
+            to: store.fileURL(for: unreadable.id),
+            options: .atomic
+        )
+        let manager = ConversationManager(
+            store: store,
+            loadRetryBaseDelay: .seconds(30)
+        )
+
+        _ = await manager.loadingTask?.value
+
+        #expect(!manager.isConversationStateAuthoritative)
+        #expect(manager.conversations.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `Authoritative state wait blocks legacy ingress until initial load succeeds`() async {
+        let stored = TestHelpers.sampleConversation(title: "Loaded before legacy ingress")
+        let store = ScriptedConversationStore(conversations: [stored])
+        let loadGate = await store.enqueue(.load, outcome: .load([stored]), blocked: true)
+        let manager = ConversationManager(store: store)
+        await loadGate.started.wait()
+
+        let waitingStarted = TestLatch()
+        let waitingFinished = TestLatch()
+        let waiting = Task { @MainActor in
+            await waitingStarted.open()
+            let authoritative = await manager.waitUntilConversationStateIsAuthoritative()
+            await waitingFinished.open()
+            return authoritative
+        }
+        await waitingStarted.wait()
+        await Task.yield()
+
+        let finishedBeforeLoad = await waitingFinished.opened()
+        #expect(!finishedBeforeLoad)
+        #expect(!manager.isConversationStateAuthoritative)
+
+        await loadGate.releaseGate.open()
+        _ = await manager.loadingTask?.value
+
+        let becameAuthoritative = await waiting.value
+        let didFinishWaiting = await waitingFinished.opened()
+        #expect(becameAuthoritative)
+        #expect(didFinishWaiting)
+        #expect(manager.isConversationStateAuthoritative)
+        #expect(manager.conversations.map(\.id) == [stored.id])
+    }
+
+    @Test
+    @MainActor
+    func `Initial load failure retries and restores authority automatically`() async {
+        let stored = TestHelpers.sampleConversation()
+        let store = ScriptedConversationStore(conversations: [stored])
+        _ = await store.enqueue(.load, outcome: .fail)
+        let manager = ConversationManager(
+            store: store,
+            loadRetryBaseDelay: .milliseconds(1)
+        )
+
+        _ = await manager.loadingTask?.value
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while !manager.isConversationStateAuthoritative, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(manager.isConversationStateAuthoritative)
+        #expect(manager.conversations.map(\.id) == [stored.id])
+        #expect(manager.conversations.first?.title == stored.title)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func `Reload failure closes authority preserves UI and retries latest load`() async {
+        let previousModels = AIService.shared.customModels
+        let model = AIService.shared.selectedModel
+        if !AIService.shared.customModels.contains(model) {
+            AIService.shared.customModels.append(model)
+        }
+        defer { AIService.shared.customModels = previousModels }
+
+        let stored = Conversation(title: "Visible before failed reload", model: model)
+        var refreshed = stored
+        refreshed.title = "Loaded by retry"
+        refreshed.updatedAt = stored.updatedAt.addingTimeInterval(1)
+        let store = ScriptedConversationStore(conversations: [stored])
+        let manager = ConversationManager(store: store, loadRetryBaseDelay: .zero)
+        _ = await manager.loadingTask?.value
+        manager.selectedConversationId = stored.id
+        _ = await store.enqueue(.load, outcome: .fail)
+        let retry = await store.enqueue(
+            .load,
+            outcome: .load([refreshed]),
+            blocked: true
+        )
+
+        await manager.reloadConversations()
+
+        guard !manager.isConversationStateAuthoritative else {
+            Issue.record("Expected the failed latest reload to close conversation authority")
+            return
+        }
+        #expect(manager.conversations == [stored])
+        #expect(manager.selectedConversationId == stored.id)
+
+        await retry.started.wait()
+        #expect(!manager.isConversationStateAuthoritative)
+        #expect(manager.conversations == [stored])
+        #expect(manager.selectedConversationId == stored.id)
+
+        await retry.releaseGate.open()
+        #expect(await manager.waitUntilConversationStateIsAuthoritative())
+        #expect(manager.conversations == [refreshed])
+        #expect(manager.selectedConversationId == stored.id)
+        #expect(await store.operations() == [.load, .load, .load])
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func `Failed reload gates stale Watch publication until retry succeeds`() async {
+        let previousModels = AIService.shared.customModels
+        let model = AIService.shared.selectedModel
+        if !AIService.shared.customModels.contains(model) {
+            AIService.shared.customModels.append(model)
+        }
+        defer { AIService.shared.customModels = previousModels }
+
+        let stored = Conversation(title: "Stale Watch snapshot", model: model)
+        var refreshed = stored
+        refreshed.title = "Fresh Watch snapshot"
+        refreshed.updatedAt = stored.updatedAt.addingTimeInterval(1)
+        let store = ScriptedConversationStore(conversations: [stored])
+        let manager = ConversationManager(store: store, loadRetryBaseDelay: .zero)
+        _ = await manager.loadingTask?.value
+        _ = await store.enqueue(.load, outcome: .fail)
+        let retry = await store.enqueue(
+            .load,
+            outcome: .load([refreshed]),
+            blocked: true
+        )
+
+        await manager.reloadConversations()
+
+        guard !manager.isConversationStateAuthoritative else {
+            Issue.record("Expected failed reload authority to gate Watch publication")
+            return
+        }
+        #expect(manager.durableConversationsForSync() == [stored])
+        let stalePublication = manager.isConversationStateAuthoritative
+            ? manager.durableConversationsForSync()
+            : nil
+        #expect(stalePublication == nil)
+
+        await retry.started.wait()
+        let publicationDuringRetry = manager.isConversationStateAuthoritative
+            ? manager.durableConversationsForSync()
+            : nil
+        #expect(publicationDuringRetry == nil)
+
+        await retry.releaseGate.open()
+        #expect(await manager.waitUntilConversationStateIsAuthoritative())
+        let publicationAfterRetry = manager.isConversationStateAuthoritative
+            ? manager.durableConversationsForSync()
+            : nil
+        #expect(publicationAfterRetry == [refreshed])
+    }
+
+    @Test
+    @MainActor
+    func `Failed clear after failed initial load remains non-authoritative and keeps retrying`() async {
+        let stored = TestHelpers.sampleConversation()
+        let store = ScriptedConversationStore(conversations: [stored])
+        _ = await store.enqueue(.load, outcome: .fail)
+        _ = await store.enqueue(.clear, outcome: .fail)
+        _ = await store.enqueue(.clear)
+        _ = await store.enqueue(.load, outcome: .fail)
+        _ = await store.enqueue(.load, outcome: .load([stored]))
+        let manager = ConversationManager(
+            store: store,
+            loadRetryBaseDelay: .milliseconds(100)
+        )
+
+        _ = await manager.loadingTask?.value
+        await manager.clearAllConversations().value
+
+        #expect(!manager.isConversationStateAuthoritative)
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while !manager.conversations.contains(where: { $0.id == stored.id }), clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(manager.isConversationStateAuthoritative)
+        #expect(manager.conversations.map(\.id) == [stored.id])
+    }
+
+    @Test
+    @MainActor
+    func `Failed delete and clear roll back optimistic UI without losing newer state`() async throws {
         AIService.keychain = InMemoryKeychainStorage()
         let previousModels = AIService.shared.customModels
         let model = AIService.shared.selectedModel
@@ -142,22 +367,28 @@ struct ConversationManagerTests {
         let deleteRollback = try #require(deleteManager.deleteConversation(deleteTarget))
         await deleteGate.started.wait()
         #expect(deleteManager.conversations.isEmpty)
+        #expect(deleteManager.pendingDestructivePersistenceOperations == 1)
         await deleteGate.releaseGate.open()
-        await deleteRollback.value
+        _ = await deleteRollback.value
+        #expect(deleteManager.pendingDestructivePersistenceOperations == 1)
         #expect(deleteManager.conversations == [deleted])
         #expect(deleteManager.selectedConversationId == deleted.id)
         await deleteRepair.started.wait()
         await deleteRepair.releaseGate.open()
         await deleteManager.flushPendingSaves()
+        #expect(await waitUntil {
+            deleteManager.pendingDestructivePersistenceOperations == 0
+        })
 
         let beforeClear = Conversation(title: "Before clear", model: model)
         let clearStore = ScriptedConversationStore(conversations: [beforeClear])
         let clearManager = ConversationManager(store: clearStore, saveDebounceDuration: .seconds(30))
         _ = await clearManager.loadingTask?.value
-        let clearGate = await clearStore.enqueue(.clear, outcome: .fail, blocked: true)
+        let clearGate = await clearStore.enqueue(.clear, outcome: .partialClear([beforeClear.id]), blocked: true)
         clearManager.selectedConversationId = beforeClear.id
         let clearRollback = clearManager.clearAllConversations()
         await clearGate.started.wait()
+        #expect(clearManager.pendingDestructivePersistenceOperations == 1)
         clearManager.createNewConversation(title: "After clear")
         let created = try #require(clearManager.conversations.first)
         clearManager.selectedConversationId = created.id
@@ -167,16 +398,20 @@ struct ConversationManagerTests {
         await clearGate.releaseGate.open()
         await saveGate.started.wait()
         await clearRollback.value
+        #expect(clearManager.pendingDestructivePersistenceOperations == 1)
         #expect(Set(clearManager.conversations.map(\.id)) == Set([beforeClear.id, created.id]))
         #expect(clearManager.selectedConversationId == created.id)
         await clearRepair.started.wait()
         await clearRepair.releaseGate.open()
         await clearManager.flushPendingSaves()
+        #expect(await waitUntil {
+            clearManager.pendingDestructivePersistenceOperations == 0
+        })
     }
 
-    @Test("Failed delete restores image placeholders as stopped")
+    @Test
     @MainActor
-    func failedDeleteRestoresImagePlaceholdersAsStopped() async throws {
+    func `Failed delete restores image placeholders as stopped`() async throws {
         let model = AIService.shared.selectedModel
         let userMessage = Message(role: .user, content: "Draw a sphere")
         let responseGroupID = UUID()
@@ -210,7 +445,7 @@ struct ConversationManagerTests {
         let rollback = try #require(manager.deleteConversation(target))
         await deleteGate.started.wait()
         await deleteGate.releaseGate.open()
-        await rollback.value
+        _ = await rollback.value
 
         let restored = try #require(manager.conversation(byId: conversation.id))
         let restoredMessage = try #require(restored.messages.first(where: { $0.id == placeholder.id }))
@@ -223,9 +458,9 @@ struct ConversationManagerTests {
         await manager.flushPendingSaves()
     }
 
-    @Test("Failed clear does not override a newer new-chat selection")
+    @Test
     @MainActor
-    func failedClearPreservesNewChatSelection() async throws {
+    func `Failed clear does not override a newer new-chat selection`() async {
         let model = AIService.shared.selectedModel
         let existing = Conversation(title: "Existing", model: model)
         let store = ScriptedConversationStore(conversations: [existing])
@@ -248,9 +483,9 @@ struct ConversationManagerTests {
         await manager.flushPendingSaves()
     }
 
-    @Test("Search finds matches in title and messages")
+    @Test
     @MainActor
-    func searchFindsMatchesInTitleAndMessages() throws {
+    func `Search finds matches in title and messages`() throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
 
         let manager = makeManager(directory: directory)
@@ -270,9 +505,9 @@ struct ConversationManagerTests {
         #expect(bodyResults.first?.title == "Random Chat")
     }
 
-    @Test("Save immediately persists manual changes")
+    @Test
     @MainActor
-    func saveImmediatelyPersistsManualChanges() async throws {
+    func `Save immediately persists manual changes`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let keychain = InMemoryKeychainStorage()
         let keyId = "test-key-id"
@@ -301,9 +536,396 @@ struct ConversationManagerTests {
         #expect(newManager.conversations.first?.messages.last?.content == "Partial content")
     }
 
-    @Test("Reload conversations removes stale non-dirty conversations")
+    @Test
     @MainActor
-    func reloadConversationsRemovesStaleNonDirtyConversations() async throws {
+    func `Proposed save publishes only after durable success is committed`() async {
+        let store = ScriptedConversationStore()
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+        let proposed = TestHelpers.sampleConversation(title: "From Watch")
+        let saveGate = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            blocked: true
+        )
+
+        let persistence = manager.persistProposedConversation(proposed)
+        await saveGate.started.wait()
+
+        #expect(manager.conversations.isEmpty)
+        #expect(manager.conversation(byId: proposed.id) == nil)
+
+        await saveGate.releaseGate.open()
+        let result = await persistence.value
+
+        #expect(result == .saved)
+        #expect(manager.conversations.isEmpty)
+        #expect(await store.persistedConversations() == [proposed])
+
+        manager.commitPersistedConversation(proposed)
+
+        #expect(manager.conversations == [proposed])
+        #expect(manager.conversation(byId: proposed.id) == proposed)
+        #expect(await store.operations() == [.load, .save(proposed.id, proposed.title)])
+    }
+
+    @Test
+    @MainActor
+    func `Failed proposed save leaves manager UI unchanged across reload`() async {
+        let previousModels = AIService.shared.customModels
+        let model = AIService.shared.selectedModel
+        if !AIService.shared.customModels.contains(model) {
+            AIService.shared.customModels.append(model)
+        }
+        defer { AIService.shared.customModels = previousModels }
+
+        let stored = Conversation(title: "Stored", model: model)
+        var proposed = stored
+        proposed.title = "Rejected Watch save"
+        proposed.updatedAt = stored.updatedAt.addingTimeInterval(1)
+        let store = ScriptedConversationStore(conversations: [stored])
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+        let saveGate = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            outcome: .fail,
+            blocked: true
+        )
+
+        let persistence = manager.persistProposedConversation(proposed)
+        await saveGate.started.wait()
+
+        #expect(manager.conversations == [stored])
+
+        await saveGate.releaseGate.open()
+        let result = await persistence.value
+
+        guard case .failed = result else {
+            Issue.record("Expected proposed save to fail, got \(result)")
+            return
+        }
+        #expect(manager.conversations == [stored])
+        #expect(manager.conversation(byId: proposed.id) == stored)
+        #expect(await store.persistedConversations() == [stored])
+
+        await manager.reloadConversations()
+        await manager.flushPendingSaves()
+
+        #expect(manager.conversations == [stored])
+        #expect(manager.conversation(byId: proposed.id) == stored)
+        #expect(await store.persistedConversations() == [stored])
+        #expect(await store.operations() == [
+            .load,
+            .save(proposed.id, proposed.title),
+            .load,
+        ])
+    }
+
+    @Test
+    @MainActor
+    func `Superseded proposed save is not committed`() async {
+        let store = ScriptedConversationStore()
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+        let older = Conversation(title: "Older Watch edit", model: AIService.shared.selectedModel)
+        var newer = older
+        newer.title = "Newer Watch edit"
+        newer.updatedAt = older.updatedAt.addingTimeInterval(1)
+        let olderGate = await store.enqueue(
+            .save(older.id, older.title),
+            blocked: true
+        )
+        let newerGate = await store.enqueue(
+            .save(newer.id, newer.title),
+            blocked: true
+        )
+
+        let olderPersistence = manager.persistProposedConversation(older)
+        await olderGate.started.wait()
+        let newerPersistence = manager.persistProposedConversation(newer)
+
+        #expect(manager.conversations.isEmpty)
+
+        await olderGate.releaseGate.open()
+        let olderResult = await olderPersistence.value
+
+        #expect(olderResult == .superseded)
+        #expect(manager.conversations.isEmpty)
+
+        await newerGate.started.wait()
+        #expect(manager.conversations.isEmpty)
+        await newerGate.releaseGate.open()
+        let newerResult = await newerPersistence.value
+
+        #expect(newerResult == .saved)
+        #expect(manager.conversations.isEmpty)
+
+        manager.commitPersistedConversation(newer)
+
+        #expect(manager.conversations == [newer])
+        #expect(await store.operations() == [
+            .load,
+            .save(older.id, older.title),
+            .save(newer.id, newer.title),
+        ])
+    }
+
+    @Test
+    @MainActor
+    func `Proposed deletion publishes only after durable success is committed`() async {
+        let previousModels = AIService.shared.customModels
+        let model = AIService.shared.selectedModel
+        if !AIService.shared.customModels.contains(model) {
+            AIService.shared.customModels.append(model)
+        }
+        defer { AIService.shared.customModels = previousModels }
+
+        let existing = Conversation(title: "Delete from Watch", model: model)
+        let store = ScriptedConversationStore(conversations: [existing])
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+        manager.selectedConversationId = existing.id
+        let deleteGate = await store.enqueue(
+            .delete(existing.id),
+            blocked: true
+        )
+
+        let persistence = manager.persistProposedDeletion(existing)
+        await deleteGate.started.wait()
+
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        #expect(manager.conversations == [existing])
+        #expect(manager.selectedConversationId == existing.id)
+
+        await deleteGate.releaseGate.open()
+        let result = await persistence.value
+
+        #expect(result == .deleted)
+        #expect(manager.pendingDestructivePersistenceOperations == 0)
+        #expect(manager.conversations == [existing])
+        #expect(manager.selectedConversationId == existing.id)
+
+        manager.commitPersistedDeletion(existing.id)
+
+        #expect(manager.conversations.isEmpty)
+        #expect(manager.conversation(byId: existing.id) == nil)
+        #expect(manager.selectedConversationId == nil)
+        #expect(await store.operations() == [.load, .delete(existing.id)])
+    }
+
+    @Test
+    @MainActor
+    func `ID-only proposed deletion removes a backing record absent from memory`() async {
+        let hidden = TestHelpers.sampleConversation(title: "Hidden backing record")
+        let store = ScriptedConversationStore(conversations: [hidden])
+        _ = await store.enqueue(.load, outcome: .load([]))
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+
+        #expect(manager.isConversationStateAuthoritative)
+        #expect(manager.conversations.isEmpty)
+        #expect(await store.persistedConversations() == [hidden])
+
+        let persistence = manager.persistProposedDeletion(conversationID: hidden.id)
+        let result = await persistence.value
+
+        #expect(result == .deleted)
+        #expect(manager.pendingDestructivePersistenceOperations == 0)
+        #expect(manager.conversations.isEmpty)
+        #expect(await store.persistedConversations().isEmpty)
+        #expect(await store.operations() == [.load, .delete(hidden.id)])
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func `Failed ID-only deletion keeps its barrier until a delete retry succeeds`() async {
+        let hidden = TestHelpers.sampleConversation(title: "Retry hidden deletion")
+        let store = ScriptedConversationStore(conversations: [hidden])
+        _ = await store.enqueue(.load, outcome: .load([]))
+        _ = await store.enqueue(.delete(hidden.id), outcome: .fail)
+        let retry = await store.enqueue(.delete(hidden.id), blocked: true)
+        let manager = ConversationManager(
+            store: store,
+            destructiveRepairRetryBaseDelay: .milliseconds(1)
+        )
+        _ = await manager.loadingTask?.value
+
+        let persistence = manager.persistProposedDeletion(conversationID: hidden.id)
+        let result = await persistence.value
+
+        guard case .failed(nil, _) = result else {
+            Issue.record("Expected an ID-only delete failure, got \(result)")
+            return
+        }
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        #expect(await store.persistedConversations() == [hidden])
+
+        await retry.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        await retry.releaseGate.open()
+
+        #expect(await waitUntil {
+            manager.pendingDestructivePersistenceOperations == 0
+        })
+        #expect(await store.persistedConversations().isEmpty)
+        #expect(await store.operations() == [
+            .load,
+            .delete(hidden.id),
+            .delete(hidden.id),
+        ])
+    }
+
+    @Test
+    @MainActor
+    func `Failed proposed deletion leaves manager UI unchanged`() async {
+        let previousModels = AIService.shared.customModels
+        let model = AIService.shared.selectedModel
+        if !AIService.shared.customModels.contains(model) {
+            AIService.shared.customModels.append(model)
+        }
+        defer { AIService.shared.customModels = previousModels }
+
+        let existing = Conversation(title: "Keep after Watch delete", model: model)
+        let store = ScriptedConversationStore(conversations: [existing])
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+        manager.selectedConversationId = existing.id
+        let deleteGate = await store.enqueue(
+            .delete(existing.id),
+            outcome: .fail,
+            blocked: true
+        )
+        let repairGate = await store.enqueue(
+            .save(existing.id, existing.title),
+            blocked: true
+        )
+
+        let persistence = manager.persistProposedDeletion(existing)
+        await deleteGate.started.wait()
+
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        #expect(manager.conversations == [existing])
+        #expect(manager.selectedConversationId == existing.id)
+
+        await deleteGate.releaseGate.open()
+        let result = await persistence.value
+
+        guard case .failed = result else {
+            Issue.record("Expected proposed deletion to fail, got \(result)")
+            return
+        }
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        #expect(manager.conversations == [existing])
+        #expect(manager.selectedConversationId == existing.id)
+
+        await repairGate.started.wait()
+        await repairGate.releaseGate.open()
+        await manager.flushPendingSaves()
+        #expect(await waitUntil {
+            manager.pendingDestructivePersistenceOperations == 0
+        })
+
+        #expect(manager.conversations == [existing])
+        #expect(await store.persistedConversations() == [existing])
+        #expect(await store.operations() == [
+            .load,
+            .delete(existing.id),
+            .save(existing.id, existing.title),
+        ])
+    }
+
+    @Test
+    @MainActor
+    func `Superseded proposed deletion is not committed`() async {
+        let previousModels = AIService.shared.customModels
+        let model = AIService.shared.selectedModel
+        if !AIService.shared.customModels.contains(model) {
+            AIService.shared.customModels.append(model)
+        }
+        defer { AIService.shared.customModels = previousModels }
+
+        let existing = Conversation(title: "Before Watch edit", model: model)
+        var newer = existing
+        newer.title = "After Watch edit"
+        newer.updatedAt = existing.updatedAt.addingTimeInterval(1)
+        let store = ScriptedConversationStore(conversations: [existing])
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+        let deleteGate = await store.enqueue(
+            .delete(existing.id),
+            blocked: true
+        )
+        let saveGate = await store.enqueue(
+            .save(newer.id, newer.title),
+            blocked: true
+        )
+
+        let deletion = manager.persistProposedDeletion(existing)
+        await deleteGate.started.wait()
+        let save = manager.persistProposedConversation(newer)
+
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        #expect(manager.conversations == [existing])
+
+        await deleteGate.releaseGate.open()
+        let deleteResult = await deletion.value
+
+        #expect(deleteResult == .superseded)
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        #expect(manager.conversations == [existing])
+
+        await saveGate.started.wait()
+        #expect(manager.conversations == [existing])
+        await saveGate.releaseGate.open()
+        let saveResult = await save.value
+
+        #expect(saveResult == .saved)
+        #expect(await waitUntil {
+            manager.pendingDestructivePersistenceOperations == 0
+        })
+        #expect(manager.conversations == [existing])
+
+        manager.commitPersistedConversation(newer)
+
+        #expect(manager.conversations == [newer])
+        #expect(await store.operations() == [
+            .load,
+            .delete(existing.id),
+            .save(newer.id, newer.title),
+        ])
+    }
+
+    @Test
+    @MainActor
+    func `Failed normal save keeps Watch sync on the last durable snapshot until retry succeeds`() async {
+        let model = AIService.shared.selectedModel
+        let stored = Conversation(title: "Durable before edit", model: model)
+        var edited = stored
+        edited.title = "Visible but not durable"
+        edited.updatedAt = stored.updatedAt.addingTimeInterval(1)
+        let store = ScriptedConversationStore(conversations: [stored])
+        _ = await store.enqueue(.save(edited.id, edited.title), outcome: .fail)
+        _ = await store.enqueue(.save(edited.id, edited.title))
+        let manager = ConversationManager(store: store, saveDebounceDuration: .zero)
+        _ = await manager.loadingTask?.value
+        let initialDurableRevision = manager.durableConversationRevision
+
+        manager.conversations = [edited]
+        manager.save(edited)
+        await manager.flushPendingSaves()
+
+        #expect(manager.conversations == [edited])
+        #expect(manager.durableConversationsForSync() == [stored])
+
+        await manager.flushPendingSaves()
+
+        #expect(manager.durableConversationsForSync() == [edited])
+        #expect(manager.durableConversationRevision > initialDurableRevision)
+        #expect(await store.persistedConversations() == [edited])
+    }
+
+    @Test
+    @MainActor
+    func `Reload conversations removes stale non-dirty conversations`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let keychain = InMemoryKeychainStorage()
         let keyId = "test-reconcile-key"
@@ -328,9 +950,9 @@ struct ConversationManagerTests {
         #expect(!manager.conversations.contains(where: { $0.id == stale.id }))
     }
 
-    @Test("Reload conversations preserves dirty in-memory conversations not yet on disk")
+    @Test
     @MainActor
-    func reloadConversationsPreservesDirtyInMemoryConversationsNotYetOnDisk() async throws {
+    func `Reload conversations preserves dirty in-memory conversations not yet on disk`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let keychain = InMemoryKeychainStorage()
         let keyId = "test-dirty-wins-key"
@@ -355,9 +977,9 @@ struct ConversationManagerTests {
         await manager.flushPendingSaves()
     }
 
-    @Test("Dirty memory wins load, then removed model repair is persisted")
+    @Test
     @MainActor
-    func dirtyMemoryWithRemovedModelMergesRepair() async throws {
+    func `Dirty memory wins load, then removed model repair is persisted`() async throws {
         AIService.keychain = InMemoryKeychainStorage()
         let previousModels = AIService.shared.customModels
         let previousSelection = AIService.shared.selectedModel
@@ -395,9 +1017,9 @@ struct ConversationManagerTests {
 
     // MARK: - Edit Message Tests
 
-    @Test("Edit message updates content and marks as edited")
+    @Test
     @MainActor
-    func editMessageUpdatesContentAndMarksAsEdited() throws {
+    func `Edit message updates content and marks as edited`() throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
 
         let manager = makeManager(directory: directory)
@@ -419,9 +1041,9 @@ struct ConversationManagerTests {
         #expect(manager.conversations.first?.messages.first?.editedAt != nil)
     }
 
-    @Test("Edit message removes subsequent messages")
+    @Test
     @MainActor
-    func editMessageRemovesSubsequentMessages() throws {
+    func `Edit message removes subsequent messages`() throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
 
         let manager = makeManager(directory: directory)
@@ -447,9 +1069,9 @@ struct ConversationManagerTests {
         #expect(manager.conversations.first?.messages.first?.isEdited == true)
     }
 
-    @Test("Edit message fails for assistant messages")
+    @Test
     @MainActor
-    func editMessageFailsForAssistantMessages() throws {
+    func `Edit message fails for assistant messages`() throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
 
         let manager = makeManager(directory: directory)
@@ -470,9 +1092,9 @@ struct ConversationManagerTests {
         #expect(manager.conversations.first?.messages.first?.isEdited == false)
     }
 
-    @Test("Edit message with same content does not mark as edited")
+    @Test
     @MainActor
-    func editMessageWithSameContentDoesNotMarkAsEdited() throws {
+    func `Edit message with same content does not mark as edited`() throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
 
         let manager = makeManager(directory: directory)
@@ -493,9 +1115,9 @@ struct ConversationManagerTests {
         #expect(manager.conversations.first?.messages.first?.isEdited == false)
     }
 
-    @Test("Edit message fails for non-existent message")
+    @Test
     @MainActor
-    func editMessageFailsForNonExistentMessage() throws {
+    func `Edit message fails for non-existent message`() throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
 
         let manager = makeManager(directory: directory)
@@ -510,4 +1132,314 @@ struct ConversationManagerTests {
 
         #expect(editResult == false)
     }
+
+    @MainActor
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        condition: @escaping @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return condition()
+    }
 }
+
+extension ConversationManagerTests {
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func `Destructive barrier retries failed delete repair until durable success`() async throws {
+        let model = AIService.shared.selectedModel
+        let existing = Conversation(title: "Retry delete rollback", model: model)
+        let store = ScriptedConversationStore(conversations: [existing])
+        let manager = ConversationManager(
+            store: store,
+            destructiveRepairRetryBaseDelay: .milliseconds(1)
+        )
+        _ = await manager.loadingTask?.value
+
+        let deleteGate = await store.enqueue(
+            .delete(existing.id),
+            outcome: .fail,
+            blocked: true
+        )
+        let firstRepair = await store.enqueue(
+            .save(existing.id, existing.title),
+            outcome: .fail,
+            blocked: true
+        )
+        let secondRepair = await store.enqueue(
+            .save(existing.id, existing.title),
+            outcome: .fail,
+            blocked: true
+        )
+        let successfulRepair = await store.enqueue(
+            .save(existing.id, existing.title),
+            blocked: true
+        )
+
+        let target = try #require(manager.conversations.first)
+        let deletion = try #require(manager.deleteConversation(target))
+        await deleteGate.started.wait()
+        await deleteGate.releaseGate.open()
+        guard case .failed = await deletion.value else {
+            Issue.record("Expected delete failure")
+            return
+        }
+
+        await firstRepair.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        await firstRepair.releaseGate.open()
+
+        await secondRepair.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        await secondRepair.releaseGate.open()
+
+        await successfulRepair.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        await successfulRepair.releaseGate.open()
+
+        #expect(await waitUntil {
+            manager.pendingDestructivePersistenceOperations == 0
+        })
+        #expect(manager.conversations == [existing])
+        #expect(await store.persistedConversations() == [existing])
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func `Edit during failed delete repair keeps barrier until newest state is durable`() async throws {
+        let existing = Conversation(
+            title: "Rollback before edit",
+            model: AIService.shared.selectedModel
+        )
+        let editedTitle = "Edited after rollback"
+        let store = ScriptedConversationStore(conversations: [existing])
+        let manager = ConversationManager(
+            store: store,
+            saveDebounceDuration: .milliseconds(0),
+            destructiveRepairRetryBaseDelay: .milliseconds(1)
+        )
+        _ = await manager.loadingTask?.value
+        await manager.flushPendingSaves()
+        let operationBaseline = await store.operations().count
+
+        let failedDelete = await store.enqueue(
+            .delete(existing.id),
+            outcome: .fail,
+            blocked: true
+        )
+        let failedRollbackSave = await store.enqueue(
+            .save(existing.id, existing.title),
+            outcome: .fail,
+            blocked: true
+        )
+        let failedEditedSave = await store.enqueue(
+            .save(existing.id, editedTitle),
+            outcome: .fail,
+            blocked: true
+        )
+        let successfulRetry = await store.enqueue(
+            .save(existing.id, editedTitle),
+            blocked: true
+        )
+
+        let target = try #require(manager.conversations.first)
+        let deletion = try #require(manager.deleteConversation(target))
+        await failedDelete.started.wait()
+        await failedDelete.releaseGate.open()
+        guard case .failed = await deletion.value else {
+            Issue.record("Expected delete failure")
+            return
+        }
+        await failedRollbackSave.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+
+        let restored = try #require(manager.conversation(byId: existing.id))
+        manager.renameConversation(restored, newTitle: editedTitle)
+        let edited = try #require(manager.conversation(byId: existing.id))
+        #expect(edited.title == editedTitle)
+
+        await failedRollbackSave.releaseGate.open()
+        await failedEditedSave.started.wait()
+        let barrierDroppedDuringEditedSave = await waitUntil(timeout: .milliseconds(50)) {
+            manager.pendingDestructivePersistenceOperations == 0
+        }
+        guard barrierDroppedDuringEditedSave == false else {
+            Issue.record("Destructive barrier dropped before the edited state was durable")
+            return
+        }
+        #expect(await store.persistedConversations() == [existing])
+
+        await failedEditedSave.releaseGate.open()
+        await successfulRetry.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        #expect(manager.conversations == [edited])
+        await successfulRetry.releaseGate.open()
+
+        #expect(await waitUntil {
+            manager.pendingDestructivePersistenceOperations == 0
+        })
+        #expect(manager.conversations == [edited])
+        #expect(await store.persistedConversations() == [edited])
+        let operations = await store.operations()
+        #expect(Array(operations.dropFirst(operationBaseline)) == [
+            .delete(existing.id),
+            .save(existing.id, existing.title),
+            .save(existing.id, editedTitle),
+            .save(existing.id, editedTitle),
+        ])
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func `Newer delete supersedes an older blocked rollback barrier`() async throws {
+        let existing = Conversation(
+            title: "Delete rollback superseded",
+            model: AIService.shared.selectedModel
+        )
+        let store = ScriptedConversationStore(conversations: [existing])
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+
+        let firstDelete = await store.enqueue(
+            .delete(existing.id),
+            outcome: .fail,
+            blocked: true
+        )
+        let oldRepair = await store.enqueue(
+            .save(existing.id, existing.title),
+            outcome: .fail,
+            blocked: true
+        )
+        let newerDelete = await store.enqueue(.delete(existing.id), blocked: true)
+
+        let firstTarget = try #require(manager.conversations.first)
+        let firstTask = try #require(manager.deleteConversation(firstTarget))
+        await firstDelete.started.wait()
+        await firstDelete.releaseGate.open()
+        guard case .failed = await firstTask.value else {
+            Issue.record("Expected first delete failure")
+            return
+        }
+        await oldRepair.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+
+        let restored = try #require(manager.conversation(byId: existing.id))
+        let newerTask = try #require(manager.deleteConversation(restored))
+
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        await oldRepair.releaseGate.open()
+        await newerDelete.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        await newerDelete.releaseGate.open()
+        #expect(await newerTask.value == .deleted)
+        #expect(await waitUntil {
+            manager.pendingDestructivePersistenceOperations == 0
+        })
+        #expect(manager.conversations.isEmpty)
+        #expect(await store.persistedConversations().isEmpty)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func `Newer clear supersedes an older blocked delete rollback barrier`() async throws {
+        let existing = Conversation(
+            title: "Delete rollback cleared",
+            model: AIService.shared.selectedModel
+        )
+        let store = ScriptedConversationStore(conversations: [existing])
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+
+        let failedDelete = await store.enqueue(
+            .delete(existing.id),
+            outcome: .fail,
+            blocked: true
+        )
+        let oldRepair = await store.enqueue(
+            .save(existing.id, existing.title),
+            outcome: .fail,
+            blocked: true
+        )
+        let newerClear = await store.enqueue(.clear, blocked: true)
+
+        let target = try #require(manager.conversations.first)
+        let deleteTask = try #require(manager.deleteConversation(target))
+        await failedDelete.started.wait()
+        await failedDelete.releaseGate.open()
+        guard case .failed = await deleteTask.value else {
+            Issue.record("Expected delete failure")
+            return
+        }
+        await oldRepair.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+
+        let clearTask = manager.clearAllConversations()
+
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        await oldRepair.releaseGate.open()
+        await newerClear.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        await newerClear.releaseGate.open()
+        await clearTask.value
+        #expect(await waitUntil {
+            manager.pendingDestructivePersistenceOperations == 0
+        })
+        #expect(manager.conversations.isEmpty)
+        #expect(await store.persistedConversations().isEmpty)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func `Newer clear supersedes an older blocked rewrite barrier`() async {
+        let existing = Conversation(
+            title: "Clear rollback superseded",
+            model: AIService.shared.selectedModel
+        )
+        let store = ScriptedConversationStore(conversations: [existing])
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+
+        let firstClear = await store.enqueue(
+            .clear,
+            outcome: .partialClear([existing.id]),
+            blocked: true
+        )
+        let oldRepair = await store.enqueue(
+            .clear,
+            outcome: .fail,
+            blocked: true
+        )
+        let newerClear = await store.enqueue(.clear, blocked: true)
+
+        let firstTask = manager.clearAllConversations()
+        await firstClear.started.wait()
+        await firstClear.releaseGate.open()
+        await firstTask.value
+        await oldRepair.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        #expect(manager.conversations == [existing])
+
+        let newerTask = manager.clearAllConversations()
+
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        await oldRepair.releaseGate.open()
+        await newerClear.started.wait()
+        #expect(manager.pendingDestructivePersistenceOperations == 1)
+        await newerClear.releaseGate.open()
+        await newerTask.value
+        #expect(await waitUntil {
+            manager.pendingDestructivePersistenceOperations == 0
+        })
+        #expect(manager.conversations.isEmpty)
+        #expect(await store.persistedConversations().isEmpty)
+    }
+}
+
+// swiftlint:enable identifier_name

--- a/Tests/AynaTests/ConversationManagerTests.swift
+++ b/Tests/AynaTests/ConversationManagerTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 import Testing
 
-@Suite("ConversationManager Tests", .tags(.viewModel, .persistence))
+@Suite("ConversationManager Tests", .tags(.viewModel, .persistence), .serialized)
 struct ConversationManagerTests {
     private var defaults: UserDefaults
 
@@ -67,13 +67,91 @@ struct ConversationManagerTests {
         manager.conversations = [TestHelpers.sampleConversation()]
         try await store.save(manager.conversations)
 
-        manager.clearAllConversations()
-
-        // Wait for async clear
-        try await Task.sleep(for: .milliseconds(100))
+        let clearing = manager.clearAllConversations()
+        await clearing.value
+        await manager.flushPendingSaves()
 
         #expect(manager.conversations.isEmpty)
-        #expect(!FileManager.default.fileExists(atPath: directory.appendingPathComponent("conversations.enc").path))
+        #expect(try await store.loadConversations().isEmpty)
+    }
+
+    @Test("Failed delete and clear roll back optimistic UI without losing newer state")
+    @MainActor
+    func persistenceFailuresRollBackOptimisticUI() async throws {
+        AIService.keychain = InMemoryKeychainStorage()
+        let previousModels = AIService.shared.customModels
+        let model = AIService.shared.selectedModel
+        if !AIService.shared.customModels.contains(model) {
+            AIService.shared.customModels.append(model)
+        }
+        defer { AIService.shared.customModels = previousModels }
+
+        let deleted = Conversation(title: "Keep me", model: model)
+        let deleteStore = ScriptedConversationStore(conversations: [deleted])
+        let deleteManager = ConversationManager(store: deleteStore)
+        _ = await deleteManager.loadingTask?.value
+        let deleteGate = await deleteStore.enqueue(.delete(deleted.id), outcome: .fail, blocked: true)
+        let deleteRepair = await deleteStore.enqueue(.save(deleted.id, nil), blocked: true)
+        deleteManager.selectedConversationId = deleted.id
+        let deleteTarget = try #require(deleteManager.conversations.first)
+        let deleteRollback = try #require(deleteManager.deleteConversation(deleteTarget))
+        await deleteGate.started.wait()
+        #expect(deleteManager.conversations.isEmpty)
+        await deleteGate.releaseGate.open()
+        await deleteRollback.value
+        #expect(deleteManager.conversations == [deleted])
+        #expect(deleteManager.selectedConversationId == deleted.id)
+        await deleteRepair.started.wait()
+        await deleteRepair.releaseGate.open()
+        await deleteManager.flushPendingSaves()
+
+        let beforeClear = Conversation(title: "Before clear", model: model)
+        let clearStore = ScriptedConversationStore(conversations: [beforeClear])
+        let clearManager = ConversationManager(store: clearStore, saveDebounceDuration: .seconds(30))
+        _ = await clearManager.loadingTask?.value
+        let clearGate = await clearStore.enqueue(.clear, outcome: .fail, blocked: true)
+        clearManager.selectedConversationId = beforeClear.id
+        let clearRollback = clearManager.clearAllConversations()
+        await clearGate.started.wait()
+        clearManager.createNewConversation(title: "After clear")
+        let created = try #require(clearManager.conversations.first)
+        clearManager.selectedConversationId = created.id
+        let saveGate = await clearStore.enqueue(.save(created.id, nil))
+        let clearRepair = await clearStore.enqueue(.clear, blocked: true)
+        _ = clearManager.saveImmediately(created)
+        await clearGate.releaseGate.open()
+        await saveGate.started.wait()
+        await clearRollback.value
+        #expect(Set(clearManager.conversations.map(\.id)) == Set([beforeClear.id, created.id]))
+        #expect(clearManager.selectedConversationId == created.id)
+        await clearRepair.started.wait()
+        await clearRepair.releaseGate.open()
+        await clearManager.flushPendingSaves()
+    }
+
+    @Test("Failed clear does not override a newer new-chat selection")
+    @MainActor
+    func failedClearPreservesNewChatSelection() async throws {
+        let model = AIService.shared.selectedModel
+        let existing = Conversation(title: "Existing", model: model)
+        let store = ScriptedConversationStore(conversations: [existing])
+        let manager = ConversationManager(store: store)
+        _ = await manager.loadingTask?.value
+        manager.selectedConversationId = existing.id
+
+        let clearGate = await store.enqueue(.clear, outcome: .fail, blocked: true)
+        _ = await store.enqueue(.clear)
+        let rollback = manager.clearAllConversations()
+        await clearGate.started.wait()
+
+        // Reassigning nil represents a newer explicit switch to New Chat.
+        manager.selectedConversationId = nil
+        await clearGate.releaseGate.open()
+        await rollback.value
+
+        #expect(manager.conversations.contains(where: { $0.id == existing.id }))
+        #expect(manager.selectedConversationId == nil)
+        await manager.flushPendingSaves()
     }
 
     @Test("Search finds matches in title and messages")
@@ -171,9 +249,6 @@ struct ConversationManagerTests {
         manager.conversations = [dirty]
         manager.save(dirty)
 
-        // Give the save() Task time to enqueue the pending save.
-        try await Task.sleep(for: .milliseconds(50))
-
         // Confirm it's not on disk yet (debounce is long)
         let diskBefore = try await store.loadConversations()
         #expect(diskBefore.isEmpty)
@@ -182,8 +257,46 @@ struct ConversationManagerTests {
 
         #expect(manager.conversations.contains(where: { $0.id == dirty.id }))
 
-        // Clean up pending saves to avoid test cross-talk.
         manager.clearAllConversations()
+        await manager.flushPendingSaves()
+    }
+
+    @Test("Dirty memory wins load, then removed model repair is persisted")
+    @MainActor
+    func dirtyMemoryWithRemovedModelMergesRepair() async throws {
+        AIService.keychain = InMemoryKeychainStorage()
+        let previousModels = AIService.shared.customModels
+        let previousSelection = AIService.shared.selectedModel
+        defer {
+            AIService.shared.customModels = previousModels
+            AIService.shared.selectedModel = previousSelection
+        }
+
+        let defaultModel = "available-model"
+        AIService.shared.customModels = [defaultModel]
+        AIService.shared.selectedModel = defaultModel
+
+        let id = UUID()
+        let disk = Conversation(id: id, title: "Disk", model: defaultModel)
+        let dirty = Conversation(id: id, title: "Dirty", model: "removed-model")
+        let store = ScriptedConversationStore(conversations: [disk])
+        let loadGate = await store.enqueue(.load, outcome: .load([disk]), blocked: true)
+        _ = await store.enqueue(.save(id, "Dirty"))
+
+        let manager = ConversationManager(store: store, saveDebounceDuration: .seconds(30))
+        await loadGate.started.wait()
+        manager.conversations = [dirty]
+        manager.save(dirty)
+        await loadGate.releaseGate.open()
+        _ = await manager.loadingTask?.value
+        await manager.flushPendingSaves()
+
+        let merged = try #require(manager.conversations.first)
+        #expect(merged.title == "Dirty")
+        #expect(merged.model == defaultModel)
+        let persisted = try #require(await store.persistedConversations().first)
+        #expect(persisted.title == "Dirty")
+        #expect(persisted.model == defaultModel)
     }
 
     // MARK: - Edit Message Tests

--- a/Tests/AynaTests/ConversationManagerTests.swift
+++ b/Tests/AynaTests/ConversationManagerTests.swift
@@ -77,6 +77,29 @@ struct ConversationManagerTests {
         #expect(manager.conversations.first?.messages.first?.content == "Completed")
     }
 
+    @Test("Appending streamed content advances the conversation revision")
+    @MainActor
+    func appendStreamedContentAdvancesConversationRevision() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let manager = makeManager(directory: directory)
+        manager.createNewConversation()
+        let conversation = try #require(manager.conversations.first)
+        let message = Message(role: .assistant, content: "")
+        manager.addMessage(to: conversation, message: message)
+        let previousUpdate = try #require(manager.conversations.first?.updatedAt)
+        try await Task.sleep(for: .milliseconds(2))
+
+        let appended = manager.appendToMessage(
+            conversationId: conversation.id,
+            messageId: message.id,
+            chunk: "stream"
+        )
+
+        #expect(appended)
+        #expect(manager.conversations.first?.messages.first?.content == "stream")
+        #expect(manager.conversations.first?.updatedAt ?? .distantPast > previousUpdate)
+    }
+
     @Test("Clear all conversations empties encrypted store")
     @MainActor
     func clearAllConversationsEmptiesEncryptedStore() async throws {

--- a/Tests/AynaTests/ConversationPersistenceCoordinatorTests.swift
+++ b/Tests/AynaTests/ConversationPersistenceCoordinatorTests.swift
@@ -344,6 +344,29 @@ struct ConversationPersistenceCoordinatorTests {
     }
 
     @Test
+    func `Flush retries a failed ID-only deletion`() async {
+        let hidden = conversation(title: "Hidden backing record")
+        let store = ScriptedConversationStore(conversations: [hidden])
+        _ = await store.enqueue(.delete(hidden.id), outcome: .fail)
+        _ = await store.enqueue(.delete(hidden.id))
+        let coordinator = makeCoordinator(store)
+
+        let deletion = coordinator.delete(id: hidden.id)
+        guard case .failed(nil, _) = await deletion.value else {
+            Issue.record("Expected an ID-only delete failure")
+            return
+        }
+
+        await coordinator.flush().value
+
+        #expect(await store.persistedConversations().isEmpty)
+        #expect(await store.operations() == [
+            .delete(hidden.id),
+            .delete(hidden.id),
+        ])
+    }
+
+    @Test
     func `Newer clear supersedes an in-flight proposed save in physical order`() async {
         let proposed = conversation(title: "Proposed")
         let store = ScriptedConversationStore()

--- a/Tests/AynaTests/ConversationPersistenceCoordinatorTests.swift
+++ b/Tests/AynaTests/ConversationPersistenceCoordinatorTests.swift
@@ -2,13 +2,15 @@
 import Foundation
 import Testing
 
+// swiftlint:disable identifier_name
 @Suite("ConversationPersistenceCoordinator Tests", .tags(.persistence, .async), .serialized)
 @MainActor
+// swiftlint:disable:next type_body_length
 struct ConversationPersistenceCoordinatorTests {
     enum InitialIntent: CaseIterable, Sendable { case save, delete, clear }
 
-    @Test("Repeated coalesced saves write only the latest value")
-    func repeatedSavesCoalesce() async {
+    @Test
+    func `Repeated coalesced saves write only the latest value`() async {
         let id = UUID(), first = conversation(id: id, title: "First"), latest = conversation(id: id, title: "Latest")
         let store = ScriptedConversationStore()
         let coordinator = makeCoordinator(store)
@@ -19,8 +21,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations() == [latest])
     }
 
-    @Test("Immediate save receipt does not activate another conversation's debounce")
-    func immediateSaveReceiptIsTargetScoped() async {
+    @Test
+    func `Immediate save receipt does not activate another conversation's debounce`() async {
         let queued = conversation(title: "Queued"), immediate = conversation(title: "Immediate")
         let store = ScriptedConversationStore()
         let gate = await store.enqueue(.save(immediate.id, nil), blocked: true)
@@ -32,14 +34,379 @@ struct ConversationPersistenceCoordinatorTests {
         }
         await gate.started.wait()
         await gate.releaseGate.open()
-        await receipt.value
+        _ = await receipt.value
         #expect(await store.operations() == [.save(immediate.id, immediate.title)])
         await coordinator.flush().value
         #expect(await store.operations() == [.save(immediate.id, immediate.title), .save(queued.id, queued.title)])
     }
 
-    @Test("Queued save followed by delete never writes the queued save")
-    func queuedSaveThenDelete() async {
+    @Test
+    func `Immediate save reports durable failure instead of a false acknowledgement`() async throws {
+        let value = conversation(title: "Must remain pending")
+        let store = ScriptedConversationStore()
+        _ = await store.enqueue(.save(value.id, value.title), outcome: .fail)
+        let coordinator = makeCoordinator(store)
+        let receipt = try #require(coordinator.apply(value, mode: .immediate))
+
+        let result = await receipt.value
+
+        guard case .failed = result else {
+            Issue.record("Expected an explicit save failure, got \(result)")
+            return
+        }
+        #expect(await store.persistedConversations().isEmpty)
+    }
+
+    @Test
+    func `Successful proposed save becomes the storage snapshot`() async {
+        let id = UUID()
+        let stored = conversation(id: id, title: "Stored")
+        let proposed = conversation(id: id, title: "Proposed")
+        let store = ScriptedConversationStore(conversations: [stored])
+        let coordinator = makeCoordinator(store)
+
+        #expect(await coordinator.load().value == .loaded([stored]))
+        #expect(await coordinator.saveProposed(proposed).value == .saved)
+        #expect(await store.persistedConversations() == [proposed])
+        #expect(await coordinator.load().value == .loaded([proposed]))
+        #expect(await store.operations() == [
+            .load,
+            .save(proposed.id, proposed.title),
+            .load,
+        ])
+    }
+
+    @Test
+    func `Failed proposed save automatically resumes displaced coalesced local save`() async {
+        let id = UUID()
+        let local = conversation(id: id, title: "Local edit")
+        let proposed = conversation(id: id, title: "Proposed edit")
+        let store = ScriptedConversationStore()
+        _ = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            outcome: .fail
+        )
+        _ = await store.enqueue(.save(local.id, local.title))
+        let coordinator = makeCoordinator(store)
+
+        coordinator.apply(local)
+        let proposedResult = await coordinator.saveProposed(proposed).value
+
+        guard case .failed = proposedResult else {
+            Issue.record("Expected proposed save failure")
+            return
+        }
+        #expect(await waitUntil {
+            await store.persistedConversations() == [local]
+        })
+        #expect(await store.operations() == [
+            .save(proposed.id, proposed.title),
+            .save(local.id, local.title),
+        ])
+    }
+
+    @Test
+    func `Flush during failed proposed save drains displaced local save exactly once`() async {
+        let id = UUID()
+        let local = conversation(id: id, title: "Local edit")
+        let proposed = conversation(id: id, title: "Proposed edit")
+        let store = ScriptedConversationStore()
+        let proposedGate = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            outcome: .fail,
+            blocked: true
+        )
+        _ = await store.enqueue(.save(local.id, local.title))
+        let coordinator = makeCoordinator(store)
+
+        coordinator.apply(local)
+        let proposedReceipt = coordinator.saveProposed(proposed)
+        await proposedGate.started.wait()
+        let flushReceipt = coordinator.flush()
+
+        await proposedGate.releaseGate.open()
+
+        guard case .failed = await proposedReceipt.value else {
+            Issue.record("Expected proposed save failure")
+            return
+        }
+        await flushReceipt.value
+        #expect(await store.operations() == [
+            .save(proposed.id, proposed.title),
+            .save(local.id, local.title),
+        ])
+        #expect(await store.persistedConversations() == [local])
+    }
+
+    @Test
+    func `Newer apply prevents failed proposed save from resuming displaced local save`() async throws {
+        let id = UUID()
+        let local = conversation(id: id, title: "Local edit")
+        let proposed = conversation(id: id, title: "Proposed edit")
+        let newer = conversation(id: id, title: "Newer edit")
+        let store = ScriptedConversationStore()
+        let proposedGate = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            outcome: .fail,
+            blocked: true
+        )
+        _ = await store.enqueue(.save(newer.id, newer.title))
+        let coordinator = makeCoordinator(store)
+
+        coordinator.apply(local)
+        let proposedReceipt = coordinator.saveProposed(proposed)
+        await proposedGate.started.wait()
+        let newerReceipt = try #require(coordinator.apply(newer, mode: .immediate))
+
+        await proposedGate.releaseGate.open()
+
+        #expect(await proposedReceipt.value == .superseded)
+        #expect(await newerReceipt.value == .saved)
+        #expect(await store.operations() == [
+            .save(proposed.id, proposed.title),
+            .save(newer.id, newer.title),
+        ])
+        #expect(await store.persistedConversations() == [newer])
+    }
+
+    @Test
+    func `Newer clear prevents failed proposed save from resuming displaced local save`() async {
+        let id = UUID()
+        let local = conversation(id: id, title: "Local edit")
+        let proposed = conversation(id: id, title: "Proposed edit")
+        let store = ScriptedConversationStore()
+        let proposedGate = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            outcome: .fail,
+            blocked: true
+        )
+        _ = await store.enqueue(.clear)
+        let coordinator = makeCoordinator(store)
+
+        coordinator.apply(local)
+        let proposedReceipt = coordinator.saveProposed(proposed)
+        await proposedGate.started.wait()
+        let clearReceipt = coordinator.clear([local])
+
+        await proposedGate.releaseGate.open()
+
+        #expect(await proposedReceipt.value == .superseded)
+        #expect(await clearReceipt.value == .cleared)
+        #expect(await store.operations() == [
+            .save(proposed.id, proposed.title),
+            .clear,
+        ])
+        #expect(await store.persistedConversations().isEmpty)
+    }
+
+    @Test
+    func `Newer apply supersedes an in-flight proposed save in physical order`() async throws {
+        let id = UUID()
+        let proposed = conversation(id: id, title: "Proposed")
+        let newer = conversation(id: id, title: "Newer apply")
+        let store = ScriptedConversationStore()
+        let proposedGate = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            blocked: true
+        )
+        let coordinator = makeCoordinator(store)
+
+        let proposedReceipt = coordinator.saveProposed(proposed)
+        await proposedGate.started.wait()
+        let newerReceipt = try #require(coordinator.apply(newer, mode: .immediate))
+
+        await proposedGate.releaseGate.open()
+
+        #expect(await proposedReceipt.value == .superseded)
+        #expect(await newerReceipt.value == .saved)
+        #expect(await store.operations() == [
+            .save(proposed.id, proposed.title),
+            .save(newer.id, newer.title),
+        ])
+        #expect(await store.persistedConversations() == [newer])
+        #expect(await coordinator.load().value == .loaded([newer]))
+    }
+
+    @Test
+    func `Settled proposed save receipt is superseded by newer apply before consumption`() async throws {
+        let id = UUID()
+        let proposed = conversation(id: id, title: "Proposed")
+        let newer = conversation(id: id, title: "Newer apply")
+        let store = ScriptedConversationStore()
+        let coordinator = makeCoordinator(store)
+
+        let proposedReceipt = coordinator.saveProposed(proposed)
+        await coordinator.flush().value
+        let newerReceipt = try #require(coordinator.apply(newer, mode: .immediate))
+
+        #expect(await newerReceipt.value == .saved)
+        #expect(await proposedReceipt.value == .superseded)
+        #expect(await store.operations() == [
+            .save(proposed.id, proposed.title),
+            .save(newer.id, newer.title),
+        ])
+        #expect(await store.persistedConversations() == [newer])
+    }
+
+    @Test
+    func `Newer delete supersedes an in-flight proposed save in physical order`() async {
+        let id = UUID()
+        let stored = conversation(id: id, title: "Stored")
+        let proposed = conversation(id: id, title: "Proposed")
+        let store = ScriptedConversationStore(conversations: [stored])
+        let proposedGate = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            blocked: true
+        )
+        let coordinator = makeCoordinator(store)
+
+        #expect(await coordinator.load().value == .loaded([stored]))
+        let proposedReceipt = coordinator.saveProposed(proposed)
+        await proposedGate.started.wait()
+        let deleteReceipt = coordinator.delete(stored)
+
+        await proposedGate.releaseGate.open()
+
+        #expect(await proposedReceipt.value == .superseded)
+        #expect(await deleteReceipt.value == .deleted)
+        #expect(await store.operations() == [
+            .load,
+            .save(proposed.id, proposed.title),
+            .delete(stored.id),
+        ])
+        #expect(await store.persistedConversations().isEmpty)
+        #expect(await coordinator.load().value == .loaded([]))
+    }
+
+    @Test
+    func `Failed proposal after superseding delete repairs the prior conversation`() async {
+        let id = UUID()
+        let stored = conversation(id: id, title: "Stored")
+        let proposed = conversation(id: id, title: "Proposed")
+        let store = ScriptedConversationStore(conversations: [stored])
+        let deleteGate = await store.enqueue(.delete(stored.id), blocked: true)
+        _ = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            outcome: .fail
+        )
+        _ = await store.enqueue(.save(stored.id, stored.title))
+        let coordinator = makeCoordinator(store)
+
+        #expect(await coordinator.load().value == .loaded([stored]))
+        let deleteReceipt = coordinator.delete(stored)
+        await deleteGate.started.wait()
+        let proposedReceipt = coordinator.saveProposed(proposed)
+
+        await deleteGate.releaseGate.open()
+
+        #expect(await deleteReceipt.value == .superseded)
+        guard case .failed = await proposedReceipt.value else {
+            Issue.record("Expected proposed save failure")
+            return
+        }
+
+        await coordinator.flush().value
+
+        #expect(await coordinator.load().value == .loaded([stored]))
+        #expect(await store.persistedConversations() == [stored])
+        #expect(await store.operations() == [
+            .load,
+            .delete(stored.id),
+            .save(proposed.id, proposed.title),
+            .save(stored.id, stored.title),
+            .load,
+        ])
+    }
+
+    @Test
+    func `ID-only delete retries the physical deletion without fabricating rollback state`() async {
+        let hidden = conversation(title: "Hidden backing record")
+        let store = ScriptedConversationStore(conversations: [hidden])
+        _ = await store.enqueue(.load, outcome: .load([]))
+        _ = await store.enqueue(.delete(hidden.id), outcome: .fail)
+        _ = await store.enqueue(.delete(hidden.id))
+        let coordinator = makeCoordinator(store)
+
+        #expect(await coordinator.load().value == .loaded([]))
+        let deletion = coordinator.delete(id: hidden.id)
+        guard case .failed(nil, _) = await deletion.value else {
+            Issue.record("Expected an ID-only delete failure")
+            return
+        }
+
+        #expect(await coordinator.settleCurrentState(for: hidden.id) == .deleted)
+        #expect(await store.persistedConversations().isEmpty)
+        #expect(await store.operations() == [
+            .load,
+            .delete(hidden.id),
+            .delete(hidden.id),
+        ])
+    }
+
+    @Test
+    func `Newer clear supersedes an in-flight proposed save in physical order`() async {
+        let proposed = conversation(title: "Proposed")
+        let store = ScriptedConversationStore()
+        let proposedGate = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            blocked: true
+        )
+        let coordinator = makeCoordinator(store)
+
+        let proposedReceipt = coordinator.saveProposed(proposed)
+        await proposedGate.started.wait()
+        let clearReceipt = coordinator.clear([])
+
+        await proposedGate.releaseGate.open()
+
+        #expect(await proposedReceipt.value == .superseded)
+        #expect(await clearReceipt.value == .cleared)
+        #expect(await store.operations() == [
+            .save(proposed.id, proposed.title),
+            .clear,
+        ])
+        #expect(await store.persistedConversations().isEmpty)
+        #expect(await coordinator.load().value == .loaded([]))
+    }
+
+    @Test
+    func `Failed newer clear does not resurrect a superseded proposed save`() async {
+        let proposed = conversation(title: "Proposed")
+        let store = ScriptedConversationStore()
+        let proposedGate = await store.enqueue(
+            .save(proposed.id, proposed.title),
+            blocked: true
+        )
+        _ = await store.enqueue(.clear, outcome: .fail)
+        _ = await store.enqueue(.clear)
+        let coordinator = makeCoordinator(store)
+
+        let proposedReceipt = coordinator.saveProposed(proposed)
+        await proposedGate.started.wait()
+        let clearReceipt = coordinator.clear([])
+
+        await proposedGate.releaseGate.open()
+
+        #expect(await proposedReceipt.value == .superseded)
+        guard case let .failed(restored, _) = await clearReceipt.value else {
+            Issue.record("Expected clear failure")
+            return
+        }
+        #expect(restored.isEmpty)
+
+        await coordinator.flush().value
+
+        #expect(await store.operations() == [
+            .save(proposed.id, proposed.title),
+            .clear,
+            .clear,
+        ])
+        #expect(await store.persistedConversations().isEmpty)
+        #expect(await coordinator.load().value == .loaded([]))
+    }
+
+    @Test
+    func `Queued save followed by delete never writes the queued save`() async {
         let value = conversation(title: "Queued")
         let store = ScriptedConversationStore(conversations: [value])
         let coordinator = makeCoordinator(store)
@@ -50,8 +417,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations().isEmpty)
     }
 
-    @Test("In-flight save is physically followed by delete")
-    func inFlightSaveThenDelete() async {
+    @Test
+    func `In-flight save is physically followed by delete`() async {
         let value = conversation(title: "Saving")
         let store = ScriptedConversationStore()
         let gate = await store.enqueue(.save(value.id, nil), blocked: true)
@@ -66,23 +433,84 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations().isEmpty)
     }
 
-    @Test("Stale save completion cannot settle an immediate newer save")
-    func staleSaveThenImmediateNewerSave() async {
+    @Test
+    func `Stale save completion cannot settle an immediate newer save`() async {
         let id = UUID(), old = conversation(id: id, title: "Older"), new = conversation(id: id, title: "Newer")
         let store = ScriptedConversationStore()
         let gate = await store.enqueue(.save(id, "Older"), blocked: true)
         let coordinator = makeCoordinator(store)
-        coordinator.apply(old, mode: .immediate)
+        let oldReceipt = coordinator.apply(old, mode: .immediate)
         await gate.started.wait()
-        coordinator.apply(new, mode: .immediate)
+        let newReceipt = coordinator.apply(new, mode: .immediate)
         await gate.releaseGate.open()
+        #expect(await oldReceipt?.value == .superseded)
+        #expect(await newReceipt?.value == .saved)
+        #expect(await coordinator.settleCurrentState(for: id) == .saved)
         await coordinator.flush().value
         #expect(await store.operations() == [.save(old.id, old.title), .save(new.id, new.title)])
         #expect(await store.persistedConversations() == [new])
     }
 
-    @Test("Clear follows an in-flight save and prevents resurrection")
-    func clearWithInFlightSave() async {
+    @Test
+    func `Blocked Watch save superseded by failed clear waits for blocked repair`() async throws {
+        let value = conversation(title: "Watch mutation")
+        let store = ScriptedConversationStore()
+        let saveGate = await store.enqueue(.save(value.id, value.title), blocked: true)
+        _ = await store.enqueue(.clear, outcome: .partialClear([value.id]))
+        let repairGate = await store.enqueue(.clear, blocked: true)
+        let coordinator = makeCoordinator(store)
+        let saveReceipt = try #require(coordinator.apply(value, mode: .immediate))
+
+        await saveGate.started.wait()
+        let clearReceipt = coordinator.clear([])
+        let settlementStarted = TestLatch()
+        let settlementFinished = TestLatch()
+        let settlement = Task { @MainActor in
+            await settlementStarted.open()
+            let result = await coordinator.settleCurrentState(for: value.id)
+            await settlementFinished.open()
+            return result
+        }
+        await settlementStarted.wait()
+
+        await saveGate.releaseGate.open()
+        await repairGate.started.wait()
+        #expect(await saveReceipt.value == .superseded)
+        guard case .failed = await clearReceipt.value else {
+            Issue.record("Expected clear failure")
+            await repairGate.releaseGate.open()
+            _ = await settlement.value
+            return
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        #expect(await settlementFinished.opened() == false)
+
+        await repairGate.releaseGate.open()
+        #expect(await settlement.value == .saved)
+        await coordinator.flush().value
+        #expect(await store.persistedConversations() == [value])
+    }
+
+    @Test
+    func `Durability settlement reports repeated save failure`() async throws {
+        let value = conversation(title: "Still failing")
+        let store = ScriptedConversationStore()
+        _ = await store.enqueue(.save(value.id, value.title), outcome: .fail)
+        _ = await store.enqueue(.save(value.id, value.title), outcome: .fail)
+        let coordinator = makeCoordinator(store)
+        let receipt = try #require(coordinator.apply(value, mode: .immediate))
+
+        guard case .failed = await receipt.value else {
+            Issue.record("Expected initial save failure")
+            return
+        }
+        #expect(await coordinator.settleCurrentState(for: value.id) == .failed)
+    }
+
+    @Test
+    func `Clear follows an in-flight save and prevents resurrection`() async {
         let value = conversation(title: "In flight")
         let store = ScriptedConversationStore()
         let gate = await store.enqueue(.save(value.id, nil), blocked: true)
@@ -96,8 +524,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations().isEmpty)
     }
 
-    @Test("Save, delete, and clear registered during initial load reconcile internally", arguments: InitialIntent.allCases)
-    func intentWhileInitialLoadBlocked(_ intent: InitialIntent) async {
+    @Test(arguments: InitialIntent.allCases)
+    func `Save, delete, and clear registered during initial load reconcile internally`(_ intent: InitialIntent) async {
         let disk = conversation(title: "Disk"), created = conversation(title: "Created")
         let store = ScriptedConversationStore(conversations: [disk])
         let gate = await store.enqueue(.load, outcome: .load([disk]), blocked: true)
@@ -125,8 +553,8 @@ struct ConversationPersistenceCoordinatorTests {
         }
     }
 
-    @Test("Older reload result is suppressed after a newer reload is registered")
-    func olderReloadCannotOverwriteNewerReload() async {
+    @Test
+    func `Older reload result is suppressed after a newer reload is registered`() async {
         let old = conversation(title: "Older"), new = conversation(title: "Newer")
         let store = ScriptedConversationStore()
         let oldGate = await store.enqueue(.load, outcome: .load([old]), blocked: true)
@@ -142,8 +570,41 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await newLoad.value == .loaded([new]))
     }
 
-    @Test("Flush waits for an in-flight immediate save")
-    func flushWaitsForInFlightImmediateSave() async {
+    @Test
+    func `Superseded reload cannot replace durable snapshot when the newer reload fails`() async {
+        let baseline = conversation(title: "Baseline")
+        let superseded = conversation(title: "Superseded")
+        let store = ScriptedConversationStore()
+        _ = await store.enqueue(.load, outcome: .load([baseline]))
+        let olderGate = await store.enqueue(
+            .load,
+            outcome: .load([superseded]),
+            blocked: true
+        )
+        let newerGate = await store.enqueue(.load, outcome: .fail, blocked: true)
+        let coordinator = ConversationPersistenceCoordinator(store: store)
+
+        #expect(await coordinator.load().value == .loaded([baseline]))
+        #expect(coordinator.durableConversations() == [baseline])
+
+        let olderLoad = coordinator.load()
+        await olderGate.started.wait()
+        let newerLoad = coordinator.load()
+        await olderGate.releaseGate.open()
+
+        #expect(await olderLoad.value == .superseded)
+        await newerGate.started.wait()
+        await newerGate.releaseGate.open()
+        guard case .failed = await newerLoad.value else {
+            Issue.record("Expected newer reload failure")
+            return
+        }
+
+        #expect(coordinator.durableConversations() == [baseline])
+    }
+
+    @Test
+    func `Flush waits for an in-flight immediate save`() async {
         let value = conversation(title: "Immediate")
         let store = ScriptedConversationStore()
         let gate = await store.enqueue(.save(value.id, nil), blocked: true)
@@ -159,8 +620,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations() == [value])
     }
 
-    @Test("Failed partial clear preserves post-clear creation and delete, then reconverges storage")
-    func failedClearPreservesPostClearChangesAndConverges() async {
+    @Test
+    func `Failed partial clear preserves post-clear creation and delete, then reconverges storage`() async {
         let before = conversation(title: "Before"), deleted = conversation(title: "Deleted after clear")
         let created = conversation(title: "Created after clear")
         let store = ScriptedConversationStore(conversations: [before, deleted])
@@ -181,8 +642,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await Set(store.persistedConversations().map(\.id)) == Set([before.id, created.id]))
     }
 
-    @Test("Failed delete restores, re-persists, and is drained by an earlier flush")
-    func failedDeleteRestoresAndRepersistsUndeliveredEdit() async {
+    @Test
+    func `Failed delete restores, re-persists, and is drained by an earlier flush`() async {
         let id = UUID(), stored = conversation(id: id, title: "Stored"), edited = conversation(id: id, title: "Edited")
         let store = ScriptedConversationStore(conversations: [stored])
         let deleteGate = await store.enqueue(.delete(id), outcome: .fail, blocked: true)
@@ -207,8 +668,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations() == [edited])
     }
 
-    @Test("Failed save remains dirty across reload and is retried by flush")
-    func failedSaveStaysDirtyAcrossReload() async {
+    @Test
+    func `Failed save remains dirty across reload and is retried by flush`() async {
         let id = UUID(), stored = conversation(id: id, title: "Stored"), edited = conversation(id: id, title: "Edited")
         let store = ScriptedConversationStore(conversations: [stored])
         _ = await store.enqueue(.save(id, nil), outcome: .fail)
@@ -221,8 +682,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations() == [edited])
     }
 
-    @Test("Cancelling a receipt waiter does not cancel accepted persistence")
-    func waiterCancellationDoesNotCancelPersistence() async {
+    @Test
+    func `Cancelling a receipt waiter does not cancel accepted persistence`() async {
         let value = conversation(title: "Delete me")
         let store = ScriptedConversationStore(conversations: [value])
         let gate = await store.enqueue(.delete(value.id), blocked: true)
@@ -236,8 +697,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations().isEmpty)
     }
 
-    @Test("Flush drains clear repair and retains a suppressed preceding load for rollback")
-    func flushDrainsClearRepairAndRetainsLoad() async {
+    @Test
+    func `Flush drains clear repair and retains a suppressed preceding load for rollback`() async {
         let disk = conversation(title: "Disk")
         let store = ScriptedConversationStore(conversations: [disk])
         let loadGate = await store.enqueue(.load, outcome: .load([disk]), blocked: true)
@@ -264,8 +725,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations() == [disk])
     }
 
-    @Test("Rewrite completion does not supersede its queued explicit delete")
-    func rewriteDoesNotSupersedeQueuedDelete() async {
+    @Test
+    func `Rewrite completion does not supersede its queued explicit delete`() async {
         let value = conversation(title: "Delete")
         let store = ScriptedConversationStore(conversations: [value])
         _ = await store.enqueue(.clear, outcome: .fail)
@@ -281,8 +742,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations().isEmpty)
     }
 
-    @Test("Overlapping failed clears retain the original rollback baseline")
-    func overlappingFailedClearsRetainOriginalBaseline() async {
+    @Test
+    func `Overlapping failed clears retain the original rollback baseline`() async {
         let original = conversation(title: "Original")
         let store = ScriptedConversationStore()
         let firstGate = await store.enqueue(.clear, outcome: .fail, blocked: true)
@@ -304,8 +765,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(collectionCount(named: "clearLayers", in: Mirror(reflecting: coordinator)) == 0)
     }
 
-    @Test("Second failed clear retains snapshot restored before first receipt consumption")
-    func secondFailedClearRetainsRestoredUnsavedEdit() async {
+    @Test
+    func `Second failed clear retains snapshot restored before first receipt consumption`() async {
         let id = UUID()
         let stored = conversation(id: id, title: "Stored")
         let edited = conversation(id: id, title: "Edited")
@@ -332,8 +793,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await store.persistedConversations() == [edited])
     }
 
-    @Test("Failed clear tombstone survives failed rewrite and later failed clear")
-    func failedClearTombstoneSurvivesUntilRewriteSuccess() async {
+    @Test
+    func `Failed clear tombstone survives failed rewrite and later failed clear`() async {
         let kept = conversation(title: "Kept")
         let deleted = conversation(title: "Deleted")
         let store = ScriptedConversationStore(conversations: [kept, deleted])
@@ -371,8 +832,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(collectionCount(named: "repairDeletedIDs", in: Mirror(reflecting: coordinator)) == 0)
     }
 
-    @Test("Settled load receipt reconciles an edit accepted before consumption")
-    func settledLoadReceiptReconcilesNewerEdit() async {
+    @Test
+    func `Settled load receipt reconciles an edit accepted before consumption`() async {
         let id = UUID()
         let disk = conversation(id: id, title: "Disk")
         let edited = conversation(id: id, title: "Edited")
@@ -386,8 +847,8 @@ struct ConversationPersistenceCoordinatorTests {
         await coordinator.flush().value
     }
 
-    @Test("Failed clear receipt excludes a deletion accepted before consumption")
-    func failedClearReceiptReconcilesLaterDelete() async {
+    @Test
+    func `Failed clear receipt excludes a deletion accepted before consumption`() async {
         let value = conversation(title: "Delete after clear")
         let store = ScriptedConversationStore(conversations: [value])
         _ = await store.enqueue(.clear, outcome: .fail)
@@ -404,8 +865,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(restored.isEmpty)
     }
 
-    @Test("Failed delete receipt is superseded by a newer clear before consumption")
-    func failedDeleteReceiptDoesNotUndoNewerClear() async {
+    @Test
+    func `Failed delete receipt is superseded by a newer clear before consumption`() async {
         let value = conversation(title: "Delete before clear")
         let store = ScriptedConversationStore(conversations: [value])
         _ = await store.enqueue(.delete(value.id), outcome: .fail)
@@ -417,8 +878,8 @@ struct ConversationPersistenceCoordinatorTests {
         #expect(await deletion.value == .superseded)
     }
 
-    @Test("Settled unique IDs leave no per-conversation auxiliary history")
-    func settledUniqueIDsLeaveBoundedAuxiliaryState() async {
+    @Test
+    func `Settled unique IDs leave no per-conversation auxiliary history`() async {
         let coordinator = ConversationPersistenceCoordinator(store: ScriptedConversationStore())
         for index in 0 ..< 2000 {
             let value = conversation(title: "Conversation \(index)")
@@ -455,7 +916,428 @@ struct ConversationPersistenceCoordinatorTests {
         return value
     }
 
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        condition: @escaping @MainActor () async -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if await condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return await condition()
+    }
+
     private func collectionCount(named label: String, in mirror: Mirror) -> Int? {
         mirror.children.first { $0.label == label }.map { Mirror(reflecting: $0.value).children.count }
     }
 }
+
+extension ConversationPersistenceCoordinatorTests {
+    @Test
+    func `Flush cutoff does not wait for a newer save accepted afterward`() async throws {
+        let id = UUID()
+        let first = conversation(id: id, title: "Before flush")
+        let newer = conversation(id: id, title: "After flush")
+        let store = ScriptedConversationStore()
+        let firstSave = await store.enqueue(.save(id, first.title), blocked: true)
+        let newerSave = await store.enqueue(.save(id, newer.title), blocked: true)
+        let coordinator = makeCoordinator(store)
+        coordinator.apply(first)
+
+        let flushStarted = TestLatch()
+        let flushFinished = TestLatch()
+        let flushWaiter = signal(
+            coordinator.flush(),
+            started: flushStarted,
+            finished: flushFinished
+        )
+        await flushStarted.wait()
+        await firstSave.started.wait()
+        let newerReceipt = try #require(coordinator.apply(newer, mode: .immediate))
+
+        await firstSave.releaseGate.open()
+        await newerSave.started.wait()
+        let finishedBeforeNewerSave = await waitUntil(timeout: .milliseconds(50)) {
+            await flushFinished.opened()
+        }
+        #expect(finishedBeforeNewerSave)
+
+        await newerSave.releaseGate.open()
+        await flushWaiter.value
+        #expect(await newerReceipt.value == .saved)
+        #expect(await store.persistedConversations() == [newer])
+    }
+
+    @Test
+    func `Current snapshot settlement waits for failed partial clear repair`() async {
+        let value = conversation(title: "Restore after partial clear")
+        let store = ScriptedConversationStore(conversations: [value])
+        let clearGate = await store.enqueue(
+            .clear,
+            outcome: .partialClear([value.id]),
+            blocked: true
+        )
+        let repairGate = await store.enqueue(.clear, blocked: true)
+        let coordinator = makeCoordinator(store)
+        let clearing = coordinator.clear([value])
+
+        await clearGate.started.wait()
+        await clearGate.releaseGate.open()
+        guard case .failed = await clearing.value else {
+            Issue.record("Expected clear failure")
+            return
+        }
+        await repairGate.started.wait()
+
+        let finished = TestLatch()
+        let settlement = Task { @MainActor in
+            let result = await coordinator.settleCurrentSnapshot(for: clearing.repairToken)
+            await finished.open()
+            return result
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(await finished.opened() == false)
+        await repairGate.releaseGate.open()
+        #expect(await settlement.value == .settled)
+        #expect(await store.persistedConversations() == [value])
+    }
+
+    @Test
+    func `Current snapshot settlement waits for failed delete repair`() async {
+        let value = conversation(title: "Restore after delete failure")
+        let store = ScriptedConversationStore(conversations: [value])
+        let deleteGate = await store.enqueue(
+            .delete(value.id),
+            outcome: .fail,
+            blocked: true
+        )
+        let repairGate = await store.enqueue(
+            .save(value.id, value.title),
+            blocked: true
+        )
+        let coordinator = makeCoordinator(store)
+        let deletion = coordinator.delete(value)
+
+        await deleteGate.started.wait()
+        await deleteGate.releaseGate.open()
+        guard case .failed = await deletion.value else {
+            Issue.record("Expected delete failure")
+            return
+        }
+        await repairGate.started.wait()
+
+        let finished = TestLatch()
+        let settlement = Task { @MainActor in
+            let result = await coordinator.settleCurrentSnapshot(for: deletion.repairToken)
+            await finished.open()
+            return result
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(await finished.opened() == false)
+        await repairGate.releaseGate.open()
+        #expect(await settlement.value == .settled)
+        #expect(await store.persistedConversations() == [value])
+    }
+
+    @Test
+    func `Delete repair settlement follows newer save through failure and retry`() async throws {
+        let id = UUID()
+        let restored = conversation(id: id, title: "Rollback before edit")
+        let edited = conversation(id: id, title: "Edited after rollback")
+        let store = ScriptedConversationStore(conversations: [restored])
+        _ = await store.enqueue(.delete(id), outcome: .fail)
+        let failedRollbackSave = await store.enqueue(
+            .save(id, restored.title),
+            outcome: .fail,
+            blocked: true
+        )
+        let failedEditedSave = await store.enqueue(
+            .save(id, edited.title),
+            outcome: .fail,
+            blocked: true
+        )
+        let successfulRetry = await store.enqueue(
+            .save(id, edited.title),
+            blocked: true
+        )
+        let coordinator = makeCoordinator(store)
+        let deletion = coordinator.delete(restored)
+
+        guard case .failed = await deletion.value else {
+            Issue.record("Expected delete failure")
+            return
+        }
+        await failedRollbackSave.started.wait()
+        let editedSave = try #require(coordinator.apply(edited, mode: .immediate))
+
+        let firstSettlementFinished = TestLatch()
+        let firstSettlement = Task { @MainActor in
+            let result = await coordinator.settleCurrentSnapshot(for: deletion.repairToken)
+            await firstSettlementFinished.open()
+            return result
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        #expect(await firstSettlementFinished.opened() == false)
+
+        await failedRollbackSave.releaseGate.open()
+        await failedEditedSave.started.wait()
+        #expect(await firstSettlementFinished.opened() == false)
+        await failedEditedSave.releaseGate.open()
+        guard case .failed = await editedSave.value else {
+            Issue.record("Expected edited save failure")
+            return
+        }
+        #expect(await firstSettlement.value == .failed)
+
+        let retrySettlement = Task { @MainActor in
+            await coordinator.settleCurrentSnapshot(
+                for: deletion.repairToken,
+                retryIfNeeded: true
+            )
+        }
+        await successfulRetry.started.wait()
+        await successfulRetry.releaseGate.open()
+
+        #expect(await retrySettlement.value == .settled)
+        #expect(await store.persistedConversations() == [edited])
+        #expect(await store.operations() == [
+            .delete(id),
+            .save(id, restored.title),
+            .save(id, edited.title),
+            .save(id, edited.title),
+        ])
+    }
+
+    @Test
+    func `Current snapshot repair retries one failed attempt at a time`() async {
+        let value = conversation(title: "Retry rollback")
+        let store = ScriptedConversationStore(conversations: [value])
+        _ = await store.enqueue(.delete(value.id), outcome: .fail)
+        _ = await store.enqueue(.save(value.id, value.title), outcome: .fail)
+        _ = await store.enqueue(.save(value.id, value.title), outcome: .fail)
+        _ = await store.enqueue(.save(value.id, value.title))
+        let coordinator = makeCoordinator(store)
+        let deletion = coordinator.delete(value)
+
+        guard case .failed = await deletion.value else {
+            Issue.record("Expected delete failure")
+            return
+        }
+        #expect(await coordinator.settleCurrentSnapshot(for: deletion.repairToken) == .failed)
+        #expect(await coordinator.settleCurrentSnapshot(
+            for: deletion.repairToken,
+            retryIfNeeded: true
+        ) == .failed)
+        #expect(await coordinator.settleCurrentSnapshot(
+            for: deletion.repairToken,
+            retryIfNeeded: true
+        ) == .settled)
+        #expect(await store.persistedConversations() == [value])
+    }
+
+    @Test
+    func `Newer delete supersedes older snapshot repair settlement`() async {
+        let value = conversation(title: "Delete supersession")
+        let edited = conversation(id: value.id, title: "Edited before newer delete")
+        let store = ScriptedConversationStore(conversations: [value])
+        _ = await store.enqueue(.delete(value.id), outcome: .fail)
+        let oldRepair = await store.enqueue(
+            .save(value.id, value.title),
+            blocked: true
+        )
+        let newerDelete = await store.enqueue(.delete(value.id), blocked: true)
+        let coordinator = makeCoordinator(store)
+        let older = coordinator.delete(value)
+
+        guard case .failed = await older.value else {
+            Issue.record("Expected older delete failure")
+            return
+        }
+        await oldRepair.started.wait()
+        let editedSave = coordinator.apply(edited, mode: .immediate)
+        let newer = coordinator.delete(edited)
+
+        #expect(await coordinator.settleCurrentSnapshot(for: older.repairToken) == .superseded)
+        await oldRepair.releaseGate.open()
+        await newerDelete.started.wait()
+        await newerDelete.releaseGate.open()
+        #expect(await editedSave?.value == .superseded)
+        #expect(await newer.value == .deleted)
+        #expect(await store.persistedConversations().isEmpty)
+    }
+
+    @Test
+    func `Newer clear supersedes older snapshot repair settlement`() async {
+        let value = conversation(title: "Clear supersession")
+        let edited = conversation(id: value.id, title: "Edited before newer clear")
+        let store = ScriptedConversationStore(conversations: [value])
+        _ = await store.enqueue(.clear, outcome: .partialClear([value.id]))
+        let oldRepair = await store.enqueue(.clear, blocked: true)
+        let newerClear = await store.enqueue(.clear, blocked: true)
+        let coordinator = makeCoordinator(store)
+        let older = coordinator.clear([value])
+
+        guard case .failed = await older.value else {
+            Issue.record("Expected older clear failure")
+            return
+        }
+        await oldRepair.started.wait()
+        let editedSave = coordinator.apply(edited, mode: .immediate)
+        let newer = coordinator.clear([edited])
+
+        #expect(await coordinator.settleCurrentSnapshot(for: older.repairToken) == .superseded)
+        await oldRepair.releaseGate.open()
+        await newerClear.started.wait()
+        await newerClear.releaseGate.open()
+        #expect(await editedSave?.value == .superseded)
+        #expect(await newer.value == .cleared)
+        #expect(await store.persistedConversations().isEmpty)
+    }
+}
+
+extension ConversationPersistenceCoordinatorTests {
+    @Test
+    func `Failed newer proposed save restores durable state from before superseded proposal`() async {
+        let id = UUID()
+        let stored = conversation(id: id, title: "Stored before proposals")
+        let first = conversation(id: id, title: "Superseded proposal")
+        let second = conversation(id: id, title: "Rejected proposal")
+        let store = ScriptedConversationStore(conversations: [stored])
+        let firstGate = await store.enqueue(.save(id, first.title), blocked: true)
+        let secondGate = await store.enqueue(.save(id, second.title), outcome: .fail, blocked: true)
+        let rollbackGate = await store.enqueue(.save(id, stored.title), blocked: true)
+        let coordinator = makeCoordinator(store)
+
+        #expect(await coordinator.load().value == .loaded([stored]))
+        #expect(coordinator.durableConversations() == [stored])
+
+        let firstReceipt = coordinator.saveProposed(first)
+        await firstGate.started.wait()
+        await firstGate.releaseGate.open()
+        await coordinator.flush().value
+
+        #expect(await store.persistedConversations() == [first])
+        #expect(coordinator.durableConversations() == [first])
+
+        let secondReceipt = coordinator.saveProposed(second)
+        await secondGate.started.wait()
+        #expect(await firstReceipt.value == .superseded)
+
+        let secondFinished = TestLatch()
+        let secondWaiter = Task { @MainActor in
+            let result = await secondReceipt.value
+            await secondFinished.open()
+            return result
+        }
+        await secondGate.releaseGate.open()
+
+        let rollbackStarted = await waitUntil(timeout: .milliseconds(100)) {
+            await rollbackGate.started.opened()
+        }
+        #expect(rollbackStarted)
+        guard rollbackStarted else {
+            _ = await secondWaiter.value
+            return
+        }
+        #expect(await secondFinished.opened() == false)
+        #expect(await store.persistedConversations() == [first])
+        #expect(coordinator.durableConversations() == [first])
+
+        await rollbackGate.releaseGate.open()
+        guard case .failed = await secondWaiter.value else {
+            Issue.record("Expected newer proposed save failure")
+            return
+        }
+
+        #expect(await store.persistedConversations() == [stored])
+        #expect(coordinator.durableConversations() == [stored])
+        #expect(await coordinator.load().value == .loaded([stored]))
+        #expect(await store.operations() == [
+            .load,
+            .save(id, first.title),
+            .save(id, second.title),
+            .save(id, stored.title),
+            .load,
+        ])
+    }
+
+    @Test
+    func `Failed newer normal save still publishes the superseded write that became durable`() async {
+        let id = UUID()
+        let stored = conversation(id: id, title: "Stored")
+        let first = conversation(id: id, title: "First durable")
+        let second = conversation(id: id, title: "Second rejected")
+        let store = ScriptedConversationStore(conversations: [stored])
+        let firstGate = await store.enqueue(.save(first.id, first.title), blocked: true)
+        _ = await store.enqueue(.save(second.id, second.title), outcome: .fail)
+        let coordinator = makeCoordinator(store)
+        var observedDurableSnapshots: [[Conversation]] = []
+        coordinator.observeDurableSnapshotChanges {
+            observedDurableSnapshots.append(coordinator.durableConversations())
+        }
+
+        #expect(await coordinator.load().value == .loaded([stored]))
+        let initialObservationCount = observedDurableSnapshots.count
+        let firstReceipt = coordinator.apply(first, mode: .immediate)
+        await firstGate.started.wait()
+        let secondReceipt = coordinator.apply(second, mode: .immediate)
+        await firstGate.releaseGate.open()
+
+        #expect(await firstReceipt?.value == .superseded)
+        guard case .failed = await secondReceipt?.value else {
+            Issue.record("Expected newer save failure")
+            return
+        }
+
+        #expect(coordinator.durableConversations() == [first])
+        #expect(observedDurableSnapshots.count == initialObservationCount + 1)
+        #expect(observedDurableSnapshots.last == [first])
+    }
+
+    @Test
+    func `Failed proposed save publishes a displaced local write that already became durable`() async {
+        let id = UUID()
+        let stored = conversation(id: id, title: "Stored")
+        let local = conversation(id: id, title: "Local durable")
+        let proposed = conversation(id: id, title: "Rejected Watch proposal")
+        let store = ScriptedConversationStore(conversations: [stored])
+        let localGate = await store.enqueue(.save(local.id, local.title), blocked: true)
+        _ = await store.enqueue(.save(proposed.id, proposed.title), outcome: .fail)
+        let coordinator = makeCoordinator(store)
+        var observedDurableSnapshots: [[Conversation]] = []
+        coordinator.observeDurableSnapshotChanges {
+            observedDurableSnapshots.append(coordinator.durableConversations())
+        }
+
+        #expect(await coordinator.load().value == .loaded([stored]))
+        let initialObservationCount = observedDurableSnapshots.count
+        let localReceipt = coordinator.apply(local, mode: .immediate)
+        await localGate.started.wait()
+        let proposedReceipt = coordinator.saveProposed(proposed)
+        await localGate.releaseGate.open()
+
+        #expect(await localReceipt?.value == .superseded)
+        guard case .failed = await proposedReceipt.value else {
+            Issue.record("Expected proposed save failure")
+            return
+        }
+
+        #expect(coordinator.durableConversations() == [local])
+        #expect(observedDurableSnapshots.count == initialObservationCount + 1)
+        #expect(observedDurableSnapshots.last == [local])
+    }
+}
+
+// swiftlint:enable identifier_name

--- a/Tests/AynaTests/ConversationPersistenceCoordinatorTests.swift
+++ b/Tests/AynaTests/ConversationPersistenceCoordinatorTests.swift
@@ -3,44 +3,459 @@ import Foundation
 import Testing
 
 @Suite("ConversationPersistenceCoordinator Tests", .tags(.persistence, .async), .serialized)
+@MainActor
 struct ConversationPersistenceCoordinatorTests {
-    @Test("Flush pending saves persists all queued conversations")
-    func flushPendingSavesPersistsAllQueuedConversations() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let coordinator = ConversationPersistenceCoordinator(
-            store: store,
-            debounceDuration: .seconds(10)
-        )
+    enum InitialIntent: CaseIterable, Sendable { case save, delete, clear }
 
-        await coordinator.enqueueSave(TestHelpers.sampleConversation(title: "Alpha"))
-        await coordinator.enqueueSave(TestHelpers.sampleConversation(title: "Beta"))
-        await coordinator.flushPendingSaves()
-
-        let loaded = try await store.loadConversations()
-        #expect(Set(loaded.map(\.title)) == Set(["Alpha", "Beta"]))
+    @Test("Repeated coalesced saves write only the latest value")
+    func repeatedSavesCoalesce() async {
+        let id = UUID(), first = conversation(id: id, title: "First"), latest = conversation(id: id, title: "Latest")
+        let store = ScriptedConversationStore()
+        let coordinator = makeCoordinator(store)
+        coordinator.apply(first)
+        coordinator.apply(latest)
+        await coordinator.flush().value
+        #expect(await store.operations() == [.save(latest.id, latest.title)])
+        #expect(await store.persistedConversations() == [latest])
     }
 
-    @Test("Flush pending saves keeps the latest enqueued version")
-    func flushPendingSavesKeepsLatestVersion() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let coordinator = ConversationPersistenceCoordinator(
-            store: store,
-            debounceDuration: .seconds(10)
-        )
+    @Test("Immediate save receipt does not activate another conversation's debounce")
+    func immediateSaveReceiptIsTargetScoped() async {
+        let queued = conversation(title: "Queued"), immediate = conversation(title: "Immediate")
+        let store = ScriptedConversationStore()
+        let gate = await store.enqueue(.save(immediate.id, nil), blocked: true)
+        let coordinator = makeCoordinator(store)
+        coordinator.apply(queued)
+        guard let receipt = coordinator.apply(immediate, mode: .immediate) else {
+            Issue.record("Missing immediate receipt")
+            return
+        }
+        await gate.started.wait()
+        await gate.releaseGate.open()
+        await receipt.value
+        #expect(await store.operations() == [.save(immediate.id, immediate.title)])
+        await coordinator.flush().value
+        #expect(await store.operations() == [.save(immediate.id, immediate.title), .save(queued.id, queued.title)])
+    }
 
-        let conversationId = UUID()
-        let original = TestHelpers.sampleConversation(id: conversationId, title: "Original")
-        var updated = original
-        updated.title = "Updated"
+    @Test("Queued save followed by delete never writes the queued save")
+    func queuedSaveThenDelete() async {
+        let value = conversation(title: "Queued")
+        let store = ScriptedConversationStore(conversations: [value])
+        let coordinator = makeCoordinator(store)
+        coordinator.apply(value)
+        #expect(await coordinator.delete(value).value == .deleted)
+        await coordinator.flush().value
+        #expect(await store.operations() == [.delete(value.id)])
+        #expect(await store.persistedConversations().isEmpty)
+    }
 
-        await coordinator.enqueueSave(original)
-        await coordinator.enqueueSave(updated)
-        await coordinator.flushPendingSaves()
+    @Test("In-flight save is physically followed by delete")
+    func inFlightSaveThenDelete() async {
+        let value = conversation(title: "Saving")
+        let store = ScriptedConversationStore()
+        let gate = await store.enqueue(.save(value.id, nil), blocked: true)
+        let coordinator = makeCoordinator(store)
+        coordinator.apply(value, mode: .immediate)
+        await gate.started.wait()
+        let deletion = coordinator.delete(value)
+        #expect(await store.operations() == [.save(value.id, value.title)])
+        await gate.releaseGate.open()
+        #expect(await deletion.value == .deleted)
+        #expect(await store.operations() == [.save(value.id, value.title), .delete(value.id)])
+        #expect(await store.persistedConversations().isEmpty)
+    }
 
-        let loaded = try await store.loadConversations()
-        #expect(loaded.count == 1)
-        #expect(loaded.first?.title == "Updated")
+    @Test("Stale save completion cannot settle an immediate newer save")
+    func staleSaveThenImmediateNewerSave() async {
+        let id = UUID(), old = conversation(id: id, title: "Older"), new = conversation(id: id, title: "Newer")
+        let store = ScriptedConversationStore()
+        let gate = await store.enqueue(.save(id, "Older"), blocked: true)
+        let coordinator = makeCoordinator(store)
+        coordinator.apply(old, mode: .immediate)
+        await gate.started.wait()
+        coordinator.apply(new, mode: .immediate)
+        await gate.releaseGate.open()
+        await coordinator.flush().value
+        #expect(await store.operations() == [.save(old.id, old.title), .save(new.id, new.title)])
+        #expect(await store.persistedConversations() == [new])
+    }
+
+    @Test("Clear follows an in-flight save and prevents resurrection")
+    func clearWithInFlightSave() async {
+        let value = conversation(title: "In flight")
+        let store = ScriptedConversationStore()
+        let gate = await store.enqueue(.save(value.id, nil), blocked: true)
+        let coordinator = makeCoordinator(store)
+        coordinator.apply(value, mode: .immediate)
+        await gate.started.wait()
+        let clearing = coordinator.clear([value])
+        await gate.releaseGate.open()
+        #expect(await clearing.value == .cleared)
+        #expect(await store.operations() == [.save(value.id, value.title), .clear])
+        #expect(await store.persistedConversations().isEmpty)
+    }
+
+    @Test("Save, delete, and clear registered during initial load reconcile internally", arguments: InitialIntent.allCases)
+    func intentWhileInitialLoadBlocked(_ intent: InitialIntent) async {
+        let disk = conversation(title: "Disk"), created = conversation(title: "Created")
+        let store = ScriptedConversationStore(conversations: [disk])
+        let gate = await store.enqueue(.load, outcome: .load([disk]), blocked: true)
+        let coordinator = makeCoordinator(store)
+        let loading = coordinator.load()
+        await gate.started.wait()
+
+        switch intent {
+        case .save:
+            coordinator.apply(created, mode: .immediate)
+            await gate.releaseGate.open()
+            #expect(await loading.value == .loaded([created, disk]))
+            await coordinator.flush().value
+            #expect(await Set(store.persistedConversations().map(\.id)) == Set([disk.id, created.id]))
+        case .delete:
+            let deletion = coordinator.delete(disk)
+            await gate.releaseGate.open()
+            #expect(await loading.value == .loaded([]))
+            #expect(await deletion.value == .deleted)
+        case .clear:
+            let clearing = coordinator.clear([])
+            await gate.releaseGate.open()
+            #expect(await loading.value == .superseded)
+            #expect(await clearing.value == .cleared)
+        }
+    }
+
+    @Test("Older reload result is suppressed after a newer reload is registered")
+    func olderReloadCannotOverwriteNewerReload() async {
+        let old = conversation(title: "Older"), new = conversation(title: "Newer")
+        let store = ScriptedConversationStore()
+        let oldGate = await store.enqueue(.load, outcome: .load([old]), blocked: true)
+        let newGate = await store.enqueue(.load, outcome: .load([new]), blocked: true)
+        let coordinator = ConversationPersistenceCoordinator(store: store)
+        let oldLoad = coordinator.load()
+        await oldGate.started.wait()
+        let newLoad = coordinator.load()
+        await oldGate.releaseGate.open()
+        #expect(await oldLoad.value == .superseded)
+        await newGate.started.wait()
+        await newGate.releaseGate.open()
+        #expect(await newLoad.value == .loaded([new]))
+    }
+
+    @Test("Flush waits for an in-flight immediate save")
+    func flushWaitsForInFlightImmediateSave() async {
+        let value = conversation(title: "Immediate")
+        let store = ScriptedConversationStore()
+        let gate = await store.enqueue(.save(value.id, nil), blocked: true)
+        let coordinator = ConversationPersistenceCoordinator(store: store)
+        coordinator.apply(value, mode: .immediate)
+        await gate.started.wait()
+        let started = TestLatch(), finished = TestLatch()
+        let waiter = signal(coordinator.flush(), started: started, finished: finished)
+        await started.wait()
+        #expect(await finished.opened() == false)
+        await gate.releaseGate.open()
+        await waiter.value
+        #expect(await store.persistedConversations() == [value])
+    }
+
+    @Test("Failed partial clear preserves post-clear creation and delete, then reconverges storage")
+    func failedClearPreservesPostClearChangesAndConverges() async {
+        let before = conversation(title: "Before"), deleted = conversation(title: "Deleted after clear")
+        let created = conversation(title: "Created after clear")
+        let store = ScriptedConversationStore(conversations: [before, deleted])
+        let gate = await store.enqueue(.clear, outcome: .partialClear([before.id]), blocked: true)
+        let coordinator = makeCoordinator(store)
+        let clearing = coordinator.clear([before, deleted])
+        await gate.started.wait()
+        coordinator.apply(created, mode: .immediate)
+        let deletion = coordinator.delete(deleted)
+        await gate.releaseGate.open()
+        guard case let .failed(restored, _) = await clearing.value else {
+            Issue.record("Expected clear failure")
+            return
+        }
+        #expect(Set(restored.map(\.id)) == Set([before.id, created.id]))
+        #expect(await deletion.value == .deleted)
+        await coordinator.flush().value
+        #expect(await Set(store.persistedConversations().map(\.id)) == Set([before.id, created.id]))
+    }
+
+    @Test("Failed delete restores, re-persists, and is drained by an earlier flush")
+    func failedDeleteRestoresAndRepersistsUndeliveredEdit() async {
+        let id = UUID(), stored = conversation(id: id, title: "Stored"), edited = conversation(id: id, title: "Edited")
+        let store = ScriptedConversationStore(conversations: [stored])
+        let deleteGate = await store.enqueue(.delete(id), outcome: .fail, blocked: true)
+        let repairGate = await store.enqueue(.save(id, nil), blocked: true)
+        let coordinator = makeCoordinator(store)
+        coordinator.apply(edited)
+        let deletion = coordinator.delete(edited)
+        await deleteGate.started.wait()
+        let started = TestLatch(), finished = TestLatch()
+        let waiter = signal(coordinator.flush(), started: started, finished: finished)
+        await started.wait()
+        await deleteGate.releaseGate.open()
+        await repairGate.started.wait()
+        #expect(await finished.opened() == false)
+        guard case let .failed(restored, _) = await deletion.value else {
+            Issue.record("Expected delete failure")
+            return
+        }
+        #expect(restored == edited)
+        await repairGate.releaseGate.open()
+        await waiter.value
+        #expect(await store.persistedConversations() == [edited])
+    }
+
+    @Test("Failed save remains dirty across reload and is retried by flush")
+    func failedSaveStaysDirtyAcrossReload() async {
+        let id = UUID(), stored = conversation(id: id, title: "Stored"), edited = conversation(id: id, title: "Edited")
+        let store = ScriptedConversationStore(conversations: [stored])
+        _ = await store.enqueue(.save(id, nil), outcome: .fail)
+        _ = await store.enqueue(.load, outcome: .load([stored]))
+        let coordinator = ConversationPersistenceCoordinator(store: store)
+        coordinator.apply(edited, mode: .immediate)
+        await coordinator.flush().value
+        #expect(await coordinator.load().value == .loaded([edited]))
+        await coordinator.flush().value
+        #expect(await store.persistedConversations() == [edited])
+    }
+
+    @Test("Cancelling a receipt waiter does not cancel accepted persistence")
+    func waiterCancellationDoesNotCancelPersistence() async {
+        let value = conversation(title: "Delete me")
+        let store = ScriptedConversationStore(conversations: [value])
+        let gate = await store.enqueue(.delete(value.id), blocked: true)
+        let coordinator = ConversationPersistenceCoordinator(store: store)
+        let receipt = coordinator.delete(value)
+        await gate.started.wait()
+        let waiter = Task { await receipt.value }
+        waiter.cancel()
+        await gate.releaseGate.open()
+        await coordinator.flush().value
+        #expect(await store.persistedConversations().isEmpty)
+    }
+
+    @Test("Flush drains clear repair and retains a suppressed preceding load for rollback")
+    func flushDrainsClearRepairAndRetainsLoad() async {
+        let disk = conversation(title: "Disk")
+        let store = ScriptedConversationStore(conversations: [disk])
+        let loadGate = await store.enqueue(.load, outcome: .load([disk]), blocked: true)
+        _ = await store.enqueue(.clear, outcome: .fail)
+        let repairGate = await store.enqueue(.clear, blocked: true)
+        let coordinator = ConversationPersistenceCoordinator(store: store)
+        let loading = coordinator.load()
+        await loadGate.started.wait()
+        let clearing = coordinator.clear([])
+        let started = TestLatch(), finished = TestLatch()
+        let waiter = signal(coordinator.flush(), started: started, finished: finished)
+        await started.wait()
+        await loadGate.releaseGate.open()
+        #expect(await loading.value == .superseded)
+        guard case let .failed(restored, _) = await clearing.value else {
+            Issue.record("Expected clear failure")
+            return
+        }
+        #expect(restored == [disk])
+        await repairGate.started.wait()
+        #expect(await finished.opened() == false)
+        await repairGate.releaseGate.open()
+        await waiter.value
+        #expect(await store.persistedConversations() == [disk])
+    }
+
+    @Test("Rewrite completion does not supersede its queued explicit delete")
+    func rewriteDoesNotSupersedeQueuedDelete() async {
+        let value = conversation(title: "Delete")
+        let store = ScriptedConversationStore(conversations: [value])
+        _ = await store.enqueue(.clear, outcome: .fail)
+        _ = await store.enqueue(.clear, outcome: .fail)
+        _ = await store.enqueue(.clear)
+        let coordinator = ConversationPersistenceCoordinator(store: store)
+        guard case .failed = await coordinator.clear([value]).value else {
+            Issue.record("Expected clear failure")
+            return
+        }
+        await coordinator.flush().value
+        #expect(await coordinator.delete(value).value == .deleted)
+        #expect(await store.persistedConversations().isEmpty)
+    }
+
+    @Test("Overlapping failed clears retain the original rollback baseline")
+    func overlappingFailedClearsRetainOriginalBaseline() async {
+        let original = conversation(title: "Original")
+        let store = ScriptedConversationStore()
+        let firstGate = await store.enqueue(.clear, outcome: .fail, blocked: true)
+        _ = await store.enqueue(.clear, outcome: .fail)
+        let coordinator = ConversationPersistenceCoordinator(store: store)
+
+        let first = coordinator.clear([original])
+        await firstGate.started.wait()
+        let second = coordinator.clear([])
+        await firstGate.releaseGate.open()
+
+        #expect(await first.value == .superseded)
+        guard case let .failed(restored, _) = await second.value else {
+            Issue.record("Expected second clear failure")
+            return
+        }
+        #expect(restored == [original])
+        await coordinator.flush().value
+        #expect(collectionCount(named: "clearLayers", in: Mirror(reflecting: coordinator)) == 0)
+    }
+
+    @Test("Second failed clear retains snapshot restored before first receipt consumption")
+    func secondFailedClearRetainsRestoredUnsavedEdit() async {
+        let id = UUID()
+        let stored = conversation(id: id, title: "Stored")
+        let edited = conversation(id: id, title: "Edited")
+        let store = ScriptedConversationStore(conversations: [stored])
+        _ = await store.enqueue(.clear, outcome: .fail)
+        let repairGate = await store.enqueue(.clear, blocked: true)
+        _ = await store.enqueue(.clear, outcome: .fail)
+        let coordinator = makeCoordinator(store)
+
+        #expect(await coordinator.load().value == .loaded([stored]))
+        coordinator.apply(edited)
+        let first = coordinator.clear([edited])
+        await repairGate.started.wait()
+        let second = coordinator.clear([])
+        await repairGate.releaseGate.open()
+
+        #expect(await first.value == .superseded)
+        guard case let .failed(restored, _) = await second.value else {
+            Issue.record("Expected second clear failure")
+            return
+        }
+        #expect(restored == [edited])
+        await coordinator.flush().value
+        #expect(await store.persistedConversations() == [edited])
+    }
+
+    @Test("Failed clear tombstone survives failed rewrite and later failed clear")
+    func failedClearTombstoneSurvivesUntilRewriteSuccess() async {
+        let kept = conversation(title: "Kept")
+        let deleted = conversation(title: "Deleted")
+        let store = ScriptedConversationStore(conversations: [kept, deleted])
+        let deleteGate = await store.enqueue(.delete(deleted.id), outcome: .fail, blocked: true)
+        _ = await store.enqueue(.clear, outcome: .fail)
+        _ = await store.enqueue(.clear, outcome: .fail)
+        _ = await store.enqueue(.clear, outcome: .fail)
+        let coordinator = makeCoordinator(store)
+
+        guard case let .loaded(loaded) = await coordinator.load().value else {
+            Issue.record("Expected initial load")
+            return
+        }
+        #expect(Set(loaded.map(\.id)) == Set([kept.id, deleted.id]))
+        let deleting = coordinator.delete(deleted)
+        await deleteGate.started.wait()
+        let firstClear = coordinator.clear([kept])
+        await deleteGate.releaseGate.open()
+        #expect(await deleting.value == .superseded)
+        guard case let .failed(firstRollback, _) = await firstClear.value else {
+            Issue.record("Expected first clear failure")
+            return
+        }
+        #expect(firstRollback == [kept])
+        await coordinator.flush().value
+
+        let secondClear = coordinator.clear([])
+        guard case let .failed(secondRollback, _) = await secondClear.value else {
+            Issue.record("Expected second clear failure")
+            return
+        }
+        #expect(secondRollback == [kept])
+        await coordinator.flush().value
+        #expect(await store.persistedConversations() == [kept])
+        #expect(collectionCount(named: "repairDeletedIDs", in: Mirror(reflecting: coordinator)) == 0)
+    }
+
+    @Test("Settled load receipt reconciles an edit accepted before consumption")
+    func settledLoadReceiptReconcilesNewerEdit() async {
+        let id = UUID()
+        let disk = conversation(id: id, title: "Disk")
+        let edited = conversation(id: id, title: "Edited")
+        let coordinator = ConversationPersistenceCoordinator(store: ScriptedConversationStore(conversations: [disk]))
+
+        let loading = coordinator.load()
+        await coordinator.flush().value
+        coordinator.apply(edited)
+
+        #expect(await loading.value == .loaded([edited]))
+        await coordinator.flush().value
+    }
+
+    @Test("Failed clear receipt excludes a deletion accepted before consumption")
+    func failedClearReceiptReconcilesLaterDelete() async {
+        let value = conversation(title: "Delete after clear")
+        let store = ScriptedConversationStore(conversations: [value])
+        _ = await store.enqueue(.clear, outcome: .fail)
+        let coordinator = ConversationPersistenceCoordinator(store: store)
+
+        let clearing = coordinator.clear([value])
+        await coordinator.flush().value
+        #expect(await coordinator.delete(value).value == .deleted)
+
+        guard case let .failed(restored, _) = await clearing.value else {
+            Issue.record("Expected clear failure")
+            return
+        }
+        #expect(restored.isEmpty)
+    }
+
+    @Test("Failed delete receipt is superseded by a newer clear before consumption")
+    func failedDeleteReceiptDoesNotUndoNewerClear() async {
+        let value = conversation(title: "Delete before clear")
+        let store = ScriptedConversationStore(conversations: [value])
+        _ = await store.enqueue(.delete(value.id), outcome: .fail)
+        let coordinator = ConversationPersistenceCoordinator(store: store)
+
+        let deletion = coordinator.delete(value)
+        await coordinator.flush().value
+        #expect(await coordinator.clear([]).value == .cleared)
+        #expect(await deletion.value == .superseded)
+    }
+
+    @Test("Settled unique IDs leave no per-conversation auxiliary history")
+    func settledUniqueIDsLeaveBoundedAuxiliaryState() async {
+        let coordinator = ConversationPersistenceCoordinator(store: ScriptedConversationStore())
+        for index in 0 ..< 2000 {
+            let value = conversation(title: "Conversation \(index)")
+            coordinator.apply(value, mode: .immediate)
+            _ = coordinator.delete(value)
+        }
+        await coordinator.flush().value
+        let mirror = Mirror(reflecting: coordinator)
+        for label in ["snapshot", "dirty", "debounceTasks", "outstandingByRoot"] {
+            #expect(collectionCount(named: label, in: mirror) == 0)
+        }
+    }
+
+    private func makeCoordinator(_ store: ScriptedConversationStore) -> ConversationPersistenceCoordinator {
+        ConversationPersistenceCoordinator(store: store, debounceDuration: .seconds(30))
+    }
+
+    private func signal(
+        _ receipt: PersistenceReceipt<Void>,
+        started: TestLatch,
+        finished: TestLatch
+    ) -> Task<Void, Never> {
+        Task {
+            await started.open()
+            await receipt.value
+            await finished.open()
+        }
+    }
+
+    private func conversation(id: UUID = UUID(), title: String) -> Conversation {
+        var value = Conversation(id: id, title: title, model: "test-model")
+        value.createdAt = .init(timeIntervalSince1970: 0)
+        value.updatedAt = .init(timeIntervalSince1970: TimeInterval(title.count))
+        return value
+    }
+
+    private func collectionCount(named label: String, in mirror: Mirror) -> Int? {
+        mirror.children.first { $0.label == label }.map { Mirror(reflecting: $0.value).children.count }
     }
 }

--- a/Tests/AynaTests/DeepLinkManagerTests.swift
+++ b/Tests/AynaTests/DeepLinkManagerTests.swift
@@ -1,4 +1,5 @@
 @testable import Ayna
+import Combine
 import Foundation
 import Testing
 
@@ -23,6 +24,30 @@ struct DeepLinkManagerTests {
         service.modelEndpointTypes = [:]
         let manager = DeepLinkManager(aiService: service)
         return (manager, service)
+    }
+
+    private func consumeExactlyOne(from manager: DeepLinkManager) throws -> ChatRequest {
+        let requests = drainReadyChats(from: manager)
+        #expect(requests.count == 1)
+        return try #require(requests.first)
+    }
+
+    private func drainReadyChats(from manager: DeepLinkManager) -> [ChatRequest] {
+        var requests: [ChatRequest] = []
+        while let request = manager.consumeNextReadyChat() {
+            requests.append(request)
+        }
+        return requests
+    }
+
+    private func confirmPendingModel(in manager: DeepLinkManager) throws {
+        let requestID = try #require(manager.pendingAddModel?.id)
+        manager.confirmAddModel(expectedRequestID: requestID)
+    }
+
+    private func cancelPendingModel(in manager: DeepLinkManager) throws {
+        let requestID = try #require(manager.pendingAddModel?.id)
+        manager.cancelAddModel(expectedRequestID: requestID)
     }
 
     // MARK: - URL Parsing Tests
@@ -80,6 +105,17 @@ struct DeepLinkManagerTests {
 
         #expect(manager.pendingAddModel == nil)
         #expect(manager.errorMessage != nil)
+    }
+
+    @Test("Parse add-model whitespace name shows error")
+    func parseAddModelWhitespaceNameShowsError() async throws {
+        let (manager, _) = makeManager()
+        let url = try #require(URL(string: "ayna://add-model?name=%20%20%20"))
+
+        await manager.handle(url: url)
+
+        #expect(manager.pendingAddModel == nil)
+        #expect(manager.errorMessage?.contains("name") == true)
     }
 
     @Test("Parse add-model invalid provider shows error")
@@ -194,7 +230,8 @@ struct DeepLinkManagerTests {
 
     @Test("Parse chat with all parameters")
     func parseChatWithAllParameters() async throws {
-        let (manager, _) = makeManager()
+        let (manager, service) = makeManager()
+        service.customModels.append("gpt-4o")
         let url = try #require(URL(string: "ayna://chat?model=gpt-4o&prompt=Hello%20world&system=You%20are%20helpful"))
 
         await manager.handle(url: url)
@@ -208,7 +245,8 @@ struct DeepLinkManagerTests {
 
     @Test("Parse chat with model only")
     func parseChatWithModelOnly() async throws {
-        let (manager, _) = makeManager()
+        let (manager, service) = makeManager()
+        service.customModels.append("claude-3")
         let url = try #require(URL(string: "ayna://chat?model=claude-3"))
 
         await manager.handle(url: url)
@@ -244,6 +282,369 @@ struct DeepLinkManagerTests {
         #expect(manager.pendingChat?.prompt == nil)
         #expect(manager.pendingChat?.systemPrompt == nil)
         #expect(manager.errorMessage == nil)
+    }
+
+    // MARK: - Pending Chat Consumption Tests
+
+    @Test("Unified chat remains pending before add-model confirmation")
+    func unifiedChatRemainsPendingBeforeAddModelConfirmation() async throws {
+        let (manager, _) = makeManager()
+        let url = try #require(URL(string: "ayna://chat?model=new-model&provider=openai&prompt=Hello"))
+
+        await manager.handle(url: url)
+
+        let consumedChats = drainReadyChats(from: manager)
+
+        #expect(consumedChats.isEmpty)
+        #expect(manager.pendingAddModel?.name == "new-model")
+        #expect(manager.pendingChat?.model == "new-model")
+        #expect(manager.pendingChat?.prompt == "Hello")
+    }
+
+    @Test("Unified chat becomes available after add-model confirmation")
+    func unifiedChatBecomesAvailableAfterAddModelConfirmation() async throws {
+        let (manager, service) = makeManager()
+        let url = try #require(URL(string: "ayna://chat?model=new-model&provider=openai&prompt=Hello"))
+
+        await manager.handle(url: url)
+        try confirmPendingModel(in: manager)
+
+        let consumedChat = try consumeExactlyOne(from: manager)
+
+        #expect(service.customModels.contains("new-model"))
+        #expect(consumedChat.model == "new-model")
+        #expect(consumedChat.prompt == "Hello")
+    }
+
+    @Test("Consuming a ready chat clears it exactly once")
+    func consumingReadyChatClearsItExactlyOnce() async throws {
+        let (manager, _) = makeManager()
+        let url = try #require(URL(string: "ayna://chat?prompt=Hello"))
+
+        await manager.handle(url: url)
+
+        let firstConsumption = drainReadyChats(from: manager)
+        let secondConsumption = drainReadyChats(from: manager)
+
+        #expect(firstConsumption.first?.prompt == "Hello")
+        #expect(manager.pendingChat == nil)
+        #expect(secondConsumption.isEmpty)
+    }
+
+    @Test("Ordinary chat is immediately available for consumption")
+    func ordinaryChatIsImmediatelyAvailableForConsumption() async throws {
+        let (manager, service) = makeManager()
+        service.customModels.append("gpt-4o")
+        let url = try #require(URL(string: "ayna://chat?model=gpt-4o&prompt=Hello&system=Be%20concise"))
+
+        await manager.handle(url: url)
+
+        let consumedChat = try consumeExactlyOne(from: manager)
+
+        #expect(manager.pendingAddModel == nil)
+        #expect(consumedChat.model == "gpt-4o")
+        #expect(consumedChat.prompt == "Hello")
+        #expect(consumedChat.systemPrompt == "Be concise")
+    }
+
+    @Test("Ordinary chat is consumed before confirming an overlapping unified chat")
+    func ordinaryChatIsConsumedBeforeConfirmingOverlappingUnifiedChat() async throws {
+        let (manager, service) = makeManager()
+        service.customModels.append("gpt-4o")
+        let unifiedURL = try #require(URL(string: "ayna://chat?model=deferred-model&provider=openai&prompt=Deferred"))
+        let ordinaryURL = try #require(URL(string: "ayna://chat?model=gpt-4o&prompt=Ready"))
+
+        await manager.handle(url: unifiedURL)
+        await manager.handle(url: ordinaryURL)
+
+        let ordinaryChat = try consumeExactlyOne(from: manager)
+
+        #expect(ordinaryChat.model == "gpt-4o")
+        #expect(ordinaryChat.prompt == "Ready")
+        #expect(manager.pendingAddModel?.name == "deferred-model")
+        #expect(manager.pendingChat?.model == "deferred-model")
+        #expect(manager.pendingChat?.prompt == "Deferred")
+        #expect(drainReadyChats(from: manager).isEmpty)
+
+        try confirmPendingModel(in: manager)
+
+        let deferredChat = try consumeExactlyOne(from: manager)
+
+        #expect(service.customModels.contains("deferred-model"))
+        #expect(deferredChat.model == "deferred-model")
+        #expect(deferredChat.prompt == "Deferred")
+    }
+
+    @Test("Ordinary chat is preserved when an overlapping unified chat arrives afterward")
+    func ordinaryChatIsPreservedWhenOverlappingUnifiedChatArrivesAfterward() async throws {
+        let (manager, service) = makeManager()
+        service.customModels.append("gpt-4o")
+        let ordinaryURL = try #require(URL(string: "ayna://chat?model=gpt-4o&prompt=Ready"))
+        let unifiedURL = try #require(URL(string: "ayna://chat?model=deferred-model&provider=openai&prompt=Deferred"))
+
+        await manager.handle(url: ordinaryURL)
+        await manager.handle(url: unifiedURL)
+
+        let ordinaryChat = try consumeExactlyOne(from: manager)
+
+        #expect(ordinaryChat.model == "gpt-4o")
+        #expect(ordinaryChat.prompt == "Ready")
+        #expect(manager.pendingAddModel?.name == "deferred-model")
+        #expect(manager.pendingChat?.model == "deferred-model")
+        #expect(manager.pendingChat?.prompt == "Deferred")
+        #expect(drainReadyChats(from: manager).isEmpty)
+
+        try confirmPendingModel(in: manager)
+
+        let deferredChat = try consumeExactlyOne(from: manager)
+
+        #expect(service.customModels.contains("deferred-model"))
+        #expect(deferredChat.model == "deferred-model")
+        #expect(deferredChat.prompt == "Deferred")
+    }
+
+    @Test("Cancelling an overlapping unified chat preserves the ordinary chat")
+    func cancellingOverlappingUnifiedChatPreservesOrdinaryChat() async throws {
+        let (manager, service) = makeManager()
+        let unifiedURL = try #require(URL(string: "ayna://chat?model=cancelled-model&provider=openai&prompt=Deferred"))
+        let ordinaryURL = try #require(URL(string: "ayna://chat?prompt=Ready"))
+
+        await manager.handle(url: unifiedURL)
+        await manager.handle(url: ordinaryURL)
+
+        try cancelPendingModel(in: manager)
+
+        #expect(manager.pendingAddModel == nil)
+        #expect(manager.pendingChat?.prompt == "Ready")
+        #expect(!service.customModels.contains("cancelled-model"))
+
+        let ordinaryChat = try consumeExactlyOne(from: manager)
+
+        #expect(ordinaryChat.prompt == "Ready")
+        #expect(drainReadyChats(from: manager).isEmpty)
+    }
+
+    @Test("Standalone add-model confirmation does not block an ordinary chat")
+    func standaloneAddModelConfirmationDoesNotBlockOrdinaryChat() async throws {
+        let (manager, _) = makeManager()
+        let addModelURL = try #require(URL(string: "ayna://add-model?name=standalone-model"))
+        let ordinaryURL = try #require(URL(string: "ayna://chat?prompt=Ready"))
+
+        await manager.handle(url: addModelURL)
+        await manager.handle(url: ordinaryURL)
+
+        let ordinaryChat = try consumeExactlyOne(from: manager)
+
+        #expect(ordinaryChat.prompt == "Ready")
+        #expect(manager.pendingAddModel?.name == "standalone-model")
+        #expect(manager.pendingChat == nil)
+    }
+
+    @Test("Ready chats are drained in URL arrival order")
+    func readyChatsAreDrainedInURLArrivalOrder() async throws {
+        let (manager, _) = makeManager()
+        let firstURL = try #require(URL(string: "ayna://chat?prompt=First"))
+        let secondURL = try #require(URL(string: "ayna://chat?prompt=Second"))
+        let thirdURL = try #require(URL(string: "ayna://chat?prompt=Third"))
+
+        await manager.handle(url: firstURL)
+        await manager.handle(url: secondURL)
+        await manager.handle(url: thirdURL)
+
+        #expect(drainReadyChats(from: manager).map(\.prompt) == ["First", "Second", "Third"])
+        #expect(drainReadyChats(from: manager).isEmpty)
+    }
+
+    @Test("Earlier ready chat stays ahead of later deferred chat")
+    func earlierReadyChatStaysAheadOfLaterDeferredChat() async throws {
+        let (manager, _) = makeManager()
+        let readyURL = try #require(URL(string: "ayna://chat?prompt=Ready"))
+        let deferredURL = try #require(URL(string: "ayna://chat?model=deferred-model&provider=openai&prompt=Deferred"))
+
+        await manager.handle(url: readyURL)
+        await manager.handle(url: deferredURL)
+        try confirmPendingModel(in: manager)
+
+        #expect(drainReadyChats(from: manager).map(\.prompt) == ["Ready", "Deferred"])
+    }
+
+    @Test("Ready chat stays ahead when older deferred chat is confirmed")
+    func readyChatStaysAheadWhenOlderDeferredChatIsConfirmed() async throws {
+        let (manager, _) = makeManager()
+        let deferredURL = try #require(URL(string: "ayna://chat?model=deferred-model&provider=openai&prompt=Deferred"))
+        let readyURL = try #require(URL(string: "ayna://chat?prompt=Ready"))
+
+        await manager.handle(url: deferredURL)
+        await manager.handle(url: readyURL)
+        try confirmPendingModel(in: manager)
+
+        #expect(drainReadyChats(from: manager).map(\.prompt) == ["Ready", "Deferred"])
+    }
+
+    @Test("Second confirmation cannot replace active confirmation")
+    func secondConfirmationCannotReplaceActiveConfirmation() async throws {
+        let (manager, service) = makeManager()
+        let firstURL = try #require(URL(string: "ayna://chat?model=first-model&provider=openai&prompt=First"))
+        let secondURL = try #require(URL(string: "ayna://chat?model=second-model&provider=openai&prompt=Second"))
+
+        await manager.handle(url: firstURL)
+        let firstRequestID = try #require(manager.pendingAddModel?.id)
+        await manager.handle(url: secondURL)
+
+        #expect(manager.errorMessage == "Another model confirmation is already in progress")
+        #expect(manager.pendingAddModel?.id == firstRequestID)
+        #expect(manager.pendingChat?.prompt == "First")
+
+        manager.confirmAddModel(expectedRequestID: firstRequestID)
+
+        let chat = try consumeExactlyOne(from: manager)
+        #expect(service.customModels.contains("first-model"))
+        #expect(!service.customModels.contains("second-model"))
+        #expect(chat.prompt == "First")
+    }
+
+    @Test("Standalone confirmation cannot replace active unified confirmation")
+    func standaloneConfirmationCannotReplaceActiveUnifiedConfirmation() async throws {
+        let (manager, _) = makeManager()
+        let unifiedURL = try #require(URL(string: "ayna://chat?model=first-model&provider=openai&prompt=First"))
+        let addModelURL = try #require(URL(string: "ayna://add-model?name=second-model"))
+
+        await manager.handle(url: unifiedURL)
+        let firstRequestID = try #require(manager.pendingAddModel?.id)
+        await manager.handle(url: addModelURL)
+
+        #expect(manager.errorMessage == "Another model confirmation is already in progress")
+        #expect(manager.pendingAddModel?.id == firstRequestID)
+        #expect(manager.pendingChat?.prompt == "First")
+    }
+
+    @Test(
+        "Active standalone confirmation rejects another confirmation",
+        arguments: [
+            "ayna://add-model?name=second-model",
+            "ayna://chat?model=second-model&provider=openai&prompt=Second"
+        ]
+    )
+    func activeStandaloneConfirmationRejectsAnotherConfirmation(incomingURLString: String) async throws {
+        let (manager, _) = makeManager()
+        let firstURL = try #require(URL(string: "ayna://add-model?name=first-model"))
+        let incomingURL = try #require(URL(string: incomingURLString))
+
+        await manager.handle(url: firstURL)
+        let firstRequestID = try #require(manager.pendingAddModel?.id)
+        await manager.handle(url: incomingURL)
+
+        #expect(manager.errorMessage == "Another model confirmation is already in progress")
+        #expect(manager.pendingAddModel?.id == firstRequestID)
+        #expect(manager.pendingAddModel?.name == "first-model")
+        #expect(manager.pendingChat == nil)
+    }
+
+    @Test("Stale cancellation cannot cancel a newer confirmation")
+    func staleCancellationCannotCancelNewerConfirmation() async throws {
+        let (manager, _) = makeManager()
+        let firstURL = try #require(URL(string: "ayna://add-model?name=first-model"))
+        let secondURL = try #require(URL(string: "ayna://add-model?name=second-model"))
+
+        await manager.handle(url: firstURL)
+        let firstRequestID = try #require(manager.pendingAddModel?.id)
+        manager.cancelAddModel(expectedRequestID: firstRequestID)
+        await manager.handle(url: secondURL)
+        let secondRequestID = try #require(manager.pendingAddModel?.id)
+
+        manager.cancelAddModel(expectedRequestID: firstRequestID)
+
+        #expect(manager.pendingAddModel?.id == secondRequestID)
+        #expect(manager.pendingAddModel?.name == "second-model")
+    }
+
+    @Test("Stale confirmation cannot confirm a newer request")
+    func staleConfirmationCannotConfirmNewerRequest() async throws {
+        let (manager, service) = makeManager()
+        let firstURL = try #require(URL(string: "ayna://add-model?name=first-model"))
+        let secondURL = try #require(URL(string: "ayna://add-model?name=second-model"))
+
+        await manager.handle(url: firstURL)
+        let firstRequestID = try #require(manager.pendingAddModel?.id)
+        manager.cancelAddModel(expectedRequestID: firstRequestID)
+        await manager.handle(url: secondURL)
+        let secondRequestID = try #require(manager.pendingAddModel?.id)
+
+        manager.confirmAddModel(expectedRequestID: firstRequestID)
+
+        #expect(manager.pendingAddModel?.id == secondRequestID)
+        #expect(!service.customModels.contains("second-model"))
+    }
+
+    @Test("Unknown named chat is rejected instead of falling back")
+    func unknownNamedChatIsRejectedInsteadOfFallingBack() async throws {
+        let (manager, _) = makeManager()
+        let url = try #require(URL(string: "ayna://chat?model=missing-model&prompt=Private"))
+
+        await manager.handle(url: url)
+
+        #expect(drainReadyChats(from: manager).isEmpty)
+        #expect(manager.pendingChat == nil)
+        #expect(manager.errorMessage == "Model 'missing-model' not found")
+    }
+
+    @Test("Whitespace model is rejected before unified confirmation")
+    func whitespaceModelIsRejectedBeforeUnifiedConfirmation() async throws {
+        let (manager, _) = makeManager()
+        let url = try #require(URL(string: "ayna://chat?model=%20%20&provider=openai&prompt=Private"))
+
+        await manager.handle(url: url)
+
+        #expect(manager.pendingAddModel == nil)
+        #expect(manager.pendingChat == nil)
+        #expect(manager.errorMessage?.contains("model") == true)
+    }
+
+    @Test("Valueless model is rejected instead of falling back")
+    func valuelessModelIsRejectedInsteadOfFallingBack() async throws {
+        let (manager, _) = makeManager()
+        let url = try #require(URL(string: "ayna://chat?model&prompt=Private"))
+
+        await manager.handle(url: url)
+
+        #expect(manager.pendingAddModel == nil)
+        #expect(manager.pendingChat == nil)
+        #expect(manager.errorMessage?.contains("model") == true)
+    }
+
+    @Test("Chat is rejected if model disappears before consumption")
+    func chatIsRejectedIfModelDisappearsBeforeConsumption() async throws {
+        let (manager, service) = makeManager()
+        service.customModels.append("temporary-model")
+        let url = try #require(URL(string: "ayna://chat?model=temporary-model&prompt=Private"))
+
+        await manager.handle(url: url)
+        service.customModels.removeAll()
+
+        #expect(drainReadyChats(from: manager).isEmpty)
+        #expect(manager.pendingChat == nil)
+        #expect(manager.errorMessage == "Model 'temporary-model' not found")
+    }
+
+    @Test("Cancelled deferred chat is absent when cancellation publishes")
+    func cancelledDeferredChatIsAbsentWhenCancellationPublishes() async throws {
+        let (manager, _) = makeManager()
+        let url = try #require(URL(string: "ayna://chat?model=cancel-model&provider=openai&prompt=Private"))
+        await manager.handle(url: url)
+
+        var chatVisibleWhenCancellationPublished: ChatRequest?
+        let cancellation = manager.$pendingAddModel
+            .dropFirst()
+            .sink { request in
+                if request == nil {
+                    chatVisibleWhenCancellationPublished = manager.pendingChat
+                }
+            }
+
+        try cancelPendingModel(in: manager)
+
+        #expect(chatVisibleWhenCancellationPublished == nil)
+        withExtendedLifetime(cancellation) {}
     }
 
     // MARK: - Invalid URL Tests
@@ -283,7 +684,7 @@ struct DeepLinkManagerTests {
 
         #expect(manager.pendingAddModel != nil)
 
-        manager.confirmAddModel()
+        try confirmPendingModel(in: manager)
 
         #expect(manager.pendingAddModel == nil)
         #expect(service.customModels.contains("test-model"))
@@ -298,7 +699,7 @@ struct DeepLinkManagerTests {
         let url = try #require(URL(string: "ayna://add-model?name=test-model&provider=github"))
         await manager.handle(url: url)
 
-        manager.confirmAddModel()
+        try confirmPendingModel(in: manager)
 
         #expect(service.customModels.contains("test-model"))
         #expect(service.modelEndpoints["test-model"] == nil)
@@ -310,7 +711,7 @@ struct DeepLinkManagerTests {
         let url = try #require(URL(string: "ayna://add-model?name=test-model"))
         await manager.handle(url: url)
 
-        manager.confirmAddModel()
+        try confirmPendingModel(in: manager)
 
         #expect(service.customModels.contains("test-model"))
         #expect(service.modelAPIKeys["test-model"] == nil)
@@ -324,7 +725,7 @@ struct DeepLinkManagerTests {
 
         #expect(manager.pendingAddModel != nil)
 
-        manager.cancelAddModel()
+        try cancelPendingModel(in: manager)
 
         #expect(manager.pendingAddModel == nil)
         #expect(!service.customModels.contains("test-model"))
@@ -336,12 +737,12 @@ struct DeepLinkManagerTests {
         // Add first model
         let url1 = try #require(URL(string: "ayna://add-model?name=duplicate-model"))
         await manager.handle(url: url1)
-        manager.confirmAddModel()
+        try confirmPendingModel(in: manager)
 
         // Try to add duplicate
         let url2 = try #require(URL(string: "ayna://add-model?name=duplicate-model"))
         await manager.handle(url: url2)
-        manager.confirmAddModel()
+        try confirmPendingModel(in: manager)
 
         #expect(manager.errorMessage != nil)
         #expect(manager.errorMessage?.contains("already exists") ?? false)
@@ -361,49 +762,6 @@ struct DeepLinkManagerTests {
 
         #expect(manager.errorMessage == nil)
         #expect(manager.errorRecoverySuggestion == nil)
-    }
-
-    @Test("Clear pending chat clears request")
-    func clearPendingChatClearsRequest() async throws {
-        let (manager, _) = makeManager()
-        let url = try #require(URL(string: "ayna://chat?prompt=test"))
-        await manager.handle(url: url)
-
-        #expect(manager.pendingChat != nil)
-
-        manager.clearPendingChat()
-
-        #expect(manager.pendingChat == nil)
-    }
-
-    @Test("New URL clears previous error")
-    func newURLClearsPreviousError() async throws {
-        let (manager, _) = makeManager()
-        // First cause an error
-        let badURL = try #require(URL(string: "ayna://unknown"))
-        await manager.handle(url: badURL)
-        #expect(manager.errorMessage != nil)
-
-        // Then handle a valid URL
-        let goodURL = try #require(URL(string: "ayna://chat?prompt=hello"))
-        await manager.handle(url: goodURL)
-
-        #expect(manager.errorMessage == nil)
-        #expect(manager.pendingChat != nil)
-    }
-
-    // MARK: - OAuth Callback Tests
-
-    @Test("OAuth callback is recognized")
-    func oAuthCallbackIsRecognized() async throws {
-        let (manager, _) = makeManager()
-        let url = try #require(URL(string: "ayna://auth/callback?code=test-code"))
-
-        await manager.handle(url: url)
-
-        // OAuth callbacks don't set pending states, they're delegated
-        #expect(manager.pendingAddModel == nil)
-        #expect(manager.errorMessage == nil)
     }
 
     // MARK: - Main Action Tests
@@ -433,7 +791,7 @@ struct DeepLinkManagerTests {
 
         #expect(manager.showAddModelConfirmation)
 
-        manager.cancelAddModel()
+        try cancelPendingModel(in: manager)
 
         #expect(!manager.showAddModelConfirmation)
     }
@@ -499,17 +857,18 @@ struct DeepLinkManagerTests {
         #expect(manager.pendingAddModel != nil)
         #expect(manager.pendingChat != nil)
 
-        manager.confirmAddModel()
+        try confirmPendingModel(in: manager)
 
         // Model should be added
         #expect(service.customModels.contains("unified-model"))
         #expect(service.modelProviders["unified-model"] == .githubModels)
         #expect(service.modelAPIKeys["unified-model"] == "test-key")
 
-        // Add model confirmation cleared, but chat preserved
+        // Add model confirmation cleared, and chat released exactly once
         #expect(manager.pendingAddModel == nil)
-        #expect(manager.pendingChat != nil)
-        #expect(manager.pendingChat?.prompt == "Test prompt")
+        let chat = try consumeExactlyOne(from: manager)
+        #expect(chat.prompt == "Test prompt")
+        #expect(drainReadyChats(from: manager).isEmpty)
     }
 
     @Test("Unified flow cancel clears both pending requests")
@@ -521,7 +880,7 @@ struct DeepLinkManagerTests {
         #expect(manager.pendingAddModel != nil)
         #expect(manager.pendingChat != nil)
 
-        manager.cancelAddModel()
+        try cancelPendingModel(in: manager)
 
         // Both should be cleared
         #expect(manager.pendingAddModel == nil)
@@ -607,7 +966,8 @@ struct DeepLinkManagerTests {
 
     @Test("Chat without config params has no model config")
     func chatWithoutConfigParamsHasNoModelConfig() async throws {
-        let (manager, _) = makeManager()
+        let (manager, service) = makeManager()
+        service.customModels.append("simple-model")
         let url = try #require(URL(string: "ayna://chat?model=simple-model&prompt=Hello"))
 
         await manager.handle(url: url)

--- a/Tests/AynaTests/EncryptedConversationStoreTests.swift
+++ b/Tests/AynaTests/EncryptedConversationStoreTests.swift
@@ -50,8 +50,8 @@ struct EncryptedConversationStoreTests {
         }
     }
 
-    @Test("Save and load round trips conversations")
-    func saveAndLoadRoundTripsConversations() async throws {
+    @Test
+    func `save and load round trips conversations`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let store = TestHelpers.makeTestStore(directory: directory)
         let conversation = TestHelpers.sampleConversation(title: "Alpha")
@@ -64,8 +64,8 @@ struct EncryptedConversationStoreTests {
         #expect(loaded.first?.messages.count == conversation.messages.count)
     }
 
-    @Test("Clear removes encrypted files")
-    func clearRemovesEncryptedFiles() async throws {
+    @Test
+    func `clear removes encrypted files`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let store = TestHelpers.makeTestStore(directory: directory)
         let conversation = TestHelpers.sampleConversation()
@@ -79,8 +79,8 @@ struct EncryptedConversationStoreTests {
         #expect(files.isEmpty)
     }
 
-    @Test("Second store instance loads data using same key")
-    func secondStoreInstanceLoadsDataUsingSameKey() async throws {
+    @Test
+    func `second store instance loads data using same key`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let keyIdentifier = UUID().uuidString
 
@@ -98,8 +98,8 @@ struct EncryptedConversationStoreTests {
         #expect(loaded.first?.title == "Persisted")
     }
 
-    @Test("Loading an empty store does not create an encryption key")
-    func loadingEmptyStoreDoesNotCreateEncryptionKey() async throws {
+    @Test
+    func `loading an empty store does not create an encryption key`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let keychain = CountingKeychainStorage()
         let store = EncryptedConversationStore(
@@ -116,8 +116,28 @@ struct EncryptedConversationStoreTests {
         #expect(counts.stringReads == 0)
     }
 
-    @Test("Encryption key is cached across repeated save and load operations")
-    func encryptionKeyIsCachedAcrossOperations() async throws {
+    @Test
+    func `one unreadable record fails the whole load instead of returning a partial snapshot`() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let store = TestHelpers.makeTestStore(directory: directory)
+        let readable = TestHelpers.sampleConversation(title: "Readable")
+        let unreadable = TestHelpers.sampleConversation(title: "Unreadable")
+        try await store.save(readable)
+        try await store.save(unreadable)
+        try Data("corrupt encrypted record".utf8).write(
+            to: store.fileURL(for: unreadable.id),
+            options: .atomic
+        )
+
+        await #expect(throws: EncryptedStoreError.self) {
+            _ = try await store.loadConversations()
+        }
+        #expect(FileManager.default.fileExists(atPath: store.fileURL(for: readable.id).path))
+        #expect(FileManager.default.fileExists(atPath: store.fileURL(for: unreadable.id).path))
+    }
+
+    @Test
+    func `encryption key is cached across repeated save and load operations`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let keychain = CountingKeychainStorage()
         let store = EncryptedConversationStore(

--- a/Tests/AynaTests/IOSChatViewModelTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelTests.swift
@@ -1,0 +1,109 @@
+#if os(iOS)
+
+    @testable import Ayna
+    import Foundation
+    import Testing
+
+    @Suite("iOS Chat View Model Tests", .tags(.viewModel), .serialized)
+    @MainActor
+    struct IOSChatViewModelTests {
+        @Test
+        func `retry sends the selected response model and provider`() async throws {
+            AIService.keychain = InMemoryKeychainStorage()
+            let conversationModel = "conversation-default"
+            let retryModel = "selected-response"
+            let userMessage = Message(role: .user, content: "Compare these models")
+            let assistantMessage = Message(
+                role: .assistant,
+                content: "Selected response",
+                model: retryModel
+            )
+            let conversation = Conversation(
+                messages: [userMessage, assistantMessage],
+                model: conversationModel,
+                systemPromptMode: .disabled
+            )
+            let store = ScriptedConversationStore()
+            let manager = ConversationManager(store: store, saveDebounceDuration: .zero)
+            await manager.loadingTask?.value
+            manager.conversations = [conversation]
+
+            let aiService = RetryCapturingAIService()
+            aiService.customModels = [conversationModel, retryModel]
+            aiService.selectedModel = conversationModel
+            aiService.modelProviders[conversationModel] = .openai
+            aiService.modelProviders[retryModel] = .anthropic
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+
+            viewModel.retryMessage(beforeMessage: assistantMessage)
+
+            let request = try #require(aiService.capturedRequests.first)
+            #expect(request.model == retryModel)
+            #expect(request.provider == .anthropic)
+            #expect(manager.conversation(byId: conversation.id)?.messages.last?.model == retryModel)
+            viewModel.cancelOwnedOperations()
+        }
+    }
+
+    private struct CapturedRetryRequest {
+        let model: String
+        let provider: AIProvider
+    }
+
+    @MainActor
+    private final class RetryCapturingAIService: AIService {
+        private(set) var capturedRequests: [CapturedRetryRequest] = []
+
+        init() {
+            super.init(responseSimulator: { _, _ in })
+        }
+
+        override func sendMessage(
+            messages: [Message],
+            model: String?,
+            temperature: Double?,
+            stream: Bool,
+            tools: [[String: Any]]?,
+            conversationId: UUID?,
+            isMultiModelRequest: Bool,
+            onChunk: @escaping @Sendable (String) -> Void,
+            onComplete: @escaping @Sendable () -> Void,
+            onError: @escaping @Sendable (Error) -> Void,
+            onToolCall: (@Sendable (String, String, [String: Any]) async -> String)?,
+            onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?,
+            onReasoning: (@Sendable (String) -> Void)?,
+            preparedAPIKey: String?,
+            requestFlightID: RequestFlightID?
+        ) -> AITextRequest {
+            let requestModel = model ?? selectedModel
+            capturedRequests.append(
+                CapturedRetryRequest(
+                    model: requestModel,
+                    provider: modelProviders[requestModel] ?? provider
+                )
+            )
+            return super.sendMessage(
+                messages: messages,
+                model: model,
+                temperature: temperature,
+                stream: stream,
+                tools: tools,
+                conversationId: conversationId,
+                isMultiModelRequest: isMultiModelRequest,
+                onChunk: onChunk,
+                onComplete: onComplete,
+                onError: onError,
+                onToolCall: onToolCall,
+                onToolCallRequested: onToolCallRequested,
+                onReasoning: onReasoning,
+                preparedAPIKey: preparedAPIKey,
+                requestFlightID: requestFlightID
+            )
+        }
+    }
+
+#endif

--- a/Tests/AynaTests/ImageGenerationCoordinatorTests.swift
+++ b/Tests/AynaTests/ImageGenerationCoordinatorTests.swift
@@ -1,0 +1,105 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+#if !os(watchOS)
+    @Suite("Image Generation Coordinator Tests", .tags(.async))
+    @MainActor
+    struct ImageGenerationCoordinatorTests {
+        @Test("Replacement cancels the previous operation without surrendering ownership")
+        func replacementCancelsPreviousOperationWithoutSurrenderingOwnership() async {
+            let coordinator = ImageGenerationCoordinator()
+            let firstID = coordinator.beginOperation()
+            let cancellationObserved = FlightTestSignal()
+            let blocker = FlightTestSignal()
+            let firstTask = Task {
+                await withTaskCancellationHandler {
+                    await blocker.wait()
+                } onCancel: {
+                    cancellationObserved.signal()
+                }
+            }
+            coordinator.track(firstTask, for: firstID)
+
+            let secondID = coordinator.beginOperation()
+            let cancelled = await cancellationObserved.wait(timeout: .seconds(1))
+
+            #expect(cancelled)
+            #expect(!coordinator.owns(firstID))
+            #expect(coordinator.owns(secondID))
+            #expect(!coordinator.finishOperation(firstID))
+            #expect(coordinator.owns(secondID))
+
+            blocker.signal()
+            coordinator.cancelCurrentOperation()
+        }
+
+        @Test("Scheduled stale work is suppressed while current work runs")
+        func scheduledStaleWorkIsSuppressedWhileCurrentWorkRuns() async {
+            let coordinator = ImageGenerationCoordinator()
+            let staleID = coordinator.beginOperation()
+            let currentID = coordinator.beginOperation()
+            let staleRan = FlightTestSignal()
+            let currentRan = FlightTestSignal()
+
+            coordinator.schedule(for: staleID) {
+                staleRan.signal()
+            }
+            coordinator.schedule(for: currentID) {
+                currentRan.signal()
+            }
+
+            let currentCompleted = await currentRan.wait(timeout: .seconds(1))
+            let staleCompleted = await staleRan.wait(timeout: .milliseconds(100))
+
+            #expect(currentCompleted)
+            #expect(!staleCompleted)
+            #expect(coordinator.owns(currentID))
+            coordinator.cancelCurrentOperation()
+        }
+
+        @Test("Cancellation cleanup runs only for cancelled operations")
+        func cancellationCleanupRunsOnlyForCancelledOperations() {
+            let coordinator = ImageGenerationCoordinator()
+            var cleanupCount = 0
+
+            let completedID = coordinator.beginOperation()
+            coordinator.onCancel(for: completedID) {
+                cleanupCount += 1
+            }
+            #expect(coordinator.finishOperation(completedID))
+            coordinator.cancelCurrentOperation()
+            #expect(cleanupCount == 0)
+
+            let cancelledID = coordinator.beginOperation()
+            coordinator.onCancel(for: cancelledID) {
+                cleanupCount += 1
+            }
+            coordinator.cancelCurrentOperation()
+            #expect(cleanupCount == 1)
+        }
+
+        @Test("Cancellation selects only responses that are still streaming")
+        func cancellationSelectsOnlyStreamingResponses() {
+            let userMessageID = UUID()
+            let completedID = UUID()
+            let streamingID = UUID()
+            let failedID = UUID()
+            let responseGroup = ResponseGroup(
+                userMessageId: userMessageID,
+                responses: [
+                    .init(id: completedID, modelName: "completed", status: .completed),
+                    .init(id: streamingID, modelName: "streaming", status: .streaming),
+                    .init(id: failedID, modelName: "failed", status: .failed),
+                ]
+            )
+
+            let pending = ImageGenerationCoordinator.pendingMessageIDs(
+                in: responseGroup,
+                candidates: [completedID, streamingID, failedID]
+            )
+
+            #expect(pending == [streamingID])
+        }
+    }
+#endif

--- a/Tests/AynaTests/MCPServerManagerTests.swift
+++ b/Tests/AynaTests/MCPServerManagerTests.swift
@@ -457,21 +457,39 @@ struct MCPServerManagerTests {
         let config = MCPServerConfig(name: "cancel-reconnect", command: "cmd", enabled: true)
         let primaryService = StubMCPService(config: config)
         let reconnectService = StubMCPService(config: config)
+        let reconnectSleepEntered = FlightTestSignal()
+        let releaseReconnectSleep = FlightTestSignal()
+        let reconnectSleepCancelled = FlightTestSignal()
         var services = [primaryService, reconnectService]
         let manager = MCPServerManager(
             serviceFactory: { _ in services.removeFirst() },
             retryDelayProvider: { _ in 0 },
-            reconnectDelayProvider: { 60 }
+            reconnectDelayProvider: { 60 },
+            reconnectSleeper: { _ in
+                reconnectSleepEntered.signal()
+                do {
+                    try await withTaskCancellationHandler {
+                        await releaseReconnectSleep.wait()
+                        try Task.checkCancellation()
+                    } onCancel: {
+                        releaseReconnectSleep.signal()
+                    }
+                } catch {
+                    reconnectSleepCancelled.signal()
+                    throw error
+                }
+            }
         )
         manager.serverConfigs = [config]
         manager.updateServerConfig(config)
 
         await manager.connectToServer(config)
         primaryService.simulateUnexpectedTermination(error: "boom")
+        await reconnectSleepEntered.wait()
         #expect(manager.getServerStatus(config.name)?.state == .reconnecting)
 
         manager.disconnectServer(config.name)
-        try? await Task.sleep(for: .milliseconds(50))
+        await reconnectSleepCancelled.wait()
 
         #expect(reconnectService.connectCallCount == 0)
         #expect(manager.getServerStatus(config.name)?.state == .idle)

--- a/Tests/AynaTests/MCPServerManagerTests.swift
+++ b/Tests/AynaTests/MCPServerManagerTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 import Testing
 
-@Suite("MCPServerManager Tests", .tags(.async, .slow))
+@Suite("MCPServerManager Tests", .tags(.async, .slow), .serialized)
 @MainActor
 struct MCPServerManagerTests {
     private var suiteName: String
@@ -169,6 +169,450 @@ struct MCPServerManagerTests {
         #expect(restartedService.connectCallCount == 1)
         #expect(manager.getServerStatus(updatedConfig.name)?.state == .connected)
     }
+
+    @Test("Cancelling retry backoff prevents another connection attempt", .timeLimit(.minutes(1)))
+    func cancellingRetryBackoffPreventsAnotherAttempt() async {
+        let config = MCPServerConfig(name: "backoff", command: "cmd", enabled: true)
+        let service = StubMCPService(
+            config: config,
+            connectResults: [.failure(MCPTestError.expected), .success(())]
+        )
+        let manager = MCPServerManager(
+            serviceFactory: { _ in service },
+            retryDelayProvider: { _ in 60 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [config]
+        manager.updateServerConfig(config)
+
+        let task = Task { @MainActor in
+            await manager.connectToServer(config)
+        }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while service.connectCallCount == 0, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(service.connectCallCount == 1)
+        task.cancel()
+        await task.value
+
+        #expect(service.connectCallCount == 1)
+        #expect(manager.serverConfigs.first?.enabled == true)
+        #expect(manager.getServerStatus(config.name)?.state == .idle)
+    }
+
+    @Test("Cancellation after discovery commit removes stale tools", .timeLimit(.minutes(1)))
+    func cancellationAfterDiscoveryCommitRemovesStaleTools() async {
+        let config = MCPServerConfig(name: "stale-tools", command: "cmd", enabled: true)
+        let service = StubMCPService(config: config)
+        service.listToolsHandler = {
+            withUnsafeCurrentTask { task in
+                task?.cancel()
+            }
+            return [
+                MCPTool(
+                    name: "stale",
+                    description: "stale",
+                    inputSchema: JSONSchema(type: "object", properties: nil, required: nil, items: nil),
+                    serverName: config.name
+                )
+            ]
+        }
+        let manager = MCPServerManager(
+            serviceFactory: { _ in service },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [config]
+        manager.updateServerConfig(config)
+
+        await manager.connectToServer(config)
+
+        #expect(!manager.availableTools.contains { $0.serverName == config.name })
+        #expect(!manager.getEnabledTools().contains { $0.serverName == config.name })
+        #expect(manager.getServerStatus(config.name)?.state == .idle)
+    }
+
+    @Test("Cancelling tool discovery does not commit connected state", .timeLimit(.minutes(1)))
+    func cancellingToolDiscoveryDoesNotCommitConnectedState() async {
+        let config = MCPServerConfig(name: "discovery", command: "cmd", enabled: true)
+        let discoveryStarted = FlightTestSignal()
+        let service = StubMCPService(config: config)
+        service.listToolsHandler = {
+            discoveryStarted.signal()
+            try await Task.sleep(for: .seconds(60))
+            return []
+        }
+        let manager = MCPServerManager(
+            serviceFactory: { _ in service },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [config]
+        manager.updateServerConfig(config)
+
+        let task = Task { @MainActor in
+            await manager.connectToServer(config)
+        }
+        #expect(await discoveryStarted.wait(timeout: .seconds(1)))
+        task.cancel()
+        await task.value
+
+        #expect(service.connectCallCount == 1)
+        #expect(service.disconnectCallCount >= 1)
+        #expect(manager.getServerStatus(config.name)?.state == .idle)
+        #expect(manager.getConnectedServerCount() == 0)
+    }
+
+    @Test("Replacement discovery batch starts fresh work without reusing its predecessor", .timeLimit(.minutes(1)))
+    func replacementDiscoveryBatchStartsFreshWork() async {
+        let config = MCPServerConfig(name: "replacement-discovery", command: "cmd", enabled: true)
+        let service = StubMCPService(config: config)
+        service.listToolsResult = .success([makeMCPTool(name: "initial", serverName: config.name)])
+        let manager = MCPServerManager(
+            serviceFactory: { _ in service },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [config]
+        manager.updateServerConfig(config)
+        await manager.connectToServer(config)
+
+        let firstDiscoveryStarted = FlightTestSignal()
+        let releaseFirstDiscovery = FlightTestSignal()
+        let invocationCount = FlightTestBox(0)
+        service.listToolsHandler = {
+            invocationCount.update { $0 += 1 }
+            if invocationCount.value == 1 {
+                firstDiscoveryStarted.signal()
+                await releaseFirstDiscovery.wait()
+            }
+            return [makeMCPTool(name: "fresh", serverName: config.name)]
+        }
+
+        let firstBatch = Task { @MainActor in
+            await manager.discoverAllTools()
+        }
+        #expect(await firstDiscoveryStarted.wait(timeout: .seconds(1)))
+
+        let replacementBatch = Task { @MainActor in
+            await manager.discoverAllTools()
+        }
+        await replacementBatch.value
+        releaseFirstDiscovery.signal()
+        await firstBatch.value
+
+        #expect(invocationCount.value == 2)
+        #expect(manager.availableTools.map(\.name) == ["fresh"])
+    }
+
+    @Test("Superseded resource discovery cannot overwrite a newer catalog", .timeLimit(.minutes(1)))
+    func supersededResourceDiscoveryCannotOverwriteNewerCatalog() async {
+        let config = MCPServerConfig(name: "resource-fence", command: "cmd", enabled: true)
+        let service = StubMCPService(config: config)
+        let manager = MCPServerManager(
+            serviceFactory: { _ in service },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [config]
+        manager.updateServerConfig(config)
+        await manager.connectToServer(config)
+
+        let firstResourceStarted = FlightTestSignal()
+        let releaseFirstResource = FlightTestSignal()
+        let toolInvocationCount = FlightTestBox(0)
+        let resourceInvocationCount = FlightTestBox(0)
+        service.listToolsHandler = {
+            toolInvocationCount.update { $0 += 1 }
+            let name = toolInvocationCount.value == 1 ? "stale-tool" : "fresh-tool"
+            return [makeMCPTool(name: name, serverName: config.name)]
+        }
+        service.listResourcesHandler = {
+            resourceInvocationCount.update { $0 += 1 }
+            if resourceInvocationCount.value == 1 {
+                firstResourceStarted.signal()
+                await releaseFirstResource.wait()
+                return [makeMCPResource(name: "stale-resource", serverName: config.name)]
+            }
+            return [makeMCPResource(name: "fresh-resource", serverName: config.name)]
+        }
+
+        let staleDiscovery = Task { @MainActor in
+            await manager.discoverTools(for: config.name)
+        }
+        #expect(await firstResourceStarted.wait(timeout: .seconds(1)))
+
+        let freshDiscovery = Task { @MainActor in
+            await manager.discoverTools(for: config.name)
+        }
+        await freshDiscovery.value
+        releaseFirstResource.signal()
+        await staleDiscovery.value
+
+        #expect(manager.availableTools.map(\.name) == ["fresh-tool"])
+        #expect(manager.availableResources.map(\.name) == ["fresh-resource"])
+    }
+
+    @Test("Repeated refreshes during initial discovery are adopted by the connection", .timeLimit(.minutes(1)))
+    func repeatedRefreshesDuringInitialDiscoveryAreAdoptedByConnection() async {
+        let config = MCPServerConfig(name: "connection-refresh", command: "cmd", enabled: true)
+        let service = StubMCPService(config: config)
+        let firstDiscoveryStarted = FlightTestSignal()
+        let secondDiscoveryStarted = FlightTestSignal()
+        let thirdDiscoveryStarted = FlightTestSignal()
+        let releaseFirstDiscovery = FlightTestSignal()
+        let releaseSecondDiscovery = FlightTestSignal()
+        let releaseThirdDiscovery = FlightTestSignal()
+        let invocationCount = FlightTestBox(0)
+        service.listToolsHandler = {
+            invocationCount.update { $0 += 1 }
+            switch invocationCount.value {
+            case 1:
+                firstDiscoveryStarted.signal()
+                await releaseFirstDiscovery.wait()
+                return [makeMCPTool(name: "superseded", serverName: config.name)]
+            case 2:
+                secondDiscoveryStarted.signal()
+                await releaseSecondDiscovery.wait()
+                return [makeMCPTool(name: "superseded-again", serverName: config.name)]
+            default:
+                thirdDiscoveryStarted.signal()
+                await releaseThirdDiscovery.wait()
+                return [makeMCPTool(name: "fresh", serverName: config.name)]
+            }
+        }
+        let manager = MCPServerManager(
+            serviceFactory: { _ in service },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [config]
+        manager.updateServerConfig(config)
+
+        let connection = Task { @MainActor in
+            await manager.connectToServer(config)
+        }
+        #expect(await firstDiscoveryStarted.wait(timeout: .seconds(1)))
+
+        let firstRefresh = Task { @MainActor in
+            await manager.discoverAllTools()
+        }
+        #expect(await secondDiscoveryStarted.wait(timeout: .seconds(1)))
+
+        let secondRefresh = Task { @MainActor in
+            await manager.discoverAllTools()
+        }
+        #expect(await thirdDiscoveryStarted.wait(timeout: .seconds(1)))
+        releaseFirstDiscovery.signal()
+        releaseSecondDiscovery.signal()
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(service.disconnectCallCount == 0)
+
+        releaseThirdDiscovery.signal()
+        await firstRefresh.value
+        await secondRefresh.value
+        await connection.value
+
+        #expect(manager.isServerConnected(config.name))
+        #expect(manager.availableTools.map(\.name) == ["fresh"])
+    }
+
+    @Test("Stale service termination cannot remove replacement", .timeLimit(.minutes(1)))
+    func staleServiceTerminationCannotRemoveReplacement() async {
+        let original = MCPServerConfig(name: "identity", command: "cmd", args: ["old"], enabled: true)
+        var updated = original
+        updated.args = ["new"]
+
+        let initialService = StubMCPService(config: original)
+        initialService.listToolsResult = .success([makeMCPTool(name: "old-tool", serverName: original.name)])
+        let replacementService = StubMCPService(config: updated)
+        replacementService.listToolsResult = .success([makeMCPTool(name: "new-tool", serverName: updated.name)])
+        let manager = MCPServerManager(
+            serviceFactory: { config in config.args == updated.args ? replacementService : initialService },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [original]
+        manager.updateServerConfig(original)
+
+        await manager.connectToServer(original)
+        let staleDelegate = initialService.delegate
+        manager.updateServerConfig(updated)
+        #expect(await waitUntil { manager.getServerStatus(updated.name)?.state == .connected })
+        #expect(manager.availableTools.contains { $0.name == "new-tool" })
+
+        staleDelegate?.mcpService(initialService, didTerminateWithError: "stale")
+        await Task.yield()
+
+        #expect(manager.isServerConnected(updated.name))
+        #expect(replacementService.disconnectCallCount == 0)
+        #expect(manager.availableTools.contains { $0.name == "new-tool" })
+        #expect(!manager.availableTools.contains { $0.name == "old-tool" })
+    }
+
+    @Test("Manual disconnect cancels retained scheduled reconnect", .timeLimit(.minutes(1)))
+    func manualDisconnectCancelsRetainedScheduledReconnect() async {
+        let config = MCPServerConfig(name: "cancel-reconnect", command: "cmd", enabled: true)
+        let primaryService = StubMCPService(config: config)
+        let reconnectService = StubMCPService(config: config)
+        var services = [primaryService, reconnectService]
+        let manager = MCPServerManager(
+            serviceFactory: { _ in services.removeFirst() },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 60 }
+        )
+        manager.serverConfigs = [config]
+        manager.updateServerConfig(config)
+
+        await manager.connectToServer(config)
+        primaryService.simulateUnexpectedTermination(error: "boom")
+        #expect(manager.getServerStatus(config.name)?.state == .reconnecting)
+
+        manager.disconnectServer(config.name)
+        try? await Task.sleep(for: .milliseconds(50))
+
+        #expect(reconnectService.connectCallCount == 0)
+        #expect(manager.getServerStatus(config.name)?.state == .idle)
+        #expect(!manager.isServerConnected(config.name))
+    }
+
+    @Test("Stale connection completion cannot replace newer generation", .timeLimit(.minutes(1)))
+    func staleConnectionCompletionCannotReplaceNewerGeneration() async {
+        let original = MCPServerConfig(name: "connect-generation", command: "cmd", args: ["old"], enabled: true)
+        var updated = original
+        updated.args = ["new"]
+
+        let oldConnectStarted = FlightTestSignal()
+        let releaseOldConnect = FlightTestSignal()
+        let oldService = StubMCPService(config: original)
+        oldService.connectHandler = {
+            oldConnectStarted.signal()
+            await releaseOldConnect.wait()
+        }
+        let replacementService = StubMCPService(config: updated)
+        replacementService.listToolsResult = .success([makeMCPTool(name: "replacement", serverName: updated.name)])
+        let manager = MCPServerManager(
+            serviceFactory: { config in config.args == updated.args ? replacementService : oldService },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [original]
+        manager.updateServerConfig(original)
+
+        let oldConnection = Task { @MainActor in
+            await manager.connectToServer(original)
+        }
+        #expect(await oldConnectStarted.wait(timeout: .seconds(1)))
+
+        manager.updateServerConfig(updated)
+        #expect(await waitUntil { manager.getServerStatus(updated.name)?.state == .connected })
+        releaseOldConnect.signal()
+        await oldConnection.value
+
+        #expect(manager.isServerConnected(updated.name))
+        #expect(replacementService.disconnectCallCount == 0)
+        #expect(manager.availableTools.map(\.name) == ["replacement"])
+    }
+
+    @Test("Stale discovery cannot overwrite replacement tools", .timeLimit(.minutes(1)))
+    func staleDiscoveryCannotOverwriteReplacementTools() async {
+        let original = MCPServerConfig(name: "discovery-generation", command: "cmd", args: ["old"], enabled: true)
+        var updated = original
+        updated.args = ["new"]
+
+        let oldService = StubMCPService(config: original)
+        oldService.listToolsResult = .success([makeMCPTool(name: "initial", serverName: original.name)])
+        let replacementService = StubMCPService(config: updated)
+        replacementService.listToolsResult = .success([makeMCPTool(name: "replacement", serverName: updated.name)])
+        let manager = MCPServerManager(
+            serviceFactory: { config in config.args == updated.args ? replacementService : oldService },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [original]
+        manager.updateServerConfig(original)
+        await manager.connectToServer(original)
+
+        let staleDiscoveryStarted = FlightTestSignal()
+        let releaseStaleDiscovery = FlightTestSignal()
+        oldService.listToolsHandler = {
+            staleDiscoveryStarted.signal()
+            await releaseStaleDiscovery.wait()
+            return [makeMCPTool(name: "stale", serverName: original.name)]
+        }
+        let staleDiscovery = Task { @MainActor in
+            await manager.discoverTools(for: original.name)
+        }
+        #expect(await staleDiscoveryStarted.wait(timeout: .seconds(1)))
+
+        manager.updateServerConfig(updated)
+        #expect(await waitUntil { manager.getServerStatus(updated.name)?.state == .connected })
+        releaseStaleDiscovery.signal()
+        await staleDiscovery.value
+
+        #expect(manager.availableTools.map(\.name) == ["replacement"])
+        #expect(manager.getServerStatus(updated.name)?.state == .connected)
+    }
+
+    @Test("Cancelling a connection does not retry or disable the server", .timeLimit(.minutes(1)))
+    func cancellingConnectionDoesNotRetryOrDisableServer() async {
+        let config = MCPServerConfig(name: "cancelled", command: "cmd", enabled: true)
+        let started = FlightTestSignal()
+        let service = StubMCPService(config: config)
+        service.connectHandler = {
+            started.signal()
+            try await Task.sleep(for: .seconds(60))
+        }
+        let manager = MCPServerManager(
+            serviceFactory: { _ in service },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [config]
+        manager.updateServerConfig(config)
+
+        let task = Task { @MainActor in
+            await manager.connectToServer(config)
+        }
+        #expect(await started.wait(timeout: .seconds(1)))
+        task.cancel()
+        await task.value
+
+        #expect(service.connectCallCount == 1)
+        #expect(manager.serverConfigs.first?.enabled == true)
+        #expect(manager.getServerStatus(config.name)?.state == .idle)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        condition: @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !condition(), clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return condition()
+    }
+}
+
+private func makeMCPTool(name: String, serverName: String) -> MCPTool {
+    MCPTool(
+        name: name,
+        description: name,
+        inputSchema: JSONSchema(type: "object", properties: nil, required: nil, items: nil),
+        serverName: serverName
+    )
+}
+
+private func makeMCPResource(name: String, serverName: String) -> MCPResource {
+    MCPResource(
+        uri: "resource://\(name)",
+        name: name,
+        serverName: serverName
+    )
 }
 
 private enum MCPTestError: Error {
@@ -187,7 +631,10 @@ private final class StubMCPService: MCPServicing, @unchecked Sendable {
     var disconnectCallCount = 0
     var listToolsResult: Result<[MCPTool], Error> = .success([])
     var listResourcesResult: Result<[MCPResource], Error> = .success([])
+    var listToolsHandler: (@Sendable () async throws -> [MCPTool])?
+    var listResourcesHandler: (@Sendable () async throws -> [MCPResource])?
     var onConnect: (() -> Void)?
+    var connectHandler: (@Sendable () async throws -> Void)?
 
     init(config: MCPServerConfig, connectResults: [Result<Void, Error>] = [.success(())]) {
         serverConfig = config
@@ -196,6 +643,12 @@ private final class StubMCPService: MCPServicing, @unchecked Sendable {
 
     func connect() async throws {
         connectCallCount += 1
+        if let connectHandler {
+            try await connectHandler()
+            isConnected = true
+            onConnect?()
+            return
+        }
         let index = min(connectCallCount - 1, connectResults.count - 1)
         let result = connectResults[index]
         switch result {
@@ -213,11 +666,17 @@ private final class StubMCPService: MCPServicing, @unchecked Sendable {
     }
 
     func listTools() async throws -> [MCPTool] {
-        try listToolsResult.get()
+        if let listToolsHandler {
+            return try await listToolsHandler()
+        }
+        return try listToolsResult.get()
     }
 
     func listResources() async throws -> [MCPResource] {
-        try listResourcesResult.get()
+        if let listResourcesHandler {
+            return try await listResourcesHandler()
+        }
+        return try listResourcesResult.get()
     }
 
     func callTool(name _: String, arguments _: [String: Any]) async throws -> String {

--- a/Tests/AynaTests/MCPServerManagerTests.swift
+++ b/Tests/AynaTests/MCPServerManagerTests.swift
@@ -170,8 +170,8 @@ struct MCPServerManagerTests {
         #expect(manager.getServerStatus(updatedConfig.name)?.state == .connected)
     }
 
-    @Test("Cancelling retry backoff prevents another connection attempt", .timeLimit(.minutes(1)))
-    func cancellingRetryBackoffPreventsAnotherAttempt() async {
+    @Test("Disconnecting during retry backoff prevents another connection attempt", .timeLimit(.minutes(1)))
+    func disconnectingDuringRetryBackoffPreventsAnotherAttempt() async {
         let config = MCPServerConfig(name: "backoff", command: "cmd", enabled: true)
         let service = StubMCPService(
             config: config,
@@ -194,7 +194,7 @@ struct MCPServerManagerTests {
             try? await Task.sleep(for: .milliseconds(5))
         }
         #expect(service.connectCallCount == 1)
-        task.cancel()
+        manager.disconnectServer(config.name)
         await task.value
 
         #expect(service.connectCallCount == 1)
@@ -234,8 +234,8 @@ struct MCPServerManagerTests {
         #expect(manager.getServerStatus(config.name)?.state == .idle)
     }
 
-    @Test("Cancelling tool discovery does not commit connected state", .timeLimit(.minutes(1)))
-    func cancellingToolDiscoveryDoesNotCommitConnectedState() async {
+    @Test("Disconnecting during tool discovery does not commit connected state", .timeLimit(.minutes(1)))
+    func disconnectingDuringToolDiscoveryDoesNotCommitConnectedState() async {
         let config = MCPServerConfig(name: "discovery", command: "cmd", enabled: true)
         let discoveryStarted = FlightTestSignal()
         let service = StubMCPService(config: config)
@@ -256,7 +256,7 @@ struct MCPServerManagerTests {
             await manager.connectToServer(config)
         }
         #expect(await discoveryStarted.wait(timeout: .seconds(1)))
-        task.cancel()
+        manager.disconnectServer(config.name)
         await task.value
 
         #expect(service.connectCallCount == 1)
@@ -574,8 +574,8 @@ struct MCPServerManagerTests {
         #expect(manager.getServerStatus(updated.name)?.state == .connected)
     }
 
-    @Test("Cancelling a connection does not retry or disable the server", .timeLimit(.minutes(1)))
-    func cancellingConnectionDoesNotRetryOrDisableServer() async {
+    @Test("Disconnecting a connection does not retry or disable the server", .timeLimit(.minutes(1)))
+    func disconnectingConnectionDoesNotRetryOrDisableServer() async {
         let config = MCPServerConfig(name: "cancelled", command: "cmd", enabled: true)
         let started = FlightTestSignal()
         let service = StubMCPService(config: config)
@@ -595,12 +595,92 @@ struct MCPServerManagerTests {
             await manager.connectToServer(config)
         }
         #expect(await started.wait(timeout: .seconds(1)))
-        task.cancel()
+        manager.disconnectServer(config.name)
         await task.value
 
         #expect(service.connectCallCount == 1)
         #expect(manager.serverConfigs.first?.enabled == true)
         #expect(manager.getServerStatus(config.name)?.state == .idle)
+    }
+
+    @Test("Cancelling one connection waiter preserves the shared connection", .timeLimit(.minutes(1)))
+    func cancellingOneConnectionWaiterPreservesSharedConnection() async {
+        let config = MCPServerConfig(name: "shared-waiter", command: "cmd", enabled: true)
+        let connectionStarted = FlightTestSignal()
+        let connectionCancelled = FlightTestSignal()
+        let releaseConnection = FlightTestSignal()
+        let service = StubMCPService(config: config)
+        service.connectHandler = {
+            connectionStarted.signal()
+            try await withTaskCancellationHandler {
+                await releaseConnection.wait()
+                try Task.checkCancellation()
+            } onCancel: {
+                connectionCancelled.signal()
+                releaseConnection.signal()
+            }
+        }
+        let manager = MCPServerManager(
+            serviceFactory: { _ in service },
+            retryDelayProvider: { _ in 0 },
+            reconnectDelayProvider: { 0 }
+        )
+        manager.serverConfigs = [config]
+        manager.updateServerConfig(config)
+
+        let activeWaiterFinished = FlightTestSignal()
+        let activeWaiter = Task { @MainActor in
+            await manager.connectToServer(config)
+            activeWaiterFinished.signal()
+        }
+        #expect(await connectionStarted.wait(timeout: .seconds(1)))
+
+        let releaseCancelledWaiter = FlightTestSignal()
+        let cancelledWaiterFinished = FlightTestSignal()
+        let cancelledWaiter = Task { @MainActor in
+            await releaseCancelledWaiter.wait()
+            await manager.connectToServer(config)
+            cancelledWaiterFinished.signal()
+        }
+        cancelledWaiter.cancel()
+        releaseCancelledWaiter.signal()
+
+        let didCancelledWaiterFinish = await cancelledWaiterFinished.wait(timeout: .seconds(1))
+        #expect(didCancelledWaiterFinish)
+        let wasConnectionCancelled = await connectionCancelled.wait(timeout: .milliseconds(100))
+        #expect(!wasConnectionCancelled)
+        #expect(!activeWaiterFinished.isSignaled)
+
+        releaseConnection.signal()
+        await activeWaiter.value
+        await cancelledWaiter.value
+
+        #expect(service.connectCallCount == 1)
+        #expect(service.disconnectCallCount == 0)
+        #expect(manager.isServerConnected(config.name))
+        #expect(manager.getServerStatus(config.name)?.state == .connected)
+    }
+
+    @Test("Cancelling registered operation waiters unregisters them immediately", .timeLimit(.minutes(1)))
+    func cancellingRegisteredOperationWaitersUnregistersImmediately() async {
+        let completion = ManagedMCPTaskCompletion()
+        let waiters = (0 ..< 32).map { _ in
+            Task {
+                await completion.wait()
+            }
+        }
+
+        let allWaitersRegistered = await waitUntil {
+            completion.pendingWaiterCount == waiters.count
+        }
+        #expect(allWaitersRegistered)
+
+        waiters.forEach { $0.cancel() }
+        for waiter in waiters {
+            await waiter.value
+        }
+
+        #expect(completion.pendingWaiterCount == 0)
     }
 
     private func waitUntil(

--- a/Tests/AynaTests/MCPServiceTests.swift
+++ b/Tests/AynaTests/MCPServiceTests.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
     @testable import Ayna
+    import Darwin
     import Foundation
     import Testing
 
@@ -28,6 +29,7 @@
             }
 
             #expect(service.pendingRequestCount == 0)
+            #expect(harness.recordedMessages(method: "notifications/cancelled").isEmpty)
         }
 
         @Test("List tools request times out and clears pending continuation", .timeLimit(.minutes(1)))
@@ -54,6 +56,233 @@
             #expect(service.pendingRequestCount == 0)
         }
 
+        @Test("Cancelling a written tool call emits an MCP cancellation notification", .timeLimit(.minutes(1)))
+        func cancellingWrittenToolCallEmitsCancellationNotification() async throws {
+            let harness = try MockMCPServerHarness(mode: .callTimeout)
+            defer { harness.cleanup() }
+
+            let service = harness.makeService(requestTimeoutSeconds: 30.0)
+            try await service.connect()
+            defer { service.disconnect() }
+
+            let task = Task {
+                try await service.callTool(name: "echo", arguments: [:])
+            }
+
+            guard let toolCall = await harness.waitForMessage(method: "tools/call"),
+                  let requestId = toolCall.id
+            else {
+                task.cancel()
+                _ = try? await task.value
+                Issue.record("Expected the mock server to receive the tool call")
+                return
+            }
+
+            task.cancel()
+            await expectCancellation(from: task)
+            #expect(service.pendingRequestCount == 0)
+
+            guard let notification = await harness.waitForMessage(method: "notifications/cancelled") else {
+                Issue.record("Expected the mock server to receive a cancellation notification")
+                return
+            }
+
+            #expect(notification.jsonrpc == "2.0")
+            #expect(notification.id == nil)
+            #expect(notification.requestId == requestId)
+            #expect(notification.reason == "Client cancelled request")
+            #expect(harness.recordedMessages(method: "notifications/cancelled").count == 1)
+        }
+
+        @Test("Cancellation before request write sends no tool call", .timeLimit(.minutes(1)))
+        func cancellationBeforeRequestWriteSendsNoToolCall() async throws {
+            let harness = try MockMCPServerHarness(mode: .callTimeout)
+            defer { harness.cleanup() }
+
+            let writeGate = MCPRequestWriteGate(targetMethod: "tools/call")
+            let service = harness.makeService(
+                requestTimeoutSeconds: 30.0,
+                requestWriteHook: { _, method in writeGate.pauseIfTarget(method) }
+            )
+            try await service.connect()
+            defer { service.disconnect() }
+            defer { writeGate.release() }
+
+            let task = Task {
+                try await service.callTool(name: "echo", arguments: [:])
+            }
+
+            let reachedWrite = await writeGate.entered.wait(timeout: .seconds(2))
+            #expect(reachedWrite)
+            #expect(service.pendingRequestCount == 1)
+
+            task.cancel()
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(2))
+            while service.pendingRequestCount != 0, clock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            #expect(service.pendingRequestCount == 0)
+
+            writeGate.release()
+            await expectCancellation(from: task)
+
+            // A following request is a deterministic transport barrier: once it receives a
+            // response, the mock server has observed every message the cancelled task could send.
+            #expect(try await service.listTools().isEmpty)
+            #expect(harness.recordedMessages(method: "tools/call").isEmpty)
+            #expect(harness.recordedMessages(method: "notifications/cancelled").isEmpty)
+            #expect(service.pendingRequestCount == 0)
+        }
+
+        @Test("Blocked request write does not block MainActor or cancellation", .timeLimit(.minutes(1)))
+        func blockedRequestWriteDoesNotBlockMainActorOrCancellation() async throws {
+            let harness = try MockMCPServerHarness(mode: .callTimeout)
+            defer { harness.cleanup() }
+
+            let writeGate = MCPMessageWriteGate(targetMethod: "tools/call")
+            let service = harness.makeService(
+                requestTimeoutSeconds: 30.0,
+                messageWriteHandler: { handle, data in
+                    writeGate.pauseIfTarget(data)
+                    try handle.write(contentsOf: data)
+                }
+            )
+            try await service.connect()
+            defer { service.disconnect() }
+            defer { writeGate.release() }
+
+            let completed = FlightTestSignal()
+            let task = Task {
+                defer { completed.signal() }
+                return try await service.callTool(name: "echo", arguments: [:])
+            }
+
+            let mainActorRan = FlightTestSignal()
+            let cancellationReturned = FlightTestSignal()
+            let startedAt = ContinuousClock.now
+
+            Task { @MainActor in
+                await writeGate.entered.wait()
+                mainActorRan.signal()
+            }
+            Task.detached {
+                await writeGate.entered.wait()
+                task.cancel()
+                cancellationReturned.signal()
+            }
+            Task.detached {
+                try? await Task.sleep(for: .seconds(1))
+                writeGate.release()
+            }
+
+            #expect(await writeGate.entered.wait(timeout: .seconds(2)))
+            #expect(await mainActorRan.wait(timeout: .milliseconds(250)))
+            #expect(await cancellationReturned.wait(timeout: .milliseconds(250)))
+            #expect(await completed.wait(timeout: .milliseconds(250)))
+            #expect(startedAt.duration(to: .now) < .milliseconds(750))
+            #expect(service.pendingRequestCount == 0)
+
+            writeGate.release()
+            await expectCancellation(from: task)
+        }
+
+        @Test("Blocked written request timeout disconnects and recovers the transport", .timeLimit(.minutes(1)))
+        @MainActor
+        func blockedWrittenRequestTimeoutDisconnectsAndRecoversTransport() async throws {
+            let harness = try MockMCPServerHarness(mode: .callTimeout)
+            defer { harness.cleanup() }
+
+            let writeGate = MCPMessageWriteGate(targetMethod: "tools/call")
+            let outcome = FlightTestBox<String?>(nil)
+            let completed = FlightTestSignal()
+            let service = harness.makeService(
+                requestTimeoutSeconds: 0.1,
+                messageWriteHandler: { handle, data in
+                    writeGate.pauseIfTarget(data)
+                    try handle.write(contentsOf: data)
+                }
+            )
+            let delegate = MCPServiceDelegateRecorder()
+            service.delegate = delegate
+            try await service.connect()
+            defer { service.disconnect() }
+            defer { writeGate.release() }
+
+            let startedAt = ContinuousClock.now
+            let task = Task {
+                defer { completed.signal() }
+                do {
+                    _ = try await service.callTool(name: "echo", arguments: [:])
+                    outcome.value = "success"
+                } catch MCPServiceError.timeout {
+                    outcome.value = "timeout"
+                } catch {
+                    outcome.value = error.localizedDescription
+                }
+            }
+            Task.detached {
+                try? await Task.sleep(for: .seconds(1))
+                writeGate.release()
+            }
+
+            #expect(await writeGate.entered.wait(timeout: .seconds(2)))
+            #expect(await completed.wait(timeout: .milliseconds(500)))
+            #expect(startedAt.duration(to: .now) < .milliseconds(750))
+            #expect(outcome.value == "timeout")
+            #expect(service.pendingRequestCount == 0)
+
+            let disconnectDeadline = ContinuousClock.now.advanced(by: .seconds(1))
+            while service.isConnected, ContinuousClock.now < disconnectDeadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            #expect(!service.isConnected)
+            let delegateDeadline = ContinuousClock.now.advanced(by: .seconds(1))
+            while delegate.terminationCount == 0, ContinuousClock.now < delegateDeadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            #expect(delegate.terminationCount == 1)
+
+            writeGate.release()
+            await task.value
+            #expect(harness.recordedMessages(method: "tools/call").isEmpty)
+            #expect(harness.recordedMessages(method: "notifications/cancelled").isEmpty)
+
+            try await service.connect()
+            #expect(service.isConnected)
+            _ = try await service.listTools()
+        }
+
+        @Test("Late response after cancellation is ignored without disrupting other requests", .timeLimit(.minutes(1)))
+        func lateResponseAfterCancellationIsIgnoredSafely() async throws {
+            let harness = try MockMCPServerHarness(mode: .lateResponseAfterCancellation)
+            defer { harness.cleanup() }
+
+            let service = harness.makeService(requestTimeoutSeconds: 30.0)
+            try await service.connect()
+            defer { service.disconnect() }
+
+            let task = Task {
+                try await service.callTool(name: "echo", arguments: [:])
+            }
+
+            guard await harness.waitForMessage(method: "tools/call") != nil else {
+                task.cancel()
+                _ = try? await task.value
+                Issue.record("Expected the mock server to receive the tool call")
+                return
+            }
+
+            task.cancel()
+            await expectCancellation(from: task)
+            #expect(service.pendingRequestCount == 0)
+
+            #expect(await harness.waitForEvent("late-response-sent"))
+            #expect(try await service.listTools().isEmpty)
+            #expect(service.pendingRequestCount == 0)
+            #expect(harness.recordedMessages(method: "notifications/cancelled").count == 1)
+        }
+
         @Test("Tool call request times out and clears pending continuation", .timeLimit(.minutes(1)))
         func callToolRequestTimesOut() async throws {
             let harness = try MockMCPServerHarness(mode: .callTimeout)
@@ -76,6 +305,64 @@
             }
 
             #expect(service.pendingRequestCount == 0)
+
+            guard let toolCall = await harness.waitForMessage(method: "tools/call"),
+                  let requestId = toolCall.id,
+                  let notification = await harness.waitForMessage(method: "notifications/cancelled")
+            else {
+                Issue.record("Expected timeout cancellation notification")
+                return
+            }
+            #expect(notification.requestId == requestId)
+            #expect(notification.reason == "Client request timed out")
+            #expect(harness.recordedMessages(method: "notifications/cancelled").count == 1)
+        }
+
+        @Test("Old TERM-resistant process exit cannot disconnect replacement", .timeLimit(.minutes(1)))
+        @MainActor
+        func oldTermResistantProcessExitCannotDisconnectReplacement() async throws {
+            let harness = try MockMCPServerHarness(mode: .termResistant)
+            defer { harness.cleanup() }
+
+            let tracker = MCPProcessTrackingRecorder()
+            let delegate = MCPServiceDelegateRecorder()
+            let service = harness.makeService(
+                requestTimeoutSeconds: 2.0,
+                terminationGracePeriod: 0.4,
+                processRegistrationHandler: { key, pid in tracker.register(key: key, pid: pid) },
+                processUnregistrationHandler: { key in tracker.unregister(key: key) }
+            )
+            service.delegate = delegate
+            defer { service.disconnect() }
+
+            try await service.connect()
+            #expect(await tracker.waitForRegistrationCount(1))
+            #expect(await harness.waitForEvent("term-resistant-ready"))
+
+            service.disconnect()
+            try await service.connect()
+            #expect(await tracker.waitForRegistrationCount(2))
+            #expect(service.isConnected)
+
+            #expect(await tracker.waitForUnregistrationCount(1, timeout: .seconds(2)))
+            #expect(tracker.unregistrations.first?.wasRunning == false)
+            #expect(service.isConnected)
+            #expect(delegate.terminationCount == 0)
+
+            service.disconnect()
+            #expect(await tracker.waitForUnregistrationCount(2, timeout: .seconds(2)))
+            #expect(tracker.unregistrations.allSatisfy { !$0.wasRunning })
+        }
+
+        private func expectCancellation(from task: Task<String, Error>) async {
+            do {
+                _ = try await task.value
+                Issue.record("Expected callTool() to throw cancellation")
+            } catch is CancellationError {
+                // Expected.
+            } catch {
+                Issue.record("Unexpected error type: \(error.localizedDescription)")
+            }
         }
     }
 
@@ -84,10 +371,13 @@
             case initializeTimeout = "initialize-timeout"
             case listTimeout = "list-timeout"
             case callTimeout = "call-timeout"
+            case lateResponseAfterCancellation = "late-response-after-cancellation"
+            case termResistant = "term-resistant"
         }
 
         let directory: URL
         let scriptURL: URL
+        let logURL: URL
         let mode: Mode
 
         init(mode: Mode) throws {
@@ -96,18 +386,75 @@
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
 
             scriptURL = directory.appendingPathComponent("mock-mcp-server.sh")
+            logURL = directory.appendingPathComponent("messages.log")
+            try Data().write(to: logURL)
             try scriptContents.write(to: scriptURL, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
         }
 
-        func makeService(requestTimeoutSeconds: TimeInterval) -> MCPService {
+        func makeService(
+            requestTimeoutSeconds: TimeInterval,
+            requestWriteHook: (@Sendable (Int, String) -> Void)? = nil,
+            messageWriteHandler: @escaping @Sendable (FileHandle, Data) throws -> Void = { handle, data in
+                try handle.write(contentsOf: data)
+            },
+            terminationGracePeriod: TimeInterval = 0.5,
+            processRegistrationHandler: @escaping @Sendable (String, pid_t) -> Void = { key, pid in
+                MCPProcessTracker.shared.register(serverName: key, pid: pid)
+            },
+            processUnregistrationHandler: @escaping @Sendable (String) -> Void = { key in
+                MCPProcessTracker.shared.unregister(serverName: key)
+            }
+        ) -> MCPService {
             let config = MCPServerConfig(
                 name: "mock-\(UUID().uuidString)",
                 command: scriptURL.path,
-                env: ["MCP_TEST_MODE": mode.rawValue]
+                env: [
+                    "MCP_TEST_LOG": logURL.path,
+                    "MCP_TEST_MODE": mode.rawValue
+                ]
             )
 
-            return MCPService(serverConfig: config, requestTimeoutSeconds: requestTimeoutSeconds)
+            return MCPService(
+                serverConfig: config,
+                requestTimeoutSeconds: requestTimeoutSeconds,
+                requestWriteHook: requestWriteHook,
+                messageWriteHandler: messageWriteHandler,
+                terminationGracePeriod: terminationGracePeriod,
+                processRegistrationHandler: processRegistrationHandler,
+                processUnregistrationHandler: processUnregistrationHandler
+            )
+        }
+
+        func waitForMessage(method: String, timeout: Duration = .seconds(2)) async -> RecordedMCPMessage? {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                if let message = recordedMessages(method: method).first {
+                    return message
+                }
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            return recordedMessages(method: method).first
+        }
+
+        func waitForEvent(_ event: String, timeout: Duration = .seconds(2)) async -> Bool {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                if recordedContents.contains("SERVER_EVENT \(event)") {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            return recordedContents.contains("SERVER_EVENT \(event)")
+        }
+
+        func recordedMessages(method: String) -> [RecordedMCPMessage] {
+            recordedContents
+                .split(separator: "\n")
+                .compactMap(RecordedMCPMessage.init)
+                .filter { $0.method == method }
         }
 
         func cleanup() {
@@ -118,35 +465,238 @@
             """
             #!/bin/sh
             mode="${MCP_TEST_MODE:-ok}"
+            log_file="${MCP_TEST_LOG:?}"
+
+            request_id() {
+              printf '%s\n' "$1" | sed -n 's/.*"id":\\([0-9][0-9]*\\).*/\\1/p'
+            }
+
+            cancelled_request_id() {
+              printf '%s\n' "$1" | sed -n 's/.*"requestId":\\([0-9][0-9]*\\).*/\\1/p'
+            }
 
             while IFS= read -r line; do
+              printf '%s\n' "$line" >> "$log_file"
               case "$line" in
                 *'"method":"initialize"'*)
                   if [ "$mode" = "initialize-timeout" ]; then
-                    sleep 60
+                    :
                   else
-                    printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{}}}'
+                    id=$(request_id "$line")
+                    printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2024-11-05","capabilities":{}}}\n' "$id"
                   fi
                   ;;
-                *'"method":"notifications/initialized"'*)
+                *notifications*initialized*)
+                  if [ "$mode" = "term-resistant" ]; then
+                    trap '' TERM
+                    printf 'SERVER_EVENT term-resistant-ready\n' >> "$log_file"
+                    while :; do :; done
+                  fi
                   ;;
-                *'"method":"tools/list"'*)
+                *notifications*cancelled*)
+                  if [ "$mode" = "late-response-after-cancellation" ]; then
+                    id=$(cancelled_request_id "$line")
+                    printf '{"jsonrpc":"2.0","id":%s,"result":{"content":"late"}}\n' "$id"
+                    printf 'SERVER_EVENT late-response-sent\n' >> "$log_file"
+                  fi
+                  ;;
+                *tools*list*)
                   if [ "$mode" = "list-timeout" ]; then
-                    sleep 60
+                    :
                   else
-                    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}'
+                    id=$(request_id "$line")
+                    printf '{"jsonrpc":"2.0","id":%s,"result":{"tools":[]}}\n' "$id"
                   fi
                   ;;
-                *'"method":"tools/call"'*)
-                  if [ "$mode" = "call-timeout" ]; then
-                    sleep 60
+                *tools*call*)
+                  if [ "$mode" = "call-timeout" ] || [ "$mode" = "late-response-after-cancellation" ]; then
+                    :
                   else
-                    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"content":"ok"}}'
+                    id=$(request_id "$line")
+                    printf '{"jsonrpc":"2.0","id":%s,"result":{"content":"ok"}}\n' "$id"
                   fi
                   ;;
               esac
             done
             """
         }
+
+        private var recordedContents: String {
+            (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+        }
+    }
+
+    private final class MCPMessageWriteGate: @unchecked Sendable {
+        let entered = FlightTestSignal()
+
+        private let targetMethod: String
+        private let condition = NSCondition()
+        private var isReleased = false
+
+        init(targetMethod: String) {
+            self.targetMethod = targetMethod
+        }
+
+        func pauseIfTarget(_ data: Data) {
+            guard let message = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  message["method"] as? String == targetMethod
+            else {
+                return
+            }
+
+            entered.signal()
+            condition.lock()
+            while !isReleased {
+                condition.wait()
+            }
+            condition.unlock()
+        }
+
+        func release() {
+            condition.lock()
+            isReleased = true
+            condition.broadcast()
+            condition.unlock()
+        }
+    }
+
+    private final class MCPRequestWriteGate: @unchecked Sendable {
+        let entered = FlightTestSignal()
+
+        private let targetMethod: String
+        private let condition = NSCondition()
+        private var isReleased = false
+
+        init(targetMethod: String) {
+            self.targetMethod = targetMethod
+        }
+
+        func pauseIfTarget(_ method: String) {
+            guard method == targetMethod else { return }
+
+            entered.signal()
+            condition.lock()
+            while !isReleased {
+                condition.wait()
+            }
+            condition.unlock()
+        }
+
+        func release() {
+            condition.lock()
+            isReleased = true
+            condition.broadcast()
+            condition.unlock()
+        }
+    }
+
+    private final class MCPProcessTrackingRecorder: @unchecked Sendable {
+        struct Unregistration: Sendable {
+            let key: String
+            let pid: pid_t
+            let wasRunning: Bool
+        }
+
+        private let lock = NSLock()
+        private var registeredPIDs: [String: pid_t] = [:]
+        private var registrationOrder: [String] = []
+        private var recordedUnregistrations: [Unregistration] = []
+
+        var unregistrations: [Unregistration] {
+            lock.lock()
+            defer { lock.unlock() }
+            return recordedUnregistrations
+        }
+
+        func register(key: String, pid: pid_t) {
+            lock.lock()
+            registeredPIDs[key] = pid
+            registrationOrder.append(key)
+            lock.unlock()
+        }
+
+        func unregister(key: String) {
+            lock.lock()
+            let pid = registeredPIDs.removeValue(forKey: key) ?? -1
+            lock.unlock()
+
+            let wasRunning = pid > 0 && Darwin.kill(pid, 0) == 0
+            lock.lock()
+            recordedUnregistrations.append(Unregistration(key: key, pid: pid, wasRunning: wasRunning))
+            lock.unlock()
+        }
+
+        func waitForRegistrationCount(_ count: Int, timeout: Duration = .seconds(2)) async -> Bool {
+            await waitForCount(count, timeout: timeout) { self.registrationCount }
+        }
+
+        func waitForUnregistrationCount(_ count: Int, timeout: Duration = .seconds(2)) async -> Bool {
+            await waitForCount(count, timeout: timeout) { self.unregistrationCount }
+        }
+
+        private var registrationCount: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return registrationOrder.count
+        }
+
+        private var unregistrationCount: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return recordedUnregistrations.count
+        }
+
+        private func waitForCount(
+            _ count: Int,
+            timeout: Duration,
+            currentCount: @escaping @Sendable () -> Int
+        ) async -> Bool {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while currentCount() < count, clock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            return currentCount() >= count
+        }
+    }
+
+    @MainActor
+    private final class MCPServiceDelegateRecorder: MCPServiceDelegate {
+        private(set) var terminationCount = 0
+
+        func mcpService(_: MCPServicing, didTerminateWithError _: String?) {
+            terminationCount += 1
+        }
+    }
+
+    private struct RecordedMCPMessage: Sendable {
+        let jsonrpc: String?
+        let id: Int?
+        let method: String?
+        let requestId: Int?
+        let reason: String?
+
+        init?(line: Substring) {
+            guard let data = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data),
+                  let message = object as? [String: Any]
+            else {
+                return nil
+            }
+
+            let params = message["params"] as? [String: Any]
+            jsonrpc = message["jsonrpc"] as? String
+            id = jsonInteger(message["id"])
+            method = message["method"] as? String
+            requestId = jsonInteger(params?["requestId"])
+            reason = params?["reason"] as? String
+        }
+    }
+
+    private func jsonInteger(_ value: Any?) -> Int? {
+        if let integer = value as? Int {
+            return integer
+        }
+        return (value as? NSNumber)?.intValue
     }
 #endif

--- a/Tests/AynaTests/MemoryContextProviderTests.swift
+++ b/Tests/AynaTests/MemoryContextProviderTests.swift
@@ -14,8 +14,8 @@ import Testing
 struct MemoryContextProviderTests {
     // MARK: - Context Building
 
-    @Test("Build context returns empty when memory disabled")
-    func buildContextReturnsEmptyWhenDisabled() {
+    @Test
+    func `build context returns empty when memory disabled`() {
         let memoryService = UserMemoryService()
         let metadataService = SessionMetadataService.shared
         let summaryService = ConversationSummaryService()
@@ -36,8 +36,8 @@ struct MemoryContextProviderTests {
         #expect(context.conversationSummaries == nil)
     }
 
-    @Test("Build context includes user memory when enabled")
-    func buildContextIncludesUserMemoryWhenEnabled() {
+    @Test
+    func `build context includes user memory when enabled`() {
         let memoryService = UserMemoryService()
         let metadataService = SessionMetadataService.shared
         let summaryService = ConversationSummaryService()
@@ -59,8 +59,8 @@ struct MemoryContextProviderTests {
         #expect(context.userMemory?.contains("Swift") == true)
     }
 
-    @Test("Build context excludes current conversation from summaries")
-    func buildContextExcludesCurrentConversation() {
+    @Test
+    func `build context excludes current conversation from summaries`() {
         let memoryService = UserMemoryService()
         let metadataService = SessionMetadataService.shared
         let summaryService = ConversationSummaryService()
@@ -92,8 +92,8 @@ struct MemoryContextProviderTests {
 
     // MARK: - Memory Command Processing
 
-    @Test("Process memory command returns nil when disabled")
-    func processMemoryCommandReturnsNilWhenDisabled() {
+    @Test
+    func `process memory command returns nil when disabled`() {
         let memoryService = UserMemoryService()
         let metadataService = SessionMetadataService.shared
         let summaryService = ConversationSummaryService()
@@ -112,8 +112,8 @@ struct MemoryContextProviderTests {
         #expect(memoryService.activeFacts().isEmpty)
     }
 
-    @Test("Process memory command stores fact when enabled")
-    func processMemoryCommandStoresFactWhenEnabled() {
+    @Test
+    func `process memory command stores fact when enabled`() {
         let memoryService = UserMemoryService()
         let metadataService = SessionMetadataService.shared
         let summaryService = ConversationSummaryService()
@@ -134,16 +134,16 @@ struct MemoryContextProviderTests {
 
     // MARK: - Context Allocation
 
-    @Test("Context allocation adapts to small context window")
-    func contextAllocationAdaptsToSmallContextWindow() {
+    @Test
+    func `context allocation adapts to small context window`() {
         let allocation = MemoryContextProvider.ContextAllocation(availableTokens: 4000)
 
         #expect(allocation.conversationSummary == 0) // Disabled for small context
         #expect(allocation.userMemory < 1000)
     }
 
-    @Test("Context allocation uses full budget for large context window")
-    func contextAllocationUsesFullBudgetForLargeContextWindow() {
+    @Test
+    func `context allocation uses full budget for large context window`() {
         let allocation = MemoryContextProvider.ContextAllocation(availableTokens: 128_000)
 
         #expect(allocation.sessionMetadata == 200)
@@ -153,8 +153,24 @@ struct MemoryContextProviderTests {
 
     // MARK: - Accessors
 
-    @Test("Memory fact count reflects service state")
-    func memoryFactCountReflectsServiceState() {
+    @Test
+    func `enabled memory requires an authoritative load even when unchanged`() {
+        #expect(MemoryContextProvider.requiresAuthoritativeLoad(
+            isEnabled: true,
+            hasAuthoritativeFacts: false
+        ))
+        #expect(!MemoryContextProvider.requiresAuthoritativeLoad(
+            isEnabled: true,
+            hasAuthoritativeFacts: true
+        ))
+        #expect(!MemoryContextProvider.requiresAuthoritativeLoad(
+            isEnabled: false,
+            hasAuthoritativeFacts: false
+        ))
+    }
+
+    @Test
+    func `memory fact count reflects service state`() {
         let memoryService = UserMemoryService()
         let metadataService = SessionMetadataService.shared
         let summaryService = ConversationSummaryService()

--- a/Tests/AynaTests/MultiModelRequestRunnerTests.swift
+++ b/Tests/AynaTests/MultiModelRequestRunnerTests.swift
@@ -1,0 +1,313 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+// swiftformat:disable swiftTestingTestCaseNames
+
+@Suite("MultiModelRequestRunner Tests", .tags(.async), .serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct MultiModelRequestRunnerTests {
+    @Test("Synchronous duplicate completion resumes and releases exactly once")
+    func synchronousDuplicateCompletionResumesAndReleasesExactlyOnce() async {
+        let startCount = FlightTestBox(0)
+        let releaseCount = FlightTestBox(0)
+        let permit = MultiModelRequestRunner.GitHubPermit(
+            acquire: {},
+            release: { releaseCount.update { $0 += 1 } }
+        )
+
+        await MultiModelRequestRunner.run(gitHubPermit: permit) { completion in
+            startCount.value += 1
+            completion()
+            completion()
+        }
+
+        #expect(startCount.value == 1)
+        #expect(releaseCount.value == 1)
+    }
+
+    @Test("Cancellation resumes a request that never calls back")
+    func cancellationResumesRequestWithoutCallback() async {
+        let started = FlightTestSignal()
+        let task = Task { @MainActor in
+            await MultiModelRequestRunner.run { _ in
+                started.signal()
+            }
+        }
+
+        await started.wait()
+        task.cancel()
+        await task.value
+
+        #expect(started.isSignaled)
+    }
+
+    @Test("Completion retained by a cancelled request is harmless")
+    func retainedCompletionAfterCancellationIsHarmless() async {
+        let started = FlightTestSignal()
+        let retainedCompletion = FlightTestBox<MultiModelRequestRunner.Completion?>(nil)
+        let task = Task { @MainActor in
+            await MultiModelRequestRunner.run { completion in
+                retainedCompletion.value = completion
+                started.signal()
+            }
+        }
+
+        await started.wait()
+        task.cancel()
+        await task.value
+        retainedCompletion.value?()
+        retainedCompletion.value?()
+
+        #expect(started.isSignaled)
+    }
+
+    @Test("Same-key GitHub permits serialize request starts")
+    func sameKeyGitHubPermitsSerializeStarts() async {
+        let queued = FlightTestSignal()
+        let gate = DeterministicGitHubGate(queued: queued)
+        let permit = makePermit(gate: gate, key: "same-token")
+        let firstStarted = FlightTestSignal()
+        let secondStarted = FlightTestSignal()
+        let firstCompletion = FlightTestBox<MultiModelRequestRunner.Completion?>(nil)
+        let secondCompletion = FlightTestBox<MultiModelRequestRunner.Completion?>(nil)
+
+        let first = Task { @MainActor in
+            await MultiModelRequestRunner.run(gitHubPermit: permit) { completion in
+                firstCompletion.value = completion
+                firstStarted.signal()
+            }
+        }
+        await firstStarted.wait()
+
+        let second = Task { @MainActor in
+            await MultiModelRequestRunner.run(gitHubPermit: permit) { completion in
+                secondCompletion.value = completion
+                secondStarted.signal()
+            }
+        }
+        await queued.wait()
+        #expect(!secondStarted.isSignaled)
+
+        firstCompletion.value?()
+        await secondStarted.wait()
+        secondCompletion.value?()
+        await first.value
+        await second.value
+
+        #expect(await gate.releaseCount == 2)
+    }
+
+    @Test("Cancellation releases a held GitHub permit")
+    func cancellationReleasesHeldGitHubPermit() async {
+        let queued = FlightTestSignal()
+        let gate = DeterministicGitHubGate(queued: queued)
+        let permit = makePermit(gate: gate, key: "same-token")
+        let firstStarted = FlightTestSignal()
+        let secondStarted = FlightTestSignal()
+        let secondCompletion = FlightTestBox<MultiModelRequestRunner.Completion?>(nil)
+
+        let first = Task { @MainActor in
+            await MultiModelRequestRunner.run(gitHubPermit: permit) { _ in
+                firstStarted.signal()
+            }
+        }
+        await firstStarted.wait()
+
+        let second = Task { @MainActor in
+            await MultiModelRequestRunner.run(gitHubPermit: permit) { completion in
+                secondCompletion.value = completion
+                secondStarted.signal()
+            }
+        }
+        await queued.wait()
+
+        first.cancel()
+        await secondStarted.wait()
+        secondCompletion.value?()
+        await first.value
+        await second.value
+
+        #expect(await gate.releaseCount == 2)
+    }
+
+    @Test("Cancellation while queued never starts or releases an unacquired permit")
+    func cancellationWhileQueuedNeverStartsOrReleasesUnacquiredPermit() async {
+        let queued = FlightTestSignal()
+        let gate = DeterministicGitHubGate(queued: queued)
+        let permit = makePermit(gate: gate, key: "same-token")
+        let firstStarted = FlightTestSignal()
+        let cancelledStarted = FlightTestSignal()
+        let replacementStarted = FlightTestSignal()
+        let firstCompletion = FlightTestBox<MultiModelRequestRunner.Completion?>(nil)
+        let replacementCompletion = FlightTestBox<MultiModelRequestRunner.Completion?>(nil)
+
+        let first = Task { @MainActor in
+            await MultiModelRequestRunner.run(gitHubPermit: permit) { completion in
+                firstCompletion.value = completion
+                firstStarted.signal()
+            }
+        }
+        await firstStarted.wait()
+
+        let cancelled = Task { @MainActor in
+            await MultiModelRequestRunner.run(gitHubPermit: permit) { completion in
+                cancelledStarted.signal()
+                completion()
+            }
+        }
+        await queued.wait()
+        cancelled.cancel()
+        await cancelled.value
+        #expect(!cancelledStarted.isSignaled)
+
+        firstCompletion.value?()
+        await first.value
+
+        let replacement = Task { @MainActor in
+            await MultiModelRequestRunner.run(gitHubPermit: permit) { completion in
+                replacementCompletion.value = completion
+                replacementStarted.signal()
+            }
+        }
+        await replacementStarted.wait()
+        replacementCompletion.value?()
+        await replacement.value
+
+        #expect(await gate.releaseCount == 2)
+    }
+
+    @Test("Cancellation after permit acquisition releases without starting")
+    func cancellationAfterPermitAcquisitionReleasesWithoutStarting() async {
+        let started = FlightTestSignal()
+        let releaseCount = FlightTestBox(0)
+        let permit = MultiModelRequestRunner.GitHubPermit(
+            acquire: {
+                withUnsafeCurrentTask { task in
+                    task?.cancel()
+                }
+            },
+            release: { releaseCount.update { $0 += 1 } }
+        )
+
+        let task = Task { @MainActor in
+            await MultiModelRequestRunner.run(gitHubPermit: permit) { completion in
+                started.signal()
+                completion()
+            }
+        }
+        await task.value
+
+        #expect(!started.isSignaled)
+        #expect(releaseCount.value == 1)
+    }
+
+    @Test("Failed permit acquisition neither starts nor releases")
+    func failedPermitAcquisitionNeitherStartsNorReleases() async {
+        let started = FlightTestSignal()
+        let releaseCount = FlightTestBox(0)
+        let permit = MultiModelRequestRunner.GitHubPermit(
+            acquire: { throw RunnerTestError.expected },
+            release: { releaseCount.update { $0 += 1 } }
+        )
+
+        await MultiModelRequestRunner.run(gitHubPermit: permit) { completion in
+            started.signal()
+            completion()
+        }
+
+        #expect(!started.isSignaled)
+        #expect(releaseCount.value == 0)
+    }
+
+    @Test("A pre-cancelled task never starts its request")
+    func preCancelledTaskNeverStartsRequest() async {
+        let started = FlightTestSignal()
+        let task = Task { @MainActor in
+            withUnsafeCurrentTask { currentTask in
+                currentTask?.cancel()
+            }
+            await MultiModelRequestRunner.run { completion in
+                started.signal()
+                completion()
+            }
+        }
+
+        await task.value
+
+        #expect(!started.isSignaled)
+    }
+
+    private func makePermit(
+        gate: DeterministicGitHubGate,
+        key: String
+    ) -> MultiModelRequestRunner.GitHubPermit {
+        MultiModelRequestRunner.GitHubPermit(
+            acquire: { try await gate.acquire(key: key) },
+            release: { await gate.release(key: key) }
+        )
+    }
+}
+
+private enum RunnerTestError: Error {
+    case expected
+}
+
+private actor DeterministicGitHubGate {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private var activeKeys: Set<String> = []
+    private var waiters: [String: [Waiter]] = [:]
+    private let queued: FlightTestSignal
+    private(set) var releaseCount = 0
+
+    init(queued: FlightTestSignal) {
+        self.queued = queued
+    }
+
+    func acquire(key: String) async throws {
+        try Task.checkCancellation()
+        guard activeKeys.contains(key) else {
+            activeKeys.insert(key)
+            return
+        }
+
+        let id = UUID()
+        queued.signal()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waiters[key, default: []].append(Waiter(id: id, continuation: continuation))
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(key: key, id: id) }
+        }
+    }
+
+    func release(key: String) {
+        releaseCount += 1
+        guard var queue = waiters[key], !queue.isEmpty else {
+            waiters[key] = nil
+            activeKeys.remove(key)
+            return
+        }
+
+        let next = queue.removeFirst()
+        waiters[key] = queue.isEmpty ? nil : queue
+        next.continuation.resume()
+    }
+
+    private func cancelWaiter(key: String, id: UUID) {
+        guard var queue = waiters[key],
+              let index = queue.firstIndex(where: { $0.id == id })
+        else {
+            return
+        }
+
+        let waiter = queue.remove(at: index)
+        waiters[key] = queue.isEmpty ? nil : queue
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+}

--- a/Tests/AynaTests/MultiModelRequestRunnerTests.swift
+++ b/Tests/AynaTests/MultiModelRequestRunnerTests.swift
@@ -238,6 +238,23 @@ struct MultiModelRequestRunnerTests {
         #expect(!started.isSignaled)
     }
 
+    @Test("Cancellation while start is invoking terminates the runner")
+    func cancellationWhileStartIsInvokingTerminatesRunner() async {
+        let returned = FlightTestSignal()
+
+        let task = Task { @MainActor in
+            await MultiModelRequestRunner.run { _ in
+                withUnsafeCurrentTask { currentTask in
+                    currentTask?.cancel()
+                }
+            }
+            returned.signal()
+        }
+
+        #expect(await returned.wait(timeout: .seconds(2)))
+        await task.value
+    }
+
     private func makePermit(
         gate: DeterministicGitHubGate,
         key: String

--- a/Tests/AynaTests/OpenAIRequestBuilderTests.swift
+++ b/Tests/AynaTests/OpenAIRequestBuilderTests.swift
@@ -114,4 +114,122 @@ struct OpenAIRequestBuilderTests {
         #expect(content[0]["type"] as? String == "input_text")
         #expect(content[0]["text"] as? String == "Current user input")
     }
+
+    @Test("Responses input strips orphaned tool calls while preserving assistant text")
+    func responsesInputStripsOrphanedToolCallsWhilePreservingAssistantText() throws {
+        var assistant = Message(role: .assistant, content: "Partial answer")
+        assistant.toolCalls = [
+            MCPToolCall(
+                id: "orphan",
+                toolName: "web_search",
+                arguments: ["query": AnyCodable("weather")]
+            )
+        ]
+        var orphanedResult = Message(role: .tool, content: "orphan result")
+        orphanedResult.toolCalls = [
+            MCPToolCall(id: "other", toolName: "web_search", arguments: [:], result: "orphan result")
+        ]
+
+        let input = OpenAIRequestBuilder.buildResponsesInput(from: [assistant, orphanedResult])
+
+        #expect(input.count == 1)
+        #expect(input[0]["type"] as? String == "message")
+        #expect(input[0]["role"] as? String == "assistant")
+        let content = try #require(input[0]["content"] as? [[String: Any]])
+        #expect(content.first?["text"] as? String == "Partial answer")
+        #expect(!input.contains(where: { $0["type"] as? String == "function_call" }))
+        #expect(!input.contains(where: { $0["type"] as? String == "function_call_output" }))
+    }
+
+    @Test("Responses input keeps paired tool calls and outputs")
+    func responsesInputKeepsPairedToolCallsAndOutputs() {
+        let call = MCPToolCall(
+            id: "paired",
+            toolName: "web_search",
+            arguments: ["query": AnyCodable("weather")]
+        )
+        var assistant = Message(role: .assistant, content: "")
+        assistant.toolCalls = [call]
+        var result = Message(role: .tool, content: "Sunny")
+        result.toolCalls = [
+            MCPToolCall(
+                id: call.id,
+                toolName: call.toolName,
+                arguments: call.arguments,
+                result: "Sunny"
+            )
+        ]
+
+        let input = OpenAIRequestBuilder.buildResponsesInput(from: [assistant, result])
+
+        #expect(input.map { $0["type"] as? String } == ["function_call", "function_call_output"])
+        #expect(input[0]["call_id"] as? String == call.id)
+        #expect(input[1]["call_id"] as? String == call.id)
+    }
+
+    @Test("Responses input requires tool outputs to follow their call in the same round")
+    func responsesInputRequiresOutputsInSameRound() {
+        let call = MCPToolCall(id: "reused", toolName: "web_search", arguments: [:])
+        var assistant = Message(role: .assistant, content: "Keep this text")
+        assistant.toolCalls = [call]
+        var result = Message(role: .tool, content: "Result")
+        result.toolCalls = [
+            MCPToolCall(id: call.id, toolName: call.toolName, arguments: [:], result: "Result")
+        ]
+
+        let outputBeforeCall = OpenAIRequestBuilder.buildResponsesInput(from: [result, assistant])
+        #expect(outputBeforeCall.map { $0["type"] as? String } == ["message"])
+
+        let separatedByUser = OpenAIRequestBuilder.buildResponsesInput(from: [
+            assistant,
+            Message(role: .user, content: "New turn"),
+            result
+        ])
+        #expect(separatedByUser.map { $0["type"] as? String } == ["message", "message"])
+        #expect(!separatedByUser.contains(where: { $0["type"] as? String == "function_call" }))
+        #expect(!separatedByUser.contains(where: { $0["type"] as? String == "function_call_output" }))
+    }
+
+    @Test("Serialized requests omit empty assistant placeholders")
+    func serializedRequestsOmitEmptyAssistantPlaceholders() throws {
+        let messages = [
+            Message(role: .user, content: "Question"),
+            Message(
+                role: .assistant,
+                content: "",
+                responseGroupId: UUID(),
+                isSelectedResponse: false
+            ),
+        ]
+        let chatURL = try #require(URL(string: "https://api.openai.com/v1/chat/completions"))
+        let chatRequest = try #require(OpenAIRequestBuilder.createChatCompletionsRequest(
+            url: chatURL,
+            messages: messages,
+            model: "gpt-4o",
+            stream: false,
+            apiKey: "test-key",
+            isAzure: false
+        ))
+        let chatBodyData = try #require(chatRequest.httpBody)
+        let chatBodyObject = try JSONSerialization.jsonObject(with: chatBodyData)
+        let chatBody = try #require(chatBodyObject as? [String: Any])
+        let chatMessages = try #require(chatBody["messages"] as? [[String: Any]])
+        #expect(chatMessages.count == 1)
+        #expect(chatMessages[0]["role"] as? String == "user")
+
+        let responsesURL = try #require(URL(string: "https://api.openai.com/v1/responses"))
+        let responsesRequest = try #require(OpenAIRequestBuilder.createResponsesRequest(
+            url: responsesURL,
+            messages: messages,
+            model: "gpt-5",
+            apiKey: "test-key",
+            isAzure: false
+        ))
+        let responsesBodyData = try #require(responsesRequest.httpBody)
+        let responsesBodyObject = try JSONSerialization.jsonObject(with: responsesBodyData)
+        let responsesBody = try #require(responsesBodyObject as? [String: Any])
+        let input = try #require(responsesBody["input"] as? [[String: Any]])
+        #expect(input.count == 1)
+        #expect(input[0]["role"] as? String == "user")
+    }
 }

--- a/Tests/AynaTests/OpenAIRequestBuilderTests.swift
+++ b/Tests/AynaTests/OpenAIRequestBuilderTests.swift
@@ -1,0 +1,117 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("OpenAIRequestBuilder Tests")
+@MainActor
+struct OpenAIRequestBuilderTests {
+    @Test
+    func `responses body promotes one system prompt to instructions`() throws {
+        let messages = [
+            Message(role: .system, content: "You are a helpful assistant."),
+            Message(role: .user, content: "What is the weather?")
+        ]
+
+        let body = OpenAIRequestBuilder.buildResponsesBody(
+            model: "gpt-5",
+            messages: messages
+        )
+
+        #expect(body["instructions"] as? String == "You are a helpful assistant.")
+
+        let input = try #require(body["input"] as? [[String: Any]])
+        #expect(input.count == 1)
+        #expect(input[0]["role"] as? String == "user")
+
+        let content = try #require(input[0]["content"] as? [[String: Any]])
+        #expect(content.count == 1)
+        #expect(content[0]["type"] as? String == "input_text")
+        #expect(content[0]["text"] as? String == "What is the weather?")
+    }
+
+    @Test
+    func `responses body concatenates system and memory blocks in order`() throws {
+        var messages = OpenAIRequestBuilder.buildMessagesWithMemory(
+            systemPrompt: "Conversation system prompt",
+            memoryContext: MemoryContext(
+                sessionMetadata: "Session metadata",
+                userMemory: "User memory",
+                conversationSummaries: "Conversation summaries"
+            ),
+            conversationHistory: [
+                Message(role: .user, content: "Current user input")
+            ]
+        )
+        messages.insert(Message(role: .system, content: ""), at: 1)
+
+        let body = OpenAIRequestBuilder.buildResponsesBody(
+            model: "gpt-5",
+            messages: messages
+        )
+
+        #expect(
+            body["instructions"] as? String ==
+                "Conversation system prompt\n\nSession metadata\n\nUser memory\n\nConversation summaries"
+        )
+
+        let input = try #require(body["input"] as? [[String: Any]])
+        #expect(input.count == 1)
+        #expect(input.allSatisfy { $0["role"] as? String != "system" })
+        #expect(input[0]["role"] as? String == "user")
+
+        let content = try #require(input[0]["content"] as? [[String: Any]])
+        #expect(content[0]["text"] as? String == "Current user input")
+    }
+
+    @Test
+    func `responses body omits instructions when system content is empty`() throws {
+        let messages = [
+            Message(role: .system, content: ""),
+            Message(role: .system, content: "  \n  "),
+            Message(role: .user, content: "Current user input")
+        ]
+
+        let body = OpenAIRequestBuilder.buildResponsesBody(
+            model: "gpt-5",
+            messages: messages
+        )
+
+        #expect(body["instructions"] == nil)
+
+        let input = try #require(body["input"] as? [[String: Any]])
+        #expect(input.count == 1)
+        #expect(input[0]["role"] as? String == "user")
+    }
+
+    @Test
+    func `responses request serializes instructions and non-system input`() throws {
+        let url = try #require(URL(string: "https://api.openai.com/v1/responses"))
+        let request = try #require(OpenAIRequestBuilder.createResponsesRequest(
+            url: url,
+            messages: [
+                Message(role: .system, content: "System prompt"),
+                Message(role: .system, content: "Memory block"),
+                Message(role: .user, content: "Current user input")
+            ],
+            model: "gpt-5",
+            apiKey: "test-api-key",
+            isAzure: false
+        ))
+        let bodyData = try #require(request.httpBody)
+        let body = try #require(
+            JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+        )
+
+        #expect(body["instructions"] as? String == "System prompt\n\nMemory block")
+
+        let input = try #require(body["input"] as? [[String: Any]])
+        #expect(input.count == 1)
+        #expect(input[0]["role"] as? String == "user")
+        #expect(input[0]["type"] as? String == "message")
+
+        let content = try #require(input[0]["content"] as? [[String: Any]])
+        #expect(content.count == 1)
+        #expect(content[0]["type"] as? String == "input_text")
+        #expect(content[0]["text"] as? String == "Current user input")
+    }
+}

--- a/Tests/AynaTests/PermissionServiceTests.swift
+++ b/Tests/AynaTests/PermissionServiceTests.swift
@@ -195,6 +195,190 @@ struct PermissionServiceTests {
         #expect(level == .automatic)
     }
 
+    @Test("Cancelling an approval request denies only that request")
+    func cancellingApprovalRequestDeniesOnlyThatRequest() async {
+        let conversationId = UUID()
+        let task = Task {
+            await sut.requestApproval(
+                toolName: "run_command",
+                description: "Run command",
+                details: "sleep 30",
+                conversationId: conversationId
+            )
+        }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while sut.pendingApprovals.isEmpty, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(sut.pendingApprovals.count == 1)
+
+        task.cancel()
+        #expect(await task.value == false)
+        #expect(sut.pendingApprovals.isEmpty)
+    }
+
+    @Test("Remembered approval is not visible until request commits")
+    func rememberedApprovalIsNotVisibleUntilRequestCommits() async {
+        let conversationId = UUID()
+        let details = "/tmp/provisional"
+        let task = Task {
+            await sut.requestApproval(
+                toolName: "write_file",
+                description: "Write",
+                details: details,
+                conversationId: conversationId
+            )
+        }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while sut.pendingApprovals.isEmpty, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        guard let approvalID = sut.pendingApprovals.first?.id else {
+            Issue.record("Approval did not become pending")
+            return
+        }
+
+        sut.approve(approvalID, rememberForSession: true)
+        #expect(sut.checkPermission(tool: "write_file", details: details, defaultLevel: .askOnce) == .askOnce)
+        #expect(await task.value)
+        #expect(sut.checkPermission(tool: "write_file", details: details, defaultLevel: .askOnce) == .automatic)
+    }
+
+    @Test("Cancelled approval cannot grant session permission")
+    func cancelledApprovalCannotGrantSessionPermission() async {
+        let conversationId = UUID()
+        let details = "echo unsafe"
+        let task = Task {
+            await sut.requestApproval(
+                toolName: "run_command",
+                description: "Run command",
+                details: details,
+                conversationId: conversationId
+            )
+        }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while sut.pendingApprovals.isEmpty, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        let approvalID = sut.pendingApprovals.first?.id
+        #expect(approvalID != nil)
+        guard let approvalID else { return }
+
+        task.cancel()
+        sut.approve(approvalID, rememberForSession: true)
+
+        #expect(await task.value == false)
+        #expect(sut.checkPermission(tool: "run_command", details: details, defaultLevel: .askAlways) == .askAlways)
+    }
+
+    @Test("Cancelling an identical approval preserves another committed grant")
+    func cancellingIdenticalApprovalPreservesCommittedGrant() async {
+        let conversationId = UUID()
+        let details = "/tmp/shared"
+        let first = Task {
+            await sut.requestApproval(
+                toolName: "write_file",
+                description: "First",
+                details: details,
+                conversationId: conversationId
+            )
+        }
+        let second = Task {
+            await sut.requestApproval(
+                toolName: "write_file",
+                description: "Second",
+                details: details,
+                conversationId: conversationId
+            )
+        }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while sut.pendingApprovals.count < 2, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(sut.pendingApprovals.count == 2)
+        guard let firstID = sut.pendingApprovals.first?.id else { return }
+
+        sut.approve(firstID, rememberForSession: true)
+        #expect(await first.value)
+        second.cancel()
+        #expect(await second.value == false)
+
+        #expect(sut.checkPermission(tool: "write_file", details: details, defaultLevel: .askOnce) == .automatic)
+    }
+
+    @Test("Cancellation after approval resumes still rejects the operation")
+    func cancellationAfterApprovalResumesStillRejectsOperation() async {
+        let conversationId = UUID()
+        let task = Task {
+            await sut.requestApproval(
+                toolName: "run_command",
+                description: "Run command",
+                details: "echo unsafe",
+                conversationId: conversationId
+            )
+        }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while sut.pendingApprovals.isEmpty, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        let approvalID = sut.pendingApprovals.first?.id
+        #expect(approvalID != nil)
+        guard let approvalID else { return }
+
+        sut.approve(approvalID)
+        task.cancel()
+
+        #expect(await task.value == false)
+    }
+
+    @Test("Cancelling a stale approval preserves a replacement in the same conversation")
+    func cancellingStaleApprovalPreservesReplacementInSameConversation() async {
+        let conversationId = UUID()
+        let staleTask = Task {
+            await sut.requestApproval(
+                toolName: "write_file",
+                description: "Stale write",
+                details: "/tmp/stale",
+                conversationId: conversationId
+            )
+        }
+        let replacementTask = Task {
+            await sut.requestApproval(
+                toolName: "write_file",
+                description: "Replacement write",
+                details: "/tmp/replacement",
+                conversationId: conversationId
+            )
+        }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while sut.pendingApprovals.count < 2, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(sut.pendingApprovals.count == 2)
+
+        staleTask.cancel()
+        #expect(await staleTask.value == false)
+        #expect(sut.pendingApprovals.count == 1)
+        #expect(sut.pendingApprovals.first?.details == "/tmp/replacement")
+
+        if let replacementID = sut.pendingApprovals.first?.id {
+            sut.deny(replacementID)
+        }
+        #expect(await replacementTask.value == false)
+    }
+
     // MARK: - Deny All Pending
 
     @Test("Deny all pending for conversation")

--- a/Tests/AynaTests/ScriptedConversationStore.swift
+++ b/Tests/AynaTests/ScriptedConversationStore.swift
@@ -1,0 +1,124 @@
+@testable import Ayna
+import Foundation
+
+actor TestLatch {
+    private var openState: Bool
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(open: Bool = false) {
+        openState = open
+    }
+
+    func wait() async {
+        guard !openState else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        guard !openState else { return }
+        openState = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func opened() -> Bool {
+        openState
+    }
+}
+
+struct ScriptedStoreHandle: Sendable { let started: TestLatch; let releaseGate: TestLatch }
+
+actor ScriptedConversationStore: ConversationStoreAdapter {
+    enum Operation: Equatable, Sendable {
+        case load, save(UUID, String?), delete(UUID), clear
+
+        func matches(_ actual: Operation) -> Bool {
+            switch (self, actual) {
+            case (.load, .load), (.clear, .clear): true
+            case let (.save(id, title), .save(actualID, actualTitle)):
+                id == actualID && (title == nil || title == actualTitle)
+            case let (.delete(expected), .delete(value)): expected == value
+            default: false
+            }
+        }
+    }
+
+    enum Outcome: Sendable { case succeed, fail, load([Conversation]), partialClear(Set<UUID>) }
+
+    private enum Failure: Error { case scripted }
+
+    private var persisted: [UUID: Conversation]
+    private var steps: [(Operation, (Outcome, ScriptedStoreHandle))] = []
+    private var recorded: [Operation] = []
+
+    init(conversations: [Conversation] = []) {
+        persisted = Dictionary(uniqueKeysWithValues: conversations.map { ($0.id, $0) })
+    }
+
+    func enqueue(
+        _ expected: Operation,
+        outcome: Outcome = .succeed,
+        blocked: Bool = false
+    ) -> ScriptedStoreHandle {
+        let handle = ScriptedStoreHandle(started: TestLatch(), releaseGate: TestLatch(open: !blocked))
+        steps.append((expected, (outcome, handle)))
+        return handle
+    }
+
+    func operations() -> [Operation] {
+        recorded
+    }
+
+    func persistedConversations() -> [Conversation] {
+        Array(persisted.values)
+    }
+
+    func loadConversations() async throws -> [Conversation] {
+        let outcome = try await next(.load)
+        switch outcome {
+        case .succeed: return persistedConversations()
+        case let .load(values): return values
+        case .fail: throw Failure.scripted
+        default: throw Failure.scripted
+        }
+    }
+
+    func save(_ conversation: Conversation) async throws {
+        let operation = Operation.save(conversation.id, conversation.title)
+        switch try await next(operation) {
+        case .succeed: persisted[conversation.id] = conversation
+        case .fail: throw Failure.scripted
+        default: throw Failure.scripted
+        }
+    }
+
+    func delete(_ id: UUID) async throws {
+        let operation = Operation.delete(id)
+        switch try await next(operation) {
+        case .succeed: persisted.removeValue(forKey: id)
+        case .fail: throw Failure.scripted
+        default: throw Failure.scripted
+        }
+    }
+
+    func clearConversations() async throws {
+        switch try await next(.clear) {
+        case .succeed: persisted.removeAll()
+        case .fail: throw Failure.scripted
+        case let .partialClear(ids):
+            ids.forEach { persisted.removeValue(forKey: $0) }
+            throw Failure.scripted
+        default: throw Failure.scripted
+        }
+    }
+
+    private func next(_ operation: Operation) async throws -> Outcome {
+        recorded.append(operation)
+        guard let index = steps.firstIndex(where: { $0.0.matches(operation) }) else { return .succeed }
+        let (_, (outcome, handle)) = steps.remove(at: index)
+        await handle.started.open()
+        await handle.releaseGate.wait()
+        return outcome
+    }
+}

--- a/Tests/AynaTests/ToolCallRequestRoundCoordinatorTests.swift
+++ b/Tests/AynaTests/ToolCallRequestRoundCoordinatorTests.swift
@@ -1,0 +1,384 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Tool Call Request Round Coordinator Tests", .tags(.fast))
+@MainActor
+struct ToolCallRequestRoundCoordinatorTests {
+    private struct ToolResult: Equatable, Sendable {
+        let callID: String
+        let output: String
+    }
+
+    private typealias Coordinator = ToolCallRequestRoundCoordinator<ToolResult>
+
+    @Test
+    func `two parallel tools launch exactly one continuation after every completion`() throws {
+        let toolChainCoordinator = ToolChainCoordinator()
+        let coordinator = Coordinator()
+        let operationID = toolChainCoordinator.beginOperation(conversationID: UUID())
+        let roundID = try #require(
+            coordinator.beginRequestRound(
+                for: operationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+        let firstToken = try #require(
+            coordinator.registerTool(for: operationID, requestRoundID: roundID)
+        )
+        let secondToken = try #require(
+            coordinator.registerTool(for: operationID, requestRoundID: roundID)
+        )
+
+        let providerResolution = coordinator.providerDidComplete(
+            operationID: operationID,
+            requestRoundID: roundID
+        )
+        guard case .pending = providerResolution else {
+            Issue.record("Provider completion must wait for both tools")
+            return
+        }
+        #expect(coordinator.registerTool(for: operationID, requestRoundID: roundID) == nil)
+
+        let firstResolution = coordinator.toolDidComplete(
+            firstToken,
+            result: ToolResult(callID: "first", output: "one")
+        )
+        guard case .pending = firstResolution else {
+            Issue.record("The first tool must not launch the continuation alone")
+            return
+        }
+
+        let secondResolution = coordinator.toolDidComplete(
+            secondToken,
+            result: ToolResult(callID: "second", output: "two")
+        )
+        guard case let .launchContinuation(continuation) = secondResolution else {
+            Issue.record("The final tool should launch the continuation")
+            return
+        }
+
+        #expect(continuation.operationID == operationID)
+        #expect(continuation.completedRequestRoundID == roundID)
+        #expect(continuation.toolResults.map(\.token) == [firstToken, secondToken])
+        #expect(continuation.toolResults.map(\.result) == [
+            ToolResult(callID: "first", output: "one"),
+            ToolResult(callID: "second", output: "two"),
+        ])
+
+        let duplicateResolution = coordinator.toolDidComplete(
+            secondToken,
+            result: ToolResult(callID: "second", output: "duplicate")
+        )
+        guard case .ignored = duplicateResolution else {
+            Issue.record("A resolved round must not launch a second continuation")
+            return
+        }
+    }
+
+    @Test
+    func `reverse tool completion preserves original callback order`() throws {
+        let toolChainCoordinator = ToolChainCoordinator()
+        let coordinator = Coordinator()
+        let operationID = toolChainCoordinator.beginOperation(conversationID: UUID())
+        let roundID = try #require(
+            coordinator.beginRequestRound(
+                for: operationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+        let firstToken = try #require(
+            coordinator.registerTool(for: operationID, requestRoundID: roundID)
+        )
+        let secondToken = try #require(
+            coordinator.registerTool(for: operationID, requestRoundID: roundID)
+        )
+
+        let secondResolution = coordinator.toolDidComplete(
+            secondToken,
+            result: ToolResult(callID: "second", output: "finished first")
+        )
+        guard case .pending = secondResolution else {
+            Issue.record("An out-of-order tool completion must wait")
+            return
+        }
+
+        let providerResolution = coordinator.providerDidComplete(
+            operationID: operationID,
+            requestRoundID: roundID
+        )
+        guard case .pending = providerResolution else {
+            Issue.record("Provider completion must still wait for the first tool")
+            return
+        }
+
+        let firstResolution = coordinator.toolDidComplete(
+            firstToken,
+            result: ToolResult(callID: "first", output: "finished second")
+        )
+        guard case let .launchContinuation(continuation) = firstResolution else {
+            Issue.record("The last outstanding tool should launch the continuation")
+            return
+        }
+
+        #expect(continuation.toolResults.map(\.token) == [firstToken, secondToken])
+        #expect(continuation.toolResults.map(\.result.callID) == ["first", "second"])
+    }
+
+    @Test
+    func `synchronous tool completion waits for onComplete and fences the next round`() throws {
+        let toolChainCoordinator = ToolChainCoordinator()
+        let coordinator = Coordinator()
+        let operationID = toolChainCoordinator.beginOperation(conversationID: UUID())
+        let originalRoundID = try #require(
+            coordinator.beginRequestRound(
+                for: operationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+        let toolToken = try #require(
+            coordinator.registerTool(for: operationID, requestRoundID: originalRoundID)
+        )
+
+        let synchronousToolResolution = coordinator.toolDidComplete(
+            toolToken,
+            result: ToolResult(callID: "sync", output: "ready")
+        )
+        guard case .pending = synchronousToolResolution else {
+            Issue.record("A synchronous tool must wait for provider onComplete")
+            return
+        }
+        #expect(
+            coordinator.beginRequestRound(
+                for: operationID,
+                coordinatedBy: toolChainCoordinator
+            ) == nil
+        )
+
+        let providerResolution = coordinator.providerDidComplete(
+            operationID: operationID,
+            requestRoundID: originalRoundID
+        )
+        guard case .launchContinuation = providerResolution else {
+            Issue.record("Provider onComplete should release the synchronous tool result")
+            return
+        }
+
+        let continuationRoundID = try #require(
+            coordinator.beginRequestRound(
+                for: operationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+
+        let lateOriginalCompletion = coordinator.providerDidComplete(
+            operationID: operationID,
+            requestRoundID: originalRoundID
+        )
+        guard case .ignored = lateOriginalCompletion else {
+            Issue.record("The original round must not close its continuation round")
+            return
+        }
+
+        #expect(
+            coordinator.registerTool(
+                for: operationID,
+                requestRoundID: continuationRoundID
+            ) != nil
+        )
+    }
+
+    @Test
+    func `replacing the operation suppresses stale round and tool completions`() throws {
+        let toolChainCoordinator = ToolChainCoordinator()
+        let coordinator = Coordinator()
+        let firstOperationID = toolChainCoordinator.beginOperation(conversationID: UUID())
+        let firstRoundID = try #require(
+            coordinator.beginRequestRound(
+                for: firstOperationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+        let firstToken = try #require(
+            coordinator.registerTool(for: firstOperationID, requestRoundID: firstRoundID)
+        )
+
+        let secondOperationID = toolChainCoordinator.beginOperation(conversationID: UUID())
+        let secondRoundID = try #require(
+            coordinator.beginRequestRound(
+                for: secondOperationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+
+        let staleProviderResolution = coordinator.providerDidComplete(
+            operationID: firstOperationID,
+            requestRoundID: firstRoundID
+        )
+        guard case .ignored = staleProviderResolution else {
+            Issue.record("A replaced provider round must be ignored")
+            return
+        }
+
+        let staleToolResolution = coordinator.toolDidComplete(
+            firstToken,
+            result: ToolResult(callID: "stale", output: "ignored")
+        )
+        guard case .ignored = staleToolResolution else {
+            Issue.record("A replaced tool completion must be ignored")
+            return
+        }
+
+        let secondToken = try #require(
+            coordinator.registerTool(for: secondOperationID, requestRoundID: secondRoundID)
+        )
+        let secondToolResolution = coordinator.toolDidComplete(
+            secondToken,
+            result: ToolResult(callID: "current", output: "kept")
+        )
+        guard case .pending = secondToolResolution else {
+            Issue.record("The replacement round should remain active")
+            return
+        }
+
+        let secondProviderResolution = coordinator.providerDidComplete(
+            operationID: secondOperationID,
+            requestRoundID: secondRoundID
+        )
+        guard case let .launchContinuation(continuation) = secondProviderResolution else {
+            Issue.record("The replacement operation should launch normally")
+            return
+        }
+        #expect(continuation.operationID == secondOperationID)
+        #expect(continuation.toolResults.map(\.result.callID) == ["current"])
+    }
+
+    @Test
+    func `stale round begin cannot erase the active replacement round`() throws {
+        let toolChainCoordinator = ToolChainCoordinator()
+        let coordinator = Coordinator()
+        let staleOperationID = toolChainCoordinator.beginOperation(conversationID: UUID())
+        _ = try #require(
+            coordinator.beginRequestRound(
+                for: staleOperationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+
+        let replacementOperationID = toolChainCoordinator.beginOperation(conversationID: UUID())
+        let replacementRoundID = try #require(
+            coordinator.beginRequestRound(
+                for: replacementOperationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+
+        #expect(
+            coordinator.beginRequestRound(
+                for: staleOperationID,
+                coordinatedBy: toolChainCoordinator
+            ) == nil
+        )
+
+        let replacementToken = try #require(
+            coordinator.registerTool(
+                for: replacementOperationID,
+                requestRoundID: replacementRoundID
+            )
+        )
+        guard case .pending = coordinator.toolDidComplete(
+            replacementToken,
+            result: ToolResult(callID: "replacement", output: "kept")
+        ) else {
+            Issue.record("The stale begin must not clear replacement tool registration")
+            return
+        }
+
+        let resolution = coordinator.providerDidComplete(
+            operationID: replacementOperationID,
+            requestRoundID: replacementRoundID
+        )
+        guard case let .launchContinuation(continuation) = resolution else {
+            Issue.record("The active replacement round should still resolve")
+            return
+        }
+        #expect(continuation.operationID == replacementOperationID)
+        #expect(continuation.toolResults.map(\.result.callID) == ["replacement"])
+    }
+
+    @Test
+    func `cancellation suppresses all later completions`() throws {
+        let toolChainCoordinator = ToolChainCoordinator()
+        let coordinator = Coordinator()
+        let operationID = toolChainCoordinator.beginOperation(conversationID: UUID())
+        let roundID = try #require(
+            coordinator.beginRequestRound(
+                for: operationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+        let token = try #require(
+            coordinator.registerTool(for: operationID, requestRoundID: roundID)
+        )
+
+        #expect(toolChainCoordinator.cancelCurrentOperation())
+
+        let providerResolution = coordinator.providerDidComplete(
+            operationID: operationID,
+            requestRoundID: roundID
+        )
+        guard case .ignored = providerResolution else {
+            Issue.record("Provider completion after cancellation must be ignored")
+            return
+        }
+
+        let toolResolution = coordinator.toolDidComplete(
+            token,
+            result: ToolResult(callID: "cancelled", output: "ignored")
+        )
+        guard case .ignored = toolResolution else {
+            Issue.record("Tool completion after cancellation must be ignored")
+            return
+        }
+
+        #expect(
+            coordinator.beginRequestRound(
+                for: operationID,
+                coordinatedBy: toolChainCoordinator
+            ) == nil
+        )
+    }
+
+    @Test
+    func `provider completion closes a round with no tools`() throws {
+        let toolChainCoordinator = ToolChainCoordinator()
+        let coordinator = Coordinator()
+        let operationID = toolChainCoordinator.beginOperation(conversationID: UUID())
+        let roundID = try #require(
+            coordinator.beginRequestRound(
+                for: operationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+
+        let resolution = coordinator.providerDidComplete(
+            operationID: operationID,
+            requestRoundID: roundID
+        )
+        guard case .responseCompleted = resolution else {
+            Issue.record("A no-tool response should complete without a continuation")
+            return
+        }
+
+        #expect(coordinator.registerTool(for: operationID, requestRoundID: roundID) == nil)
+
+        let duplicateResolution = coordinator.providerDidComplete(
+            operationID: operationID,
+            requestRoundID: roundID
+        )
+        guard case .ignored = duplicateResolution else {
+            Issue.record("A closed round must ignore duplicate provider completion")
+            return
+        }
+    }
+}

--- a/Tests/AynaTests/ToolCallRequestRoundCoordinatorTests.swift
+++ b/Tests/AynaTests/ToolCallRequestRoundCoordinatorTests.swift
@@ -13,6 +13,80 @@ struct ToolCallRequestRoundCoordinatorTests {
     private typealias Coordinator = ToolCallRequestRoundCoordinator<ToolResult>
 
     @Test
+    func `ingress gate admits at most the hard limit under concurrent fan out`() async {
+        let gate = ToolCallRequestAdmissionGate()
+
+        let admittedCount = await withTaskGroup(of: Bool.self, returning: Int.self) { group in
+            for index in 0 ..< 100 {
+                group.addTask {
+                    gate.admit(providerID: "call-\(index)")
+                }
+            }
+
+            var count = 0
+            for await admitted in group where admitted {
+                count += 1
+            }
+            return count
+        }
+
+        #expect(admittedCount == ToolCallRequestRoundPolicy.maximumToolCallsPerRound)
+    }
+
+    @Test
+    func `ingress gate rejects duplicate provider callback IDs`() {
+        let gate = ToolCallRequestAdmissionGate()
+
+        #expect(gate.admit(providerID: "duplicate"))
+        #expect(!gate.admit(providerID: "duplicate"))
+    }
+
+    @Test
+    func `duplicate id less callbacks do not consume ingress capacity`() {
+        let gate = ToolCallRequestAdmissionGate()
+        let admittedTools = FlightTestBox<[String]>([])
+        let callback = gate.admittedCallback { _, toolName, _ in
+            admittedTools.update { $0.append(toolName) }
+        }
+
+        for _ in 0 ..< ToolCallRequestRoundPolicy.maximumToolCallsPerRound {
+            callback("", "duplicate", ["position": 1])
+        }
+        callback("   ", "distinct", ["position": 2])
+
+        #expect(admittedTools.value == ["duplicate", "distinct"])
+    }
+
+    @Test
+    func `request round rejects tool fan out beyond the hard limit`() throws {
+        let toolChainCoordinator = ToolChainCoordinator()
+        let coordinator = Coordinator()
+        let operationID = toolChainCoordinator.beginOperation(conversationID: UUID())
+        let roundID = try #require(
+            coordinator.beginRequestRound(
+                for: operationID,
+                coordinatedBy: toolChainCoordinator
+            )
+        )
+
+        for _ in 0 ..< ToolCallRequestRoundPolicy.maximumToolCallsPerRound {
+            #expect(
+                coordinator.registerTool(
+                    for: operationID,
+                    requestRoundID: roundID
+                ) != nil
+            )
+        }
+
+        #expect(
+            coordinator.registerTool(
+                for: operationID,
+                requestRoundID: roundID
+            ) == nil
+        )
+    }
+
+    @Test
     func `two parallel tools launch exactly one continuation after every completion`() throws {
         let toolChainCoordinator = ToolChainCoordinator()
         let coordinator = Coordinator()

--- a/Tests/AynaTests/ToolChainCoordinatorTests.swift
+++ b/Tests/AynaTests/ToolChainCoordinatorTests.swift
@@ -1,0 +1,269 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Tool Chain Coordinator Tests", .tags(.async))
+@MainActor
+struct ToolChainCoordinatorTests {
+    @Test
+    func `provider callback bookkeeping preserves enqueue order`() async throws {
+        let coordinator = ToolChainCoordinator()
+        let requestRounds = ToolCallRequestRoundCoordinator<String>()
+        let conversationID = UUID()
+        let operationID = coordinator.beginOperation(conversationID: conversationID)
+        let requestRoundID = try #require(
+            requestRounds.beginRequestRound(for: operationID, coordinatedBy: coordinator)
+        )
+        let drained = FlightTestSignal()
+        var callbackOrder: [String] = []
+        var registrationIndexes: [Int] = []
+        var completionWaitedForTools = false
+
+        coordinator.enqueueCallback(for: operationID, conversationID: conversationID) {
+            callbackOrder.append("chunk")
+        }
+        coordinator.enqueueCallback(for: operationID, conversationID: conversationID) {
+            if let token = requestRounds.registerTool(
+                for: operationID,
+                requestRoundID: requestRoundID
+            ) {
+                registrationIndexes.append(token.registrationIndex)
+            }
+            callbackOrder.append("tool-1")
+        }
+        coordinator.enqueueCallback(for: operationID, conversationID: conversationID) {
+            if let token = requestRounds.registerTool(
+                for: operationID,
+                requestRoundID: requestRoundID
+            ) {
+                registrationIndexes.append(token.registrationIndex)
+            }
+            callbackOrder.append("tool-2")
+        }
+        coordinator.enqueueCallback(for: operationID, conversationID: conversationID) {
+            let resolution = requestRounds.providerDidComplete(
+                operationID: operationID,
+                requestRoundID: requestRoundID
+            )
+            if case .pending = resolution {
+                completionWaitedForTools = true
+            }
+            callbackOrder.append("complete")
+            drained.signal()
+        }
+
+        #expect(await drained.wait(timeout: .seconds(1)))
+        #expect(callbackOrder == ["chunk", "tool-1", "tool-2", "complete"])
+        #expect(registrationIndexes == [0, 1])
+        #expect(completionWaitedForTools)
+        coordinator.cancelCurrentOperation()
+    }
+
+    @Test
+    func `callback handoff is safe to enqueue off the main actor`() async {
+        let coordinator = ToolChainCoordinator()
+        let conversationID = UUID()
+        let operationID = coordinator.beginOperation(conversationID: conversationID)
+        let observed = FlightTestBox<[Int]>([])
+        let drained = FlightTestSignal()
+
+        await Task.detached {
+            for value in 0 ..< 20 {
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationID) {
+                    observed.update { $0.append(value) }
+                    if value == 19 {
+                        drained.signal()
+                    }
+                }
+            }
+        }.value
+
+        #expect(await drained.wait(timeout: .seconds(1)))
+        #expect(observed.value == Array(0 ..< 20))
+        coordinator.cancelCurrentOperation()
+    }
+
+    @Test
+    func `cancellation suppresses callbacks already waiting for the main actor`() async {
+        let coordinator = ToolChainCoordinator()
+        let conversationID = UUID()
+        let operationID = coordinator.beginOperation(conversationID: conversationID)
+        let staleMutation = FlightTestSignal()
+
+        coordinator.enqueueCallback(for: operationID, conversationID: conversationID) {
+            staleMutation.signal()
+        }
+        #expect(coordinator.cancelCurrentOperation())
+
+        #expect(await !(staleMutation.wait(timeout: .milliseconds(100))))
+    }
+
+    @Test
+    func `lifecycle cancellation drains bookkeeping before finalization and invalidation`() {
+        let coordinator = ToolChainCoordinator()
+        let conversationID = UUID()
+        let operationID = coordinator.beginOperation(conversationID: conversationID)
+        var callbackOrder: [String] = []
+        var ownedDuringFinalization = false
+
+        coordinator.enqueueCallback(for: operationID, conversationID: conversationID) {
+            callbackOrder.append("chunk")
+        }
+        coordinator.enqueueCallback(for: operationID, conversationID: conversationID) {
+            callbackOrder.append("status")
+        }
+
+        #expect(coordinator.cancelCurrentOperation {
+            ownedDuringFinalization = coordinator.owns(operationID, conversationID: conversationID)
+            callbackOrder.append("finalize")
+        })
+
+        #expect(callbackOrder == ["chunk", "status", "finalize"])
+        #expect(ownedDuringFinalization)
+        #expect(!coordinator.owns(operationID, conversationID: conversationID))
+    }
+
+    @Test
+    func `replacement suppresses queued callbacks from the previous operation`() async {
+        let coordinator = ToolChainCoordinator()
+        let firstConversationID = UUID()
+        let firstOperationID = coordinator.beginOperation(conversationID: firstConversationID)
+        let observed = FlightTestBox<[String]>([])
+        let replacementRan = FlightTestSignal()
+
+        coordinator.enqueueCallback(for: firstOperationID, conversationID: firstConversationID) {
+            observed.update { $0.append("stale") }
+        }
+
+        let secondConversationID = UUID()
+        let secondOperationID = coordinator.beginOperation(conversationID: secondConversationID)
+        coordinator.enqueueCallback(for: secondOperationID, conversationID: secondConversationID) {
+            observed.update { $0.append("replacement") }
+            replacementRan.signal()
+        }
+
+        #expect(await replacementRan.wait(timeout: .seconds(1)))
+        #expect(observed.value == ["replacement"])
+        coordinator.cancelCurrentOperation()
+    }
+
+    @Test
+    func `scheduled async work is not serialized by callback ordering`() async {
+        let coordinator = ToolChainCoordinator()
+        let conversationID = UUID()
+        let operationID = coordinator.beginOperation(conversationID: conversationID)
+        let firstStarted = FlightTestSignal()
+        let releaseFirst = FlightTestSignal()
+        let firstFinished = FlightTestSignal()
+        let secondStarted = FlightTestSignal()
+
+        coordinator.schedule(for: operationID, conversationID: conversationID) {
+            firstStarted.signal()
+            await releaseFirst.wait()
+            firstFinished.signal()
+        }
+        coordinator.schedule(for: operationID, conversationID: conversationID) {
+            secondStarted.signal()
+        }
+
+        #expect(await firstStarted.wait(timeout: .seconds(1)))
+        #expect(await secondStarted.wait(timeout: .seconds(1)))
+        #expect(!firstFinished.isSignaled)
+
+        releaseFirst.signal()
+        #expect(await firstFinished.wait(timeout: .seconds(1)))
+        coordinator.cancelCurrentOperation()
+    }
+
+    @Test
+    func `cancelling a chain stops its tool task and suppresses late completion`() async {
+        let coordinator = ToolChainCoordinator()
+        let conversationID = UUID()
+        let operationID = coordinator.beginOperation(conversationID: conversationID)
+        let cancellationObserved = FlightTestSignal()
+        let allowLateCompletion = FlightTestSignal()
+        let staleMutation = FlightTestSignal()
+
+        let task = Task {
+            await withTaskCancellationHandler {
+                await allowLateCompletion.wait()
+                coordinator.schedule(for: operationID, conversationID: conversationID) {
+                    staleMutation.signal()
+                }
+            } onCancel: {
+                cancellationObserved.signal()
+            }
+        }
+        coordinator.track(task, for: operationID)
+
+        #expect(coordinator.cancelCurrentOperation())
+        #expect(await cancellationObserved.wait(timeout: .seconds(1)))
+        allowLateCompletion.signal()
+        #expect(await !(staleMutation.wait(timeout: .milliseconds(100))))
+        #expect(!coordinator.owns(operationID, conversationID: conversationID))
+    }
+
+    @Test
+    func `replacement cancels the old tool chain without surrendering ownership`() async {
+        let coordinator = ToolChainCoordinator()
+        let firstConversationID = UUID()
+        let secondConversationID = UUID()
+        let firstID = coordinator.beginOperation(conversationID: firstConversationID)
+        let cancellationObserved = FlightTestSignal()
+        let blocker = FlightTestSignal()
+        let firstTask = Task {
+            await withTaskCancellationHandler {
+                await blocker.wait()
+            } onCancel: {
+                cancellationObserved.signal()
+            }
+        }
+        coordinator.track(firstTask, for: firstID)
+
+        let secondID = coordinator.beginOperation(conversationID: secondConversationID)
+
+        #expect(await cancellationObserved.wait(timeout: .seconds(1)))
+        #expect(!coordinator.owns(firstID, conversationID: firstConversationID))
+        #expect(coordinator.owns(secondID, conversationID: secondConversationID))
+        #expect(!coordinator.finishOperation(firstID))
+        #expect(coordinator.owns(secondID, conversationID: secondConversationID))
+
+        blocker.signal()
+        coordinator.cancelCurrentOperation()
+    }
+
+    @Test
+    func `tracking work after cancellation cancels it immediately`() async {
+        let coordinator = ToolChainCoordinator()
+        let operationID = coordinator.beginOperation(conversationID: UUID())
+        coordinator.cancelCurrentOperation()
+        let cancellationObserved = FlightTestSignal()
+        let blocker = FlightTestSignal()
+        let task = Task {
+            await withTaskCancellationHandler {
+                await blocker.wait()
+            } onCancel: {
+                cancellationObserved.signal()
+            }
+        }
+
+        coordinator.track(task, for: operationID)
+
+        #expect(await cancellationObserved.wait(timeout: .seconds(1)))
+        blocker.signal()
+    }
+
+    @Test
+    func `finishing a chain does not run cancellation cleanup`() {
+        let coordinator = ToolChainCoordinator()
+        let operationID = coordinator.beginOperation(conversationID: UUID())
+        var cleanupCount = 0
+        coordinator.onCancel(for: operationID) {
+            cleanupCount += 1
+        }
+
+        #expect(coordinator.finishOperation(operationID))
+        #expect(!coordinator.cancelCurrentOperation())
+        #expect(cleanupCount == 0)
+    }
+}

--- a/Tests/AynaTests/ToolExecutionResultTests.swift
+++ b/Tests/AynaTests/ToolExecutionResultTests.swift
@@ -1,0 +1,101 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Tool Execution Result Tests")
+@MainActor
+struct ToolExecutionResultTests {
+    @Test("Persisted tool message retains the matching call and output")
+    func persistedToolMessageRetainsMatchingCallAndOutput() {
+        let result = ToolExecutionResult(
+            callID: "call-1",
+            toolName: "web_search",
+            arguments: ["query": AnyCodable("Swift concurrency")],
+            output: "Search result"
+        )
+
+        let message = result.makeMessage()
+
+        #expect(message.role == .tool)
+        #expect(message.content == "Search result")
+        #expect(message.toolCalls?.count == 1)
+        #expect(message.toolCalls?.first?.id == "call-1")
+        #expect(message.toolCalls?.first?.toolName == "web_search")
+        #expect(message.toolCalls?.first?.result == "Search result")
+    }
+
+    @Test("Combined citations preserve tool order and receive stable numbering")
+    func combinedCitationsPreserveToolOrderAndStableNumbering() {
+        let first = ToolExecutionResult(
+            callID: "first",
+            toolName: "web_search",
+            arguments: [:],
+            output: "one",
+            citations: [CitationReference(number: 9, title: "First", url: "https://first.example")]
+        )
+        let second = ToolExecutionResult(
+            callID: "second",
+            toolName: "web_search",
+            arguments: [:],
+            output: "two",
+            citations: [CitationReference(number: 3, title: "Second", url: "https://second.example")]
+        )
+
+        let citations = ToolExecutionResult.combinedCitations(from: [first, second])
+
+        #expect(citations.map(\.number) == [1, 2])
+        #expect(citations.map(\.title) == ["First", "Second"])
+    }
+    @Test("Watch message round trip preserves tool metadata")
+    func watchMessageRoundTripPreservesToolMetadata() throws {
+        let result = ToolExecutionResult(
+            callID: "watch-call",
+            toolName: "web_search",
+            arguments: ["query": AnyCodable("weather")],
+            output: "Sunny",
+            citations: [CitationReference(number: 1, title: "Forecast", url: "https://weather.example")]
+        )
+        var original = result.makeMessage()
+        original.citations = result.citations
+
+        let data = try JSONEncoder().encode(WatchMessage(from: original))
+        let decoded = try JSONDecoder().decode(WatchMessage.self, from: data).toMessage()
+
+        #expect(decoded.toolCalls?.first?.id == "watch-call")
+        #expect(decoded.toolCalls?.first?.toolName == "web_search")
+        #expect(decoded.toolCalls?.first?.arguments["query"] == AnyCodable("weather"))
+        #expect(decoded.toolCalls?.first?.result == "Sunny")
+        #expect(decoded.citations?.first?.title == "Forecast")
+        #expect(decoded.citations?.first?.url == "https://weather.example")
+    }
+
+    @Test("Provider builders serialize preserved tool metadata")
+    func providerBuildersSerializePreservedToolMetadata() throws {
+        let call = MCPToolCall(
+            id: "builder-call",
+            toolName: "web_search",
+            arguments: ["query": AnyCodable("weather")]
+        )
+        var assistant = Message(role: .assistant, content: "")
+        assistant.toolCalls = [call]
+        let result = ToolExecutionResult(
+            callID: call.id,
+            toolName: call.toolName,
+            arguments: call.arguments,
+            output: "Sunny"
+        ).makeMessage()
+
+        let assistantPayload = OpenAIRequestBuilder.buildMessagePayload(from: assistant)
+        let resultPayload = OpenAIRequestBuilder.buildMessagePayload(from: result)
+        #expect((assistantPayload["tool_calls"] as? [[String: Any]])?.count == 1)
+        #expect(resultPayload["tool_call_id"] as? String == call.id)
+
+        let anthropic = try AnthropicRequestBuilder.extractSystemAndConvertMessages([assistant, result]).messages
+        #expect(anthropic.count == 2)
+        let assistantContent = anthropic[0]["content"] as? [[String: Any]]
+        let resultContent = anthropic[1]["content"] as? [[String: Any]]
+        #expect(assistantContent?.contains(where: { $0["type"] as? String == "tool_use" }) == true)
+        #expect(resultContent?.contains(where: { $0["type"] as? String == "tool_result" }) == true)
+    }
+
+}

--- a/Tests/AynaTests/ToolTranscriptSanitizerTests.swift
+++ b/Tests/AynaTests/ToolTranscriptSanitizerTests.swift
@@ -1,0 +1,114 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Tool Transcript Sanitizer Tests")
+@MainActor
+struct ToolTranscriptSanitizerTests {
+    @Test("Keeps only contiguous outputs that follow their assistant call")
+    func keepsOnlyContiguousFollowingOutputs() {
+        let call = MCPToolCall(id: "call", toolName: "lookup", arguments: [:])
+        var assistant = Message(role: .assistant, content: "partial")
+        assistant.toolCalls = [call]
+        var result = Message(role: .tool, content: "result")
+        result.toolCalls = [MCPToolCall(id: call.id, toolName: call.toolName, arguments: [:], result: "result")]
+
+        let outputBefore = ToolTranscriptSanitizer.sanitize([result, assistant])
+        #expect(outputBefore.count == 1)
+        #expect(outputBefore[0].content == "partial")
+        #expect(outputBefore[0].toolCalls == nil)
+
+        let separated = ToolTranscriptSanitizer.sanitize([
+            assistant,
+            Message(role: .user, content: "new turn"),
+            result
+        ])
+        #expect(separated.map(\.role) == [.assistant, .user])
+        #expect(separated[0].toolCalls == nil)
+    }
+
+    @Test("Preserves parallel calls and results in call order")
+    func preservesParallelCallsAndResultsInCallOrder() {
+        let first = MCPToolCall(id: "first", toolName: "one", arguments: [:])
+        let second = MCPToolCall(id: "second", toolName: "two", arguments: [:])
+        var assistant = Message(role: .assistant, content: "")
+        assistant.toolCalls = [first, second]
+        var secondResult = Message(role: .tool, content: "two-result")
+        secondResult.toolCalls = [MCPToolCall(id: second.id, toolName: second.toolName, arguments: [:], result: "two-result")]
+        var firstResult = Message(role: .tool, content: "one-result")
+        firstResult.toolCalls = [MCPToolCall(id: first.id, toolName: first.toolName, arguments: [:], result: "one-result")]
+
+        let sanitized = ToolTranscriptSanitizer.sanitize([assistant, secondResult, firstResult])
+
+        #expect(sanitized[0].toolCalls?.map(\.id) == ["first", "second"])
+        #expect(sanitized.dropFirst().map(\.content) == ["one-result", "two-result"])
+    }
+
+    @Test("Drops orphan tool-only assistants")
+    func dropsOrphanToolOnlyAssistants() {
+        var assistant = Message(role: .assistant, content: "")
+        assistant.toolCalls = [MCPToolCall(id: "orphan", toolName: "lookup", arguments: [:])]
+
+        #expect(ToolTranscriptSanitizer.sanitize([assistant]).isEmpty)
+    }
+
+    @Test("Preserves non-tool assistant content when orphan calls are stripped")
+    func preservesMeaningfulAssistantContent() throws {
+        let orphanCall = MCPToolCall(id: "orphan", toolName: "lookup", arguments: [:])
+
+        var textMessage = Message(role: .assistant, content: "Partial answer")
+        textMessage.toolCalls = [orphanCall]
+
+        var reasoningMessage = Message(role: .assistant, content: "", reasoning: "Useful reasoning")
+        reasoningMessage.toolCalls = [orphanCall]
+
+        var citationMessage = Message(
+            role: .assistant,
+            content: "",
+            citations: [CitationReference(number: 1, title: "Source", url: "https://example.com")]
+        )
+        citationMessage.toolCalls = [orphanCall]
+
+        var mediaMessage = Message(
+            role: .assistant,
+            content: "",
+            mediaType: .image,
+            imageData: Data([0x01])
+        )
+        mediaMessage.toolCalls = [orphanCall]
+
+        for message in [textMessage, reasoningMessage, citationMessage, mediaMessage] {
+            let sanitized = ToolTranscriptSanitizer.sanitize([message])
+            #expect(sanitized.count == 1)
+            let preserved = try #require(sanitized.first)
+            #expect(preserved.id == message.id)
+            #expect(preserved.toolCalls == nil)
+        }
+    }
+
+    @Test("Provider builders omit cross-round tool pairs")
+    func providerBuildersOmitCrossRoundToolPairs() throws {
+        let call = MCPToolCall(id: "cross-round", toolName: "lookup", arguments: [:])
+        var assistant = Message(role: .assistant, content: "partial")
+        assistant.toolCalls = [call]
+        var result = Message(role: .tool, content: "late result")
+        result.toolCalls = [
+            MCPToolCall(id: call.id, toolName: call.toolName, arguments: [:], result: "late result")
+        ]
+        let history = [assistant, Message(role: .user, content: "new turn"), result]
+
+        let chatBody = OpenAIRequestBuilder.buildChatCompletionsBody(
+            messages: history,
+            model: "gpt-4o",
+            stream: false
+        )
+        let chatMessages = try #require(chatBody["messages"] as? [[String: Any]])
+        #expect(chatMessages.count == 2)
+        #expect(chatMessages[0]["tool_calls"] == nil)
+
+        let anthropic = try AnthropicRequestBuilder.extractSystemAndConvertMessages(history).messages
+        #expect(anthropic.count == 2)
+        #expect(anthropic[0]["role"] as? String == "assistant")
+        #expect(anthropic[0]["content"] as? String == "partial")
+    }
+}

--- a/Tests/AynaTests/UserMemoryServiceTests.swift
+++ b/Tests/AynaTests/UserMemoryServiceTests.swift
@@ -65,6 +65,74 @@ struct UserMemoryServiceTests {
     }
 
     @Test
+    func `pre-load mutation preserves seeded facts when persistence initiates load`() async {
+        let seededFact = UserMemoryFact(content: "Seeded fact")
+        let store = ScriptedUserMemoryStore(loadFacts: [seededFact])
+        let center = NotificationCenter()
+        let notifications = NotificationCounter(name: .watchSyncContextDidChange, center: center)
+        defer { notifications.stop() }
+        let service = UserMemoryService(
+            store: store,
+            saveDebounceDuration: .seconds(60),
+            notificationCenter: center
+        )
+
+        let localFact = service.addFact("Local fact")
+        await service.saveImmediately()
+
+        #expect(await store.loadAttemptCount == 1)
+        #expect(await store.saveAttemptCount == 1)
+        #expect(service.isLoaded)
+        #expect(service.facts == [localFact, seededFact])
+        #expect(service.hasAuthoritativeFacts)
+        #expect(notifications.received == 1)
+        #expect(await store.saveAttempts == [[localFact, seededFact]])
+        #expect(await store.persistedFacts == [localFact, seededFact])
+    }
+
+    @Test
+    func `failed pre-load reconciliation never overwrites stored facts and retries safely`() async {
+        let seededFact = UserMemoryFact(content: "Seeded fact")
+        let store = ScriptedUserMemoryStore(
+            loadFacts: [seededFact],
+            loadPlans: [
+                .init(outcome: .failure),
+                .init(outcome: .success),
+            ]
+        )
+        let center = NotificationCenter()
+        let notifications = NotificationCounter(name: .watchSyncContextDidChange, center: center)
+        defer { notifications.stop() }
+        let service = UserMemoryService(
+            store: store,
+            saveDebounceDuration: .seconds(60),
+            notificationCenter: center
+        )
+
+        let firstLocalFact = service.addFact("First local fact")
+        await service.saveImmediately()
+
+        #expect(await store.loadAttemptCount == 1)
+        #expect(await store.saveAttemptCount == 0)
+        #expect(await store.persistedFacts == [seededFact])
+        #expect(service.facts == [firstLocalFact])
+        #expect(!service.hasAuthoritativeFacts)
+        #expect(notifications.received == 0)
+
+        let secondLocalFact = service.addFact("Second local fact")
+        await service.saveImmediately()
+
+        let expected = [secondLocalFact, firstLocalFact, seededFact]
+        #expect(await store.loadAttemptCount == 2)
+        #expect(await store.saveAttemptCount == 1)
+        #expect(await store.saveAttempts == [expected])
+        #expect(await store.persistedFacts == expected)
+        #expect(service.facts == expected)
+        #expect(service.hasAuthoritativeFacts)
+        #expect(notifications.received == 1)
+    }
+
+    @Test
     func `local CRUD during initial load merges stored facts before publishing`() async {
         let persistedFact = UserMemoryFact(content: "Persisted fact")
         let deletedPersistedFact = UserMemoryFact(content: "Delete this persisted fact")
@@ -134,24 +202,54 @@ struct UserMemoryServiceTests {
         #expect(await eventually { await store.loadAttemptCount == 1 })
 
         service.loadFactsFromSync([syncedFact])
-        await loadGate.open()
-        await load.value
-
-        #expect(service.isLoaded)
-        #expect(service.facts == [syncedFact])
-        #expect(!service.hasAuthoritativeFacts)
-        #expect(notifications.received == 0)
-
         let save = Task { await service.saveImmediately() }
         #expect(await eventually { await store.saveAttemptCount == 1 })
         #expect(await store.saveAttempts == [[syncedFact]])
 
         await saveGate.open()
         await save.value
+        await loadGate.open()
+        await load.value
 
+        #expect(service.isLoaded)
+        #expect(service.facts == [syncedFact])
         #expect(service.hasAuthoritativeFacts)
         #expect(notifications.received == 1)
         #expect(await store.persistedFacts == [syncedFact])
+    }
+
+    @Test
+    func `clear supersedes a blocked initial load without waiting`() async {
+        let staleDiskFact = UserMemoryFact(content: "Stale disk fact")
+        let loadGate = TestGate()
+        let store = ScriptedUserMemoryStore(
+            loadFacts: [staleDiskFact],
+            loadPlan: .init(gate: loadGate)
+        )
+        let center = NotificationCenter()
+        let notifications = NotificationCounter(name: .watchSyncContextDidChange, center: center)
+        defer { notifications.stop() }
+        let service = UserMemoryService(store: store, notificationCenter: center)
+
+        let load = Task { await service.loadFacts() }
+        #expect(await eventually { await store.loadAttemptCount == 1 })
+
+        let clear = Task { await service.clearAllFacts() }
+        #expect(await eventually { await store.clearAttemptCount == 1 })
+        await clear.value
+
+        #expect(service.isLoaded)
+        #expect(service.facts.isEmpty)
+        #expect(service.hasAuthoritativeFacts)
+        #expect(notifications.received == 1)
+        #expect(await store.persistedFacts.isEmpty)
+
+        await loadGate.open()
+        await load.value
+
+        #expect(service.facts.isEmpty)
+        #expect(service.hasAuthoritativeFacts)
+        #expect(await store.persistedFacts.isEmpty)
     }
 
     @Test
@@ -628,7 +726,7 @@ private actor TestGate {
 
 private actor ScriptedUserMemoryStore: UserMemoryStoreAdapter {
     private let loadFactsValue: [UserMemoryFact]
-    private let loadPlan: ScriptedOperationPlan
+    private let loadPlans: [ScriptedOperationPlan]
     private let savePlans: [ScriptedOperationPlan]
     private let clearPlans: [ScriptedOperationPlan]
 
@@ -644,19 +742,22 @@ private actor ScriptedUserMemoryStore: UserMemoryStoreAdapter {
     init(
         loadFacts: [UserMemoryFact] = [],
         loadPlan: ScriptedOperationPlan = .init(),
+        loadPlans: [ScriptedOperationPlan]? = nil,
         savePlans: [ScriptedOperationPlan] = [],
         clearPlans: [ScriptedOperationPlan] = []
     ) {
         loadFactsValue = loadFacts
-        self.loadPlan = loadPlan
+        self.loadPlans = loadPlans ?? [loadPlan]
         self.savePlans = savePlans
         self.clearPlans = clearPlans
         persistedFacts = loadFacts
     }
 
     func loadMemory() async throws -> UserMemoryStore {
+        let attempt = loadAttemptCount
         loadAttemptCount += 1
-        try await execute(loadPlan)
+        let plan = attempt < loadPlans.count ? loadPlans[attempt] : loadPlans.last ?? .init()
+        try await execute(plan)
         return UserMemoryStore(facts: loadFactsValue)
     }
 

--- a/Tests/AynaTests/UserMemoryServiceTests.swift
+++ b/Tests/AynaTests/UserMemoryServiceTests.swift
@@ -12,10 +12,371 @@ import Testing
 @Suite("UserMemoryService Tests")
 @MainActor
 struct UserMemoryServiceTests {
+    @Test
+    func `load publishes only after authoritative storage succeeds`() async {
+        let loadedFact = UserMemoryFact(content: "Persisted fact")
+        let successGate = TestGate()
+        let successStore = ScriptedUserMemoryStore(
+            loadFacts: [loadedFact],
+            loadPlan: .init(gate: successGate, outcome: .success)
+        )
+        let successCenter = NotificationCenter()
+        let successNotifications = NotificationCounter(
+            name: .watchSyncContextDidChange,
+            center: successCenter
+        )
+        defer { successNotifications.stop() }
+        let successful = UserMemoryService(
+            store: successStore,
+            notificationCenter: successCenter
+        )
+
+        let successfulLoad = Task { await successful.loadFacts() }
+        #expect(await eventually { await successStore.loadAttemptCount == 1 })
+        #expect(!successful.hasAuthoritativeFacts)
+        #expect(successNotifications.received == 0)
+
+        await successGate.open()
+        await successfulLoad.value
+
+        #expect(successful.isLoaded)
+        #expect(successful.hasAuthoritativeFacts)
+        #expect(successful.facts == [loadedFact])
+        #expect(successNotifications.received == 1)
+
+        let failureStore = ScriptedUserMemoryStore(loadPlan: .init(outcome: .failure))
+        let failureCenter = NotificationCenter()
+        let failureNotifications = NotificationCounter(
+            name: .watchSyncContextDidChange,
+            center: failureCenter
+        )
+        defer { failureNotifications.stop() }
+        let failing = UserMemoryService(
+            store: failureStore,
+            notificationCenter: failureCenter
+        )
+
+        await failing.loadFacts()
+
+        #expect(failing.isLoaded)
+        #expect(!failing.hasAuthoritativeFacts)
+        #expect(failing.facts.isEmpty)
+        #expect(failureNotifications.received == 0)
+    }
+
+    @Test
+    func `local CRUD during initial load merges stored facts before publishing`() async {
+        let persistedFact = UserMemoryFact(content: "Persisted fact")
+        let deletedPersistedFact = UserMemoryFact(content: "Delete this persisted fact")
+        let loadGate = TestGate()
+        let saveGate = TestGate()
+        let store = ScriptedUserMemoryStore(
+            loadFacts: [persistedFact, deletedPersistedFact],
+            loadPlan: .init(gate: loadGate),
+            savePlans: [.init(gate: saveGate)]
+        )
+        let center = NotificationCenter()
+        let notifications = NotificationCounter(name: .watchSyncContextDidChange, center: center)
+        defer { notifications.stop() }
+        let service = UserMemoryService(
+            store: store,
+            saveDebounceDuration: .zero,
+            notificationCenter: center
+        )
+
+        let load = Task { await service.loadFacts() }
+        #expect(await eventually { await store.loadAttemptCount == 1 })
+
+        let localFact = service.addFact("Local fact")
+        service.deleteFact(deletedPersistedFact.id)
+
+        await loadGate.open()
+        await load.value
+
+        #expect(service.isLoaded)
+        #expect(service.facts == [localFact, persistedFact])
+        #expect(!service.hasAuthoritativeFacts)
+        #expect(notifications.received == 0)
+        #expect(await eventually { await store.saveAttemptCount == 1 })
+        #expect(await store.saveAttempts == [[localFact, persistedFact]])
+        #expect(!service.hasAuthoritativeFacts)
+        #expect(notifications.received == 0)
+
+        await saveGate.open()
+        #expect(await eventually { service.hasAuthoritativeFacts })
+
+        #expect(service.hasAuthoritativeFacts)
+        #expect(notifications.received == 1)
+        #expect(await store.persistedFacts == [localFact, persistedFact])
+    }
+
+    @Test
+    func `sync replacement supersedes an in-flight initial load`() async {
+        let staleDiskFact = UserMemoryFact(content: "Stale disk fact")
+        let syncedFact = UserMemoryFact(content: "Synced fact")
+        let loadGate = TestGate()
+        let saveGate = TestGate()
+        let store = ScriptedUserMemoryStore(
+            loadFacts: [staleDiskFact],
+            loadPlan: .init(gate: loadGate),
+            savePlans: [.init(gate: saveGate)]
+        )
+        let center = NotificationCenter()
+        let notifications = NotificationCounter(name: .watchSyncContextDidChange, center: center)
+        defer { notifications.stop() }
+        let service = UserMemoryService(
+            store: store,
+            saveDebounceDuration: .seconds(60),
+            notificationCenter: center
+        )
+
+        let load = Task { await service.loadFacts() }
+        #expect(await eventually { await store.loadAttemptCount == 1 })
+
+        service.loadFactsFromSync([syncedFact])
+        await loadGate.open()
+        await load.value
+
+        #expect(service.isLoaded)
+        #expect(service.facts == [syncedFact])
+        #expect(!service.hasAuthoritativeFacts)
+        #expect(notifications.received == 0)
+
+        let save = Task { await service.saveImmediately() }
+        #expect(await eventually { await store.saveAttemptCount == 1 })
+        #expect(await store.saveAttempts == [[syncedFact]])
+
+        await saveGate.open()
+        await save.value
+
+        #expect(service.hasAuthoritativeFacts)
+        #expect(notifications.received == 1)
+        #expect(await store.persistedFacts == [syncedFact])
+    }
+
+    @Test
+    func `debounced local CRUD publishes only after its exact snapshot is durable`() async {
+        let saveGate = TestGate()
+        let store = ScriptedUserMemoryStore(
+            savePlans: [.init(gate: saveGate, outcome: .success)]
+        )
+        let center = NotificationCenter()
+        let notifications = NotificationCounter(name: .watchSyncContextDidChange, center: center)
+        defer { notifications.stop() }
+        let service = UserMemoryService(
+            store: store,
+            saveDebounceDuration: .zero,
+            notificationCenter: center
+        )
+        await service.loadFacts()
+        #expect(service.hasAuthoritativeFacts)
+        notifications.reset()
+
+        service.addFact("Optimistic local fact")
+
+        #expect(service.facts.map(\.content) == ["Optimistic local fact"])
+        #expect(!service.hasAuthoritativeFacts)
+        #expect(await eventually { await store.saveAttemptCount == 1 })
+        #expect(notifications.received == 0)
+
+        await saveGate.open()
+        #expect(await eventually { service.hasAuthoritativeFacts })
+
+        #expect(notifications.received == 1)
+        #expect(await store.persistedFacts.map(\.content) == ["Optimistic local fact"])
+    }
+
+    @Test
+    func `failed immediate save keeps optimistic facts private`() async {
+        let store = ScriptedUserMemoryStore(savePlans: [.init(outcome: .failure)])
+        let center = NotificationCenter()
+        let notifications = NotificationCounter(name: .watchSyncContextDidChange, center: center)
+        defer { notifications.stop() }
+        let service = UserMemoryService(
+            store: store,
+            saveDebounceDuration: .seconds(60),
+            notificationCenter: center
+        )
+        await service.loadFacts()
+        #expect(service.hasAuthoritativeFacts)
+        notifications.reset()
+
+        service.addFact("Optimistic local fact")
+        await service.saveImmediately()
+
+        #expect(service.facts.map(\.content) == ["Optimistic local fact"])
+        #expect(!service.hasAuthoritativeFacts)
+        #expect(notifications.received == 0)
+        #expect(await store.saveAttemptCount == 1)
+        #expect(await store.persistedFacts.isEmpty)
+    }
+
+    @Test
+    func `stale saves serialize and only the latest durable generation publishes`() async {
+        let firstSaveGate = TestGate()
+        let secondSaveGate = TestGate()
+        let store = ScriptedUserMemoryStore(savePlans: [
+            .init(gate: firstSaveGate, outcome: .success),
+            .init(gate: secondSaveGate, outcome: .success)
+        ])
+        let center = NotificationCenter()
+        let notifications = NotificationCounter(name: .watchSyncContextDidChange, center: center)
+        defer { notifications.stop() }
+        let service = UserMemoryService(
+            store: store,
+            saveDebounceDuration: .seconds(60),
+            notificationCenter: center
+        )
+        await service.loadFacts()
+        #expect(service.hasAuthoritativeFacts)
+        notifications.reset()
+
+        service.addFact("First generation")
+        let firstSave = Task { await service.saveImmediately() }
+        #expect(await eventually { await store.saveAttemptCount == 1 })
+
+        service.addFact("Second generation")
+        let secondSave = Task { await service.saveImmediately() }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+
+        #expect(await store.saveAttemptCount == 1)
+        #expect(!service.hasAuthoritativeFacts)
+        #expect(notifications.received == 0)
+
+        await firstSaveGate.open()
+        await firstSave.value
+        #expect(await eventually { await store.saveAttemptCount == 2 })
+        #expect(!service.hasAuthoritativeFacts)
+        #expect(notifications.received == 0)
+
+        await secondSaveGate.open()
+        await secondSave.value
+
+        #expect(service.hasAuthoritativeFacts)
+        #expect(notifications.received == 1)
+        #expect(await store.saveAttempts.map { $0.map(\.content) } == [
+            ["First generation"],
+            ["Second generation", "First generation"]
+        ])
+        #expect(await store.persistedFacts.map(\.content) == [
+            "Second generation",
+            "First generation"
+        ])
+    }
+
+    @Test
+    func `synced facts retry persistence without reloading stale disk state`() async {
+        let syncedFact = UserMemoryFact(content: "Synced fact")
+        let store = ScriptedUserMemoryStore(
+            loadFacts: [UserMemoryFact(content: "Stale disk fact")],
+            savePlans: [
+                .init(outcome: .failure),
+                .init(outcome: .success)
+            ]
+        )
+        let center = NotificationCenter()
+        let notifications = NotificationCounter(name: .watchSyncContextDidChange, center: center)
+        defer { notifications.stop() }
+        let service = UserMemoryService(
+            store: store,
+            saveDebounceDuration: .seconds(60),
+            notificationCenter: center
+        )
+
+        service.loadFactsFromSync([syncedFact])
+        #expect(service.facts == [syncedFact])
+        #expect(!service.hasAuthoritativeFacts)
+
+        await service.saveImmediately()
+        #expect(service.facts == [syncedFact])
+        #expect(!service.hasAuthoritativeFacts)
+        #expect(notifications.received == 0)
+
+        await service.loadFacts()
+
+        #expect(await store.loadAttemptCount == 0)
+        #expect(await store.saveAttemptCount == 2)
+        #expect(service.facts == [syncedFact])
+        #expect(service.hasAuthoritativeFacts)
+        #expect(notifications.received == 1)
+        #expect(await store.persistedFacts == [syncedFact])
+    }
+
+    @Test
+    func `clear publishes only after encrypted clear succeeds`() async {
+        let persistedFact = UserMemoryFact(content: "Persisted fact")
+        let successGate = TestGate()
+        let successStore = ScriptedUserMemoryStore(
+            loadFacts: [persistedFact],
+            clearPlans: [.init(gate: successGate, outcome: .success)]
+        )
+        let successCenter = NotificationCenter()
+        let successNotifications = NotificationCounter(
+            name: .watchSyncContextDidChange,
+            center: successCenter
+        )
+        defer { successNotifications.stop() }
+        let successful = UserMemoryService(
+            store: successStore,
+            notificationCenter: successCenter
+        )
+        await successful.loadFacts()
+        successNotifications.reset()
+
+        let successfulClear = Task { await successful.clearAllFacts() }
+        #expect(await eventually { await successStore.clearAttemptCount == 1 })
+        #expect(successful.facts.isEmpty)
+        #expect(!successful.hasAuthoritativeFacts)
+        #expect(successNotifications.received == 0)
+
+        await successGate.open()
+        await successfulClear.value
+
+        #expect(successful.hasAuthoritativeFacts)
+        #expect(successNotifications.received == 1)
+        #expect(await successStore.persistedFacts.isEmpty)
+
+        let failureStore = ScriptedUserMemoryStore(
+            loadFacts: [persistedFact],
+            clearPlans: [.init(outcome: .failure)]
+        )
+        let failureCenter = NotificationCenter()
+        let failureNotifications = NotificationCounter(
+            name: .watchSyncContextDidChange,
+            center: failureCenter
+        )
+        defer { failureNotifications.stop() }
+        let failing = UserMemoryService(
+            store: failureStore,
+            notificationCenter: failureCenter
+        )
+        await failing.loadFacts()
+        failureNotifications.reset()
+
+        await failing.clearAllFacts()
+
+        #expect(failing.facts.isEmpty)
+        #expect(!failing.hasAuthoritativeFacts)
+        #expect(failureNotifications.received == 0)
+        #expect(await failureStore.persistedFacts == [persistedFact])
+    }
+
+    private func eventually(_ condition: () async -> Bool) async -> Bool {
+        for _ in 0 ..< 200 {
+            if await condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return false
+    }
+
     // MARK: - Fact Management
 
-    @Test("Add fact stores fact correctly")
-    func addFactStoresFactCorrectly() {
+    @Test
+    func `add fact stores fact correctly`() {
         let service = UserMemoryService()
         service.addFact("I prefer Swift")
 
@@ -26,8 +387,8 @@ struct UserMemoryServiceTests {
         #expect(facts.first?.isActive == true)
     }
 
-    @Test("Add multiple facts preserves order")
-    func addMultipleFactsPreservesOrder() {
+    @Test
+    func `add multiple facts preserves order`() {
         let service = UserMemoryService()
         service.addFact("Fact 1")
         service.addFact("Fact 2")
@@ -41,8 +402,8 @@ struct UserMemoryServiceTests {
         #expect(facts[2].content == "Fact 1")
     }
 
-    @Test("Delete fact removes from store")
-    func deleteFactRemovesFromStore() {
+    @Test
+    func `delete fact removes from store`() {
         let service = UserMemoryService()
         service.addFact("To be deleted")
 
@@ -57,8 +418,8 @@ struct UserMemoryServiceTests {
         #expect(service.activeFacts().isEmpty)
     }
 
-    @Test("Toggle fact changes isActive status")
-    func toggleFactChangesIsActiveStatus() {
+    @Test
+    func `toggle fact changes isActive status`() {
         let service = UserMemoryService()
         service.addFact("Toggleable fact")
 
@@ -80,8 +441,8 @@ struct UserMemoryServiceTests {
         #expect(service.activeFacts().count == 1)
     }
 
-    @Test("Update fact content works correctly")
-    func updateFactContentWorksCorrectly() {
+    @Test
+    func `update fact content works correctly`() {
         let service = UserMemoryService()
         service.addFact("Original content")
 
@@ -96,8 +457,8 @@ struct UserMemoryServiceTests {
         #expect(updated?.content == "Updated content")
     }
 
-    @Test("Clear all facts removes all facts")
-    func clearAllFactsRemovesAllFacts() async {
+    @Test
+    func `clear all facts removes all facts`() async {
         let service = UserMemoryService()
         service.addFact("Fact 1")
         service.addFact("Fact 2")
@@ -111,14 +472,14 @@ struct UserMemoryServiceTests {
 
     // MARK: - Context Formatting
 
-    @Test("Formatted for context returns nil when empty")
-    func formattedForContextReturnsNilWhenEmpty() {
+    @Test
+    func `formatted for context returns nil when empty`() {
         let service = UserMemoryService()
         #expect(service.formattedForContext(tokenBudget: 1000) == nil)
     }
 
-    @Test("Formatted for context includes active facts only")
-    func formattedForContextIncludesActiveFactsOnly() {
+    @Test
+    func `formatted for context includes active facts only`() {
         let service = UserMemoryService()
         service.addFact("Active fact")
         service.addFact("Inactive fact")
@@ -133,8 +494,8 @@ struct UserMemoryServiceTests {
         #expect(context?.contains("Inactive fact") != true)
     }
 
-    @Test("Formatted for context respects token budget")
-    func formattedForContextRespectsTokenBudget() {
+    @Test
+    func `formatted for context respects token budget`() {
         let service = UserMemoryService()
         // Add a long fact
         let longContent = String(repeating: "This is a very long fact. ", count: 100)
@@ -149,8 +510,8 @@ struct UserMemoryServiceTests {
 
     // MARK: - Memory Summary
 
-    @Test("Memory summary reflects fact count")
-    func memorySummaryReflectsFactCount() {
+    @Test
+    func `memory summary reflects fact count`() {
         let service = UserMemoryService()
         #expect(service.memorySummary == "No facts stored")
 
@@ -163,8 +524,8 @@ struct UserMemoryServiceTests {
 
     // MARK: - Command Processing
 
-    @Test("Process store command adds fact")
-    func processStoreCommandAddsFact() {
+    @Test
+    func `process store command adds fact`() {
         let service = UserMemoryService()
         let response = service.processCommand(.store(content: "I love coding"))
 
@@ -173,8 +534,8 @@ struct UserMemoryServiceTests {
         #expect(service.activeFacts().first?.content == "I love coding")
     }
 
-    @Test("Process remove command removes matching fact")
-    func processRemoveCommandRemovesMatchingFact() {
+    @Test
+    func `process remove command removes matching fact`() {
         let service = UserMemoryService()
         service.addFact("I love coding")
         #expect(service.activeFacts().count == 1)
@@ -186,8 +547,8 @@ struct UserMemoryServiceTests {
         #expect(service.activeFacts().isEmpty)
     }
 
-    @Test("Process query command returns summary")
-    func processQueryCommandReturnsSummary() {
+    @Test
+    func `process query command returns summary`() {
         let service = UserMemoryService()
         service.addFact("I prefer dark mode")
         service.addFact("I work as a developer")
@@ -198,8 +559,8 @@ struct UserMemoryServiceTests {
         #expect(response?.contains("remember") == true)
     }
 
-    @Test("Process clearAll command returns guidance")
-    func processClearAllCommandReturnsGuidance() {
+    @Test
+    func `process clearAll command returns guidance`() {
         let service = UserMemoryService()
         service.addFact("Fact 1")
         service.addFact("Fact 2")
@@ -211,11 +572,152 @@ struct UserMemoryServiceTests {
         #expect(response?.contains("Settings") == true)
     }
 
-    @Test("Process none command returns nil")
-    func processNoneCommandReturnsNil() {
+    @Test
+    func `process none command returns nil`() {
         let service = UserMemoryService()
         let response = service.processCommand(.none)
         #expect(response == nil)
+    }
+}
+
+private enum ScriptedStoreError: Error {
+    case requestedFailure
+}
+
+private enum ScriptedOperationOutcome: Sendable {
+    case success
+    case failure
+}
+
+private struct ScriptedOperationPlan: Sendable {
+    let gate: TestGate?
+    let outcome: ScriptedOperationOutcome
+
+    init(
+        gate: TestGate? = nil,
+        outcome: ScriptedOperationOutcome = .success
+    ) {
+        self.gate = gate
+        self.outcome = outcome
+    }
+}
+
+private actor TestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        for waiter in pendingWaiters {
+            waiter.resume()
+        }
+    }
+}
+
+private actor ScriptedUserMemoryStore: UserMemoryStoreAdapter {
+    private let loadFactsValue: [UserMemoryFact]
+    private let loadPlan: ScriptedOperationPlan
+    private let savePlans: [ScriptedOperationPlan]
+    private let clearPlans: [ScriptedOperationPlan]
+
+    private(set) var loadAttemptCount = 0
+    private(set) var saveAttempts: [[UserMemoryFact]] = []
+    private(set) var clearAttemptCount = 0
+    private(set) var persistedFacts: [UserMemoryFact]
+
+    var saveAttemptCount: Int {
+        saveAttempts.count
+    }
+
+    init(
+        loadFacts: [UserMemoryFact] = [],
+        loadPlan: ScriptedOperationPlan = .init(),
+        savePlans: [ScriptedOperationPlan] = [],
+        clearPlans: [ScriptedOperationPlan] = []
+    ) {
+        loadFactsValue = loadFacts
+        self.loadPlan = loadPlan
+        self.savePlans = savePlans
+        self.clearPlans = clearPlans
+        persistedFacts = loadFacts
+    }
+
+    func loadMemory() async throws -> UserMemoryStore {
+        loadAttemptCount += 1
+        try await execute(loadPlan)
+        return UserMemoryStore(facts: loadFactsValue)
+    }
+
+    func saveMemory(_ store: UserMemoryStore) async throws {
+        let attempt = saveAttempts.count
+        saveAttempts.append(store.facts)
+        let plan = attempt < savePlans.count ? savePlans[attempt] : .init()
+        try await execute(plan)
+        persistedFacts = store.facts
+    }
+
+    func clearMemory() async throws {
+        let attempt = clearAttemptCount
+        clearAttemptCount += 1
+        let plan = attempt < clearPlans.count ? clearPlans[attempt] : .init()
+        try await execute(plan)
+        persistedFacts = []
+    }
+
+    private func execute(_ plan: ScriptedOperationPlan) async throws {
+        if let gate = plan.gate {
+            await gate.wait()
+        }
+        if plan.outcome == .failure {
+            throw ScriptedStoreError.requestedFailure
+        }
+    }
+}
+
+private final class NotificationCounter: @unchecked Sendable {
+    private let center: NotificationCenter
+    private let lock = NSLock()
+    private var notificationCount = 0
+    private var observer: NSObjectProtocol?
+
+    init(name: Notification.Name, center: NotificationCenter = .default) {
+        self.center = center
+        observer = center.addObserver(forName: name, object: nil, queue: nil) { [weak self] _ in
+            guard let self else { return }
+            lock.lock()
+            notificationCount += 1
+            lock.unlock()
+        }
+    }
+
+    var received: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return notificationCount
+    }
+
+    func reset() {
+        lock.lock()
+        notificationCount = 0
+        lock.unlock()
+    }
+
+    func stop() {
+        guard let observer else { return }
+        center.removeObserver(observer)
+        self.observer = nil
     }
 }
 
@@ -223,8 +725,8 @@ struct UserMemoryServiceTests {
 
 @Suite("MemoryCommandPattern Tests")
 struct MemoryCommandPatternTests {
-    @Test("Detect store command from message")
-    func detectStoreCommandFromMessage() {
+    @Test
+    func `detect store command from message`() {
         let command = MemoryCommandPattern.detect(in: "Remember that I prefer dark mode")
 
         if case let .store(content) = command {
@@ -234,8 +736,8 @@ struct MemoryCommandPatternTests {
         }
     }
 
-    @Test("Detect remove command from message")
-    func detectRemoveCommandFromMessage() {
+    @Test
+    func `detect remove command from message`() {
         let command = MemoryCommandPattern.detect(in: "Forget that I like coffee")
 
         if case let .remove(content) = command {
@@ -245,8 +747,8 @@ struct MemoryCommandPatternTests {
         }
     }
 
-    @Test("Detect query command from message")
-    func detectQueryCommandFromMessage() {
+    @Test
+    func `detect query command from message`() {
         let command = MemoryCommandPattern.detect(in: "What do you remember about me?")
 
         if case .query = command {
@@ -256,8 +758,8 @@ struct MemoryCommandPatternTests {
         }
     }
 
-    @Test("Detect clearAll command from message")
-    func detectClearAllCommandFromMessage() {
+    @Test
+    func `detect clearAll command from message`() {
         let command = MemoryCommandPattern.detect(in: "Clear my memory")
 
         if case .clearAll = command {
@@ -267,8 +769,8 @@ struct MemoryCommandPatternTests {
         }
     }
 
-    @Test("Detect none for regular message")
-    func detectNoneForRegularMessage() {
+    @Test
+    func `detect none for regular message`() {
         let command = MemoryCommandPattern.detect(in: "Tell me about Swift programming")
 
         if case .none = command {
@@ -278,8 +780,8 @@ struct MemoryCommandPatternTests {
         }
     }
 
-    @Test("Avoid false positive for 'I can't remember that'")
-    func avoidFalsePositiveForCantRemember() {
+    @Test
+    func `avoid false positive for 'I can't remember that'`() {
         // This should NOT trigger a store command
         let command = MemoryCommandPattern.detect(in: "I can't remember that password")
 
@@ -290,8 +792,8 @@ struct MemoryCommandPatternTests {
         }
     }
 
-    @Test("Avoid false positive when 'remember that' is mid-sentence")
-    func avoidFalsePositiveForMidSentenceRemember() {
+    @Test
+    func `avoid false positive when 'remember that' is mid-sentence`() {
         // This should NOT trigger a store command
         let command = MemoryCommandPattern.detect(in: "Do you remember that meeting we had?")
 
@@ -302,8 +804,8 @@ struct MemoryCommandPatternTests {
         }
     }
 
-    @Test("Still detect valid store command at start")
-    func stillDetectValidStoreCommandAtStart() {
+    @Test
+    func `still detect valid store command at start`() {
         let command = MemoryCommandPattern.detect(in: "Remember that I like coffee")
 
         if case let .store(content) = command {
@@ -313,8 +815,8 @@ struct MemoryCommandPatternTests {
         }
     }
 
-    @Test("Detect store command after 'please'")
-    func detectStoreCommandAfterPlease() {
+    @Test
+    func `detect store command after 'please'`() {
         let command = MemoryCommandPattern.detect(in: "Please remember that I prefer dark mode")
 
         if case let .store(content) = command {

--- a/Tests/AynaTests/WatchChatViewModelNativeTests.swift
+++ b/Tests/AynaTests/WatchChatViewModelNativeTests.swift
@@ -1,136 +1,158 @@
 #if os(watchOS)
 
-//
-//  WatchChatViewModelNativeTests.swift
-//  Ayna-watchOSTests
-//
-//  Unit tests for WatchChatViewModel running natively on watchOS
-//
+    // swiftlint:disable identifier_name
 
-@testable import Ayna
-import Foundation
-import Testing
+    //
+    //  WatchChatViewModelNativeTests.swift
+    //  Ayna-watchOSTests
+    //
+    //  Unit tests for WatchChatViewModel running natively on watchOS
+    //
 
-@Suite("WatchChatViewModel Native Tests")
-@MainActor
-struct WatchChatViewModelNativeTests {
-    private var viewModel: WatchChatViewModel
-    private var store: WatchConversationStore
+    @testable import Ayna
+    import Foundation
+    import Testing
 
-    init() {
-        store = WatchConversationStore.shared
-        // Clear existing conversations
-        store.updateConversations([])
-        viewModel = WatchChatViewModel()
+    @Suite("WatchChatViewModel Native Tests")
+    @MainActor
+    struct WatchChatViewModelNativeTests {
+        private let viewModel: WatchChatViewModel
+        private let store: WatchConversationStore
+
+        init() {
+            let suiteName = "WatchChatViewModelNativeTests.\(UUID().uuidString)"
+            guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+                fatalError("Failed to create isolated UserDefaults suite")
+            }
+            userDefaults.removePersistentDomain(forName: suiteName)
+
+            let store = WatchConversationStore(
+                userDefaults: userDefaults,
+                persistenceKey: "state",
+                mutationEnqueuer: { _ in }
+            )
+            let aiService = AIService()
+            aiService.modelProviders = ["gpt-4o": .openai]
+            aiService.modelEndpoints = [:]
+            aiService.modelAPIKeys = [:]
+
+            self.store = store
+            viewModel = WatchChatViewModel(
+                conversationStore: store,
+                aiService: aiService
+            )
+        }
+
+        // MARK: - Initial State Tests
+
+        @Test
+        func `Initial state is correct`() {
+            #expect(!viewModel.isLoading)
+            #expect(!viewModel.isStreaming)
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.streamingContent.isEmpty)
+            #expect(viewModel.currentToolName == nil)
+            #expect(viewModel.failedMessage == nil)
+        }
+
+        // MARK: - Conversation Management Tests
+
+        @Test
+        func `Create new conversation`() {
+            let conversationId = viewModel.createNewConversation()
+
+            #expect(conversationId != nil)
+            #expect(conversationId.flatMap { store.conversation(for: $0) } != nil)
+        }
+
+        @Test
+        func `Set conversation resets state`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+
+            viewModel.setConversation(conversation.id)
+
+            // State should be reset
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.streamingContent.isEmpty)
+            #expect(viewModel.currentToolName == nil)
+            #expect(viewModel.failedMessage == nil)
+        }
+
+        @Test
+        func `Set conversation clears previous error`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+
+            viewModel.setConversation(conversation.id)
+
+            #expect(viewModel.errorMessage == nil)
+        }
+
+        // MARK: - Error Handling Tests
+
+        @Test
+        func `Send message without conversation is rejected`() {
+            // Don't call setConversation, so no conversation is selected
+            let result = viewModel.sendMessage("Hello")
+
+            #expect(result == .notConsumed)
+            #expect(viewModel.errorMessage == "No conversation selected")
+        }
+
+        @Test
+        func `Dismiss error clears state`() async throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            viewModel.setConversation(conversation.id)
+
+            // Trigger an error by sending without API key configured
+            viewModel.sendMessage("Hello")
+
+            // Let any async operations settle
+            try? await Task.sleep(for: .milliseconds(100))
+
+            // Dismiss the error
+            viewModel.dismissError()
+
+            #expect(viewModel.failedMessage == nil)
+            #expect(viewModel.errorMessage == nil)
+        }
+
+        // MARK: - Cancel Tests
+
+        @Test
+        func `Cancel request resets loading state`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            viewModel.setConversation(conversation.id)
+
+            viewModel.cancelRequest()
+
+            #expect(!viewModel.isLoading)
+            #expect(!viewModel.isStreaming)
+            #expect(viewModel.currentToolName == nil)
+        }
+
+        // MARK: - State Management Tests
+
+        @Test
+        func `Streaming content reset on set conversation`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+
+            viewModel.setConversation(conversation.id)
+
+            #expect(viewModel.streamingContent.isEmpty)
+        }
+
+        // MARK: - Retry Tests
+
+        @Test
+        func `Retry without failed message does nothing`() {
+            // Calling retry when there's no failed message should do nothing
+            viewModel.retryFailedMessage()
+
+            // Should not crash and state should remain unchanged
+            #expect(!viewModel.isLoading)
+        }
     }
 
-    // MARK: - Initial State Tests
-
-    @Test("Initial state is correct")
-    func initialState() {
-        #expect(!viewModel.isLoading)
-        #expect(!viewModel.isStreaming)
-        #expect(viewModel.errorMessage == nil)
-        #expect(viewModel.streamingContent.isEmpty)
-        #expect(viewModel.currentToolName == nil)
-        #expect(viewModel.failedMessage == nil)
-    }
-
-    // MARK: - Conversation Management Tests
-
-    @Test("Create new conversation")
-    func createNewConversation() {
-        let conversationId = viewModel.createNewConversation()
-
-        #expect(store.conversation(for: conversationId) != nil)
-    }
-
-    @Test("Set conversation resets state")
-    func setConversation() {
-        let conversation = store.createConversation(model: "gpt-4o")
-
-        viewModel.setConversation(conversation.id)
-
-        // State should be reset
-        #expect(viewModel.errorMessage == nil)
-        #expect(viewModel.streamingContent.isEmpty)
-        #expect(viewModel.currentToolName == nil)
-        #expect(viewModel.failedMessage == nil)
-    }
-
-    @Test("Set conversation clears previous error")
-    func setConversationClearsPreviousError() {
-        let conversation = store.createConversation(model: "gpt-4o")
-
-        viewModel.setConversation(conversation.id)
-
-        #expect(viewModel.errorMessage == nil)
-    }
-
-    // MARK: - Error Handling Tests
-
-    @Test("Send message without conversation shows error")
-    func sendMessageWithoutConversation() {
-        // Don't call setConversation, so no conversation is selected
-        viewModel.sendMessage("Hello")
-
-        #expect(viewModel.errorMessage != nil)
-        #expect(viewModel.errorMessage == "No conversation selected")
-    }
-
-    @Test("Dismiss error clears state")
-    func dismissError() async {
-        let conversation = store.createConversation(model: "gpt-4o")
-        viewModel.setConversation(conversation.id)
-
-        // Trigger an error by sending without API key configured
-        viewModel.sendMessage("Hello")
-
-        // Let any async operations settle
-        try? await Task.sleep(for: .milliseconds(100))
-
-        // Dismiss the error
-        viewModel.dismissError()
-
-        #expect(viewModel.failedMessage == nil)
-        #expect(viewModel.errorMessage == nil)
-    }
-
-    // MARK: - Cancel Tests
-
-    @Test("Cancel request resets loading state")
-    func cancelRequest() {
-        let conversation = store.createConversation(model: "gpt-4o")
-        viewModel.setConversation(conversation.id)
-
-        viewModel.cancelRequest()
-
-        #expect(!viewModel.isLoading)
-        #expect(!viewModel.isStreaming)
-        #expect(viewModel.currentToolName == nil)
-    }
-
-    // MARK: - State Management Tests
-
-    @Test("Streaming content reset on set conversation")
-    func streamingContentReset() {
-        let conversation = store.createConversation(model: "gpt-4o")
-
-        viewModel.setConversation(conversation.id)
-
-        #expect(viewModel.streamingContent.isEmpty)
-    }
-
-    // MARK: - Retry Tests
-
-    @Test("Retry without failed message does nothing")
-    func retryWithoutFailedMessage() {
-        // Calling retry when there's no failed message should do nothing
-        viewModel.retryFailedMessage()
-
-        // Should not crash and state should remain unchanged
-        #expect(!viewModel.isLoading)
-    }
-}
+    // swiftlint:enable identifier_name
 
 #endif

--- a/Tests/AynaTests/WatchChatViewModelRoundRegistryTests.swift
+++ b/Tests/AynaTests/WatchChatViewModelRoundRegistryTests.swift
@@ -1,0 +1,38 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Watch tool call round registry tests")
+@MainActor
+struct WatchToolCallRoundRegistryTests {
+    @Test
+    func `provider I ds deduplicate only within one request round`() {
+        let providerID = "reused-call"
+        let firstRound = WatchToolCallRoundRegistry(roundID: UUID())
+        let secondRound = WatchToolCallRoundRegistry(roundID: UUID())
+
+        #expect(firstRound.register(providerID: providerID, toolName: "tool", arguments: [:]) == providerID)
+        #expect(firstRound.register(providerID: providerID, toolName: "tool", arguments: [:]) == nil)
+        #expect(secondRound.register(providerID: providerID, toolName: "tool", arguments: [:]) == providerID)
+    }
+
+    @Test
+    func `id less callbacks receive stable distinct round local I ds`() throws {
+        let roundID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let registry = WatchToolCallRoundRegistry(roundID: roundID)
+        let firstArguments = ["position": AnyCodable(1)]
+        let secondArguments = ["position": AnyCodable(2)]
+
+        let firstID = try #require(
+            registry.register(providerID: "", toolName: "tool", arguments: firstArguments)
+        )
+        let secondID = try #require(
+            registry.register(providerID: "   ", toolName: "tool", arguments: secondArguments)
+        )
+        #expect(registry.register(providerID: "", toolName: "tool", arguments: firstArguments) == nil)
+
+        #expect(firstID == "watch-tool-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-0")
+        #expect(secondID == "watch-tool-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1")
+        #expect(firstID != secondID)
+    }
+}

--- a/Tests/AynaTests/WatchChatViewModelRoundRegistryTests.swift
+++ b/Tests/AynaTests/WatchChatViewModelRoundRegistryTests.swift
@@ -6,6 +6,29 @@ import Testing
 @MainActor
 struct WatchToolCallRoundRegistryTests {
     @Test
+    func `registry rejects tool fan out beyond the hard limit`() {
+        let registry = WatchToolCallRoundRegistry(roundID: UUID())
+
+        for index in 0 ..< ToolCallRequestRoundPolicy.maximumToolCallsPerRound {
+            #expect(
+                registry.register(
+                    providerID: "call-\(index)",
+                    toolName: "tool",
+                    arguments: [:]
+                ) != nil
+            )
+        }
+
+        #expect(
+            registry.register(
+                providerID: "call-over-limit",
+                toolName: "tool",
+                arguments: [:]
+            ) == nil
+        )
+    }
+
+    @Test
     func `provider I ds deduplicate only within one request round`() {
         let providerID = "reused-call"
         let firstRound = WatchToolCallRoundRegistry(roundID: UUID())

--- a/Tests/AynaTests/WatchChatViewModelTests.swift
+++ b/Tests/AynaTests/WatchChatViewModelTests.swift
@@ -1,135 +1,130 @@
 #if os(watchOS)
 
-@testable import Ayna
-import Foundation
-import Testing
+    @testable import Ayna
+    import Foundation
+    import Testing
 
-// Note: WatchChatViewModel is only available on watchOS. These tests verify the
-// AIService tool integration and the data flow patterns used by the watch.
-// The actual WatchChatViewModel cannot be tested directly on macOS.
+    // Note: WatchChatViewModel is only available on watchOS. These tests verify the
+    // AIService tool integration and the data flow patterns used by the watch.
+    // The actual WatchChatViewModel cannot be tested directly on macOS.
 
-@Suite("WatchChatViewModel Integration Tests", .serialized)
-@MainActor
-struct WatchChatViewModelIntegrationTests {
-    private var defaults: UserDefaults
-    private var keychain: InMemoryKeychainStorage
+    @Suite("WatchChatViewModel Integration Tests", .serialized)
+    @MainActor
+    struct WatchChatViewModelIntegrationTests {
+        private var defaults: UserDefaults
+        private var keychain: InMemoryKeychainStorage
 
-    init() {
-        guard let suite = UserDefaults(suiteName: "WatchChatViewModelTests") else {
-            fatalError("Failed to create UserDefaults suite")
-        }
-        defaults = suite
-        defaults.removePersistentDomain(forName: "WatchChatViewModelTests")
-        defaults.synchronize()
-        AppPreferences.use(defaults)
+        init() {
+            guard let suite = UserDefaults(suiteName: "WatchChatViewModelTests") else {
+                fatalError("Failed to create UserDefaults suite")
+            }
+            defaults = suite
+            defaults.removePersistentDomain(forName: "WatchChatViewModelTests")
+            defaults.synchronize()
+            AppPreferences.use(defaults)
 
-        keychain = InMemoryKeychainStorage()
-        WatchMockURLProtocol.reset()
-    }
-
-    // MARK: - Tool Integration Tests
-
-    @Test("OpenAI service includes Tavily tool when configured")
-    func aiServiceIncludesTavilyToolWhenConfigured() {
-        // Configure TavilyService with a test API key
-        let tavilyService = TavilyService(keychain: keychain)
-        tavilyService.apiKey = "tvly-test-key"
-        tavilyService.isEnabled = true
-
-        // Note: In the actual app, AIService.getAllAvailableTools() includes Tavily
-        // when TavilyService.shared.isAvailable is true
-        #expect(tavilyService.isAvailable)
-        #expect(tavilyService.isConfigured)
-
-        let toolDef = tavilyService.toolDefinition()
-        guard let function = toolDef["function"] as? [String: Any],
-              let name = function["name"] as? String
-        else {
-            Issue.record("Invalid tool definition")
-            return
+            keychain = InMemoryKeychainStorage()
         }
 
-        #expect(name == "web_search")
-    }
+        // MARK: - Tool Integration Tests
 
-    @Test("OpenAI service excludes Tavily tool when disabled")
-    func aiServiceExcludesTavilyToolWhenDisabled() {
-        let tavilyService = TavilyService(keychain: keychain)
-        tavilyService.apiKey = "tvly-test-key"
-        tavilyService.isEnabled = false
+        @Test
+        func `openAI service includes Tavily tool when configured`() {
+            // Configure TavilyService with a test API key
+            let tavilyService = TavilyService(keychain: keychain)
+            tavilyService.apiKey = "tvly-test-key"
+            tavilyService.isEnabled = true
 
-        #expect(tavilyService.isConfigured)
-        #expect(!tavilyService.isAvailable)
-    }
+            // Note: In the actual app, AIService.getAllAvailableTools() includes Tavily
+            // when TavilyService.shared.isAvailable is true
+            #expect(tavilyService.isAvailable)
+            #expect(tavilyService.isConfigured)
 
-    @Test("OpenAI service excludes Tavily tool when not configured")
-    func aiServiceExcludesTavilyToolWhenNotConfigured() {
-        let tavilyService = TavilyService(keychain: keychain)
-        tavilyService.apiKey = ""
-        tavilyService.isEnabled = true
+            let toolDef = tavilyService.toolDefinition()
+            guard let function = toolDef["function"] as? [String: Any],
+                  let name = function["name"] as? String
+            else {
+                Issue.record("Invalid tool definition")
+                return
+            }
 
-        #expect(!tavilyService.isConfigured)
-        #expect(!tavilyService.isAvailable)
-    }
+            #expect(name == "web_search")
+        }
 
-    // MARK: - Message Flow Tests
+        @Test
+        func `openAI service excludes Tavily tool when disabled`() {
+            let tavilyService = TavilyService(keychain: keychain)
+            tavilyService.apiKey = "tvly-test-key"
+            tavilyService.isEnabled = false
 
-    @Test("Watch message sync flow")
-    func watchMessageSyncFlow() throws {
-        // Simulate the message flow: User sends message → WatchMessage → sync to iPhone
-        let userContent = "What's the weather?"
-        let userMessage = Message(role: .user, content: userContent)
-        let watchMessage = WatchMessage(from: userMessage)
+            #expect(tavilyService.isConfigured)
+            #expect(!tavilyService.isAvailable)
+        }
 
-        // Encode for WatchConnectivity
-        let data = try JSONEncoder().encode(watchMessage)
-        #expect(!data.isEmpty)
+        @Test
+        func `openAI service excludes Tavily tool when not configured`() {
+            let tavilyService = TavilyService(keychain: keychain)
+            tavilyService.apiKey = ""
+            tavilyService.isEnabled = true
 
-        // Decode on iPhone side
-        let decoded = try JSONDecoder().decode(WatchMessage.self, from: data)
-        #expect(decoded.content == userContent)
-        #expect(decoded.role == "user")
+            #expect(!tavilyService.isConfigured)
+            #expect(!tavilyService.isAvailable)
+        }
 
-        // Convert to Message for ConversationManager
-        let message = decoded.toMessage()
-        #expect(message.content == userContent)
-        #expect(message.role == .user)
-    }
+        // MARK: - Message Flow Tests
 
-    @Test("Assistant message sync flow")
-    func assistantMessageSyncFlow() throws {
-        // Simulate: API response → Update local → WatchMessage → sync to iPhone
-        let assistantContent = "The weather is sunny with a high of 72°F."
-        let assistantMessage = Message(role: .assistant, content: assistantContent, model: "gpt-4o")
-        let watchMessage = WatchMessage(from: assistantMessage)
+        @Test
+        func `watch message sync flow`() throws {
+            // Simulate the message flow: User sends message → WatchMessage → sync to iPhone
+            let userContent = "What's the weather?"
+            let userMessage = Message(role: .user, content: userContent)
+            let watchMessage = WatchMessage(from: userMessage)
 
-        let data = try JSONEncoder().encode(watchMessage)
-        let decoded = try JSONDecoder().decode(WatchMessage.self, from: data)
+            // Encode for WatchConnectivity
+            let data = try JSONEncoder().encode(watchMessage)
+            #expect(!data.isEmpty)
 
-        #expect(decoded.content == assistantContent)
-        #expect(decoded.role == "assistant")
-        #expect(decoded.model == "gpt-4o")
-    }
+            // Decode on iPhone side
+            let decoded = try JSONDecoder().decode(WatchMessage.self, from: data)
+            #expect(decoded.content == userContent)
+            #expect(decoded.role == "user")
 
-    // MARK: - Tool Execution Flow Tests
+            // Convert to Message for ConversationManager
+            let message = decoded.toMessage()
+            #expect(message.content == userContent)
+            #expect(message.role == .user)
+        }
 
-    @Test("Tavily tool call execution")
-    func tavilyToolCallExecution() async {
-        // Configure mock Tavily service
-        let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [WatchMockURLProtocol.self]
-        let session = URLSession(configuration: config)
-        let tavilyService = TavilyService(keychain: keychain, urlSession: session)
-        tavilyService.apiKey = "tvly-test-key"
-        tavilyService.isEnabled = true
+        @Test
+        func `assistant message sync flow`() throws {
+            // Simulate: API response → Update local → WatchMessage → sync to iPhone
+            let assistantContent = "The weather is sunny with a high of 72°F."
+            let assistantMessage = Message(role: .assistant, content: assistantContent, model: "gpt-4o")
+            let watchMessage = WatchMessage(from: assistantMessage)
 
-        WatchMockURLProtocol.requestHandler = { _ in
-            let response = HTTPURLResponse(
-                url: URL(string: "https://api.tavily.com/search")!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
+            let data = try JSONEncoder().encode(watchMessage)
+            let decoded = try JSONDecoder().decode(WatchMessage.self, from: data)
+
+            #expect(decoded.content == assistantContent)
+            #expect(decoded.role == "assistant")
+            #expect(decoded.model == "gpt-4o")
+        }
+
+        // MARK: - Tool Execution Flow Tests
+
+        @Test
+        func `tavily tool call execution`() async {
+            guard let url = URL(string: "https://api.tavily.com/search"),
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 200,
+                      httpVersion: nil,
+                      headerFields: nil
+                  )
+            else {
+                Issue.record("Failed to construct Tavily test response")
+                return
+            }
             let body = Data("""
             {
                 "query": "weather",
@@ -138,297 +133,262 @@ struct WatchChatViewModelIntegrationTests {
                     {
                         "title": "Weather.com",
                         "url": "https://weather.com",
-                       "content": "Today's forecast shows clear skies.",
+                        "content": "Today's forecast shows clear skies.",
                         "score": 0.9
                     }
                 ],
                 "response_time": 0.5
             }
             """.utf8)
-            return (response, body)
-        }
-
-        let result = await tavilyService.executeToolCall(arguments: ["query": "weather"])
-
-        #expect(result.contains("Answer"))
-        #expect(result.contains("Sunny"))
-        #expect(result.contains("Sources"))
-    }
-
-    @Test("Tool call depth limit")
-    func toolCallDepthLimit() {
-        // The WatchChatViewModel has a maxToolCallDepth of 5
-        // This test verifies the concept of depth limiting
-        let maxDepth = 5
-        var currentDepth = 0
-
-        // Simulate recursive tool calls
-        for _ in 1 ... 10 {
-            guard currentDepth < maxDepth else {
-                break
+            let tavilyService = TavilyService(keychain: keychain) { request in
+                #expect(request.url == response.url)
+                return (body, response)
             }
-            currentDepth += 1
-        }
+            tavilyService.apiKey = "tvly-test-key"
+            tavilyService.isEnabled = true
 
-        #expect(currentDepth == maxDepth, "Tool call depth should be limited to \(maxDepth)")
-    }
-
-    // MARK: - Model Filtering Tests
-
-    @Test("WatchOS model filtering")
-    func watchOSModelFiltering() {
-        // On watchOS, Apple Intelligence models should be filtered out
-        let allModels = ["gpt-4o", "gpt-4", "apple-intelligence"]
-        let modelProviders: [String: AIProvider] = [
-            "gpt-4o": .openai,
-            "gpt-4": .openai,
-            "apple-intelligence": .appleIntelligence
-        ]
-
-        let usableModels = allModels.filter { model in
-            let provider = modelProviders[model]
-            return provider != .appleIntelligence
-        }
-
-        #expect(usableModels.count == 2)
-        #expect(usableModels.contains("gpt-4o"))
-        #expect(usableModels.contains("gpt-4"))
-        #expect(!usableModels.contains("apple-intelligence"))
-    }
-
-    // MARK: - Conversation State Tests
-
-    @Test("Title generation trigger")
-    func titleGenerationTrigger() {
-        // Title generation should only trigger on the first message
-        var conversation = Conversation(title: "New Chat", model: "gpt-4o")
-
-        let isFirstMessage = conversation.messages.isEmpty
-        #expect(isFirstMessage, "First message should trigger title generation")
-
-        conversation.addMessage(Message(role: .user, content: "Hello"))
-        conversation.addMessage(Message(role: .assistant, content: "Hi!"))
-
-        let isStillFirstMessage = conversation.messages.isEmpty
-        #expect(!isStillFirstMessage, "Subsequent messages should not trigger title generation")
-    }
-
-    @Test("Conversation update preserves local title")
-    func conversationUpdatePreservesLocalTitle() {
-        // When iPhone syncs with "New Chat" but watch has generated a title,
-        // the local title should be preserved
-        let conversationId = UUID()
-
-        // Simulate local conversation with generated title
-        let localTitle = "Weather Discussion"
-        var localConv = Conversation(id: conversationId, title: localTitle, model: "gpt-4o")
-        localConv.addMessage(Message(role: .user, content: "What's the weather?"))
-
-        // Simulate sync from iPhone with "New Chat" title
-        let syncedTitle = "New Chat"
-        var syncedConv = Conversation(id: conversationId, title: syncedTitle, model: "gpt-4o")
-        syncedConv.addMessage(Message(role: .user, content: "What's the weather?"))
-
-        // Merge logic: preserve local title if iPhone still has "New Chat"
-        let shouldPreserveLocal = syncedConv.title == "New Chat" && localConv.title != "New Chat"
-        let finalTitle = shouldPreserveLocal ? localConv.title : syncedConv.title
-
-        #expect(finalTitle == localTitle)
-    }
-
-    // MARK: - Additional Watch Integration Tests
-
-    @Test("Streaming throttle interval")
-    func streamingThrottleInterval() {
-        // Verify the throttle interval constant is reasonable for Watch performance
-        let uiUpdateInterval: TimeInterval = 0.1 // 100ms as used in WatchChatViewModel
-        #expect(uiUpdateInterval == 0.1)
-        #expect(uiUpdateInterval >= 0.05, "Throttle should be at least 50ms for performance")
-        #expect(uiUpdateInterval <= 0.2, "Throttle should be at most 200ms for responsiveness")
-    }
-
-    @Test("Max tool call depth constant")
-    func maxToolCallDepthConstant() {
-        // The WatchChatViewModel should limit recursive tool calls
-        let maxToolCallDepth = 5
-
-        // Simulate checking depth limit
-        var currentDepth = 0
-        var reachedLimit = false
-
-        for _ in 1 ... 10 {
-            if currentDepth >= maxToolCallDepth {
-                reachedLimit = true
-                break
-            }
-            currentDepth += 1
-        }
-
-        #expect(reachedLimit, "Should reach tool call depth limit")
-        #expect(currentDepth == maxToolCallDepth)
-    }
-
-    @Test("Watch conversation sync merge logic")
-    func watchConversationSyncMergeLogic() {
-        // Test the merge logic used in WatchConversationStore.updateConversations
-        let conversationId = UUID()
-
-        // Local has more messages (during streaming)
-        var localConv = Conversation(id: conversationId, title: "Chat", model: "gpt-4o")
-        localConv.addMessage(Message(role: .user, content: "Hello"))
-        localConv.addMessage(Message(role: .assistant, content: "Hi!"))
-        localConv.addMessage(Message(role: .assistant, content: "")) // Streaming placeholder
-
-        // Remote has fewer messages (hasn't received streaming update yet)
-        var remoteConv = Conversation(id: conversationId, title: "Chat", model: "gpt-4o")
-        remoteConv.addMessage(Message(role: .user, content: "Hello"))
-        remoteConv.addMessage(Message(role: .assistant, content: "Hi!"))
-
-        // Merge logic should preserve local when it has more messages
-        let shouldPreserveLocalMessages = localConv.messages.count > remoteConv.messages.count
-        #expect(shouldPreserveLocalMessages)
-    }
-
-    @Test("Watch message round trip with all fields")
-    func watchMessageRoundTripWithAllFields() throws {
-        let originalId = UUID()
-        let timestamp = Date()
-        let original = Message(
-            id: originalId,
-            role: .assistant,
-            content: "Response with **markdown** and `code`",
-            timestamp: timestamp,
-            model: "gpt-4o"
-        )
-
-        // Convert to WatchMessage
-        let watchMessage = WatchMessage(from: original)
-
-        // Encode/decode (simulating WatchConnectivity transfer)
-        let data = try JSONEncoder().encode(watchMessage)
-        let decoded = try JSONDecoder().decode(WatchMessage.self, from: data)
-
-        // Convert back to Message
-        let final = decoded.toMessage()
-
-        #expect(final.id == originalId)
-        #expect(final.role == .assistant)
-        #expect(final.content == original.content)
-        #expect(final.model == "gpt-4o")
-        #expect(abs(final.timestamp.timeIntervalSince1970 - timestamp.timeIntervalSince1970) < 0.001)
-    }
-
-    @Test("Watch conversation round trip with messages")
-    func watchConversationRoundTripWithMessages() throws {
-        let originalId = UUID()
-        let createdAt = Date()
-        var original = Conversation(
-            id: originalId,
-            title: "Test Chat",
-            createdAt: createdAt,
-            model: "gpt-4o"
-        )
-        original.addMessage(Message(role: .user, content: "Question"))
-        original.addMessage(Message(role: .assistant, content: "Answer", model: "gpt-4o"))
-
-        // Convert to WatchConversation
-        let watchConv = WatchConversation(from: original)
-
-        // Encode/decode
-        let data = try JSONEncoder().encode(watchConv)
-        let decoded = try JSONDecoder().decode(WatchConversation.self, from: data)
-
-        // Convert back
-        let final = decoded.toConversation()
-
-        #expect(final.id == originalId)
-        #expect(final.title == "Test Chat")
-        #expect(final.model == "gpt-4o")
-        #expect(final.messages.count == 2)
-        #expect(final.messages[0].content == "Question")
-        #expect(final.messages[1].content == "Answer")
-    }
-
-    @Test("Model usability check logic")
-    func modelUsabilityCheckLogic() {
-        // Test the filtering logic for watchOS-compatible models
-        let allModels = ["gpt-4o", "gpt-4", "gpt-3.5-turbo", "apple-intelligence-chat"]
-        let modelProviders: [String: AIProvider] = [
-            "gpt-4o": .openai,
-            "gpt-4": .openai,
-            "gpt-3.5-turbo": .openai,
-            "apple-intelligence-chat": .appleIntelligence
-        ]
-
-        // watchOS can only use cloud-based models (not Apple Intelligence)
-        let usableModels = allModels.filter { model in
-            let provider = modelProviders[model]
-            return provider != .appleIntelligence
-        }
-
-        #expect(usableModels.count == 3)
-        #expect(usableModels.contains("gpt-4o"))
-        #expect(usableModels.contains("gpt-4"))
-        #expect(usableModels.contains("gpt-3.5-turbo"))
-        #expect(!usableModels.contains("apple-intelligence-chat"))
-    }
-
-    @Test("Azure provider allowed on Watch")
-    func azureProviderAllowedOnWatch() {
-        // GitHub Models should work on watchOS (uses cloud API)
-        let modelProviders: [String: AIProvider] = [
-            "github-gpt-4o": .githubModels,
-            "openai-gpt-4": .openai
-        ]
-
-        for (model, provider) in modelProviders {
-            let isUsableOnWatch = provider != .appleIntelligence
-            #expect(isUsableOnWatch, "\(model) should be usable on watchOS")
-        }
-    }
-}
-
-// MARK: - Mock URL Protocol for Watch Tests
-
-private final class WatchMockURLProtocol: URLProtocol, @unchecked Sendable {
-    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
-
-    static func reset() {
-        requestHandler = nil
-    }
-
-    override static func canInit(with _: URLRequest) -> Bool {
-        true
-    }
-
-    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        guard let handler = WatchMockURLProtocol.requestHandler else {
-            client?.urlProtocol(
-                self,
-                didFailWithError: NSError(
-                    domain: "WatchMockURLProtocol",
-                    code: 0,
-                    userInfo: [NSLocalizedDescriptionKey: "Handler not set"]
-                )
+            let (result, citations) = await tavilyService.executeToolCallWithCitations(
+                arguments: ["query": "weather"]
             )
-            return
+
+            #expect(result.contains("Answer"))
+            #expect(result.contains("Sunny"))
+            #expect(citations.count == 1)
+            #expect(citations.first?.title == "Weather.com")
+            #expect(citations.first?.url == "https://weather.com")
         }
 
-        do {
-            let (response, data) = try handler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
+        @Test
+        func `tool call depth limit`() {
+            // The WatchChatViewModel has a maxToolCallDepth of 5
+            // This test verifies the concept of depth limiting
+            let maxDepth = 5
+            var currentDepth = 0
+
+            // Simulate recursive tool calls
+            for _ in 1 ... 10 {
+                guard currentDepth < maxDepth else {
+                    break
+                }
+                currentDepth += 1
+            }
+
+            #expect(currentDepth == maxDepth, "Tool call depth should be limited to \(maxDepth)")
+        }
+
+        // MARK: - Model Filtering Tests
+
+        @Test
+        func `watchOS model filtering`() {
+            // On watchOS, Apple Intelligence models should be filtered out
+            let allModels = ["gpt-4o", "gpt-4", "apple-intelligence"]
+            let modelProviders: [String: AIProvider] = [
+                "gpt-4o": .openai,
+                "gpt-4": .openai,
+                "apple-intelligence": .appleIntelligence
+            ]
+
+            let usableModels = allModels.filter { model in
+                let provider = modelProviders[model]
+                return provider != .appleIntelligence
+            }
+
+            #expect(usableModels.count == 2)
+            #expect(usableModels.contains("gpt-4o"))
+            #expect(usableModels.contains("gpt-4"))
+            #expect(!usableModels.contains("apple-intelligence"))
+        }
+
+        // MARK: - Conversation State Tests
+
+        @Test
+        func `title generation trigger`() {
+            // Title generation should only trigger on the first message
+            var conversation = Conversation(title: "New Chat", model: "gpt-4o")
+
+            let isFirstMessage = conversation.messages.isEmpty
+            #expect(isFirstMessage, "First message should trigger title generation")
+
+            conversation.addMessage(Message(role: .user, content: "Hello"))
+            conversation.addMessage(Message(role: .assistant, content: "Hi!"))
+
+            let isStillFirstMessage = conversation.messages.isEmpty
+            #expect(!isStillFirstMessage, "Subsequent messages should not trigger title generation")
+        }
+
+        @Test
+        func `conversation update preserves local title`() {
+            // When iPhone syncs with "New Chat" but watch has generated a title,
+            // the local title should be preserved
+            let conversationId = UUID()
+
+            // Simulate local conversation with generated title
+            let localTitle = "Weather Discussion"
+            var localConv = Conversation(id: conversationId, title: localTitle, model: "gpt-4o")
+            localConv.addMessage(Message(role: .user, content: "What's the weather?"))
+
+            // Simulate sync from iPhone with "New Chat" title
+            let syncedTitle = "New Chat"
+            var syncedConv = Conversation(id: conversationId, title: syncedTitle, model: "gpt-4o")
+            syncedConv.addMessage(Message(role: .user, content: "What's the weather?"))
+
+            // Merge logic: preserve local title if iPhone still has "New Chat"
+            let shouldPreserveLocal = syncedConv.title == "New Chat" && localConv.title != "New Chat"
+            let finalTitle = shouldPreserveLocal ? localConv.title : syncedConv.title
+
+            #expect(finalTitle == localTitle)
+        }
+
+        // MARK: - Additional Watch Integration Tests
+
+        @Test
+        func `streaming throttle interval`() {
+            // Verify the throttle interval constant is reasonable for Watch performance
+            let uiUpdateInterval: TimeInterval = 0.1 // 100ms as used in WatchChatViewModel
+            #expect(uiUpdateInterval == 0.1)
+            #expect(uiUpdateInterval >= 0.05, "Throttle should be at least 50ms for performance")
+            #expect(uiUpdateInterval <= 0.2, "Throttle should be at most 200ms for responsiveness")
+        }
+
+        @Test
+        func `max tool call depth constant`() {
+            // The WatchChatViewModel should limit recursive tool calls
+            let maxToolCallDepth = 5
+
+            // Simulate checking depth limit
+            var currentDepth = 0
+            var reachedLimit = false
+
+            for _ in 1 ... 10 {
+                if currentDepth >= maxToolCallDepth {
+                    reachedLimit = true
+                    break
+                }
+                currentDepth += 1
+            }
+
+            #expect(reachedLimit, "Should reach tool call depth limit")
+            #expect(currentDepth == maxToolCallDepth)
+        }
+
+        @Test
+        func `watch conversation sync merge logic`() {
+            // Test the merge logic used in WatchConversationStore.updateConversations
+            let conversationId = UUID()
+
+            // Local has more messages (during streaming)
+            var localConv = Conversation(id: conversationId, title: "Chat", model: "gpt-4o")
+            localConv.addMessage(Message(role: .user, content: "Hello"))
+            localConv.addMessage(Message(role: .assistant, content: "Hi!"))
+            localConv.addMessage(Message(role: .assistant, content: "")) // Streaming placeholder
+
+            // Remote has fewer messages (hasn't received streaming update yet)
+            var remoteConv = Conversation(id: conversationId, title: "Chat", model: "gpt-4o")
+            remoteConv.addMessage(Message(role: .user, content: "Hello"))
+            remoteConv.addMessage(Message(role: .assistant, content: "Hi!"))
+
+            // Merge logic should preserve local when it has more messages
+            let shouldPreserveLocalMessages = localConv.messages.count > remoteConv.messages.count
+            #expect(shouldPreserveLocalMessages)
+        }
+
+        @Test
+        func `watch message round trip with all fields`() throws {
+            let originalId = UUID()
+            let timestamp = Date()
+            let original = Message(
+                id: originalId,
+                role: .assistant,
+                content: "Response with **markdown** and `code`",
+                timestamp: timestamp,
+                model: "gpt-4o"
+            )
+
+            // Convert to WatchMessage
+            let watchMessage = WatchMessage(from: original)
+
+            // Encode/decode (simulating WatchConnectivity transfer)
+            let data = try JSONEncoder().encode(watchMessage)
+            let decoded = try JSONDecoder().decode(WatchMessage.self, from: data)
+
+            // Convert back to Message
+            let final = decoded.toMessage()
+
+            #expect(final.id == originalId)
+            #expect(final.role == .assistant)
+            #expect(final.content == original.content)
+            #expect(final.model == "gpt-4o")
+            #expect(abs(final.timestamp.timeIntervalSince1970 - timestamp.timeIntervalSince1970) < 0.001)
+        }
+
+        @Test
+        func `watch conversation round trip with messages`() throws {
+            let originalId = UUID()
+            let createdAt = Date()
+            var original = Conversation(
+                id: originalId,
+                title: "Test Chat",
+                createdAt: createdAt,
+                model: "gpt-4o"
+            )
+            original.addMessage(Message(role: .user, content: "Question"))
+            original.addMessage(Message(role: .assistant, content: "Answer", model: "gpt-4o"))
+
+            // Convert to WatchConversation
+            let watchConv = WatchConversation(from: original)
+
+            // Encode/decode
+            let data = try JSONEncoder().encode(watchConv)
+            let decoded = try JSONDecoder().decode(WatchConversation.self, from: data)
+
+            // Convert back
+            let final = decoded.toConversation()
+
+            #expect(final.id == originalId)
+            #expect(final.title == "Test Chat")
+            #expect(final.model == "gpt-4o")
+            #expect(final.messages.count == 2)
+            #expect(final.messages[0].content == "Question")
+            #expect(final.messages[1].content == "Answer")
+        }
+
+        @Test
+        func `model usability check logic`() {
+            // Test the filtering logic for watchOS-compatible models
+            let allModels = ["gpt-4o", "gpt-4", "gpt-3.5-turbo", "apple-intelligence-chat"]
+            let modelProviders: [String: AIProvider] = [
+                "gpt-4o": .openai,
+                "gpt-4": .openai,
+                "gpt-3.5-turbo": .openai,
+                "apple-intelligence-chat": .appleIntelligence
+            ]
+
+            // watchOS can only use cloud-based models (not Apple Intelligence)
+            let usableModels = allModels.filter { model in
+                let provider = modelProviders[model]
+                return provider != .appleIntelligence
+            }
+
+            #expect(usableModels.count == 3)
+            #expect(usableModels.contains("gpt-4o"))
+            #expect(usableModels.contains("gpt-4"))
+            #expect(usableModels.contains("gpt-3.5-turbo"))
+            #expect(!usableModels.contains("apple-intelligence-chat"))
+        }
+
+        @Test
+        func `azure provider allowed on Watch`() {
+            // GitHub Models should work on watchOS (uses cloud API)
+            let modelProviders: [String: AIProvider] = [
+                "github-gpt-4o": .githubModels,
+                "openai-gpt-4": .openai
+            ]
+
+            for (model, provider) in modelProviders {
+                let isUsableOnWatch = provider != .appleIntelligence
+                #expect(isUsableOnWatch, "\(model) should be usable on watchOS")
+            }
         }
     }
-
-    override func stopLoading() {}
-}
 
 #endif

--- a/Tests/AynaTests/WatchConnectivitySupportTests.swift
+++ b/Tests/AynaTests/WatchConnectivitySupportTests.swift
@@ -1,0 +1,3409 @@
+// swiftlint:disable file_length
+@testable import Ayna
+import Combine
+import Foundation
+import Testing
+
+@Suite("Watch connectivity support tests", .tags(.fast))
+// swiftlint:disable:next type_body_length
+struct WatchConnectivitySupportTests {
+    @Test
+    func `memory facts are omitted from reduced contexts unless they represent an explicit clear`() {
+        let facts = Data("facts".utf8)
+        let explicitClear = Data("[]".utf8)
+
+        let ordinary = WatchApplicationContextAttempt.fallbacks(
+            memoryFacts: WatchMemoryFactsPayload(
+                data: facts,
+                preservesAcrossFallbacks: false
+            )
+        )
+        let clearing = WatchApplicationContextAttempt.fallbacks(
+            memoryFacts: WatchMemoryFactsPayload(
+                data: explicitClear,
+                preservesAcrossFallbacks: true
+            )
+        )
+        let oversized = WatchApplicationContextAttempt.fallbacks(
+            memoryFacts: WatchMemoryFactsPayload(
+                data: nil,
+                preservesAcrossFallbacks: false
+            )
+        )
+
+        #expect(ordinary.map(\.facts) == [facts, nil, nil, nil])
+        #expect(clearing.map(\.facts) == [explicitClear, explicitClear, explicitClear, explicitClear])
+        #expect(oversized.allSatisfy { $0.facts == nil })
+    }
+
+    @Test
+    func `retained default prompt persists across restart and explicit clear`() throws {
+        let suiteName = "WatchDefaultSystemPromptPersistenceTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+
+        WatchDefaultSystemPromptPersistence.store("retained prompt", in: defaults)
+        #expect(WatchDefaultSystemPromptPersistence.load(from: defaults) == "retained prompt")
+
+        WatchDefaultSystemPromptPersistence.store(nil, in: defaults)
+        #expect(WatchDefaultSystemPromptPersistence.load(from: defaults) == nil)
+    }
+
+    @Test
+    func `legacy awaiting echo results require scheduled sync retry`() {
+        let awaiting = WatchLegacySendResult(
+            userInfos: [],
+            awaitingEchoComponentIDs: ["message:1"],
+            fullyRepresented: true
+        )
+        let settled = WatchLegacySendResult(
+            userInfos: [],
+            awaitingEchoComponentIDs: [],
+            fullyRepresented: true
+        )
+
+        #expect(awaiting.requiresEchoRetry)
+        #expect(!settled.requiresEchoRetry)
+    }
+
+    @Test
+    func `invalid persisted revision rotates an otherwise valid source identity`() {
+        let persistedSourceID = UUID()
+        let replacementSourceID = UUID()
+        let invalidRevisions: [Any?] = [
+            nil,
+            "12",
+            true,
+            NSNumber(value: -1),
+            NSNumber(value: 1.5)
+        ]
+
+        for invalidRevision in invalidRevisions {
+            let metadata = WatchSyncSourceMetadata.resolve(
+                persistedSourceID: persistedSourceID.uuidString,
+                persistedSnapshotRevision: invalidRevision,
+                replacementSourceID: replacementSourceID
+            )
+
+            #expect(metadata.sourceID == replacementSourceID)
+            #expect(metadata.snapshotRevision == 0)
+        }
+    }
+
+    @Test
+    func `matching application context echo covers every legacy mutation component`() {
+        let message = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "Durable prompt",
+            timestamp: Date(timeIntervalSince1970: 20)
+        )
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Durable title",
+            messages: [message],
+            model: "durable-model",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            createdAt: Date(timeIntervalSince1970: 10),
+            temperature: 0.4,
+            resolvedSystemPrompt: "Durable system prompt",
+            watchRevision: 4
+        )
+        let mutation = WatchConversationMutation(
+            revision: 4,
+            conversation: conversation,
+            fields: .fullState,
+            createRevision: 1,
+            titleRevision: 2,
+            configurationRevision: 3,
+            messageChanges: [message],
+            messageChangeRevisions: [message.id: 4]
+        )
+
+        let reconciliation = WatchLegacyEchoReconciler.reconcile(
+            mutation,
+            echoedConversations: [conversation]
+        )
+
+        #expect(reconciliation.matchedComponents == [
+            .create(revision: 1),
+            .title(revision: 2),
+            .configuration(revision: 3),
+            .message(id: message.id, revision: 4)
+        ])
+        #expect(reconciliation.unsupportedFields.isEmpty)
+        #expect(reconciliation.canAcknowledgeMutation)
+    }
+
+    @Test
+    func `same ID placeholder echo does not confirm legacy create with mismatched configuration`() {
+        let message = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "Arrived before create",
+            timestamp: Date(timeIntervalSince1970: 20)
+        )
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Watch title",
+            messages: [message],
+            model: "watch-model",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            createdAt: Date(timeIntervalSince1970: 10),
+            temperature: 0.3,
+            resolvedSystemPrompt: "Watch prompt",
+            watchRevision: 2
+        )
+        let mutation = WatchConversationMutation(
+            revision: 2,
+            conversation: conversation,
+            fields: .fullState,
+            createRevision: 1,
+            titleRevision: 1,
+            configurationRevision: 1,
+            messageChanges: [message],
+            messageChangeRevisions: [message.id: 2]
+        )
+        let placeholder = WatchConversation(
+            id: conversation.id,
+            title: conversation.title,
+            messages: [message],
+            model: "phone-placeholder-model",
+            updatedAt: conversation.updatedAt,
+            createdAt: message.timestamp,
+            temperature: 0.7,
+            resolvedSystemPrompt: nil,
+            watchRevision: 0
+        )
+
+        let reconciliation = WatchLegacyEchoReconciler.reconcile(
+            mutation,
+            echoedConversations: [placeholder]
+        )
+
+        #expect(!reconciliation.matchedComponents.contains(.create(revision: 1)))
+        #expect(reconciliation.matchedComponents.contains(.title(revision: 1)))
+        #expect(reconciliation.matchedComponents.contains(.message(id: message.id, revision: 2)))
+        #expect(!reconciliation.canAcknowledgeMutation)
+    }
+
+    @Test
+    func `covered or unrelated legacy creates cannot overwrite existing conversations`() {
+        let conversationID = UUID()
+        let activePeerID = UUID()
+        let coveredMetadata = WatchLegacyMutationMetadata(message: [
+            WatchMessageKeys.peerId: activePeerID.uuidString,
+            WatchMessageKeys.mutationRevision: NSNumber(value: 3)
+        ])
+
+        #expect(WatchLegacyCreateIngressResolver.action(
+            metadata: coveredMetadata,
+            conversationID: conversationID,
+            activePeerID: activePeerID,
+            acknowledgements: [conversationID: 3],
+            conversationExists: true,
+            isTrackedPlaceholder: true
+        ) == .ignore)
+        #expect(WatchLegacyCreateIngressResolver.action(
+            metadata: WatchLegacyMutationMetadata(message: [:]),
+            conversationID: conversationID,
+            activePeerID: activePeerID,
+            acknowledgements: [:],
+            conversationExists: true,
+            isTrackedPlaceholder: true
+        ) == .repairPlaceholder)
+        #expect(WatchLegacyCreateIngressResolver.action(
+            metadata: WatchLegacyMutationMetadata(message: [:]),
+            conversationID: conversationID,
+            activePeerID: activePeerID,
+            acknowledgements: [:],
+            conversationExists: true,
+            isTrackedPlaceholder: false
+        ) == .ignore)
+        #expect(WatchLegacyCreateIngressResolver.action(
+            metadata: WatchLegacyMutationMetadata(message: [:]),
+            conversationID: conversationID,
+            activePeerID: activePeerID,
+            acknowledgements: [:],
+            conversationExists: false,
+            isTrackedPlaceholder: false
+        ) == .create)
+        #expect(WatchLegacyCreateIngressResolver.action(
+            metadata: WatchLegacyMutationMetadata(message: [
+                WatchMessageKeys.peerId: UUID().uuidString,
+                WatchMessageKeys.mutationRevision: NSNumber(value: 4)
+            ]),
+            conversationID: conversationID,
+            activePeerID: activePeerID,
+            acknowledgements: [:],
+            conversationExists: false,
+            isTrackedPlaceholder: false
+        ) == .ignore)
+    }
+
+    @Test
+    func `late legacy create repairs a message placeholder without losing messages`() {
+        let conversationID = UUID()
+        let message = Message(
+            id: UUID(),
+            role: .user,
+            content: "Arrived first",
+            timestamp: Date(timeIntervalSince1970: 20)
+        )
+        let placeholder = Conversation(
+            id: conversationID,
+            title: "Watch Chat",
+            messages: [message],
+            createdAt: message.timestamp,
+            updatedAt: message.timestamp,
+            model: "phone-placeholder-model",
+            temperature: 0.7
+        )
+        let create = WatchConversation(
+            id: conversationID,
+            title: "Watch title",
+            model: "watch-model",
+            updatedAt: Date(timeIntervalSince1970: 10),
+            createdAt: Date(timeIntervalSince1970: 10),
+            temperature: 0.3,
+            resolvedSystemPrompt: "Watch prompt",
+            watchRevision: 1
+        )
+
+        let repaired = WatchLegacyConversationMerger.mergeCreate(create, into: placeholder)
+
+        #expect(repaired.title == "Watch title")
+        #expect(repaired.model == "watch-model")
+        #expect(repaired.temperature == 0.3)
+        #expect(repaired.systemPromptMode == .inheritGlobal)
+        #expect(repaired.createdAt == create.createdAt)
+        #expect(repaired.updatedAt == message.timestamp)
+        #expect(repaired.messages == [message])
+    }
+
+    @Test
+    func `nonmatching application context echo covers no legacy components`() {
+        let message = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "Pending",
+            timestamp: Date(timeIntervalSince1970: 20)
+        )
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Pending",
+            messages: [message],
+            model: "pending-model",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            createdAt: Date(timeIntervalSince1970: 10),
+            watchRevision: 1
+        )
+        let mutation = WatchConversationMutation(
+            revision: 1,
+            conversation: conversation,
+            fields: .fullState,
+            messageChanges: [message]
+        )
+        let unrelatedConversation = WatchConversation(
+            id: UUID(),
+            title: conversation.title,
+            messages: conversation.messages,
+            model: conversation.model,
+            updatedAt: conversation.updatedAt,
+            createdAt: conversation.createdAt,
+            temperature: conversation.temperature,
+            resolvedSystemPrompt: conversation.resolvedSystemPrompt,
+            watchRevision: conversation.watchRevision
+        )
+
+        let reconciliation = WatchLegacyEchoReconciler.reconcile(
+            mutation,
+            echoedConversations: [unrelatedConversation]
+        )
+
+        #expect(reconciliation.matchedComponents.isEmpty)
+        #expect(!reconciliation.canAcknowledgeMutation)
+    }
+
+    @Test
+    func `partial application context echo covers only matching message components`() {
+        let firstMessage = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "First",
+            timestamp: Date(timeIntervalSince1970: 20)
+        )
+        let secondMessage = WatchMessage(
+            id: UUID(),
+            role: Message.Role.assistant.rawValue,
+            content: "Second",
+            timestamp: Date(timeIntervalSince1970: 21)
+        )
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Existing",
+            messages: [firstMessage, secondMessage],
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 21),
+            createdAt: Date(timeIntervalSince1970: 10),
+            watchRevision: 3
+        )
+        let mutation = WatchConversationMutation(
+            revision: 3,
+            conversation: conversation,
+            fields: [.messages],
+            messageChanges: [firstMessage, secondMessage],
+            messageChangeRevisions: [firstMessage.id: 2, secondMessage.id: 3]
+        )
+        var partialEcho = conversation
+        partialEcho.messages = [firstMessage]
+
+        let reconciliation = WatchLegacyEchoReconciler.reconcile(
+            mutation,
+            echoedConversations: [partialEcho]
+        )
+
+        #expect(reconciliation.matchedComponents == [
+            .message(id: firstMessage.id, revision: 2)
+        ])
+        #expect(reconciliation.unsupportedFields.isEmpty)
+        #expect(!reconciliation.canAcknowledgeMutation)
+    }
+
+    @Test
+    @MainActor
+    func `partial echo suppresses only the components durably reflected by phone`() throws {
+        let suiteName = "WatchLegacyEchoCoverageTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "coverage"
+        )
+        let message = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "Echoed",
+            timestamp: Date(timeIntervalSince1970: 20)
+        )
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Existing",
+            messages: [message],
+            model: "new-model",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            createdAt: Date(timeIntervalSince1970: 10),
+            watchRevision: 2
+        )
+        let mutation = WatchConversationMutation(
+            revision: 2,
+            conversation: conversation,
+            fields: [.messages, .configuration],
+            configurationRevision: 2,
+            messageChanges: [message],
+            messageChangeRevisions: [message.id: 2]
+        )
+        let reconciliation = WatchLegacyEchoReconciler.reconcile(
+            mutation,
+            echoedConversations: [conversation]
+        )
+
+        for component in reconciliation.matchedComponents {
+            tracker.confirm(component.deliveryUserInfo(for: mutation))
+        }
+
+        #expect(tracker.pendingMessages(from: mutation).isEmpty)
+        #expect(!tracker.configurationIsRepresented(by: mutation, createWillBeSent: false))
+        #expect(!reconciliation.canAcknowledgeMutation)
+    }
+
+    @Test
+    @MainActor
+    func `successful legacy transfer waits for echo without duplicate retransmission`() throws {
+        let suiteName = "WatchLegacyAwaitingEchoSuccessTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "state"
+        )
+        let message = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "Send once",
+            timestamp: Date(timeIntervalSince1970: 20)
+        )
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Legacy",
+            messages: [message],
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            createdAt: Date(timeIntervalSince1970: 10),
+            watchRevision: 1
+        )
+        let mutation = WatchConversationMutation(
+            revision: 1,
+            conversation: conversation,
+            fields: [.messages],
+            messageChanges: [message],
+            messageChangeRevisions: [message.id: 1]
+        )
+        let initialSend = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let componentID = try #require(initialSend.componentIDs.first)
+
+        tracker.recordTransferCompletion(componentID: componentID, succeeded: true)
+
+        let retry = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        #expect(retry.userInfos.isEmpty)
+        #expect(retry.awaitingEchoComponentIDs == [componentID])
+        #expect(tracker.isAwaitingEcho(componentID: componentID))
+        #expect(retry.fullyRepresented)
+    }
+
+    @Test
+    @MainActor
+    func `legacy delivery evidence reset makes persisted components sendable to a new counterpart`() throws {
+        let suiteName = "WatchLegacyCounterpartResetTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "state"
+        )
+        let mutation = makeLegacyMessageMutation(content: "Deliver to replacement phone")
+        let initial = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let componentID = try #require(initial.componentIDs.first)
+        let component = try #require(initial.userInfos.first)
+        tracker.confirm(component)
+
+        #expect(try WatchLegacyMutationSender.prepare(mutation, tracker: tracker).componentIDs.isEmpty)
+
+        tracker.reset()
+        let reloaded = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "state"
+        )
+        let replacementSend = try WatchLegacyMutationSender.prepare(mutation, tracker: reloaded)
+
+        #expect(replacementSend.componentIDs == [componentID])
+        #expect(replacementSend.awaitingEchoComponentIDs.isEmpty)
+        #expect(!WatchLegacyEchoReconciler.canAcknowledge(
+            mutation,
+            currentMatches: [],
+            durableCoverage: WatchMutationDeliveryCoverage(
+                messageRevisions: [mutation.messageChanges[0].id: mutation.revision]
+            )
+        ))
+    }
+
+    @Test
+    @MainActor
+    func `legacy transfer retransmits after bounded unanswered echo retries`() throws {
+        let suiteName = "WatchLegacyEchoExpiryTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(userDefaults: defaults, persistenceKey: "state")
+        let mutation = makeLegacyMessageMutation(content: "Retry after missing durable echo")
+        let initial = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let componentID = try #require(initial.componentIDs.first)
+        tracker.recordTransferCompletion(componentID: componentID, succeeded: true)
+
+        for _ in 0 ..< 3 {
+            let awaiting = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+            #expect(awaiting.userInfos.isEmpty)
+            #expect(awaiting.awaitingEchoComponentIDs == [componentID])
+        }
+        let retry = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+
+        #expect(retry.componentIDs == [componentID])
+        #expect(retry.awaitingEchoComponentIDs.isEmpty)
+        #expect(!tracker.isAwaitingEcho(componentID: componentID))
+    }
+
+    @Test
+    @MainActor
+    func `legacy create and title transfers expire into retransmission`() throws {
+        let suiteName = "WatchLegacyCreateTitleExpiryTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(userDefaults: defaults, persistenceKey: "state")
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Create me",
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 2),
+            createdAt: Date(timeIntervalSince1970: 1),
+            watchRevision: 1
+        )
+        let mutation = WatchConversationMutation(
+            revision: 1,
+            conversation: conversation,
+            fields: [.create, .title, .configuration]
+        )
+        let initial = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        #expect(initial.componentIDs.count == 2)
+        for componentID in initial.componentIDs {
+            tracker.recordTransferCompletion(componentID: componentID, succeeded: true)
+        }
+
+        for _ in 0 ..< 3 {
+            let awaiting = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+            #expect(awaiting.userInfos.isEmpty)
+            #expect(awaiting.awaitingEchoComponentIDs == initial.componentIDs)
+        }
+        let retry = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+
+        #expect(retry.componentIDs == initial.componentIDs)
+        #expect(retry.awaitingEchoComponentIDs.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `expired legacy retransmissions do not starve never-sent message tail`() throws {
+        let suiteName = "WatchLegacyTailProgressTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(userDefaults: defaults, persistenceKey: "state")
+        let messages = (0 ..< 25).map { index in
+            WatchMessage(
+                id: UUID(),
+                role: Message.Role.user.rawValue,
+                content: "message-\(index)",
+                timestamp: Date(timeIntervalSince1970: Double(index))
+            )
+        }
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Paged",
+            messages: messages,
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 30),
+            createdAt: Date(timeIntervalSince1970: 1),
+            watchRevision: 25
+        )
+        let mutation = WatchConversationMutation(
+            revision: 25,
+            conversation: conversation,
+            fields: [.messages],
+            messageChanges: messages,
+            messageChangeRevisions: Dictionary(
+                uniqueKeysWithValues: messages.enumerated().map { ($0.element.id, UInt64($0.offset + 1)) }
+            )
+        )
+        let first = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        for componentID in first.componentIDs {
+            tracker.recordTransferCompletion(componentID: componentID, succeeded: true)
+        }
+        for _ in 0 ..< 3 {
+            _ = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        }
+
+        let retry = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let retryMessageIDs = retry.userInfos.compactMap {
+            ($0[WatchMessageKeys.messageId] as? String).flatMap(UUID.init(uuidString:))
+        }
+
+        #expect(Array(retryMessageIDs.prefix(5)) == messages.suffix(5).map(\.id))
+        #expect(Set(retryMessageIDs).count == retryMessageIDs.count)
+    }
+
+    @Test
+    @MainActor
+    func `failed legacy transfer becomes eligible for retry`() throws {
+        let suiteName = "WatchLegacyAwaitingEchoFailureTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "state"
+        )
+        let mutation = makeLegacyMessageMutation(content: "Retry after failure")
+        let initialSend = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let componentID = try #require(initialSend.componentIDs.first)
+        tracker.recordTransferCompletion(componentID: componentID, succeeded: true)
+
+        tracker.recordTransferCompletion(componentID: componentID, succeeded: false)
+
+        let retry = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        #expect(retry.componentIDs == [componentID])
+        #expect(retry.awaitingEchoComponentIDs.isEmpty)
+        #expect(!tracker.isAwaitingEcho(componentID: componentID))
+    }
+
+    @Test
+    @MainActor
+    func `legacy completion follows a retained component into a coalesced operation`() throws {
+        let suiteName = "WatchLegacyCoalescedCompletionTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "state"
+        )
+        let conversationID = UUID()
+        let firstMessage = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "First",
+            timestamp: Date(timeIntervalSince1970: 20)
+        )
+        let firstConversation = WatchConversation(
+            id: conversationID,
+            title: "Legacy",
+            messages: [firstMessage],
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            createdAt: Date(timeIntervalSince1970: 10),
+            watchRevision: 1
+        )
+        let firstMutation = WatchConversationMutation(
+            revision: 1,
+            conversation: firstConversation,
+            fields: [.messages],
+            messageChanges: [firstMessage]
+        )
+        let initialSend = try WatchLegacyMutationSender.prepare(firstMutation, tracker: tracker)
+        let componentID = try #require(initialSend.componentIDs.first)
+        let secondMessage = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "Second",
+            timestamp: Date(timeIntervalSince1970: 21)
+        )
+        var secondConversation = firstConversation
+        secondConversation.messages.append(secondMessage)
+        secondConversation.updatedAt = Date(timeIntervalSince1970: 21)
+        secondConversation.watchRevision = 2
+        let secondMutation = WatchConversationMutation(
+            revision: 2,
+            conversation: secondConversation,
+            fields: [.messages],
+            messageChanges: [secondMessage]
+        )
+        let coalesced = try #require(firstMutation.coalescing(with: secondMutation))
+
+        let resolved = WatchLegacyTransferCompletionResolver.pendingMutation(
+            originalOperationID: firstMutation.operationID,
+            componentID: componentID,
+            pendingMutations: [coalesced]
+        )
+
+        #expect(resolved?.operationID == secondMutation.operationID)
+    }
+
+    @Test
+    @MainActor
+    func `durable phone echo clears legacy transfer awaiting state`() throws {
+        let suiteName = "WatchLegacyAwaitingEchoClearTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "state"
+        )
+        let mutation = makeLegacyMessageMutation(content: "Echoed once")
+        let initialSend = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let componentID = try #require(initialSend.componentIDs.first)
+        tracker.recordTransferCompletion(componentID: componentID, succeeded: true)
+        var echoedConversation = mutation.conversation
+        echoedConversation.messages = mutation.messageChanges
+        let reconciliation = tracker.reconcile(
+            mutation,
+            echoedConversations: [echoedConversation]
+        )
+
+        for component in reconciliation.matchedComponents {
+            tracker.confirm(component.deliveryUserInfo(for: mutation))
+        }
+
+        #expect(!tracker.isAwaitingEcho(componentID: componentID))
+        let retry = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        #expect(retry.userInfos.isEmpty)
+        #expect(retry.awaitingEchoComponentIDs.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `legacy transfer awaiting echo survives tracker restart`() throws {
+        let suiteName = "WatchLegacyAwaitingEchoRestartTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let persistenceKey = "state"
+        let mutation = makeLegacyMessageMutation(content: "Persist awaiting echo")
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: persistenceKey
+        )
+        let initialSend = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let componentID = try #require(initialSend.componentIDs.first)
+        tracker.recordTransferCompletion(componentID: componentID, succeeded: true)
+
+        let reloaded = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: persistenceKey
+        )
+        let retry = try WatchLegacyMutationSender.prepare(mutation, tracker: reloaded)
+
+        #expect(retry.userInfos.isEmpty)
+        #expect(retry.awaitingEchoComponentIDs == [componentID])
+        #expect(reloaded.isAwaitingEcho(componentID: componentID))
+    }
+
+    @Test
+    func `partial echo covers matching messages but leaves unsupported configuration pending`() {
+        let message = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "Echoed",
+            timestamp: Date(timeIntervalSince1970: 20)
+        )
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Existing",
+            messages: [message],
+            model: "new-model",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            createdAt: Date(timeIntervalSince1970: 10),
+            watchRevision: 2
+        )
+        let mutation = WatchConversationMutation(
+            revision: 2,
+            conversation: conversation,
+            fields: [.messages, .configuration],
+            configurationRevision: 2,
+            messageChanges: [message],
+            messageChangeRevisions: [message.id: 2]
+        )
+
+        let reconciliation = WatchLegacyEchoReconciler.reconcile(
+            mutation,
+            echoedConversations: [conversation]
+        )
+
+        #expect(reconciliation.matchedComponents == [
+            .message(id: message.id, revision: 2)
+        ])
+        #expect(reconciliation.unsupportedFields == [.configuration])
+        #expect(!reconciliation.canAcknowledgeMutation)
+        #expect(!WatchLegacyEchoReconciler.canAcknowledge(
+            mutation,
+            currentMatches: reconciliation.matchedComponents,
+            durableCoverage: WatchMutationDeliveryCoverage(
+                configurationRevision: 2,
+                messageRevisions: [message.id: 2]
+            )
+        ))
+    }
+
+    @Test
+    @MainActor
+    func `title delivery tracking resends a higher revision when text returns to a prior value`() throws {
+        let suiteName = "WatchLegacyTitleRevisionTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "state"
+        )
+        let conversationID = UUID()
+
+        tracker.confirm([
+            WatchMessageKeys.conversationId: conversationID.uuidString,
+            WatchMessageKeys.legacyComponentKind: WatchMessageKeys.legacyComponentTitle,
+            WatchMessageKeys.title: "A",
+            WatchMessageKeys.mutationRevision: NSNumber(value: 1)
+        ])
+
+        #expect(tracker.needsTitle(conversationID: conversationID, title: "B", revision: 2))
+        #expect(tracker.needsTitle(conversationID: conversationID, title: "A", revision: 3))
+
+        tracker.confirm([
+            WatchMessageKeys.conversationId: conversationID.uuidString,
+            WatchMessageKeys.legacyComponentKind: WatchMessageKeys.legacyComponentTitle,
+            WatchMessageKeys.title: "A",
+            WatchMessageKeys.mutationRevision: NSNumber(value: 3)
+        ])
+
+        #expect(!tracker.needsTitle(conversationID: conversationID, title: "A", revision: 3))
+    }
+
+    @Test
+    @MainActor
+    func `stale A echo cannot confirm final A after A B A title sequence`() throws {
+        let suiteName = "WatchLegacyTitleEchoFenceTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "state"
+        )
+        let conversationID = UUID()
+        let initial = WatchConversation(
+            id: conversationID,
+            title: "A",
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 10),
+            createdAt: Date(timeIntervalSince1970: 1),
+            watchRevision: 1
+        )
+        tracker.confirm([
+            WatchMessageKeys.conversationId: conversationID.uuidString,
+            WatchMessageKeys.legacyComponentKind: WatchMessageKeys.legacyComponentTitle,
+            WatchMessageKeys.title: "A",
+            WatchMessageKeys.mutationRevision: NSNumber(value: 1)
+        ])
+
+        var middle = initial
+        middle.title = "B"
+        middle.updatedAt = Date(timeIntervalSince1970: 20)
+        middle.watchRevision = 2
+        tracker.recordTitleMutation(WatchConversationMutation(
+            revision: 2,
+            conversation: middle,
+            fields: [.title]
+        ))
+
+        var final = middle
+        final.title = "A"
+        final.updatedAt = Date(timeIntervalSince1970: 30)
+        final.watchRevision = 3
+        let finalMutation = WatchConversationMutation(
+            revision: 3,
+            conversation: final,
+            fields: [.title]
+        )
+        tracker.recordTitleMutation(finalMutation)
+
+        var staleEcho = initial
+        staleEcho.watchRevision = 0
+        let staleReconciliation = tracker.reconcile(
+            finalMutation,
+            echoedConversations: [staleEcho]
+        )
+
+        #expect(staleReconciliation.matchedComponents.isEmpty)
+        #expect(!staleReconciliation.canAcknowledgeMutation)
+        #expect(tracker.needsTitle(
+            conversationID: conversationID,
+            title: "A",
+            revision: 3
+        ))
+
+        var freshEcho = final
+        freshEcho.updatedAt = Date(timeIntervalSince1970: 40)
+        freshEcho.watchRevision = 0
+        let freshReconciliation = tracker.reconcile(
+            finalMutation,
+            echoedConversations: [freshEcho]
+        )
+
+        #expect(freshReconciliation.matchedComponents == [.title(revision: 3)])
+        #expect(freshReconciliation.canAcknowledgeMutation)
+        for component in freshReconciliation.matchedComponents {
+            tracker.confirm(component.deliveryUserInfo(for: finalMutation))
+        }
+        #expect(!tracker.needsTitle(
+            conversationID: conversationID,
+            title: "A",
+            revision: 3
+        ))
+    }
+
+    @Test
+    @MainActor
+    func `legacy string-only title tracker state migrates without suppressing newer revisions`() throws {
+        let suiteName = "WatchLegacyTitleMigrationTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let key = "state"
+        let conversationID = UUID()
+        let legacyState = LegacyTitleDeliveryState(
+            titles: [conversationID: "A"]
+        )
+        try defaults.set(JSONEncoder().encode(legacyState), forKey: key)
+
+        let migrated = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: key
+        )
+
+        #expect(migrated.needsTitle(
+            conversationID: conversationID,
+            title: "A",
+            revision: 3
+        ))
+        migrated.confirm([
+            WatchMessageKeys.conversationId: conversationID.uuidString,
+            WatchMessageKeys.legacyComponentKind: WatchMessageKeys.legacyComponentTitle,
+            WatchMessageKeys.title: "A",
+            WatchMessageKeys.mutationRevision: NSNumber(value: 3)
+        ])
+
+        let reloaded = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: key
+        )
+        #expect(!reloaded.needsTitle(
+            conversationID: conversationID,
+            title: "A",
+            revision: 3
+        ))
+    }
+
+    @Test
+    func `model selection retains manifest-only conversation configuration beyond nominal limit`() throws {
+        let bodyConversation = Conversation(
+            title: "Body",
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 20),
+            model: "body-model"
+        )
+        let manifestOnlyConversation = Conversation(
+            title: "Manifest only",
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 15),
+            model: "manifest-only-model"
+        )
+        let state = PhoneWatchSyncState(conversations: [
+            bodyConversation,
+            manifestOnlyConversation
+        ])
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 1
+        let payload = try WatchSyncPayloadBuilder.build(
+            state: state,
+            snapshotRevision: 1,
+            configuration: configuration
+        )
+
+        #expect(payload.snapshot.conversations.map(\.id) == [bodyConversation.id])
+        #expect(payload.snapshot.authoritativeConversationIDs == [
+            bodyConversation.id,
+            manifestOnlyConversation.id
+        ])
+
+        let models = WatchModelSyncSelection.models(
+            selectedModel: "selected-model",
+            availableModels: ["fallback-model"],
+            authoritativeState: state,
+            snapshot: payload.snapshot,
+            limit: 1
+        )
+
+        #expect(models == [
+            "selected-model",
+            "body-model",
+            "manifest-only-model"
+        ])
+    }
+
+    @Test
+    func `reduced publication covers advertised models without selecting transport-only references`() throws {
+        let selectableModels = (1 ... 5).map { "selectable-\($0)" }
+        let transportOnlyModels = (1 ... 4).map { "transport-only-\($0)" }
+        let conversations = transportOnlyModels.enumerated().map { index, model in
+            Conversation(
+                id: UUID(uuidString: String(
+                    format: "00000000-0000-0003-0000-%012d",
+                    index + 1
+                ))!,
+                title: "Historical \(index)",
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index)),
+                model: model
+            )
+        }
+        let state = PhoneWatchSyncState(conversations: conversations)
+        let snapshot = try WatchSyncPayloadBuilder.build(
+            state: state,
+            snapshotRevision: 1
+        ).snapshot
+        let publication = WatchModelSyncSelection.publication(
+            selectedModel: selectableModels[0],
+            availableModels: selectableModels,
+            authoritativeState: state,
+            snapshot: snapshot,
+            limit: 5
+        )
+
+        #expect(publication.availableModels == selectableModels)
+        #expect(publication.metadataModels == [selectableModels[0]] + transportOnlyModels + selectableModels.dropFirst())
+        #expect(transportOnlyModels.allSatisfy { !publication.availableModels.contains($0) })
+        #expect(Set(publication.availableModels).isSubset(of: publication.metadataModelIDs))
+    }
+
+    @Test
+    func `fresh watch receives credentials for every model advertised by a reduced publication`() {
+        let selectableModels = (1 ... 5).map { "selectable-\($0)" }
+        let selectedModel = selectableModels[0]
+        let transportOnlyModels = (1 ... 4).map { "transport-only-\($0)" }
+        let allModels = selectableModels + transportOnlyModels
+        let publication = WatchModelSyncSelection.publication(
+            selectedModel: selectedModel,
+            availableModels: selectableModels,
+            referencedModels: transportOnlyModels,
+            limit: 5
+        )
+        let providers = Dictionary(uniqueKeysWithValues: allModels.map { ($0, "provider-\($0)") })
+        let endpoints = Dictionary(uniqueKeysWithValues: allModels.map { ($0, "https://\($0).example/v1") })
+        let endpointTypes = Dictionary(uniqueKeysWithValues: allModels.map { ($0, "endpoint-\($0)") })
+        let oauth = Dictionary(uniqueKeysWithValues: allModels.enumerated().map { index, model in
+            (model, index.isMultiple(of: 2))
+        })
+        let apiKeys = Dictionary(uniqueKeysWithValues: allModels.map { ($0, "key-\($0)") })
+        let page = WatchModelMetadataPage(
+            selectedModel: selectedModel,
+            availableModels: publication.availableModels,
+            customModels: selectableModels.filter(publication.metadataModelIDs.contains),
+            defaultProvider: "default-provider",
+            modelProviders: publication.metadataValues(from: providers),
+            modelEndpoints: publication.metadataValues(from: endpoints),
+            modelEndpointTypes: publication.metadataValues(from: endpointTypes),
+            modelUsesGitHubOAuth: publication.metadataValues(from: oauth),
+            modelAPIKeys: publication.metadataValues(from: apiKeys)
+        )
+        var state = WatchModelMetadataState(
+            selectedModel: "",
+            availableModels: [],
+            customModels: [],
+            defaultProvider: "",
+            modelProviders: [:],
+            modelEndpoints: [:],
+            modelEndpointTypes: [:],
+            modelUsesGitHubOAuth: [:],
+            modelAPIKeys: [:]
+        )
+        var accumulator = WatchModelMetadataCycleAccumulator()
+
+        accumulator.applyStandaloneContext(page, isComplete: false, to: &state)
+
+        #expect(state.availableModels == selectableModels)
+        #expect(transportOnlyModels.allSatisfy { !state.availableModels.contains($0) })
+        for model in state.availableModels {
+            #expect(state.modelProviders[model] == providers[model])
+            #expect(state.modelEndpoints[model] == endpoints[model])
+            #expect(state.modelEndpointTypes[model] == endpointTypes[model])
+            #expect(state.modelUsesGitHubOAuth[model] == oauth[model])
+            #expect(state.modelAPIKeys[model] == apiKeys[model])
+        }
+    }
+
+    @Test
+    @MainActor
+    func `shared session FIFO prevents stale source rollback from unordered task completion`() async {
+        let sourceA = UUID()
+        let sourceB = UUID()
+        let snapshotA = WatchSyncSnapshot(
+            sourceID: sourceA,
+            revision: 1,
+            conversations: [],
+            authoritativeConversationIDs: []
+        )
+        let snapshotB = WatchSyncSnapshot(
+            sourceID: sourceB,
+            revision: 1,
+            conversations: [],
+            authoritativeConversationIDs: []
+        )
+        let unorderedAStarted = TestAsyncGate()
+        let releaseUnorderedA = TestAsyncGate()
+        let unorderedBFinished = TestAsyncGate()
+        var unorderedState = WatchSyncLocalState()
+
+        let staleTask = Task { @MainActor in
+            unorderedAStarted.open()
+            await releaseUnorderedA.wait()
+            unorderedState = WatchSnapshotReconciler.reconcile(snapshotA, with: unorderedState).state
+        }
+        await unorderedAStarted.wait()
+        let newerTask = Task { @MainActor in
+            unorderedState = WatchSnapshotReconciler.reconcile(snapshotB, with: unorderedState).state
+            unorderedBFinished.open()
+        }
+        await unorderedBFinished.wait()
+        releaseUnorderedA.open()
+        await staleTask.value
+        await newerTask.value
+
+        #expect(unorderedState.sourceID == sourceA)
+
+        let queue = WatchSessionEventQueue()
+        let queuedAStarted = TestAsyncGate()
+        let releaseQueuedA = TestAsyncGate()
+        let queueFinished = TestAsyncGate()
+        var sequencedState = WatchSyncLocalState()
+
+        queue.enqueue {
+            queuedAStarted.open()
+            await releaseQueuedA.wait()
+            sequencedState = WatchSnapshotReconciler.reconcile(snapshotA, with: sequencedState).state
+        }
+        await queuedAStarted.wait()
+        queue.enqueue {
+            sequencedState = WatchSnapshotReconciler.reconcile(snapshotB, with: sequencedState).state
+            queueFinished.open()
+        }
+        releaseQueuedA.open()
+        await queueFinished.wait()
+
+        #expect(sequencedState.sourceID == sourceB)
+    }
+
+    @Test
+    @MainActor
+    func `phone publication reconciles durable deletions before deferring transport`() {
+        var events: [String] = []
+
+        let shouldPublish = WatchPhonePublicationBarrier.prepare(
+            pendingOperationCount: { 1 },
+            reconcile: { events.append("reconcile durable manifest") }
+        )
+
+        #expect(!shouldPublish)
+        #expect(events == ["reconcile durable manifest"])
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func `destructive legacy deferral keeps later session events live`() async {
+        let sessionQueue = WatchSessionEventQueue()
+        let legacyDeferral = WatchLegacyIngressDeferralQueue()
+        let pendingState = PendingDestructiveOperationState(count: 1)
+        let laterEventFinished = TestAsyncGate()
+        let legacyFinished = TestAsyncGate()
+        var events: [String] = []
+
+        sessionQueue.enqueue {
+            guard WatchLegacyIngressRouting.shouldDefer(
+                isAuthoritative: true,
+                pendingDestructiveOperationCount: pendingState.count
+            ) else {
+                Issue.record("Destructive legacy ingress must leave the WCSession FIFO")
+                return
+            }
+            legacyDeferral.retain(
+                untilReady: { true },
+                operation: {
+                    await WatchLegacyPersistenceBarrier.perform(
+                        pendingOperationCount: { pendingState.count },
+                        changes: pendingState.$count,
+                        reconcile: { events.append("reconcile") },
+                        apply: { events.append("legacy") }
+                    )
+                    legacyFinished.open()
+                }
+            )
+        }
+        sessionQueue.enqueue {
+            events.append("later")
+            laterEventFinished.open()
+        }
+
+        await laterEventFinished.wait()
+        #expect(events == ["later"])
+
+        pendingState.count = 0
+        await legacyFinished.wait()
+        #expect(events == ["later", "reconcile", "legacy"])
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    @MainActor
+    func `deferred legacy ingress stays retained without blocking later session events`() async {
+        let sessionQueue = WatchSessionEventQueue()
+        let legacyDeferral = WatchLegacyIngressDeferralQueue()
+        let authority = TestAsyncGate()
+        let laterEventFinished = TestAsyncGate()
+        let legacyFinished = TestAsyncGate()
+        var events: [String] = []
+
+        sessionQueue.enqueue {
+            legacyDeferral.retain(
+                untilReady: {
+                    await authority.wait()
+                    return true
+                },
+                operation: {
+                    events.append("legacy")
+                    legacyFinished.open()
+                }
+            )
+        }
+        sessionQueue.enqueue {
+            events.append("later")
+            laterEventFinished.open()
+        }
+
+        await laterEventFinished.wait()
+        #expect(events == ["later"])
+
+        authority.open()
+        await legacyFinished.wait()
+        #expect(events == ["later", "legacy"])
+    }
+
+    @Test
+    func `received mutation does not override negotiated legacy capability`() {
+        var capability = WatchPeerCapabilityState()
+        capability.apply(.advertisedMaximumSchema(1))
+        #expect(!capability.supportsCurrentSchema)
+
+        capability.apply(.receivedMutation)
+        #expect(!capability.supportsCurrentSchema)
+
+        capability.apply(.advertisedMaximumSchema(WatchSyncSnapshot.currentSchemaVersion))
+        capability.apply(.receivedMutation)
+        #expect(capability.supportsCurrentSchema)
+    }
+
+    @Test
+    func `peer capability strictly rejects malformed and nonpositive schema advertisements`() {
+        let invalidValues: [Any?] = [
+            nil,
+            NSNull(),
+            "2",
+            true,
+            NSNumber(value: 0),
+            NSNumber(value: -1),
+            NSNumber(value: 1.5),
+            NSNumber(value: Double.infinity),
+            NSNumber(value: Double.nan),
+            NSNumber(value: UInt64.max)
+        ]
+
+        for value in invalidValues {
+            #expect(WatchSyncCapability.advertisedMaximumSchemaVersion(value) == nil)
+            #expect(!WatchSyncCapability.supportsCurrentSchema(value))
+        }
+    }
+
+    @Test
+    func `peer capability requires an advertised schema at least as new as current`() {
+        #expect(!WatchSyncCapability.supportsCurrentSchema(NSNumber(value: 1)))
+        #expect(WatchSyncCapability.supportsCurrentSchema(
+            NSNumber(value: WatchSyncSnapshot.currentSchemaVersion)
+        ))
+        #expect(WatchSyncCapability.supportsCurrentSchema(
+            NSNumber(value: WatchSyncSnapshot.currentSchemaVersion + 1)
+        ))
+    }
+
+    @Test
+    @MainActor
+    func `legacy payload waits for destructive persistence then reconciles before applying`() async {
+        let pendingState = PendingDestructiveOperationState(count: 1)
+        let started = TestAsyncGate()
+        var events: [String] = []
+
+        let task = Task { @MainActor in
+            started.open()
+            await WatchLegacyPersistenceBarrier.perform(
+                pendingOperationCount: { pendingState.count },
+                changes: pendingState.$count,
+                reconcile: { events.append("reconcile") },
+                apply: { events.append("apply") }
+            )
+        }
+
+        await started.wait()
+        #expect(events.isEmpty)
+
+        pendingState.count = 0
+        await task.value
+
+        #expect(events == ["reconcile", "apply"])
+    }
+}
+
+@Suite("Watch connectivity autoreview regression tests", .tags(.fast))
+struct WatchConnectivityRegressionTests {
+    @Test
+    func `retired activation rejects delayed peer and source payloads on a reused session`() {
+        let fence = WatchSessionActivationFence()
+        let retiredActivation = fence.beginActivation()
+        let currentActivation = fence.beginActivation()
+        let retiredPeerID = UUID()
+        let currentPeerID = UUID()
+        let retiredSourceID = UUID()
+        let currentSourceID = UUID()
+        var activePeerID: UUID?
+        var appliedSourceID: UUID?
+
+        func apply(
+            activation: WatchSessionActivationToken,
+            peerID: UUID,
+            sourceID: UUID
+        ) {
+            guard fence.isCurrent(activation) else { return }
+            activePeerID = peerID
+            appliedSourceID = sourceID
+        }
+
+        apply(
+            activation: currentActivation,
+            peerID: currentPeerID,
+            sourceID: currentSourceID
+        )
+        apply(
+            activation: retiredActivation,
+            peerID: retiredPeerID,
+            sourceID: retiredSourceID
+        )
+
+        #expect(activePeerID == currentPeerID)
+        #expect(appliedSourceID == currentSourceID)
+        #expect(!fence.isCurrent(retiredActivation))
+        #expect(fence.isCurrent(currentActivation))
+    }
+
+    @Test
+    func `bounded model fallback follows represented snapshot pages with full model IDs`() throws {
+        let conversations = (0 ..< 80).map { index in
+            Conversation(
+                id: UUID(uuidString: String(
+                    format: "00000000-0000-0002-0000-%012d",
+                    index + 1
+                ))!,
+                title: "Historical \(index)",
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(200 - index)),
+                model: "historical-model-\(index)-" + String(
+                    repeating: String(index % 10),
+                    count: 180
+                )
+            )
+        }
+        let state = PhoneWatchSyncState(conversations: conversations)
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 1
+        configuration.maximumConversationConfigurations = 2
+        configuration.byteBudget = 32000
+        let firstPayload = try WatchSyncPayloadBuilder.build(
+            state: state,
+            snapshotRevision: 1,
+            configuration: configuration
+        )
+        let secondPayload = try WatchSyncPayloadBuilder.build(
+            state: state,
+            snapshotRevision: 2,
+            configuration: configuration
+        )
+        let allModels = conversations.map(\.model)
+
+        let firstModels = WatchModelSyncSelection.models(
+            selectedModel: "selected-model",
+            availableModels: allModels,
+            authoritativeState: state,
+            snapshot: firstPayload.snapshot,
+            limit: 5
+        )
+        let secondModels = WatchModelSyncSelection.models(
+            selectedModel: "selected-model",
+            availableModels: allModels,
+            authoritativeState: state,
+            snapshot: secondPayload.snapshot,
+            limit: 5
+        )
+        let firstRepresentedIDs = Set(
+            firstPayload.snapshot.conversations.map(\.id)
+                + firstPayload.snapshot.conversationConfigurations.map(\.id)
+        )
+        let secondRepresentedIDs = Set(
+            secondPayload.snapshot.conversations.map(\.id)
+                + secondPayload.snapshot.conversationConfigurations.map(\.id)
+        )
+        let firstRepresentedModels = conversations
+            .filter { firstRepresentedIDs.contains($0.id) }
+            .map(\.model)
+        let secondRepresentedModels = conversations
+            .filter { secondRepresentedIDs.contains($0.id) }
+            .map(\.model)
+
+        #expect(firstRepresentedIDs != secondRepresentedIDs)
+        #expect(firstRepresentedModels.allSatisfy(firstModels.contains))
+        #expect(secondRepresentedModels.allSatisfy(secondModels.contains))
+        #expect(firstModels.contains("selected-model"))
+        #expect(try !firstModels.contains(#require(conversations.last?.model)))
+        #expect(firstModels.allSatisfy { $0 == "selected-model" || $0.count > 160 })
+
+        let metadata = Dictionary(uniqueKeysWithValues: allModels.enumerated().map { index, model in
+            (
+                model,
+                "metadata-\(index)-" + String(
+                    repeating: String(format: "%02d", index),
+                    count: 1024
+                )
+            )
+        })
+        let boundedModelSet = Set(firstModels)
+        let boundedContext: [String: Any] = [
+            WatchContextKeys.syncSnapshot: firstPayload.data,
+            WatchContextKeys.selectedModel: "selected-model",
+            WatchContextKeys.availableModels: firstModels,
+            WatchContextKeys.modelEndpoints: metadata.filter { boundedModelSet.contains($0.key) },
+            WatchContextKeys.modelAPIKeys: metadata.filter { boundedModelSet.contains($0.key) },
+            WatchContextKeys.modelUsesGitHubOAuth: [String: Bool](
+                uniqueKeysWithValues: firstModels.map { ($0, false) }
+            )
+        ]
+        let unboundedContext: [String: Any] = [
+            WatchContextKeys.syncSnapshot: firstPayload.data,
+            WatchContextKeys.selectedModel: "selected-model",
+            WatchContextKeys.availableModels: allModels,
+            WatchContextKeys.modelEndpoints: metadata,
+            WatchContextKeys.modelAPIKeys: metadata
+        ]
+
+        #expect(
+            WatchApplicationContextSizer.size(unboundedContext)
+                > WatchApplicationContextSizer.maximumSafeBytes
+        )
+        #expect(WatchApplicationContextSizer.isWithinSafeLimit(boundedContext))
+    }
+}
+
+@Suite("Watch context application tests", .tags(.fast))
+struct WatchContextApplicationTests {
+    @Test
+    func `rejected standalone snapshots cannot apply snapshot-coupled settings`() {
+        let rejectedOutcomes: [WatchSyncSnapshotApplyOutcome] = [
+            .persistenceFailed,
+            .ignoredStale,
+            .ignoredUnsupportedSchema,
+        ]
+
+        for outcome in rejectedOutcomes {
+            let mode = WatchContextApplicationMode.standalone(
+                after: outcome,
+                metadataIsComplete: true
+            )
+
+            #expect(mode == .ignore)
+            #expect(!mode.appliesSnapshotSettings)
+        }
+    }
+
+    @Test
+    func `durable standalone snapshots pages and legacy fallback keep metadata semantics`() {
+        let completeStandalone = WatchContextApplicationMode.standalone(
+            after: .applied,
+            metadataIsComplete: true
+        )
+        let provisionalStandalone = WatchContextApplicationMode.standalone(
+            after: .alreadyDurable,
+            metadataIsComplete: false
+        )
+
+        #expect(completeStandalone == .complete)
+        #expect(completeStandalone.appliesSnapshotSettings)
+        #expect(provisionalStandalone == .provisional)
+        #expect(provisionalStandalone.appliesSnapshotSettings)
+        #expect(WatchContextApplicationMode.page(
+            cycleID: UUID(),
+            completesCycle: false,
+            metadataComplete: false
+        ).appliesSnapshotSettings)
+        #expect(WatchContextApplicationMode.legacy(metadataIsComplete: true) == .complete)
+        #expect(WatchContextApplicationMode.legacy(metadataIsComplete: false) == .provisional)
+    }
+}
+
+@Suite("Watch model metadata cycle tests", .tags(.fast))
+struct WatchModelMetadataCycleTests {
+    @Test
+    func `distinct paged model configurations accumulate before authoritative pruning`() {
+        let staleModel = "stale-model"
+        let firstModel = "page-one-model"
+        let secondModel = "page-two-model"
+        var state = WatchModelMetadataState(
+            selectedModel: staleModel,
+            availableModels: [staleModel],
+            customModels: [staleModel],
+            defaultProvider: "openai",
+            modelProviders: [staleModel: "openai"],
+            modelEndpoints: [staleModel: "https://stale.example/v1"],
+            modelEndpointTypes: [staleModel: "chatCompletions"],
+            modelUsesGitHubOAuth: [staleModel: false],
+            modelAPIKeys: [staleModel: "stale-key"]
+        )
+        let firstPage = WatchModelMetadataPage(
+            selectedModel: firstModel,
+            availableModels: [firstModel],
+            customModels: [firstModel],
+            defaultProvider: "openai",
+            modelProviders: [firstModel: "openai"],
+            modelEndpoints: [firstModel: "https://one.example/v1"],
+            modelEndpointTypes: [firstModel: "responses"],
+            modelUsesGitHubOAuth: [firstModel: false],
+            modelAPIKeys: [firstModel: "key-one"]
+        )
+        let secondPage = WatchModelMetadataPage(
+            selectedModel: firstModel,
+            availableModels: [secondModel],
+            customModels: [secondModel],
+            defaultProvider: "openai",
+            modelProviders: [secondModel: "anthropic"],
+            modelEndpoints: [secondModel: "https://two.example/v1"],
+            modelEndpointTypes: [secondModel: "messages"],
+            modelUsesGitHubOAuth: [secondModel: true],
+            modelAPIKeys: [secondModel: "key-two"]
+        )
+        let cycleID = UUID()
+        var accumulator = WatchModelMetadataCycleAccumulator()
+
+        accumulator.apply(
+            firstPage,
+            cycleID: cycleID,
+            completesCycle: false,
+            to: &state
+        )
+
+        #expect(state.availableModels == [staleModel, firstModel])
+        #expect(state.customModels == [staleModel, firstModel])
+        #expect(state.modelProviders == [staleModel: "openai", firstModel: "openai"])
+        #expect(state.modelAPIKeys == [staleModel: "stale-key", firstModel: "key-one"])
+
+        accumulator.apply(
+            secondPage,
+            cycleID: cycleID,
+            completesCycle: true,
+            to: &state
+        )
+
+        #expect(state.selectedModel == firstModel)
+        #expect(state.availableModels == [firstModel, secondModel])
+        #expect(state.customModels == [firstModel, secondModel])
+        #expect(state.modelProviders == [firstModel: "openai", secondModel: "anthropic"])
+        #expect(state.modelEndpoints == [
+            firstModel: "https://one.example/v1",
+            secondModel: "https://two.example/v1"
+        ])
+        #expect(state.modelEndpointTypes == [firstModel: "responses", secondModel: "messages"])
+        #expect(state.modelUsesGitHubOAuth == [firstModel: false, secondModel: true])
+        #expect(state.modelAPIKeys == [firstModel: "key-one", secondModel: "key-two"])
+    }
+
+    @Test
+    func `only a completed lossless two-page cycle prunes stale model credentials`() throws {
+        let sourceID = UUID()
+        let firstCursor = WatchSyncPageCycleCursor.initial
+        let firstMetadata = WatchSyncPageCycleMetadata(
+            cycleID: UUID(),
+            sourceID: sourceID,
+            snapshotRevision: 1,
+            cursor: firstCursor,
+            manifest: WatchSyncPageSection(offset: 0, itemCount: 1, totalCount: 2),
+            configurations: WatchSyncPageSection(offset: 0, itemCount: 1, totalCount: 2),
+            tombstones: WatchSyncPageSection(offset: 0, itemCount: 0, totalCount: 0)
+        )
+        let secondCursor = try #require(firstMetadata.nextCursor)
+        let secondMetadata = WatchSyncPageCycleMetadata(
+            cycleID: firstMetadata.cycleID,
+            sourceID: sourceID,
+            snapshotRevision: 2,
+            cursor: secondCursor,
+            manifest: WatchSyncPageSection(offset: 1, itemCount: 1, totalCount: 2),
+            configurations: WatchSyncPageSection(offset: 1, itemCount: 1, totalCount: 2),
+            tombstones: WatchSyncPageSection(offset: 0, itemCount: 0, totalCount: 0)
+        )
+        var losslessPhone = WatchPhonePageCycleCoordinator()
+        _ = losslessPhone.beginCycle(id: firstMetadata.cycleID)
+        let losslessFirst = losslessPhone.metadataForPublication(
+            firstMetadata,
+            modelMetadataPageIsLossless: true
+        )
+        losslessPhone.recordPublished(
+            losslessFirst,
+            modelMetadataPageIsLossless: true
+        )
+        let losslessFinal = losslessPhone.metadataForPublication(
+            secondMetadata,
+            modelMetadataPageIsLossless: true
+        )
+
+        #expect(!losslessFirst.modelMetadataCycleIsAuthoritative)
+        #expect(losslessFinal.modelMetadataCycleIsAuthoritative)
+        losslessPhone.recordPublished(
+            losslessFinal,
+            modelMetadataPageIsLossless: true
+        )
+        let retriedLosslessFinal = losslessPhone.metadataForPublication(
+            secondMetadata,
+            modelMetadataPageIsLossless: true
+        )
+        #expect(retriedLosslessFinal.modelMetadataCycleIsAuthoritative)
+
+        let staleModel = "stale-model"
+        let firstModel = "first-model"
+        let secondModel = "second-model"
+        let firstPage = WatchModelMetadataPage(
+            selectedModel: firstModel,
+            availableModels: [firstModel],
+            modelProviders: [firstModel: "openai"],
+            modelAPIKeys: [firstModel: "first-key"]
+        )
+        let secondPage = WatchModelMetadataPage(
+            selectedModel: firstModel,
+            availableModels: [secondModel],
+            modelProviders: [secondModel: "anthropic"],
+            modelAPIKeys: [secondModel: "second-key"]
+        )
+        var losslessState = modelMetadataState(model: staleModel, key: "stale-key")
+        var losslessWatch = WatchModelMetadataCycleAccumulator()
+        losslessWatch.apply(
+            firstPage,
+            cycleID: firstMetadata.cycleID,
+            completesCycle: false,
+            isAuthoritative: losslessFirst.modelMetadataCycleIsAuthoritative,
+            to: &losslessState
+        )
+        losslessWatch.apply(
+            secondPage,
+            cycleID: firstMetadata.cycleID,
+            completesCycle: true,
+            isAuthoritative: losslessFinal.modelMetadataCycleIsAuthoritative,
+            to: &losslessState
+        )
+
+        #expect(losslessState.availableModels == [firstModel, secondModel])
+        #expect(losslessState.modelAPIKeys == [firstModel: "first-key", secondModel: "second-key"])
+
+        let boundedCycleID = UUID()
+        let boundedFirstMetadata = WatchSyncPageCycleMetadata(
+            cycleID: boundedCycleID,
+            sourceID: sourceID,
+            snapshotRevision: 3,
+            cursor: firstCursor,
+            manifest: firstMetadata.manifest,
+            configurations: firstMetadata.configurations,
+            tombstones: firstMetadata.tombstones
+        )
+        let boundedFinalMetadata = WatchSyncPageCycleMetadata(
+            cycleID: boundedCycleID,
+            sourceID: sourceID,
+            snapshotRevision: 4,
+            cursor: secondCursor,
+            manifest: secondMetadata.manifest,
+            configurations: secondMetadata.configurations,
+            tombstones: secondMetadata.tombstones
+        )
+        var boundedPhone = WatchPhonePageCycleCoordinator()
+        _ = boundedPhone.beginCycle(id: boundedCycleID)
+        let boundedFirst = boundedPhone.metadataForPublication(
+            boundedFirstMetadata,
+            modelMetadataPageIsLossless: false
+        )
+        boundedPhone.recordPublished(
+            boundedFirst,
+            modelMetadataPageIsLossless: false
+        )
+        let boundedFinal = boundedPhone.metadataForPublication(
+            boundedFinalMetadata,
+            modelMetadataPageIsLossless: true
+        )
+
+        #expect(!boundedFinal.modelMetadataCycleIsAuthoritative)
+
+        var boundedState = modelMetadataState(model: staleModel, key: "stale-key")
+        var boundedWatch = WatchModelMetadataCycleAccumulator()
+        boundedWatch.apply(
+            firstPage,
+            cycleID: boundedCycleID,
+            completesCycle: false,
+            isAuthoritative: boundedFirst.modelMetadataCycleIsAuthoritative,
+            to: &boundedState
+        )
+        boundedWatch.apply(
+            secondPage,
+            cycleID: boundedCycleID,
+            completesCycle: true,
+            isAuthoritative: boundedFinal.modelMetadataCycleIsAuthoritative,
+            to: &boundedState
+        )
+
+        #expect(boundedState.availableModels == [staleModel, firstModel, secondModel])
+        #expect(boundedState.modelAPIKeys == [
+            staleModel: "stale-key",
+            firstModel: "first-key",
+            secondModel: "second-key"
+        ])
+    }
+
+    @Test
+    func `bounded page cycle completion preserves metadata omitted by the cycle`() {
+        let retainedModel = "retained-model"
+        let incomingModel = "incoming-model"
+        var state = WatchModelMetadataState(
+            selectedModel: retainedModel,
+            availableModels: [retainedModel],
+            customModels: [retainedModel],
+            defaultProvider: "openai",
+            modelProviders: [retainedModel: "openai"],
+            modelEndpoints: [retainedModel: "https://retained.example/v1"],
+            modelEndpointTypes: [retainedModel: "responses"],
+            modelUsesGitHubOAuth: [retainedModel: false],
+            modelAPIKeys: [retainedModel: "retained-key"]
+        )
+        let page = WatchModelMetadataPage(
+            selectedModel: incomingModel,
+            availableModels: [incomingModel],
+            customModels: [incomingModel],
+            defaultProvider: "openai",
+            modelProviders: [incomingModel: "anthropic"],
+            modelEndpoints: [incomingModel: "https://incoming.example/v1"],
+            modelEndpointTypes: [incomingModel: "messages"],
+            modelUsesGitHubOAuth: [incomingModel: false],
+            modelAPIKeys: [incomingModel: "incoming-key"]
+        )
+        var accumulator = WatchModelMetadataCycleAccumulator()
+
+        accumulator.apply(
+            page,
+            cycleID: UUID(),
+            completesCycle: true,
+            isAuthoritative: false,
+            to: &state
+        )
+
+        #expect(state.availableModels == [retainedModel, incomingModel])
+        #expect(state.modelAPIKeys == [
+            retainedModel: "retained-key",
+            incomingModel: "incoming-key"
+        ])
+    }
+
+    @Test
+    func `new epoch provisional metadata preserves omitted models until complete replacement`() {
+        let retainedModel = "retained-model"
+        let removedModel = "removed-model"
+        let incomingModel = "incoming-model"
+        let previousEpoch = UUID()
+        let incomingEpoch = UUID()
+        var state = WatchModelMetadataState(
+            selectedModel: retainedModel,
+            availableModels: [retainedModel, removedModel],
+            customModels: [retainedModel, removedModel],
+            defaultProvider: "openai",
+            modelProviders: [retainedModel: "openai", removedModel: "anthropic"],
+            modelEndpoints: [retainedModel: "https://retained.example", removedModel: "https://removed.example"],
+            modelEndpointTypes: [retainedModel: "responses", removedModel: "messages"],
+            modelUsesGitHubOAuth: [retainedModel: false, removedModel: true],
+            modelAPIKeys: [retainedModel: "retained-key", removedModel: "removed-key"]
+        )
+        var accumulator = WatchModelMetadataCycleAccumulator()
+        var pendingEpoch: UUID?
+        let provisional = WatchModelMetadataPage(
+            selectedModel: incomingModel,
+            availableModels: [incomingModel],
+            customModels: [incomingModel],
+            defaultProvider: "anthropic",
+            modelProviders: [incomingModel: "anthropic"],
+            modelEndpoints: [incomingModel: "https://incoming.example"],
+            modelEndpointTypes: [incomingModel: "messages"],
+            modelUsesGitHubOAuth: [incomingModel: false],
+            modelAPIKeys: [incomingModel: "incoming-key"],
+            removedModelDigests: [WatchModelIdentity.digest(removedModel)]
+        )
+
+        let provisionalEpoch = WatchModelMetadataContextReducer.apply(
+            provisional,
+            mode: .provisional,
+            incomingEpoch: incomingEpoch,
+            appliedEpoch: previousEpoch,
+            pendingEpoch: &pendingEpoch,
+            accumulator: &accumulator,
+            to: &state
+        )
+
+        #expect(provisionalEpoch == nil)
+        #expect(pendingEpoch == incomingEpoch)
+        #expect(state.availableModels == [retainedModel, incomingModel])
+        #expect(state.modelAPIKeys == [retainedModel: "retained-key", incomingModel: "incoming-key"])
+        #expect(state.modelAPIKeys[removedModel] == nil)
+
+        let complete = WatchModelMetadataPage(
+            selectedModel: incomingModel,
+            availableModels: [incomingModel],
+            customModels: [incomingModel],
+            defaultProvider: "anthropic",
+            modelProviders: [incomingModel: "anthropic"],
+            modelEndpoints: [incomingModel: "https://incoming.example"],
+            modelEndpointTypes: [incomingModel: "messages"],
+            modelUsesGitHubOAuth: [incomingModel: false],
+            modelAPIKeys: [incomingModel: "incoming-key"]
+        )
+        let committedEpoch = WatchModelMetadataContextReducer.apply(
+            complete,
+            mode: .complete,
+            incomingEpoch: incomingEpoch,
+            appliedEpoch: previousEpoch,
+            pendingEpoch: &pendingEpoch,
+            accumulator: &accumulator,
+            to: &state
+        )
+
+        #expect(committedEpoch == incomingEpoch)
+        #expect(pendingEpoch == nil)
+        #expect(state.availableModels == [incomingModel])
+        #expect(state.modelAPIKeys == [incomingModel: "incoming-key"])
+    }
+
+    @Test
+    func `bounded current schema bootstrap retains omitted model credentials`() throws {
+        let retainedModel = "retained-model"
+        let incomingModel = "incoming-model"
+        var state = WatchModelMetadataState(
+            selectedModel: retainedModel,
+            availableModels: [retainedModel],
+            customModels: [retainedModel],
+            defaultProvider: "openai",
+            modelProviders: [retainedModel: "openai"],
+            modelEndpoints: [retainedModel: "https://retained.example/v1"],
+            modelEndpointTypes: [retainedModel: "responses"],
+            modelUsesGitHubOAuth: [retainedModel: false],
+            modelAPIKeys: [retainedModel: "retained-key"]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 1,
+            conversations: [],
+            authoritativeConversationIDs: [],
+            authoritativeConversationIDsAreComplete: false,
+            conversationConfigurations: [],
+            conversationConfigurationsAreComplete: false
+        )
+        let modelMetadataComplete = WatchModelMetadataCompleteness.isCompletePublication(
+            snapshot: snapshot,
+            modelLimit: 1
+        )
+        let context: [String: Any] = try [
+            WatchContextKeys.syncSnapshot: JSONEncoder().encode(snapshot),
+            WatchContextKeys.selectedModel: incomingModel,
+            WatchContextKeys.availableModels: [incomingModel],
+            WatchContextKeys.modelProviders: [incomingModel: "anthropic"],
+            WatchContextKeys.modelAPIKeys: [incomingModel: "incoming-key"],
+            WatchContextKeys.modelMetadataComplete: modelMetadataComplete
+        ]
+        let page = WatchModelMetadataPage(context: context)
+        let isComplete = WatchModelMetadataCompleteness.isExplicitlyComplete(in: context)
+        #expect(!modelMetadataComplete)
+        var accumulator = WatchModelMetadataCycleAccumulator()
+
+        accumulator.applyStandaloneContext(
+            page,
+            isComplete: isComplete,
+            to: &state
+        )
+
+        #expect(state.selectedModel == incomingModel)
+        #expect(state.availableModels == [retainedModel, incomingModel])
+        #expect(state.modelProviders == [retainedModel: "openai", incomingModel: "anthropic"])
+        #expect(state.modelAPIKeys == [
+            retainedModel: "retained-key",
+            incomingModel: "incoming-key"
+        ])
+    }
+}
+
+@Suite("Watch model selection coordinator tests", .tags(.fast))
+struct WatchModelSelectionCoordinatorTests {
+    @Test
+    @MainActor
+    func `failed conversation model persistence leaves global selection unchanged`() {
+        let conversationID = UUID()
+        var globalModels: [String] = []
+        var persistenceAttempts: [String] = []
+
+        let selected = WatchModelSelectionCoordinator.select(
+            model: "new-model",
+            conversationID: conversationID,
+            currentConversationModel: { _ in "old-model" },
+            persistConversationModel: { model, _ in
+                persistenceAttempts.append(model)
+                return false
+            },
+            applyGlobalModel: { globalModels.append($0) }
+        )
+
+        #expect(!selected)
+        #expect(persistenceAttempts == ["new-model"])
+        #expect(globalModels.isEmpty)
+    }
+
+    @Test
+    func `single model auto selection is limited to new chat`() {
+        #expect(WatchModelSelectionCoordinator.shouldAutoSelect(
+            availableModelCount: 1,
+            conversationID: nil
+        ))
+        #expect(!WatchModelSelectionCoordinator.shouldAutoSelect(
+            availableModelCount: 1,
+            conversationID: UUID()
+        ))
+        #expect(!WatchModelSelectionCoordinator.shouldAutoSelect(
+            availableModelCount: 2,
+            conversationID: nil
+        ))
+    }
+
+    @Test
+    @MainActor
+    func `already selected conversation model commits globals without another write`() {
+        let conversationID = UUID()
+        var globalModels: [String] = []
+        var attemptedPersistence = false
+
+        let selected = WatchModelSelectionCoordinator.select(
+            model: "same-model",
+            conversationID: conversationID,
+            currentConversationModel: { _ in "same-model" },
+            persistConversationModel: { _, _ in
+                attemptedPersistence = true
+                return false
+            },
+            applyGlobalModel: { globalModels.append($0) }
+        )
+
+        #expect(selected)
+        #expect(!attemptedPersistence)
+        #expect(globalModels == ["same-model"])
+    }
+}
+
+@Suite("Watch legacy metadata compatibility tests", .tags(.fast))
+struct WatchLegacyMetadataCompatibilityTests {
+    @Test
+    func `markerless legacy metadata is authoritative while explicit false remains provisional`() {
+        let staleModel = "stale-model"
+        let currentModel = "current-model"
+        let markerlessContext: [String: Any] = [
+            WatchContextKeys.selectedModel: currentModel,
+            WatchContextKeys.availableModels: [currentModel],
+            WatchContextKeys.customModels: [currentModel],
+            WatchContextKeys.defaultProvider: "openai",
+            WatchContextKeys.modelProviders: [currentModel: "openai"],
+            WatchContextKeys.modelEndpoints: [currentModel: "https://current.example/v1"],
+            WatchContextKeys.modelEndpointTypes: [currentModel: "responses"],
+            WatchContextKeys.modelUsesGitHubOAuth: [currentModel: false],
+            WatchContextKeys.modelAPIKeys: [currentModel: "current-key"]
+        ]
+        var state = modelMetadataState(model: staleModel, key: "stale-key")
+        var accumulator = WatchModelMetadataCycleAccumulator()
+
+        #expect(WatchModelMetadataCompleteness.legacyContextIsComplete(in: markerlessContext))
+        accumulator.applyStandaloneContext(
+            WatchModelMetadataPage(context: markerlessContext),
+            isComplete: WatchModelMetadataCompleteness.legacyContextIsComplete(in: markerlessContext),
+            to: &state
+        )
+
+        #expect(state.availableModels == [currentModel])
+        #expect(state.modelAPIKeys == [currentModel: "current-key"])
+
+        var explicitBoundedContext = markerlessContext
+        explicitBoundedContext[WatchContextKeys.modelMetadataComplete] = false
+        #expect(!WatchModelMetadataCompleteness.legacyContextIsComplete(in: explicitBoundedContext))
+        #expect(WatchContextApplicationMode.complete.treatsOmittedCredentialsAsRemoved)
+        #expect(!WatchContextApplicationMode.provisional.treatsOmittedCredentialsAsRemoved)
+
+        var missingKeysState = modelMetadataState(model: staleModel, key: "stale-key")
+        accumulator.applyCompleteContext(
+            WatchModelMetadataPage(context: [
+                WatchContextKeys.selectedModel: currentModel,
+                WatchContextKeys.availableModels: [currentModel],
+                WatchContextKeys.customModels: [currentModel]
+            ]),
+            to: &missingKeysState
+        )
+        #expect(missingKeysState.modelAPIKeys.isEmpty)
+        #expect(missingKeysState.modelProviders.isEmpty)
+        #expect(missingKeysState.modelEndpoints.isEmpty)
+    }
+}
+
+@Suite("Watch model removal compatibility tests", .tags(.fast))
+struct WatchModelRemovalCompatibilityTests {
+    @Test
+    func `removed model digests persist across publications until the model is readded`() throws {
+        var tracker = WatchModelRemovalTracker()
+
+        #expect(tracker.publication(inventory: modelInventory(["model-a", "model-b"])).isEmpty)
+        let removed = tracker.publication(inventory: modelInventory(["model-b"]))
+        #expect(removed.removedModelDigests == [WatchModelIdentity.digest("model-a")])
+        #expect(tracker.publication(inventory: modelInventory(["model-b"])) == removed)
+        let restored = try JSONDecoder().decode(
+            WatchModelRemovalTracker.self,
+            from: JSONEncoder().encode(tracker)
+        )
+        #expect(restored == tracker)
+        #expect(tracker.publication(inventory: modelInventory(["model-a", "model-b"])).isEmpty)
+    }
+
+    @Test
+    func `model removal history rotates epoch before tombstones exceed the context budget`() throws {
+        let limit = WatchModelRemovalTracker.maximumRetiredDigestCount
+        let fieldRetirementCount = limit / 6
+        let modelRetirementCount = limit - (fieldRetirementCount * 5)
+        let retiredModels = (0 ..< modelRetirementCount).map { "retired-model-\($0)" }
+        let retiredFieldModels = Array(retiredModels.prefix(fieldRetirementCount))
+        let retainedModel = "retained-model"
+        var tracker = WatchModelRemovalTracker()
+        let originalEpoch = tracker.epoch
+
+        #expect(tracker.publication(inventory: WatchModelMetadataInventory(
+            modelIDs: retiredModels + [retainedModel],
+            providerModelIDs: retiredFieldModels + [retainedModel],
+            endpointModelIDs: retiredFieldModels,
+            endpointTypeModelIDs: retiredFieldModels,
+            gitHubOAuthModelIDs: retiredFieldModels,
+            apiKeyModelIDs: retiredFieldModels
+        )).isEmpty)
+        let atLimit = tracker.publication(inventory: WatchModelMetadataInventory(
+            modelIDs: [retainedModel],
+            providerModelIDs: [retainedModel],
+            endpointModelIDs: [],
+            endpointTypeModelIDs: [],
+            gitHubOAuthModelIDs: [],
+            apiKeyModelIDs: []
+        ))
+        let atLimitContext: [String: Any] = [
+            WatchContextKeys.removedModelDigests: atLimit.removedModelDigests,
+            WatchContextKeys.removedModelProviderDigests: atLimit.removedProviderDigests,
+            WatchContextKeys.removedModelEndpointDigests: atLimit.removedEndpointDigests,
+            WatchContextKeys.removedModelEndpointTypeDigests: atLimit.removedEndpointTypeDigests,
+            WatchContextKeys.removedModelGitHubOAuthDigests: atLimit.removedGitHubOAuthDigests,
+            WatchContextKeys.removedModelAPIKeyDigests: atLimit.removedAPIKeyDigests,
+            WatchContextKeys.modelMetadataEpoch: tracker.epoch.uuidString
+        ]
+        let encodedAtLimit = try JSONEncoder().encode(tracker)
+        let retiredCount = atLimit.removedModelDigests.count
+            + atLimit.removedProviderDigests.count
+            + atLimit.removedEndpointDigests.count
+            + atLimit.removedEndpointTypeDigests.count
+            + atLimit.removedGitHubOAuthDigests.count
+            + atLimit.removedAPIKeyDigests.count
+
+        #expect(retiredCount == limit)
+        #expect(tracker.epoch == originalEpoch)
+        #expect(WatchApplicationContextSizer.isWithinSafeLimit(atLimitContext))
+        #expect(encodedAtLimit.count <= WatchApplicationContextSizer.maximumSafeBytes)
+
+        let afterRotation = tracker.publication(inventory: WatchModelMetadataInventory(
+            modelIDs: [retainedModel],
+            providerModelIDs: [],
+            endpointModelIDs: [],
+            endpointTypeModelIDs: [],
+            gitHubOAuthModelIDs: [],
+            apiKeyModelIDs: []
+        ))
+        let encodedAfterRotation = try JSONEncoder().encode(tracker)
+
+        #expect(afterRotation.isEmpty)
+        #expect(tracker.epoch != originalEpoch)
+        #expect(tracker.publishedDigests == [WatchModelIdentity.digest(retainedModel)])
+        #expect(tracker.publishedProviderDigests.isEmpty)
+        #expect(tracker.retiredDigests.isEmpty)
+        #expect(tracker.retiredProviderDigests.isEmpty)
+        #expect(encodedAfterRotation.count < encodedAtLimit.count)
+    }
+
+    @Test
+    func `changed bounded metadata invalidates stale values until replacements arrive`() {
+        let model = "changed-model"
+        let modelDigest = WatchModelIdentity.digest(model)
+        var tracker = WatchModelRemovalTracker()
+        let oldInventory = WatchModelMetadataInventory(
+            modelIDs: [model],
+            providerModelIDs: [model],
+            endpointModelIDs: [model],
+            endpointTypeModelIDs: [model],
+            gitHubOAuthModelIDs: [model],
+            apiKeyModelIDs: [model],
+            valueDigests: WatchModelMetadataValueDigests(
+                providers: [modelDigest: WatchModelIdentity.digest("openai")],
+                endpoints: [modelDigest: WatchModelIdentity.digest("https://old.example")],
+                endpointTypes: [modelDigest: WatchModelIdentity.digest("responses")],
+                gitHubOAuth: [modelDigest: WatchModelIdentity.digest("false")],
+                apiKeys: [modelDigest: WatchModelIdentity.digest("old-key")]
+            )
+        )
+        let newInventory = WatchModelMetadataInventory(
+            modelIDs: [model],
+            providerModelIDs: [model],
+            endpointModelIDs: [model],
+            endpointTypeModelIDs: [model],
+            gitHubOAuthModelIDs: [model],
+            apiKeyModelIDs: [model],
+            valueDigests: WatchModelMetadataValueDigests(
+                providers: [modelDigest: WatchModelIdentity.digest("anthropic")],
+                endpoints: [modelDigest: WatchModelIdentity.digest("https://new.example")],
+                endpointTypes: [modelDigest: WatchModelIdentity.digest("messages")],
+                gitHubOAuth: [modelDigest: WatchModelIdentity.digest("true")],
+                apiKeys: [modelDigest: WatchModelIdentity.digest("new-key")]
+            )
+        )
+
+        #expect(tracker.publication(inventory: oldInventory).isEmpty)
+        let invalidations = tracker.publication(inventory: newInventory)
+
+        #expect(invalidations.removedProviderDigests == [modelDigest])
+        #expect(invalidations.removedEndpointDigests == [modelDigest])
+        #expect(invalidations.removedEndpointTypeDigests == [modelDigest])
+        #expect(invalidations.removedGitHubOAuthDigests == [modelDigest])
+        #expect(invalidations.removedAPIKeyDigests == [modelDigest])
+        #expect(tracker.publication(inventory: newInventory) == invalidations)
+
+        var state = WatchModelMetadataState(
+            selectedModel: model,
+            availableModels: [model],
+            customModels: [model],
+            defaultProvider: "openai",
+            modelProviders: [model: "openai"],
+            modelEndpoints: [model: "https://old.example"],
+            modelEndpointTypes: [model: "responses"],
+            modelUsesGitHubOAuth: [model: false],
+            modelAPIKeys: [model: "old-key"]
+        )
+        state.merge(WatchModelMetadataPage(
+            removedModelProviderDigests: invalidations.removedProviderDigests,
+            removedModelEndpointDigests: invalidations.removedEndpointDigests,
+            removedModelEndpointTypeDigests: invalidations.removedEndpointTypeDigests,
+            removedModelGitHubOAuthDigests: invalidations.removedGitHubOAuthDigests,
+            removedModelAPIKeyDigests: invalidations.removedAPIKeyDigests
+        ))
+
+        #expect(state.modelProviders[model] == nil)
+        #expect(state.modelEndpoints[model] == nil)
+        #expect(state.modelEndpointTypes[model] == nil)
+        #expect(state.modelUsesGitHubOAuth[model] == nil)
+        #expect(state.modelAPIKeys[model] == nil)
+
+        state.merge(WatchModelMetadataPage(
+            modelProviders: [model: "anthropic"],
+            modelEndpoints: [model: "https://new.example"],
+            modelEndpointTypes: [model: "messages"],
+            modelUsesGitHubOAuth: [model: true],
+            modelAPIKeys: [model: "new-key"],
+            removedModelProviderDigests: invalidations.removedProviderDigests,
+            removedModelEndpointDigests: invalidations.removedEndpointDigests,
+            removedModelEndpointTypeDigests: invalidations.removedEndpointTypeDigests,
+            removedModelGitHubOAuthDigests: invalidations.removedGitHubOAuthDigests,
+            removedModelAPIKeyDigests: invalidations.removedAPIKeyDigests
+        ))
+
+        #expect(state.modelProviders[model] == "anthropic")
+        #expect(state.modelEndpoints[model] == "https://new.example")
+        #expect(state.modelEndpointTypes[model] == "messages")
+        #expect(state.modelUsesGitHubOAuth[model] == true)
+        #expect(state.modelAPIKeys[model] == "new-key")
+    }
+
+    @Test
+    func `provisional metadata removes retired model credentials immediately`() {
+        let removedModel = "removed-model"
+        let retainedModel = "retained-model"
+        var state = WatchModelMetadataState(
+            selectedModel: removedModel,
+            availableModels: [removedModel, retainedModel],
+            customModels: [removedModel, retainedModel],
+            defaultProvider: "openai",
+            modelProviders: [removedModel: "openai", retainedModel: "anthropic"],
+            modelEndpoints: [removedModel: "https://removed.example", retainedModel: "https://retained.example"],
+            modelEndpointTypes: [removedModel: "responses", retainedModel: "messages"],
+            modelUsesGitHubOAuth: [removedModel: false, retainedModel: false],
+            modelAPIKeys: [removedModel: "revoked-key", retainedModel: "retained-key"]
+        )
+        let epoch = UUID()
+        let pageContext: [String: Any] = [
+            WatchContextKeys.selectedModel: retainedModel,
+            WatchContextKeys.removedModelDigests: [WatchModelIdentity.digest(removedModel)],
+            WatchContextKeys.modelMetadataEpoch: epoch.uuidString
+        ]
+        let page = WatchModelMetadataPage(context: pageContext)
+
+        state.merge(page)
+
+        #expect(state.selectedModel == retainedModel)
+        #expect(state.availableModels == [retainedModel])
+        #expect(state.customModels == [retainedModel])
+        #expect(state.modelProviders[removedModel] == nil)
+        #expect(state.modelEndpoints[removedModel] == nil)
+        #expect(state.modelEndpointTypes[removedModel] == nil)
+        #expect(state.modelUsesGitHubOAuth[removedModel] == nil)
+        #expect(state.modelAPIKeys[removedModel] == nil)
+        #expect(state.modelAPIKeys[retainedModel] == "retained-key")
+        #expect(pageContext[WatchContextKeys.modelMetadataEpoch] as? String == epoch.uuidString)
+
+        state.resetModelSpecificState()
+        #expect(state.selectedModel.isEmpty)
+        #expect(state.availableModels.isEmpty)
+        #expect(state.modelAPIKeys.isEmpty)
+    }
+
+    @Test
+    func `provisional metadata revokes fields while retaining the model`() {
+        let model = "retained-model"
+        var tracker = WatchModelRemovalTracker()
+        _ = tracker.publication(inventory: WatchModelMetadataInventory(
+            modelIDs: [model],
+            providerModelIDs: [model],
+            endpointModelIDs: [model],
+            endpointTypeModelIDs: [model],
+            gitHubOAuthModelIDs: [model],
+            apiKeyModelIDs: [model]
+        ))
+        let removals = tracker.publication(inventory: WatchModelMetadataInventory(
+            modelIDs: [model],
+            providerModelIDs: [model],
+            endpointModelIDs: [],
+            endpointTypeModelIDs: [],
+            gitHubOAuthModelIDs: [],
+            apiKeyModelIDs: []
+        ))
+        var state = WatchModelMetadataState(
+            selectedModel: model,
+            availableModels: [model],
+            customModels: [model],
+            defaultProvider: "openai",
+            modelProviders: [model: "openai"],
+            modelEndpoints: [model: "https://removed.example"],
+            modelEndpointTypes: [model: "responses"],
+            modelUsesGitHubOAuth: [model: true],
+            modelAPIKeys: [model: "revoked-key"]
+        )
+        state.merge(WatchModelMetadataPage(context: [
+            WatchContextKeys.selectedModel: model,
+            WatchContextKeys.availableModels: [model],
+            WatchContextKeys.customModels: [model],
+            WatchContextKeys.modelProviders: [model: "openai"],
+            WatchContextKeys.removedModelEndpointDigests: removals.removedEndpointDigests,
+            WatchContextKeys.removedModelEndpointTypeDigests: removals.removedEndpointTypeDigests,
+            WatchContextKeys.removedModelGitHubOAuthDigests: removals.removedGitHubOAuthDigests,
+            WatchContextKeys.removedModelAPIKeyDigests: removals.removedAPIKeyDigests
+        ]))
+
+        #expect(state.availableModels == [model])
+        #expect(state.modelProviders[model] == "openai")
+        #expect(state.modelEndpoints[model] == nil)
+        #expect(state.modelEndpointTypes[model] == nil)
+        #expect(state.modelUsesGitHubOAuth[model] == nil)
+        #expect(state.modelAPIKeys[model] == nil)
+    }
+
+    private func modelInventory(_ models: [String]) -> WatchModelMetadataInventory {
+        WatchModelMetadataInventory(
+            modelIDs: models,
+            providerModelIDs: [],
+            endpointModelIDs: [],
+            endpointTypeModelIDs: [],
+            gitHubOAuthModelIDs: [],
+            apiKeyModelIDs: []
+        )
+    }
+}
+
+@Suite("Watch page cycle coordinator tests", .tags(.fast))
+struct WatchPageCycleCoordinatorTests {
+    @Test
+    func `phone continuation does not skip an unacknowledged page and repeats exact prior pages`() {
+        let cycleID = UUID()
+        let sourceID = UUID()
+        let firstCursor = WatchSyncPageCycleCursor.initial
+        let expectedSecondCursor = WatchSyncPageCycleCursor(
+            pageIndex: 1,
+            manifestOffset: 32,
+            configurationOffset: 32,
+            tombstoneOffset: 32
+        )
+        var coordinator = WatchPhonePageCycleCoordinator()
+
+        #expect(coordinator.beginCycle(id: cycleID) == firstCursor)
+        coordinator.recordPublished(
+            WatchSyncPageCycleMetadata(
+                cycleID: cycleID,
+                sourceID: sourceID,
+                snapshotRevision: 10,
+                cursor: firstCursor,
+                manifest: WatchSyncPageSection(
+                    offset: 0,
+                    itemCount: 32,
+                    totalCount: 80
+                ),
+                configurations: WatchSyncPageSection(
+                    offset: 0,
+                    itemCount: 32,
+                    totalCount: 80
+                ),
+                tombstones: WatchSyncPageSection(
+                    offset: 0,
+                    itemCount: 32,
+                    totalCount: 70
+                )
+            )
+        )
+
+        let skipped = WatchSyncPageCycleRequest(
+            cycleID: cycleID,
+            cursor: WatchSyncPageCycleCursor(
+                pageIndex: 2,
+                manifestOffset: 64,
+                configurationOffset: 64,
+                tombstoneOffset: 64
+            )
+        )
+        let repeated = WatchSyncPageCycleRequest(cycleID: cycleID, cursor: firstCursor)
+        let exact = WatchSyncPageCycleRequest(cycleID: cycleID, cursor: expectedSecondCursor)
+
+        #expect(coordinator.publication(for: skipped) == expectedSecondCursor)
+        #expect(coordinator.publication(for: repeated) == firstCursor)
+        #expect(coordinator.publication(for: exact) == expectedSecondCursor)
+    }
+
+    @Test
+    func `new state cycle retires continuation requests from the prior cycle`() {
+        let oldCycleID = UUID()
+        let newCycleID = UUID()
+        let oldFirst = WatchSyncPageCycleCursor.initial
+        let oldSecond = WatchSyncPageCycleCursor(
+            pageIndex: 1,
+            manifestOffset: 32,
+            configurationOffset: 32,
+            tombstoneOffset: 32
+        )
+        var coordinator = WatchPhonePageCycleCoordinator()
+        _ = coordinator.beginCycle(id: oldCycleID)
+        coordinator.recordPublished(
+            makePageCycleMetadata(
+                cycleID: oldCycleID,
+                sourceID: UUID(),
+                revision: 1,
+                cursor: oldFirst,
+                itemCount: 32,
+                totalCount: 80
+            )
+        )
+
+        #expect(coordinator.beginCycle(id: newCycleID) == .initial)
+        let staleRequest = WatchSyncPageCycleRequest(
+            cycleID: oldCycleID,
+            cursor: oldSecond
+        )
+
+        #expect(coordinator.publicationRequest(for: staleRequest) == WatchSyncPageCycleRequest(
+            cycleID: newCycleID,
+            cursor: .initial
+        ))
+    }
+
+    @Test
+    func `durable page one after restart requests one fresh cycle`() throws {
+        let cycleID = UUID()
+        let sourceID = UUID()
+        let pageZero = makePageCycleMetadata(
+            cycleID: cycleID,
+            sourceID: sourceID,
+            revision: 40,
+            cursor: .initial,
+            itemCount: 32,
+            totalCount: 80
+        )
+        let pageOneCursor = try #require(pageZero.nextCursor)
+        let pageOne = makePageCycleMetadata(
+            cycleID: cycleID,
+            sourceID: sourceID,
+            revision: 41,
+            cursor: pageOneCursor,
+            itemCount: 32,
+            totalCount: 80
+        )
+        var beforeRestart = WatchPageCycleCoordinator()
+
+        #expect(beforeRestart.receive(pageZero, after: .applied).acceptedPage)
+        #expect(beforeRestart.receive(pageOne, after: .applied).acceptedPage)
+
+        var afterRestart = WatchPageCycleCoordinator()
+        let recovery = afterRestart.receive(pageOne, after: .alreadyDurable)
+
+        #expect(!recovery.acceptedPage)
+        #expect(recovery.pendingRequest == nil)
+        #expect(recovery.requiresFreshCycle)
+
+        let repeatedContext = afterRestart.receive(pageOne, after: .alreadyDurable)
+        #expect(!repeatedContext.requiresFreshCycle)
+        #expect(repeatedContext.pendingRequest == nil)
+    }
+
+    @Test
+    func `watch requests the missing exact page and stops only after cycle completion`() throws {
+        let cycleID = UUID()
+        let sourceID = UUID()
+        let first = makePageCycleMetadata(
+            cycleID: cycleID,
+            sourceID: sourceID,
+            revision: 20,
+            cursor: .initial,
+            itemCount: 32,
+            totalCount: 80
+        )
+        let secondCursor = try #require(first.nextCursor)
+        let second = makePageCycleMetadata(
+            cycleID: cycleID,
+            sourceID: sourceID,
+            revision: 23,
+            cursor: secondCursor,
+            itemCount: 32,
+            totalCount: 80
+        )
+        let thirdCursor = try #require(second.nextCursor)
+        let skippedThird = makePageCycleMetadata(
+            cycleID: cycleID,
+            sourceID: sourceID,
+            revision: 21,
+            cursor: thirdCursor,
+            itemCount: 16,
+            totalCount: 80
+        )
+        let repeatedFirst = makePageCycleMetadata(
+            cycleID: cycleID,
+            sourceID: sourceID,
+            revision: 22,
+            cursor: .initial,
+            itemCount: 32,
+            totalCount: 80
+        )
+        let finalThird = makePageCycleMetadata(
+            cycleID: cycleID,
+            sourceID: sourceID,
+            revision: 24,
+            cursor: thirdCursor,
+            itemCount: 16,
+            totalCount: 80
+        )
+        var coordinator = WatchPageCycleCoordinator()
+
+        #expect(coordinator.receive(first) == WatchSyncPageCycleRequest(
+            cycleID: cycleID,
+            cursor: secondCursor
+        ))
+        #expect(coordinator.receive(skippedThird) == WatchSyncPageCycleRequest(
+            cycleID: cycleID,
+            cursor: secondCursor
+        ))
+        #expect(coordinator.receive(repeatedFirst) == WatchSyncPageCycleRequest(
+            cycleID: cycleID,
+            cursor: secondCursor
+        ))
+        #expect(coordinator.receive(second) == WatchSyncPageCycleRequest(
+            cycleID: cycleID,
+            cursor: thirdCursor
+        ))
+        #expect(coordinator.receive(finalThird) == nil)
+        #expect(coordinator.pendingRequest == nil)
+    }
+
+    @Test
+    func `watch page cycle keeps stale revision fences while accepting a new source`() throws {
+        let originalCycleID = UUID()
+        let replacementCycleID = UUID()
+        let originalSourceID = UUID()
+        let replacementSourceID = UUID()
+        let original = makePageCycleMetadata(
+            cycleID: originalCycleID,
+            sourceID: originalSourceID,
+            revision: 50,
+            cursor: .initial,
+            itemCount: 32,
+            totalCount: 80
+        )
+        let stale = makePageCycleMetadata(
+            cycleID: UUID(),
+            sourceID: originalSourceID,
+            revision: 49,
+            cursor: .initial,
+            itemCount: 32,
+            totalCount: 80
+        )
+        let replacement = makePageCycleMetadata(
+            cycleID: replacementCycleID,
+            sourceID: replacementSourceID,
+            revision: 1,
+            cursor: .initial,
+            itemCount: 32,
+            totalCount: 80
+        )
+        var coordinator = WatchPageCycleCoordinator()
+        let originalRequest = coordinator.receive(original)
+
+        #expect(coordinator.receive(stale) == originalRequest)
+        #expect(try coordinator.receive(replacement) == WatchSyncPageCycleRequest(
+            cycleID: replacementCycleID,
+            cursor: #require(replacement.nextCursor)
+        ))
+    }
+
+    @Test
+    func `eighty conversations configurations and tombstones complete one explicit page cycle`() throws {
+        let conversations = (0 ..< 80).map { index in
+            Conversation(
+                id: UUID(uuidString: String(
+                    format: "00000000-0000-0005-0000-%012d",
+                    index + 1
+                ))!,
+                title: "Conversation \(index)",
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index)),
+                model: "model-\(index)"
+            )
+        }
+        let tombstones = Dictionary(uniqueKeysWithValues: (0 ..< 70).map { index in
+            (
+                UUID(uuidString: String(
+                    format: "00000000-0000-0006-0000-%012d",
+                    index + 1
+                ))!,
+                WatchSyncRevision(index + 1)
+            )
+        })
+        let state = PhoneWatchSyncState(
+            conversations: conversations,
+            tombstoneRevisions: tombstones
+        )
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumManifestConversationIDs = 32
+        configuration.maximumConversationConfigurations = 32
+        configuration.maximumTombstones = 32
+        configuration.byteBudget = 30000
+        let cycleID = UUID()
+        let sourceID = UUID()
+        var phone = WatchPhonePageCycleCoordinator()
+        var watch = WatchPageCycleCoordinator()
+        var publication = WatchSyncPageCycleRequest(
+            cycleID: cycleID,
+            cursor: phone.beginCycle(id: cycleID)
+        )
+        var revision: WatchSyncRevision = 100
+        var revisions: [WatchSyncRevision] = []
+        var manifestIDs: Set<UUID> = []
+        var configurationIDs: Set<UUID> = []
+        var tombstoneIDs: Set<UUID> = []
+
+        for _ in 0 ..< 10 {
+            let page = try WatchSyncPayloadBuilder.buildPageCycle(
+                state: state,
+                sourceID: sourceID,
+                snapshotRevision: revision,
+                cycleID: publication.cycleID,
+                cursor: publication.cursor,
+                configuration: configuration
+            )
+            revisions.append(page.snapshot.revision)
+            manifestIDs.formUnion(page.snapshot.authoritativeConversationIDs)
+            configurationIDs.formUnion(page.snapshot.conversationConfigurations.map(\.id))
+            tombstoneIDs.formUnion(page.snapshot.tombstones.map(\.conversationID))
+            phone.recordPublished(page.metadata)
+
+            guard let request = watch.receive(page.metadata) else { break }
+            publication = try #require(phone.publicationRequest(for: request))
+            revision += 1
+        }
+
+        #expect(manifestIDs == Set(conversations.map(\.id)))
+        #expect(configurationIDs == Set(conversations.map(\.id)))
+        #expect(tombstoneIDs == Set(tombstones.keys))
+        #expect(revisions == [100, 101, 102])
+        #expect(watch.pendingRequest == nil)
+    }
+
+    @Test
+    func `completed shorter sections stay empty while longer sections continue`() throws {
+        let conversations = (0 ..< 80).map { index in
+            Conversation(
+                id: UUID(uuidString: String(
+                    format: "00000000-0000-0007-0000-%012d",
+                    index + 1
+                ))!,
+                title: "Conversation \(index)",
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index)),
+                model: "model"
+            )
+        }
+        let tombstones = Dictionary(uniqueKeysWithValues: (0 ..< 33).map { index in
+            (
+                UUID(uuidString: String(
+                    format: "00000000-0000-0008-0000-%012d",
+                    index + 1
+                ))!,
+                WatchSyncRevision(index + 1)
+            )
+        })
+        let state = PhoneWatchSyncState(
+            conversations: conversations,
+            tombstoneRevisions: tombstones
+        )
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumManifestConversationIDs = 32
+        configuration.maximumConversationConfigurations = 32
+        configuration.maximumTombstones = 32
+        configuration.byteBudget = 30000
+        let cycleID = UUID()
+        let sourceID = UUID()
+        var phone = WatchPhonePageCycleCoordinator()
+        var watch = WatchPageCycleCoordinator()
+        var publication = WatchSyncPageCycleRequest(
+            cycleID: cycleID,
+            cursor: phone.beginCycle(id: cycleID)
+        )
+        var revision: WatchSyncRevision = 200
+        var finalPage: WatchSyncPageCyclePayload?
+
+        for _ in 0 ..< 10 {
+            let page = try WatchSyncPayloadBuilder.buildPageCycle(
+                state: state,
+                sourceID: sourceID,
+                snapshotRevision: revision,
+                cycleID: publication.cycleID,
+                cursor: publication.cursor,
+                configuration: configuration
+            )
+            finalPage = page
+            phone.recordPublished(page.metadata)
+            guard let request = watch.receive(page.metadata) else { break }
+            publication = try #require(phone.publicationRequest(for: request))
+            revision += 1
+        }
+
+        let completed = try #require(finalPage)
+        #expect(completed.metadata.cursor.pageIndex == 2)
+        #expect(completed.metadata.tombstones.offset == 33)
+        #expect(completed.snapshot.tombstones.isEmpty)
+        #expect(completed.metadata.tombstones.itemCount == 0)
+        #expect(watch.pendingRequest == nil)
+    }
+}
+
+@Suite("Watch page cycle handshake tests", .tags(.fast))
+struct WatchPageCycleHandshakeTests {
+    @Test
+    func `standalone identity preserves retries and page cycles reset the fence`() {
+        let firstSource = UUID()
+        let replacementSource = UUID()
+        var tracker = WatchPageCycleHandshakeTracker()
+
+        let first = tracker.disposition(
+            sourceID: firstSource,
+            snapshotRevision: 1,
+            pendingRequest: nil
+        )
+        let duplicateWithRetry = tracker.disposition(
+            sourceID: firstSource,
+            snapshotRevision: 1,
+            pendingRequest: .freshCycle
+        )
+        let duplicateWithoutRetry = tracker.disposition(
+            sourceID: firstSource,
+            snapshotRevision: 1,
+            pendingRequest: nil
+        )
+        let replacementSourceSameRevision = tracker.disposition(
+            sourceID: replacementSource,
+            snapshotRevision: 1,
+            pendingRequest: nil
+        )
+        tracker.pageCycleReceived()
+        let afterPage = tracker.disposition(
+            sourceID: replacementSource,
+            snapshotRevision: 1,
+            pendingRequest: nil
+        )
+        tracker.reset()
+        let afterReset = tracker.disposition(
+            sourceID: replacementSource,
+            snapshotRevision: 1,
+            pendingRequest: nil
+        )
+
+        #expect(first == .requestFreshCycle)
+        #expect(duplicateWithRetry == .preservePendingFreshCycle)
+        #expect(duplicateWithoutRetry == .retireWithoutRequest)
+        #expect(replacementSourceSameRevision == .requestFreshCycle)
+        #expect(afterPage == .requestFreshCycle)
+        #expect(afterReset == .requestFreshCycle)
+    }
+}
+
+@Suite("Watch page cycle retry tests", .tags(.fast))
+@MainActor
+struct WatchPageCycleRetryTests {
+    @Test
+    func `lost publication repeats one exact request with bounded backoff until cancellation`() async {
+        let sleeper = TestPageCycleRetrySleeper()
+        let controller = WatchPageCycleRequestRetryController { delay in
+            try await sleeper.sleep(for: delay)
+        }
+        let request = WatchSyncPageCycleRequest(
+            cycleID: UUID(),
+            cursor: WatchSyncPageCycleCursor(
+                pageIndex: 2,
+                manifestOffset: 64,
+                configurationOffset: 48,
+                tombstoneOffset: 32
+            )
+        )
+        let requestIdentity = WatchSyncRequestIdentity.pageCycle(request)
+        var resentRequests: [WatchSyncRequestIdentity] = []
+        let resend: @MainActor @Sendable (WatchSyncRequestIdentity) -> Void = { request in
+            resentRequests.append(request)
+        }
+
+        controller.retain(requestIdentity, resend: resend)
+        await sleeper.waitForPendingSleepCount(1)
+        controller.retain(requestIdentity, resend: resend)
+
+        #expect(sleeper.delays == [5])
+        #expect(sleeper.pendingSleepCount == 1)
+
+        sleeper.resumeNext()
+        await sleeper.waitForPendingSleepCount(1)
+        await waitUntil { resentRequests.count == 1 }
+
+        #expect(resentRequests == [requestIdentity])
+        #expect(sleeper.delays == [5, 10])
+
+        sleeper.resumeNext()
+        await sleeper.waitForPendingSleepCount(1)
+        await waitUntil { resentRequests.count == 2 }
+
+        #expect(resentRequests == [requestIdentity, requestIdentity])
+        #expect(sleeper.delays == [5, 10, 20])
+
+        controller.retain(nil, resend: resend)
+        sleeper.resumeAll()
+        await Task.yield()
+
+        #expect(controller.pendingRequest == nil)
+        #expect(resentRequests == [requestIdentity, requestIdentity])
+        #expect(WatchPageCycleRetryBackoff.seconds(forAttempt: 20) == 60)
+    }
+
+    @Test
+    func `lost fresh-cycle publication retries until the first page replaces the handshake`() async {
+        let sleeper = TestPageCycleRetrySleeper()
+        let controller = WatchPageCycleRequestRetryController { delay in
+            try await sleeper.sleep(for: delay)
+        }
+        let freshCycle = WatchSyncRequestIdentity.freshCycle
+        let nextPage = WatchSyncRequestIdentity.pageCycle(WatchSyncPageCycleRequest(
+            cycleID: UUID(),
+            cursor: WatchSyncPageCycleCursor(
+                pageIndex: 1,
+                manifestOffset: 32,
+                configurationOffset: 32,
+                tombstoneOffset: 0
+            )
+        ))
+        var resentRequests: [WatchSyncRequestIdentity] = []
+        let resend: @MainActor @Sendable (WatchSyncRequestIdentity) -> Void = { request in
+            resentRequests.append(request)
+        }
+
+        controller.retain(freshCycle, resend: resend)
+        await sleeper.waitForPendingSleepCount(1)
+        sleeper.resumeNext()
+        await sleeper.waitForPendingSleepCount(1)
+        await waitUntil { resentRequests == [freshCycle] }
+
+        controller.retain(nextPage, resend: resend)
+        await sleeper.waitForPendingSleepCount(2)
+        sleeper.resumeNext()
+        await Task.yield()
+
+        #expect(resentRequests == [freshCycle])
+        #expect(controller.pendingRequest == nextPage)
+
+        sleeper.resumeNext()
+        await sleeper.waitForPendingSleepCount(1)
+        await waitUntil { resentRequests == [freshCycle, nextPage] }
+
+        #expect(sleeper.delays == [5, 10, 5, 10])
+
+        controller.cancel()
+        sleeper.resumeAll()
+    }
+
+    private func waitUntil(_ condition: @MainActor () -> Bool) async {
+        for _ in 0 ..< 100 where !condition() {
+            await Task.yield()
+        }
+        #expect(condition())
+    }
+}
+
+@Suite("Watch legacy message paging tests", .tags(.fast))
+struct WatchLegacyMessagePagingTests {
+    @Test
+    @MainActor
+    func `legacy message deltas page behind durable echoes without duplicate sends`() throws {
+        let suiteName = "WatchLegacyMessagePagingTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "state"
+        )
+        let conversationID = UUID()
+        let messages = (0 ..< 25).map { index in
+            WatchMessage(
+                id: UUID(uuidString: String(
+                    format: "00000000-0000-0000-0000-%012d",
+                    index + 1
+                ))!,
+                role: Message.Role.user.rawValue,
+                content: "message-\(index)",
+                timestamp: Date(timeIntervalSince1970: TimeInterval(index + 1))
+            )
+        }
+        let conversation = WatchConversation(
+            id: conversationID,
+            title: "Paged legacy messages",
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 25),
+            createdAt: Date(timeIntervalSince1970: 1),
+            watchRevision: 25
+        )
+        let mutation = WatchConversationMutation(
+            revision: 25,
+            conversation: conversation,
+            fields: [.messages],
+            messageChanges: messages,
+            messageChangeRevisions: Dictionary(
+                uniqueKeysWithValues: messages.enumerated().map { index, message in
+                    (message.id, WatchSyncRevision(index + 1))
+                }
+            )
+        )
+
+        let firstSend = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let firstComponentIDs = firstSend.userInfos.compactMap {
+            $0[WatchMessageKeys.legacyComponentId] as? String
+        }
+        #expect(firstComponentIDs.count == 20)
+        #expect(firstSend.userInfos.compactMap {
+            $0[WatchMessageKeys.messageId] as? String
+        } == messages.prefix(20).map(\.id.uuidString))
+
+        for componentID in firstComponentIDs.prefix(20) {
+            tracker.recordTransferCompletion(componentID: componentID, succeeded: true)
+        }
+        let beforeFirstEcho = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        #expect(beforeFirstEcho.userInfos.isEmpty)
+        #expect(beforeFirstEcho.awaitingEchoComponentIDs == Set(firstComponentIDs.prefix(20)))
+
+        var firstEcho = conversation
+        firstEcho.messages = Array(messages.prefix(20))
+        let firstReconciliation = tracker.reconcile(
+            mutation,
+            echoedConversations: [firstEcho]
+        )
+        var cumulativeCoverage = WatchMutationDeliveryCoverage()
+        for component in firstReconciliation.matchedComponents {
+            tracker.confirm(component.deliveryUserInfo(for: mutation))
+            if case let .message(messageID, revision) = component {
+                cumulativeCoverage.messageRevisions[messageID] = revision
+            }
+        }
+        #expect(!WatchLegacyEchoReconciler.canAcknowledge(
+            mutation,
+            currentMatches: firstReconciliation.matchedComponents,
+            durableCoverage: cumulativeCoverage
+        ))
+
+        let secondSend = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let secondComponentIDs = secondSend.userInfos.compactMap {
+            $0[WatchMessageKeys.legacyComponentId] as? String
+        }
+        #expect(secondComponentIDs.count == 5)
+        #expect(secondSend.userInfos.compactMap {
+            $0[WatchMessageKeys.messageId] as? String
+        } == messages.suffix(5).map(\.id.uuidString))
+        let allSentComponentIDs = firstComponentIDs + secondComponentIDs
+        #expect(Set(allSentComponentIDs).count == allSentComponentIDs.count)
+
+        for componentID in secondComponentIDs {
+            tracker.recordTransferCompletion(componentID: componentID, succeeded: true)
+        }
+        let beforeSecondEcho = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        #expect(beforeSecondEcho.userInfos.isEmpty)
+        #expect(beforeSecondEcho.awaitingEchoComponentIDs == Set(secondComponentIDs))
+
+        var secondEcho = conversation
+        secondEcho.messages = Array(messages.suffix(20))
+        let secondReconciliation = tracker.reconcile(
+            mutation,
+            echoedConversations: [secondEcho]
+        )
+        for component in secondReconciliation.matchedComponents {
+            tracker.confirm(component.deliveryUserInfo(for: mutation))
+            if case let .message(messageID, revision) = component {
+                cumulativeCoverage.messageRevisions[messageID] = revision
+            }
+        }
+
+        #expect(WatchLegacyEchoReconciler.canAcknowledge(
+            mutation,
+            currentMatches: secondReconciliation.matchedComponents,
+            durableCoverage: cumulativeCoverage
+        ))
+        let afterCumulativeEcho = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        #expect(afterCumulativeEcho.userInfos.isEmpty)
+        #expect(afterCumulativeEcho.awaitingEchoComponentIDs.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `legacy batching advances past an early awaiting echo without retransmission`() throws {
+        let suiteName = "WatchLegacyMessagePagingTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let tracker = WatchLegacyDeliveryTracker(
+            userDefaults: defaults,
+            persistenceKey: "state"
+        )
+        let messages = (0 ..< 25).map { index in
+            WatchMessage(
+                id: UUID(uuidString: String(
+                    format: "00000000-0000-0000-0001-%012d",
+                    index + 1
+                ))!,
+                role: Message.Role.user.rawValue,
+                content: "message-\(index)",
+                timestamp: Date(timeIntervalSince1970: TimeInterval(index + 1))
+            )
+        }
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Bounded suffix",
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 25),
+            createdAt: Date(timeIntervalSince1970: 1),
+            watchRevision: 25
+        )
+        let mutation = WatchConversationMutation(
+            revision: 25,
+            conversation: conversation,
+            fields: [.messages],
+            messageChanges: messages,
+            messageChangeRevisions: Dictionary(
+                uniqueKeysWithValues: messages.enumerated().map { index, message in
+                    (message.id, WatchSyncRevision(index + 1))
+                }
+            )
+        )
+
+        let firstSend = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let firstComponentIDs = firstSend.userInfos.compactMap {
+            $0[WatchMessageKeys.legacyComponentId] as? String
+        }
+        #expect(firstComponentIDs.count == 20)
+        for componentID in firstComponentIDs {
+            tracker.recordTransferCompletion(componentID: componentID, succeeded: true)
+        }
+        for index in 1 ..< 20 {
+            tracker.confirm(WatchLegacyEchoComponent.message(
+                id: messages[index].id,
+                revision: WatchSyncRevision(index + 1)
+            ).deliveryUserInfo(for: mutation))
+        }
+
+        let nextSend = try WatchLegacyMutationSender.prepare(mutation, tracker: tracker)
+        let nextMessageIDs = nextSend.userInfos.compactMap {
+            $0[WatchMessageKeys.messageId] as? String
+        }
+
+        #expect(nextMessageIDs == messages.suffix(5).map(\.id.uuidString))
+        #expect(nextSend.awaitingEchoComponentIDs == [firstComponentIDs[0]])
+        #expect(!nextSend.componentIDs.contains(firstComponentIDs[0]))
+        #expect(nextSend.userInfos.count + nextSend.awaitingEchoComponentIDs.count <= 20)
+    }
+}
+
+@Suite("Watch mutation ingress validation tests", .tags(.fast))
+struct WatchMutationIngressValidationTests {
+    @Test
+    func `mutation ingress accepts supported schemas and rejects malformed or future versions`() {
+        for schemaVersion in 1 ... WatchSyncSnapshot.currentSchemaVersion {
+            #expect(WatchMutationIngressValidator.validate(
+                schemaVersion: NSNumber(value: schemaVersion),
+                fields: [.messages]
+            ) == .accepted(schemaVersion: schemaVersion))
+        }
+
+        let malformedSchemas: [Any?] = [
+            nil,
+            "1",
+            true,
+            NSNumber(value: 0),
+            NSNumber(value: -1),
+            NSNumber(value: 1.5)
+        ]
+        for schemaVersion in malformedSchemas {
+            #expect(WatchMutationIngressValidator.validate(
+                schemaVersion: schemaVersion,
+                fields: [.messages]
+            ) == .rejected(.malformedSchema))
+        }
+
+        let futureSchema = WatchSyncSnapshot.currentSchemaVersion + 1
+        #expect(WatchMutationIngressValidator.validate(
+            schemaVersion: NSNumber(value: futureSchema),
+            fields: [.messages]
+        ) == .rejected(.unsupportedSchema(futureSchema)))
+    }
+
+    @Test
+    func `mutation ingress rejects an empty field mask before reduction`() {
+        #expect(WatchMutationIngressValidator.validate(
+            schemaVersion: NSNumber(value: WatchSyncSnapshot.currentSchemaVersion),
+            fields: []
+        ) == .rejected(.emptyFieldMask))
+    }
+
+    @Test
+    func `mutation ingress rejects unknown field mask bits before reduction`() {
+        let unknownBit: UInt8 = 1 << 7
+        for fields in [
+            WatchConversationMutationFields(rawValue: unknownBit),
+            WatchConversationMutationFields.messages.union(
+                WatchConversationMutationFields(rawValue: unknownBit)
+            )
+        ] {
+            #expect(WatchMutationIngressValidator.validate(
+                schemaVersion: NSNumber(value: WatchSyncSnapshot.currentSchemaVersion),
+                fields: fields
+            ) == .rejected(.unknownFieldMask(unknownBit)))
+        }
+    }
+
+    @Test
+    func `unsupported mutation reply cannot acknowledge the durable outbox`() {
+        let mutation = makeLegacyMessageMutation(content: "Unsupported")
+
+        let reply = WatchMutationReply.unsupported(for: mutation).message
+
+        #expect(reply[WatchMessageKeys.status] as? String == "unsupported")
+        #expect(reply[WatchMessageKeys.operationId] as? String == mutation.operationID.uuidString)
+        #expect(reply[WatchMessageKeys.conversationId] as? String == mutation.conversationID.uuidString)
+        #expect(reply[WatchMessageKeys.acknowledgedRevision] == nil)
+    }
+}
+
+@Suite("Watch mutation file transport tests", .tags(.fast))
+struct WatchMutationFileTransportTests {
+    @Test
+    func `stale sessions and malformed metadata are rejected before file inspection`() {
+        let missingFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let mutation = makeLegacyMessageMutation(content: "metadata fence")
+
+        expectWatchMutationFileError(.staleSession) {
+            _ = try WatchMutationFileTransport.receive(
+                fileURL: missingFileURL,
+                metadata: [:],
+                sessionIsCurrent: false
+            )
+        }
+
+        var malformedMetadata = mutationFileMetadata(for: mutation)
+        malformedMetadata.removeValue(forKey: WatchMessageKeys.operationId)
+        expectWatchMutationFileError(.invalidMetadata) {
+            _ = try WatchMutationFileTransport.receive(
+                fileURL: missingFileURL,
+                metadata: malformedMetadata,
+                sessionIsCurrent: true
+            )
+        }
+    }
+
+    @Test
+    func `oversized mutation files are rejected from resource size`() throws {
+        let mutation = makeLegacyMessageMutation(content: "oversized")
+        let fileURL = try temporaryMutationFileURL()
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+        #expect(FileManager.default.createFile(atPath: fileURL.path, contents: nil))
+        let fileHandle = try FileHandle(forWritingTo: fileURL)
+        try fileHandle.truncate(
+            atOffset: UInt64(WatchMutationFileTransport.maximumBytes + 1)
+        )
+        try fileHandle.close()
+
+        expectWatchMutationFileError(.exceedsMaximum(
+            actualBytes: WatchMutationFileTransport.maximumBytes + 1,
+            maximumBytes: WatchMutationFileTransport.maximumBytes
+        )) {
+            _ = try WatchMutationFileTransport.receive(
+                fileURL: fileURL,
+                metadata: mutationFileMetadata(for: mutation),
+                sessionIsCurrent: true
+            )
+        }
+    }
+
+    @Test
+    func `malformed mutation files and metadata identity mismatches are rejected`() throws {
+        let mutation = makeLegacyMessageMutation(content: "malformed")
+        let malformedFileURL = try temporaryMutationFileURL()
+        let mismatchedFileURL = try temporaryMutationFileURL()
+        defer {
+            try? FileManager.default.removeItem(at: malformedFileURL.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: mismatchedFileURL.deletingLastPathComponent())
+        }
+
+        try Data("not-json".utf8).write(to: malformedFileURL)
+        expectWatchMutationFileError(.malformedPayload) {
+            _ = try WatchMutationFileTransport.receive(
+                fileURL: malformedFileURL,
+                metadata: mutationFileMetadata(for: mutation),
+                sessionIsCurrent: true
+            )
+        }
+
+        try WatchSyncPayloadBuilder.encodeMutation(mutation).write(to: mismatchedFileURL)
+        var mismatchedMetadata = mutationFileMetadata(for: mutation)
+        mismatchedMetadata[WatchMessageKeys.operationId] = UUID().uuidString
+        expectWatchMutationFileError(.metadataIdentityMismatch) {
+            _ = try WatchMutationFileTransport.receive(
+                fileURL: mismatchedFileURL,
+                metadata: mismatchedMetadata,
+                sessionIsCurrent: true
+            )
+        }
+    }
+
+    @Test
+    func `valid mutation file at the hard boundary is accepted`() throws {
+        let mutation = makeLegacyMessageMutation(content: "boundary")
+        var data = try WatchSyncPayloadBuilder.encodeMutation(mutation)
+        #expect(data.count < WatchMutationFileTransport.maximumBytes)
+        data.append(Data(
+            repeating: 0x20,
+            count: WatchMutationFileTransport.maximumBytes - data.count
+        ))
+        let fileURL = try temporaryMutationFileURL()
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+        try data.write(to: fileURL)
+
+        let received = try WatchMutationFileTransport.receive(
+            fileURL: fileURL,
+            metadata: mutationFileMetadata(for: mutation),
+            sessionIsCurrent: true
+        )
+
+        #expect(received.mutation == mutation)
+        #expect(received.schemaVersion == WatchSyncSnapshot.currentSchemaVersion)
+        #expect(received.byteCount == WatchMutationFileTransport.maximumBytes)
+    }
+
+    @Test
+    func `outgoing mutation files enforce the ingress hard maximum`() throws {
+        let mutation = makeLegacyMessageMutation(
+            content: String(
+                repeating: "x",
+                count: WatchMutationFileTransport.maximumBytes + 1
+            )
+        )
+        let encoded = try WatchSyncPayloadBuilder.encodeMutation(mutation)
+        #expect(encoded.count > WatchMutationFileTransport.maximumBytes)
+
+        expectWatchMutationFileError(.exceedsMaximum(
+            actualBytes: encoded.count,
+            maximumBytes: WatchMutationFileTransport.maximumBytes
+        )) {
+            _ = try WatchMutationFileTransport.encodedData(for: mutation)
+        }
+    }
+}
+
+private func modelMetadataState(model: String, key: String) -> WatchModelMetadataState {
+    WatchModelMetadataState(
+        selectedModel: model,
+        availableModels: [model],
+        customModels: [model],
+        defaultProvider: "openai",
+        modelProviders: [model: "openai"],
+        modelEndpoints: [model: "https://example.com/v1"],
+        modelEndpointTypes: [model: "responses"],
+        modelUsesGitHubOAuth: [model: false],
+        modelAPIKeys: [model: key]
+    )
+}
+
+private func makePageCycleMetadata(
+    cycleID: UUID,
+    sourceID: UUID,
+    revision: WatchSyncRevision,
+    cursor: WatchSyncPageCycleCursor,
+    itemCount: Int,
+    totalCount: Int
+) -> WatchSyncPageCycleMetadata {
+    let section = WatchSyncPageSection(
+        offset: cursor.manifestOffset,
+        itemCount: itemCount,
+        totalCount: totalCount
+    )
+    return WatchSyncPageCycleMetadata(
+        cycleID: cycleID,
+        sourceID: sourceID,
+        snapshotRevision: revision,
+        cursor: cursor,
+        manifest: section,
+        configurations: WatchSyncPageSection(
+            offset: cursor.configurationOffset,
+            itemCount: itemCount,
+            totalCount: totalCount
+        ),
+        tombstones: WatchSyncPageSection(
+            offset: cursor.tombstoneOffset,
+            itemCount: itemCount,
+            totalCount: totalCount
+        )
+    )
+}
+
+private func makeLegacyMessageMutation(content: String) -> WatchConversationMutation {
+    let message = WatchMessage(
+        id: UUID(),
+        role: Message.Role.user.rawValue,
+        content: content,
+        timestamp: Date(timeIntervalSince1970: 20)
+    )
+    let conversation = WatchConversation(
+        id: UUID(),
+        title: "Legacy",
+        messages: [message],
+        model: "model",
+        updatedAt: Date(timeIntervalSince1970: 20),
+        createdAt: Date(timeIntervalSince1970: 10),
+        watchRevision: 1
+    )
+    return WatchConversationMutation(
+        revision: 1,
+        conversation: conversation,
+        fields: [.messages],
+        messageChanges: [message],
+        messageChangeRevisions: [message.id: 1]
+    )
+}
+
+private func mutationFileMetadata(
+    for mutation: WatchConversationMutation
+) -> [String: Any] {
+    [
+        WatchMessageKeys.type: WatchMessageKeys.typeMutationFile,
+        WatchMessageKeys.operationId: mutation.operationID.uuidString,
+        WatchMessageKeys.conversationId: mutation.conversationID.uuidString,
+        WatchMessageKeys.schemaVersion: NSNumber(value: WatchSyncSnapshot.currentSchemaVersion)
+    ]
+}
+
+private func temporaryMutationFileURL() throws -> URL {
+    let directoryURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("WatchMutationFileTransportTests", isDirectory: true)
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: true
+    )
+    return directoryURL.appendingPathComponent("mutation.json")
+}
+
+private func expectWatchMutationFileError(
+    _ expected: WatchMutationFileTransportError,
+    performing operation: () throws -> Void
+) {
+    do {
+        try operation()
+        Issue.record("Expected Watch mutation file error: \(expected)")
+    } catch let error as WatchMutationFileTransportError {
+        #expect(error == expected)
+    } catch {
+        Issue.record("Unexpected Watch mutation file error: \(error)")
+    }
+}
+
+private struct LegacyTitleDeliveryState: Codable {
+    var createdConversationIDs: Set<UUID> = []
+    var messageRevisions: [UUID: [UUID: WatchSyncRevision]] = [:]
+    var titles: [UUID: String]
+    var configurationRevisions: [UUID: WatchSyncRevision] = [:]
+}
+
+@MainActor
+private final class PendingDestructiveOperationState {
+    @Published var count: Int
+
+    init(count: Int) {
+        self.count = count
+    }
+}
+
+@MainActor
+private final class TestPageCycleRetrySleeper {
+    private(set) var delays: [TimeInterval] = []
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    var pendingSleepCount: Int {
+        continuations.count
+    }
+
+    func sleep(for delay: TimeInterval) async throws {
+        delays.append(delay)
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+        try Task.checkCancellation()
+    }
+
+    func waitForPendingSleepCount(_ count: Int) async {
+        for _ in 0 ..< 100 where pendingSleepCount < count {
+            await Task.yield()
+        }
+        #expect(pendingSleepCount == count)
+    }
+
+    func resumeNext() {
+        guard !continuations.isEmpty else { return }
+        continuations.removeFirst().resume()
+    }
+
+    func resumeAll() {
+        let pending = continuations
+        continuations.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}
+
+@MainActor
+private final class TestAsyncGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = continuations
+        continuations.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}

--- a/Tests/AynaTests/WatchConversationStoreNativeTests.swift
+++ b/Tests/AynaTests/WatchConversationStoreNativeTests.swift
@@ -1,321 +1,329 @@
 #if os(watchOS)
 
 //
-//  WatchConversationStoreNativeTests.swift
-//  Ayna-watchOSTests
+    //  WatchConversationStoreNativeTests.swift
+    //  Ayna-watchOSTests
 //
-//  Unit tests for WatchConversationStore running natively on watchOS
+    //  Unit tests for WatchConversationStore running natively on watchOS
 //
 
-@testable import Ayna
-import Foundation
-import Testing
+    @testable import Ayna
+    import Foundation
+    import Testing
 
-@Suite("WatchConversationStore Native Tests")
-@MainActor
-struct WatchConversationStoreNativeTests {
-    private var store: WatchConversationStore
-    private let persistenceKey = "com.sertacozercan.ayna.watch.conversations"
+    @Suite("WatchConversationStore Native Tests")
+    @MainActor
+    struct WatchConversationStoreNativeTests {
+        private let userDefaults: UserDefaults
+        private let persistenceKey: String
+        private let store: WatchConversationStore
 
-    init() {
-        // Clear any existing test data
-        UserDefaults.standard.removeObject(forKey: persistenceKey)
-        // Note: WatchConversationStore.shared is a singleton, so we test through it
-        store = WatchConversationStore.shared
-        // Clear existing conversations for clean test state
-        store.updateConversations([])
-    }
+        init() {
+            let suiteName = "WatchConversationStoreNativeTests.\(UUID().uuidString)"
+            guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+                fatalError("Failed to create isolated UserDefaults suite")
+            }
+            userDefaults.removePersistentDomain(forName: suiteName)
 
-    // MARK: - Conversation Creation Tests
-
-    @Test("Create conversation with title and model")
-    func createConversation() {
-        let conversation = store.createConversation(title: "Test Chat", model: "gpt-4o")
-
-        #expect(conversation.title == "Test Chat")
-        #expect(conversation.model == "gpt-4o")
-        #expect(conversation.messages.isEmpty)
-        #expect(store.conversations.contains { $0.id == conversation.id })
-    }
-
-    @Test("Create conversation with default title")
-    func createConversationWithDefaultTitle() {
-        let conversation = store.createConversation(model: "gpt-4")
-
-        #expect(conversation.title == "New Chat")
-        #expect(conversation.model == "gpt-4")
-    }
-
-    @Test("New conversation appears first")
-    func newConversationAppearsFirst() async {
-        // Create first conversation
-        let first = store.createConversation(model: "gpt-4o")
-
-        // Wait a bit to ensure different timestamps
-        try? await Task.sleep(for: .milliseconds(100))
-
-        // Create second conversation
-        let second = store.createConversation(model: "gpt-4")
-
-        // Second should be at index 0 (most recent)
-        #expect(store.conversations.first?.id == second.id)
-        #expect(store.conversations.contains { $0.id == first.id })
-    }
-
-    // MARK: - Message Management Tests
-
-    @Test("Add message to conversation")
-    func addMessageToConversation() {
-        let conversation = store.createConversation(model: "gpt-4o")
-        let message = WatchMessage(from: Message(role: .user, content: "Hello"))
-
-        store.addMessage(message, to: conversation.id)
-
-        let updated = store.conversation(for: conversation.id)
-        #expect(updated?.messages.count == 1)
-        #expect(updated?.messages.first?.content == "Hello")
-        #expect(updated?.messages.first?.role == "user")
-    }
-
-    @Test("Add multiple messages")
-    func addMultipleMessages() {
-        let conversation = store.createConversation(model: "gpt-4o")
-
-        let userMessage = WatchMessage(from: Message(role: .user, content: "Hi"))
-        let assistantMessage = WatchMessage(from: Message(role: .assistant, content: "Hello!"))
-
-        store.addMessage(userMessage, to: conversation.id)
-        store.addMessage(assistantMessage, to: conversation.id)
-
-        let updated = store.conversation(for: conversation.id)
-        #expect(updated?.messages.count == 2)
-        #expect(updated?.messages[0].role == "user")
-        #expect(updated?.messages[1].role == "assistant")
-    }
-
-    @Test("Update last message")
-    func updateLastMessage() {
-        let conversation = store.createConversation(model: "gpt-4o")
-        let message = WatchMessage(from: Message(role: .assistant, content: ""))
-
-        store.addMessage(message, to: conversation.id)
-        store.updateLastMessage(in: conversation.id, content: "Streaming content...")
-
-        let updated = store.conversation(for: conversation.id)
-        #expect(updated?.messages.last?.content == "Streaming content...")
-    }
-
-    @Test("Update last message streaming")
-    func updateLastMessageStreaming() {
-        let conversation = store.createConversation(model: "gpt-4o")
-        let message = WatchMessage(from: Message(role: .assistant, content: ""))
-
-        store.addMessage(message, to: conversation.id)
-
-        // Simulate streaming updates
-        store.updateLastMessage(in: conversation.id, content: "Hello")
-        store.updateLastMessage(in: conversation.id, content: "Hello, ")
-        store.updateLastMessage(in: conversation.id, content: "Hello, World!")
-
-        let updated = store.conversation(for: conversation.id)
-        #expect(updated?.messages.last?.content == "Hello, World!")
-    }
-
-    @Test("Update last message persists streamed content")
-    func updateLastMessagePersistsStreamedContent() throws {
-        let conversation = store.createConversation(model: "gpt-4o")
-        let message = WatchMessage(from: Message(role: .assistant, content: ""))
-
-        store.addMessage(message, to: conversation.id)
-        store.updateLastMessage(in: conversation.id, content: "Persist me")
-
-        guard let data = UserDefaults.standard.data(forKey: persistenceKey) else {
-            Issue.record("Expected persisted watch conversations data")
-            return
+            let persistenceKey = "state"
+            self.userDefaults = userDefaults
+            self.persistenceKey = persistenceKey
+            store = WatchConversationStore(
+                userDefaults: userDefaults,
+                persistenceKey: persistenceKey,
+                mutationEnqueuer: { _ in }
+            )
         }
 
-        let decoded = try JSONDecoder().decode([WatchConversation].self, from: data)
-        let persistedConversation = decoded.first { $0.id == conversation.id }
-        #expect(persistedConversation?.messages.last?.content == "Persist me")
-    }
+        // MARK: - Conversation Creation Tests
 
-    // MARK: - Conversation Retrieval Tests
+        @Test
+        func `create conversation with title and model`() throws {
+            let conversation = try #require(store.createConversation(title: "Test Chat", model: "gpt-4o"))
 
-    @Test("Get conversation for valid ID")
-    func conversationForValidId() {
-        let conversation = store.createConversation(model: "gpt-4o")
+            #expect(conversation.title == "Test Chat")
+            #expect(conversation.model == "gpt-4o")
+            #expect(conversation.messages.isEmpty)
+            #expect(store.conversations.contains { $0.id == conversation.id })
+        }
 
-        let retrieved = store.conversation(for: conversation.id)
+        @Test
+        func `create conversation with default title`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4"))
 
-        #expect(retrieved != nil)
-        #expect(retrieved?.id == conversation.id)
-    }
+            #expect(conversation.title == "New Chat")
+            #expect(conversation.model == "gpt-4")
+        }
 
-    @Test("Get conversation for invalid ID returns nil")
-    func conversationForInvalidId() {
-        let randomId = UUID()
-        let retrieved = store.conversation(for: randomId)
+        @Test
+        func `new conversation appears first`() async throws {
+            // Create first conversation
+            let first = try #require(store.createConversation(model: "gpt-4o"))
 
-        #expect(retrieved == nil)
-    }
+            // Wait a bit to ensure different timestamps
+            try? await Task.sleep(for: .milliseconds(100))
 
-    // MARK: - Preview Text Tests
+            // Create second conversation
+            let second = try #require(store.createConversation(model: "gpt-4"))
 
-    @Test("Preview text with messages")
-    func previewTextWithMessages() {
-        let conversation = store.createConversation(model: "gpt-4o")
-        let message = WatchMessage(from: Message(role: .assistant, content: "This is a response"))
+            // Second should be at index 0 (most recent)
+            #expect(store.conversations.first?.id == second.id)
+            #expect(store.conversations.contains { $0.id == first.id })
+        }
 
-        store.addMessage(message, to: conversation.id)
+        // MARK: - Message Management Tests
 
-        if let updated = store.conversation(for: conversation.id) {
-            let preview = store.previewText(for: updated)
-            #expect(preview == "This is a response")
-        } else {
-            Issue.record("Conversation should exist")
+        @Test
+        func `add message to conversation`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            let message = WatchMessage(from: Message(role: .user, content: "Hello"))
+
+            store.addMessage(message, to: conversation.id)
+
+            let updated = store.conversation(for: conversation.id)
+            #expect(updated?.messages.count == 1)
+            #expect(updated?.messages.first?.content == "Hello")
+            #expect(updated?.messages.first?.role == "user")
+        }
+
+        @Test
+        func `add multiple messages`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+
+            let userMessage = WatchMessage(from: Message(role: .user, content: "Hi"))
+            let assistantMessage = WatchMessage(from: Message(role: .assistant, content: "Hello!"))
+
+            store.addMessage(userMessage, to: conversation.id)
+            store.addMessage(assistantMessage, to: conversation.id)
+
+            let updated = store.conversation(for: conversation.id)
+            #expect(updated?.messages.count == 2)
+            #expect(updated?.messages[0].role == "user")
+            #expect(updated?.messages[1].role == "assistant")
+        }
+
+        @Test
+        func `update last message`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            let message = WatchMessage(from: Message(role: .assistant, content: ""))
+
+            store.addMessage(message, to: conversation.id)
+            store.updateLastMessage(in: conversation.id, content: "Streaming content...")
+
+            let updated = store.conversation(for: conversation.id)
+            #expect(updated?.messages.last?.content == "Streaming content...")
+        }
+
+        @Test
+        func `update last message streaming`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            let message = WatchMessage(from: Message(role: .assistant, content: ""))
+
+            store.addMessage(message, to: conversation.id)
+
+            // Simulate streaming updates
+            store.updateLastMessage(in: conversation.id, content: "Hello")
+            store.updateLastMessage(in: conversation.id, content: "Hello, ")
+            store.updateLastMessage(in: conversation.id, content: "Hello, World!")
+
+            let updated = store.conversation(for: conversation.id)
+            #expect(updated?.messages.last?.content == "Hello, World!")
+        }
+
+        @Test
+        func `update last message persists streamed content`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            let message = WatchMessage(from: Message(role: .assistant, content: ""))
+
+            store.addMessage(message, to: conversation.id)
+            store.updateLastMessage(in: conversation.id, content: "Persist me")
+
+            let reloadedStore = WatchConversationStore(
+                userDefaults: userDefaults,
+                persistenceKey: persistenceKey,
+                mutationEnqueuer: { _ in }
+            )
+            let persistedConversation = reloadedStore.conversation(for: conversation.id)
+            #expect(persistedConversation?.messages.last?.content == "Persist me")
+        }
+
+        // MARK: - Conversation Retrieval Tests
+
+        @Test
+        func `get conversation for valid ID`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+
+            let retrieved = store.conversation(for: conversation.id)
+
+            #expect(retrieved != nil)
+            #expect(retrieved?.id == conversation.id)
+        }
+
+        @Test
+        func `get conversation for invalid ID returns nil`() {
+            let randomId = UUID()
+            let retrieved = store.conversation(for: randomId)
+
+            #expect(retrieved == nil)
+        }
+
+        // MARK: - Preview Text Tests
+
+        @Test
+        func `preview text with messages`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            let message = WatchMessage(from: Message(role: .assistant, content: "This is a response"))
+
+            store.addMessage(message, to: conversation.id)
+
+            if let updated = store.conversation(for: conversation.id) {
+                let preview = store.previewText(for: updated)
+                #expect(preview == "This is a response")
+            } else {
+                Issue.record("Conversation should exist")
+            }
+        }
+
+        @Test
+        func `preview text with long message truncates`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            let longContent = String(repeating: "A", count: 100)
+            let message = WatchMessage(from: Message(role: .assistant, content: longContent))
+
+            store.addMessage(message, to: conversation.id)
+
+            if let updated = store.conversation(for: conversation.id) {
+                let preview = store.previewText(for: updated)
+                #expect(preview.count <= 53) // 50 chars + "..."
+                #expect(preview.hasSuffix("..."))
+            } else {
+                Issue.record("Conversation should exist")
+            }
+        }
+
+        @Test
+        func `preview text for empty conversation`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+
+            let preview = store.previewText(for: conversation)
+            #expect(preview == "No messages")
+        }
+
+        // MARK: - Delete Tests
+
+        @Test
+        func `delete conversation`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            #expect(store.conversations.contains { $0.id == conversation.id })
+
+            store.deleteConversation(conversation.id)
+
+            #expect(!store.conversations.contains { $0.id == conversation.id })
+            #expect(store.conversation(for: conversation.id) == nil)
+        }
+
+        @Test
+        func `delete conversation clears selection`() throws {
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            store.selectedConversationId = conversation.id
+
+            store.deleteConversation(conversation.id)
+
+            #expect(store.selectedConversationId == nil)
+        }
+
+        // MARK: - Rename Tests
+
+        @Test
+        func `rename conversation`() throws {
+            let conversation = try #require(store.createConversation(title: "Original", model: "gpt-4o"))
+
+            store.renameConversation(conversation.id, newTitle: "Renamed Chat")
+
+            let updated = store.conversation(for: conversation.id)
+            #expect(updated?.title == "Renamed Chat")
+        }
+
+        // MARK: - Update Conversations Tests
+
+        @Test
+        func `update conversations merges with remote`() throws {
+            // Create a local conversation
+            let local = try #require(store.createConversation(title: "Local Chat", model: "gpt-4o"))
+
+            // Simulate sync from iPhone with a new conversation
+            let remoteId = UUID()
+            let remote = WatchConversation(
+                from: Conversation(id: remoteId, title: "Remote Chat", model: "gpt-4")
+            )
+
+            store.updateConversations([remote])
+
+            // Both should exist
+            #expect(store.conversation(for: local.id) != nil)
+            #expect(store.conversation(for: remoteId) != nil)
+        }
+
+        @Test
+        func `update conversations preserves local title`() throws {
+            // Create a local conversation with generated title
+            let conversation = try #require(store.createConversation(title: "Generated Title", model: "gpt-4o"))
+
+            // Simulate sync from iPhone with "New Chat" title (not yet generated on iPhone)
+            let syncedConversation = WatchConversation(
+                from: Conversation(id: conversation.id, title: "New Chat", model: "gpt-4o")
+            )
+
+            store.updateConversations([syncedConversation])
+
+            // Local title should be preserved
+            let updated = store.conversation(for: conversation.id)
+            #expect(updated?.title == "Generated Title")
+        }
+
+        @Test
+        func `update conversations preserves local messages`() throws {
+            // Create a local conversation with messages
+            let conversation = try #require(store.createConversation(model: "gpt-4o"))
+            let userMsg = WatchMessage(from: Message(role: .user, content: "Hello"))
+            let assistantMsg = WatchMessage(from: Message(role: .assistant, content: "Hi!"))
+            store.addMessage(userMsg, to: conversation.id)
+            store.addMessage(assistantMsg, to: conversation.id)
+
+            // Simulate sync from iPhone with fewer messages (iPhone behind during streaming)
+            var syncedConversation = WatchConversation(
+                from: Conversation(id: conversation.id, title: "New Chat", model: "gpt-4o")
+            )
+            syncedConversation.messages = [userMsg] // Only 1 message
+
+            store.updateConversations([syncedConversation])
+
+            // Local messages should be preserved (we have more)
+            let updated = store.conversation(for: conversation.id)
+            #expect(updated?.messages.count == 2)
+        }
+
+        @Test
+        func `update conversations sorts by recent`() async throws {
+            // Create conversations
+            let older = try #require(store.createConversation(title: "Older", model: "gpt-4o"))
+            try? await Task.sleep(for: .milliseconds(100))
+            let newer = try #require(store.createConversation(title: "Newer", model: "gpt-4o"))
+
+            // Verify newer is first
+            #expect(store.conversations.first?.id == newer.id)
+
+            // Update older conversation to have newer updatedAt
+            var updatedOlder = WatchConversation(
+                from: Conversation(id: older.id, title: "Older Updated", model: "gpt-4o")
+            )
+            updatedOlder.updatedAt = Date()
+
+            store.updateConversations([updatedOlder])
+
+            // Older should now be first (most recently updated)
+            #expect(store.conversations.first?.id == older.id)
         }
     }
-
-    @Test("Preview text with long message truncates")
-    func previewTextWithLongMessage() {
-        let conversation = store.createConversation(model: "gpt-4o")
-        let longContent = String(repeating: "A", count: 100)
-        let message = WatchMessage(from: Message(role: .assistant, content: longContent))
-
-        store.addMessage(message, to: conversation.id)
-
-        if let updated = store.conversation(for: conversation.id) {
-            let preview = store.previewText(for: updated)
-            #expect(preview.count <= 53) // 50 chars + "..."
-            #expect(preview.hasSuffix("..."))
-        } else {
-            Issue.record("Conversation should exist")
-        }
-    }
-
-    @Test("Preview text for empty conversation")
-    func previewTextEmptyConversation() {
-        let conversation = store.createConversation(model: "gpt-4o")
-
-        let preview = store.previewText(for: conversation)
-        #expect(preview == "No messages")
-    }
-
-    // MARK: - Delete Tests
-
-    @Test("Delete conversation")
-    func deleteConversation() {
-        let conversation = store.createConversation(model: "gpt-4o")
-        #expect(store.conversations.contains { $0.id == conversation.id })
-
-        store.deleteConversation(conversation.id)
-
-        #expect(!store.conversations.contains { $0.id == conversation.id })
-        #expect(store.conversation(for: conversation.id) == nil)
-    }
-
-    @Test("Delete conversation clears selection")
-    func deleteConversationClearsSelection() {
-        let conversation = store.createConversation(model: "gpt-4o")
-        store.selectedConversationId = conversation.id
-
-        store.deleteConversation(conversation.id)
-
-        #expect(store.selectedConversationId == nil)
-    }
-
-    // MARK: - Rename Tests
-
-    @Test("Rename conversation")
-    func renameConversation() {
-        let conversation = store.createConversation(title: "Original", model: "gpt-4o")
-
-        store.renameConversation(conversation.id, newTitle: "Renamed Chat")
-
-        let updated = store.conversation(for: conversation.id)
-        #expect(updated?.title == "Renamed Chat")
-    }
-
-    // MARK: - Update Conversations Tests
-
-    @Test("Update conversations merges with remote")
-    func updateConversationsMerge() {
-        // Create a local conversation
-        let local = store.createConversation(title: "Local Chat", model: "gpt-4o")
-
-        // Simulate sync from iPhone with a new conversation
-        let remoteId = UUID()
-        let remote = WatchConversation(
-            from: Conversation(id: remoteId, title: "Remote Chat", model: "gpt-4")
-        )
-
-        store.updateConversations([remote])
-
-        // Both should exist
-        #expect(store.conversation(for: local.id) != nil)
-        #expect(store.conversation(for: remoteId) != nil)
-    }
-
-    @Test("Update conversations preserves local title")
-    func updateConversationsPreservesLocalTitle() {
-        // Create a local conversation with generated title
-        let conversation = store.createConversation(title: "Generated Title", model: "gpt-4o")
-
-        // Simulate sync from iPhone with "New Chat" title (not yet generated on iPhone)
-        let syncedConversation = WatchConversation(
-            from: Conversation(id: conversation.id, title: "New Chat", model: "gpt-4o")
-        )
-
-        store.updateConversations([syncedConversation])
-
-        // Local title should be preserved
-        let updated = store.conversation(for: conversation.id)
-        #expect(updated?.title == "Generated Title")
-    }
-
-    @Test("Update conversations preserves local messages")
-    func updateConversationsPreservesLocalMessages() {
-        // Create a local conversation with messages
-        let conversation = store.createConversation(model: "gpt-4o")
-        let userMsg = WatchMessage(from: Message(role: .user, content: "Hello"))
-        let assistantMsg = WatchMessage(from: Message(role: .assistant, content: "Hi!"))
-        store.addMessage(userMsg, to: conversation.id)
-        store.addMessage(assistantMsg, to: conversation.id)
-
-        // Simulate sync from iPhone with fewer messages (iPhone behind during streaming)
-        var syncedConversation = WatchConversation(
-            from: Conversation(id: conversation.id, title: "New Chat", model: "gpt-4o")
-        )
-        syncedConversation.messages = [userMsg] // Only 1 message
-
-        store.updateConversations([syncedConversation])
-
-        // Local messages should be preserved (we have more)
-        let updated = store.conversation(for: conversation.id)
-        #expect(updated?.messages.count == 2)
-    }
-
-    @Test("Update conversations sorts by recent")
-    func updateConversationsSortsByRecent() async {
-        // Create conversations
-        let older = store.createConversation(title: "Older", model: "gpt-4o")
-        try? await Task.sleep(for: .milliseconds(100))
-        let newer = store.createConversation(title: "Newer", model: "gpt-4o")
-
-        // Verify newer is first
-        #expect(store.conversations.first?.id == newer.id)
-
-        // Update older conversation to have newer updatedAt
-        var updatedOlder = WatchConversation(
-            from: Conversation(id: older.id, title: "Older Updated", model: "gpt-4o")
-        )
-        updatedOlder.updatedAt = Date()
-
-        store.updateConversations([updatedOlder])
-
-        // Older should now be first (most recently updated)
-        #expect(store.conversations.first?.id == older.id)
-    }
-}
 
 #endif

--- a/Tests/AynaTests/WatchDataModelHostTests.swift
+++ b/Tests/AynaTests/WatchDataModelHostTests.swift
@@ -1,0 +1,331 @@
+// swiftlint:disable identifier_name
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Watch data model host tests", .tags(.fast))
+struct WatchDataModelHostTests {
+    @Test
+    func `Watch message round trips stable identity and metadata`() throws {
+        let id = UUID()
+        let timestamp = Date(timeIntervalSince1970: 100)
+        let call = MCPToolCall(
+            id: "call",
+            toolName: "lookup",
+            arguments: ["query": AnyCodable("weather")],
+            result: "sunny",
+            timestamp: timestamp
+        )
+        let original = Message(
+            id: id,
+            role: .assistant,
+            content: "Result",
+            timestamp: timestamp,
+            toolCalls: [call],
+            model: "gpt-test",
+            citations: [CitationReference(number: 1, title: "Source", url: "https://example.com")]
+        )
+
+        let encoded = try JSONEncoder().encode(WatchMessage(from: original))
+        let decoded = try JSONDecoder().decode(WatchMessage.self, from: encoded)
+        let restored = decoded.toMessage()
+
+        #expect(restored.id == id)
+        #expect(restored.role == .assistant)
+        #expect(restored.content == "Result")
+        #expect(restored.timestamp == timestamp)
+        #expect(restored.model == "gpt-test")
+        #expect(restored.toolCalls == [call])
+        #expect(restored.citations == original.citations)
+    }
+
+    @Test
+    func `Compact request configuration round trips and clears a retained prompt without touching messages`() throws {
+        let conversationID = UUID()
+        let retainedMessage = WatchMessage(from: Message(role: .user, content: "Keep me"))
+        var conversation = WatchConversation(
+            id: conversationID,
+            title: "Retained",
+            messages: [retainedMessage],
+            model: "old-model",
+            updatedAt: Date(timeIntervalSince1970: 2),
+            createdAt: Date(timeIntervalSince1970: 1),
+            temperature: 1.0,
+            resolvedSystemPrompt: "Old prompt"
+        )
+        let original = WatchConversationRequestConfiguration(
+            id: conversationID,
+            model: "new-model",
+            temperature: 0.3,
+            resolvedSystemPrompt: nil
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            WatchConversationRequestConfiguration.self,
+            from: data
+        )
+        decoded.apply(to: &conversation)
+
+        #expect(decoded == original)
+        #expect(conversation.model == "new-model")
+        #expect(conversation.temperature == 0.3)
+        #expect(conversation.resolvedSystemPrompt == nil)
+        #expect(conversation.messages == [retainedMessage])
+    }
+
+    @Test
+    func `Long custom model identifiers preserve settings key identity across data model Codable`() throws {
+        let maximumModelCharacters = WatchSyncPayloadConfiguration.default.maximumModelCharacters
+        let model = "custom-provider/" + String(repeating: "data-model-segment-", count: 12)
+        #expect(model.count > maximumModelCharacters)
+        let message = WatchMessage(
+            id: UUID(),
+            role: Message.Role.assistant.rawValue,
+            content: "Response",
+            timestamp: Date(timeIntervalSince1970: 2),
+            model: model
+        )
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Long model",
+            messages: [message],
+            model: model,
+            updatedAt: Date(timeIntervalSince1970: 2),
+            createdAt: Date(timeIntervalSince1970: 1)
+        )
+        let compactConfiguration = WatchConversationRequestConfiguration(
+            id: conversation.id,
+            model: model,
+            temperature: 0.4,
+            resolvedSystemPrompt: "Prompt"
+        )
+
+        let decodedConversation = try JSONDecoder().decode(
+            WatchConversation.self,
+            from: JSONEncoder().encode(conversation)
+        )
+        let decodedConfiguration = try JSONDecoder().decode(
+            WatchConversationRequestConfiguration.self,
+            from: JSONEncoder().encode(compactConfiguration)
+        )
+        var applied = conversation
+        applied.model = "old-model"
+        decodedConfiguration.apply(to: &applied)
+        let settingsByModel = [model: "exact-settings"]
+
+        #expect(decodedConversation.model == model)
+        #expect(decodedConversation.messages.first?.model == model)
+        #expect(decodedConversation.toConversation().model == model)
+        #expect(decodedConfiguration.model == model)
+        #expect(applied.model == model)
+        #expect(settingsByModel[decodedConversation.model] == "exact-settings")
+        #expect(settingsByModel[decodedConfiguration.model] == "exact-settings")
+    }
+
+    @Test
+    func `Conversation conversion carries temperature prompt revision and effective history`() {
+        let groupID = UUID()
+        let userID = UUID()
+        let rejectedID = UUID()
+        let selectedID = UUID()
+        let timestamp = Date(timeIntervalSince1970: 200)
+        let user = Message(id: userID, role: .user, content: "Question", timestamp: timestamp)
+        let rejected = Message(
+            id: rejectedID,
+            role: .assistant,
+            content: "Rejected",
+            timestamp: timestamp.addingTimeInterval(1),
+            model: "other",
+            responseGroupId: groupID,
+            isSelectedResponse: false
+        )
+        let selected = Message(
+            id: selectedID,
+            role: .assistant,
+            content: "Selected",
+            timestamp: timestamp.addingTimeInterval(2),
+            model: "chosen",
+            responseGroupId: groupID,
+            isSelectedResponse: true
+        )
+        let group = ResponseGroup(
+            id: groupID,
+            userMessageId: userID,
+            responses: [
+                ResponseGroupEntry(id: rejectedID, modelName: "other", status: .completed),
+                ResponseGroupEntry(id: selectedID, modelName: "chosen", status: .selected)
+            ],
+            selectedResponseId: selectedID,
+            createdAt: timestamp
+        )
+        var conversation = Conversation(
+            title: "Effective",
+            messages: [user, rejected, selected],
+            createdAt: timestamp,
+            updatedAt: timestamp.addingTimeInterval(3),
+            model: "chosen",
+            systemPromptMode: .custom("Be precise"),
+            temperature: 0.25,
+            responseGroups: [group]
+        )
+
+        let watch = WatchConversation(
+            from: conversation,
+            resolvedSystemPrompt: "Be precise",
+            watchRevision: 7
+        )
+
+        #expect(watch.temperature == 0.25)
+        #expect(watch.resolvedSystemPrompt == "Be precise")
+        #expect(watch.watchRevision == 7)
+        #expect(watch.messages.map(\.id) == [userID, selectedID])
+        #expect(watch.effectiveHistory.map(\.role) == [.system, .user, .assistant])
+        #expect(watch.effectiveHistory.first?.content == "Be precise")
+
+        conversation.pendingAutoSendPrompt = "phone-only"
+        let restored = watch.toConversation()
+        #expect(restored.temperature == 0.25)
+        #expect(restored.systemPromptMode == .inheritGlobal)
+        #expect(restored.messages.map(\.id) == [userID, selectedID])
+    }
+
+    @Test
+    func `Conversation conversion keeps only the newest bounded messages`() {
+        let base = Date(timeIntervalSince1970: 1000)
+        let messages = (0 ..< 30).map { index in
+            Message(
+                role: index.isMultiple(of: 2) ? .user : .assistant,
+                content: "message-\(index)",
+                timestamp: base.addingTimeInterval(Double(index))
+            )
+        }
+        let conversation = Conversation(title: "Long", messages: messages, model: "model")
+
+        let watch = WatchConversation(from: conversation, maximumMessages: 20)
+
+        #expect(watch.messages.count == 20)
+        #expect(watch.messages.first?.content == "message-10")
+        #expect(watch.messages.last?.content == "message-29")
+    }
+
+    @Test
+    func `Legacy WatchConversation payload decodes new fields with safe defaults`() throws {
+        let legacy = LegacyWatchConversation(
+            id: UUID(),
+            title: "Legacy",
+            messages: [],
+            model: "legacy-model",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            createdAt: Date(timeIntervalSince1970: 10)
+        )
+
+        let data = try JSONEncoder().encode(legacy)
+        let decoded = try JSONDecoder().decode(WatchConversation.self, from: data)
+
+        #expect(decoded.temperature == 0.7)
+        #expect(decoded.resolvedSystemPrompt == nil)
+        #expect(decoded.watchRevision == 0)
+        #expect(decoded.title == "Legacy")
+    }
+
+    @Test
+    func `WatchConversation Codable preserves new fields`() throws {
+        let original = WatchConversation(
+            id: UUID(),
+            title: "Codable",
+            messages: [WatchMessage(from: Message(role: .user, content: "Hello"))],
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 30),
+            createdAt: Date(timeIntervalSince1970: 10),
+            temperature: 1.1,
+            resolvedSystemPrompt: "Prompt",
+            watchRevision: 42
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(WatchConversation.self, from: data)
+
+        #expect(decoded == original)
+    }
+
+    @Test
+    func `Snapshot construction and decoding canonicalize duplicate conversation IDs`() throws {
+        let conversationID = UUID()
+        let newerTimestamp = WatchConversation(
+            id: conversationID,
+            title: "Newer timestamp",
+            model: "timestamp-model",
+            updatedAt: Date(timeIntervalSince1970: 40),
+            createdAt: Date(timeIntervalSince1970: 1),
+            watchRevision: 4
+        )
+        let newerRevision = WatchConversation(
+            id: conversationID,
+            title: "Newer revision",
+            model: "revision-model",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            createdAt: Date(timeIntervalSince1970: 1),
+            watchRevision: 5
+        )
+
+        let constructed = WatchSyncSnapshot(
+            revision: 1,
+            conversations: [newerTimestamp, newerRevision],
+            authoritativeConversationIDs: [conversationID, conversationID]
+        )
+        let encoded = try JSONEncoder().encode(DuplicateConversationSnapshotPayload(
+            sourceID: constructed.sourceID,
+            revision: constructed.revision,
+            conversations: [newerTimestamp, newerRevision],
+            authoritativeConversationIDs: [conversationID, conversationID]
+        ))
+        let decoded = try JSONDecoder().decode(WatchSyncSnapshot.self, from: encoded)
+
+        for snapshot in [constructed, decoded] {
+            #expect(snapshot.conversations.count == 1)
+            #expect(snapshot.conversations.first?.title == "Newer revision")
+            #expect(snapshot.conversations.first?.watchRevision == 5)
+            #expect(snapshot.authoritativeConversationIDs == [conversationID])
+        }
+    }
+
+    @Test
+    func `Explicit null snapshot schema is rejected instead of defaulting to legacy version one`() throws {
+        let snapshot = WatchSyncSnapshot(
+            revision: 1,
+            conversations: [],
+            authoritativeConversationIDs: []
+        )
+        let encoded = try JSONEncoder().encode(snapshot)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        object["schemaVersion"] = NSNull()
+        let malformed = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(WatchSyncSnapshot.self, from: malformed)
+        }
+    }
+}
+
+private struct DuplicateConversationSnapshotPayload: Encodable {
+    let schemaVersion = WatchSyncSnapshot.currentSchemaVersion
+    let sourceID: UUID
+    let revision: WatchSyncRevision
+    let conversations: [WatchConversation]
+    let authoritativeConversationIDs: [UUID]
+    let authoritativeConversationIDsAreComplete = true
+}
+
+private struct LegacyWatchConversation: Codable {
+    let id: UUID
+    let title: String
+    let messages: [WatchMessage]
+    let model: String
+    let updatedAt: Date
+    let createdAt: Date
+}
+
+// swiftlint:enable identifier_name

--- a/Tests/AynaTests/WatchDataModelHostTests.swift
+++ b/Tests/AynaTests/WatchDataModelHostTests.swift
@@ -191,6 +191,40 @@ struct WatchDataModelHostTests {
     }
 
     @Test
+    func `Conversation conversion preserves a failed partial response fallback`() {
+        let groupID = UUID()
+        let timestamp = Date(timeIntervalSince1970: 1000)
+        let user = Message(role: .user, content: "Question", timestamp: timestamp)
+        let failed = Message(
+            role: .assistant,
+            content: "Saved partial",
+            timestamp: timestamp.addingTimeInterval(1),
+            model: "model-a",
+            responseGroupId: groupID
+        )
+        let group = ResponseGroup(
+            id: groupID,
+            userMessageId: user.id,
+            responses: [
+                ResponseGroupEntry(id: failed.id, modelName: "model-a", status: .failed)
+            ],
+            createdAt: timestamp
+        )
+        let conversation = Conversation(
+            messages: [user, failed],
+            createdAt: timestamp,
+            updatedAt: timestamp.addingTimeInterval(2),
+            model: "model-a",
+            responseGroups: [group]
+        )
+
+        let watch = WatchConversation(from: conversation)
+
+        #expect(watch.messages.map(\.id) == [user.id, failed.id])
+        #expect(watch.effectiveHistory.last?.content == "Saved partial")
+    }
+
+    @Test
     func `Conversation conversion keeps only the newest bounded messages`() {
         let base = Date(timeIntervalSince1970: 1000)
         let messages = (0 ..< 30).map { index in

--- a/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
+++ b/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
@@ -1,0 +1,1641 @@
+// swiftlint:disable file_length
+#if os(watchOS)
+
+    // swiftlint:disable identifier_name type_body_length
+
+    @testable import Ayna
+    import Foundation
+    import Testing
+
+    @Suite("Watch sync chat view model native tests")
+    @MainActor
+    struct WatchSyncChatViewModelNativeTests {
+        @Test
+        func `Request uses durable prompt, effective history, conversation model, and temperature`() async throws {
+            let fixture = makeViewModelFixture()
+            let callbacks = FlightTestBox<AIServiceResponseSimulationCallbacks?>(nil)
+            let aiService = configuredAIService(model: fixture.conversation.model) { _, value in
+                callbacks.value = value
+            }
+            var observed: WatchChatViewModel.RequestConfiguration?
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService,
+                requestObserver: { observed = $0 }
+            )
+            WatchConnectivityService.shared.selectedModel = "different-global-model"
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            viewModel.sendMessage("Durable prompt")
+
+            let request = try #require(observed)
+            #expect(request.model == fixture.conversation.model)
+            #expect(request.temperature == fixture.conversation.temperature)
+            #expect(request.conversationID == fixture.conversation.id)
+            #expect(request.messages.map(\.role) == [.system, .user])
+            #expect(request.messages.first?.content == fixture.conversation.resolvedSystemPrompt)
+            #expect(request.messages.last?.content == "Durable prompt")
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.model == request.model)
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(reloaded.conversation(for: fixture.conversation.id)?.messages.contains {
+                $0.role == Message.Role.user.rawValue && $0.content == "Durable prompt"
+            } == true)
+
+            let response = try #require(callbacks.value)
+            response.onChunk("Answer")
+            response.onComplete()
+            #expect(await waitUntil { !viewModel.isLoading })
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.content == "Answer")
+            #expect(fixture.store.pendingMutationsForSync.first?.revision == 2)
+        }
+
+        @Test
+        func `Re-selecting the same conversation preserves generation and cancellation syncs partial once`() throws {
+            let fixture = makeViewModelFixture()
+            let callbacks = FlightTestBox<AIServiceResponseSimulationCallbacks?>(nil)
+            let aiService = configuredAIService(model: fixture.conversation.model) { _, value in
+                callbacks.value = value
+            }
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            viewModel.sendMessage("Prompt")
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.isLoading)
+
+            let response = try #require(callbacks.value)
+            response.onChunk("Partial")
+            viewModel.cancelRequest()
+
+            #expect(!viewModel.isLoading)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.content == "Partial")
+            let revisionAfterFirstCancel = fixture.store.pendingMutationsForSync.first?.revision
+            #expect(revisionAfterFirstCancel == 2)
+
+            viewModel.cancelRequest()
+            #expect(fixture.store.pendingMutationsForSync.first?.revision == revisionAfterFirstCancel)
+        }
+
+        @Test
+        func `Switching conversations cancels the owned generation`() {
+            let fixture = makeViewModelFixture()
+            let aiService = configuredAIService(model: fixture.conversation.model) { _, _ in }
+            let other = WatchConversation(
+                id: UUID(),
+                title: "Other",
+                model: fixture.conversation.model,
+                updatedAt: Date(timeIntervalSince1970: 2),
+                createdAt: Date(timeIntervalSince1970: 2)
+            )
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 2,
+                    conversations: [fixture.conversation, other],
+                    authoritativeConversationIDs: [fixture.conversation.id, other.id]
+                )
+            )
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+
+            viewModel.setConversation(fixture.conversation.id)
+            viewModel.sendMessage("Prompt")
+            #expect(viewModel.isLoading)
+            viewModel.setConversation(other.id)
+
+            #expect(!viewModel.isLoading)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.role == Message.Role.user.rawValue)
+        }
+
+        @Test
+        func `Creating a new conversation finalizes and cancels the previous generation`() throws {
+            let fixture = makeViewModelFixture()
+            let callbacks = FlightTestBox<AIServiceResponseSimulationCallbacks?>(nil)
+            let aiService = configuredAIService(model: fixture.conversation.model) { _, value in
+                callbacks.value = value
+            }
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.selectedModel = fixture.conversation.model
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            viewModel.sendMessage("Prompt")
+            let response = try #require(callbacks.value)
+            response.onChunk("Partial")
+
+            let newConversationID = try #require(viewModel.createNewConversation())
+
+            #expect(!viewModel.isLoading)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.content == "Partial")
+            #expect(fixture.store.pendingMutationsForSync.first {
+                $0.conversationID == fixture.conversation.id
+            }?.revision == 2)
+            #expect(fixture.store.conversation(for: newConversationID) != nil)
+
+            response.onChunk(" stale")
+            response.onComplete()
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.content == "Partial")
+        }
+
+        @Test
+        func `Pre-output cancellation ignores historical tool activity`() {
+            let historicalMessages = [
+                WatchMessage(from: Message(role: .user, content: "Earlier prompt")),
+                WatchMessage(from: Message(role: .assistant, content: "Earlier answer")),
+                WatchMessage(from: Message(role: .tool, content: "Earlier tool result")),
+            ]
+            let fixture = makeViewModelFixture(messages: historicalMessages)
+            let aiService = configuredAIService(model: fixture.conversation.model) { _, _ in }
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            viewModel.sendMessage("Current prompt")
+            viewModel.cancelRequest()
+
+            let conversation = fixture.store.conversation(for: fixture.conversation.id)
+            #expect(conversation?.messages.count == historicalMessages.count + 1)
+            #expect(conversation?.messages.last?.role == Message.Role.user.rawValue)
+            #expect(conversation?.messages.last?.content == "Current prompt")
+            #expect(fixture.store.pendingMutationsForSync.first {
+                $0.conversationID == fixture.conversation.id
+            }?.revision == 1)
+        }
+
+        @Test
+        func `Cancellation preserves tool state from the current request turn`() throws {
+            let fixture = makeViewModelFixture()
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            viewModel.sendMessage("Prompt")
+            let request = try #require(aiService.capturedRequests.value.first)
+            let onToolCallRequested = try #require(request.onToolCallRequested)
+            onToolCallRequested("current-call", "unavailable_watch_tool", [:])
+            viewModel.cancelRequest()
+
+            let conversation = fixture.store.conversation(for: fixture.conversation.id)
+            #expect(conversation?.messages.last?.role == Message.Role.assistant.rawValue)
+            #expect(conversation?.messages.last?.content.isEmpty == true)
+            #expect(conversation?.messages.last?.toolCalls?.map(\.id) == ["current-call"])
+            #expect(fixture.store.pendingMutationsForSync.first {
+                $0.conversationID == fixture.conversation.id
+            }?.revision == 2)
+        }
+
+        @Test
+        func `Cancelled response promotion failure retries the same draft`() async throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                title: "Existing",
+                persistenceWriter: { persistence.write($0) }
+            )
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+            persistence.rejectNextWrite { data in
+                isPromotionWrite(data, assistantContent: "Partial")
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let request = try #require(aiService.capturedRequests.value.first)
+            request.onChunk("Partial")
+            #expect(await waitUntil {
+                fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.content == "Partial"
+            })
+            let draft = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            let userMessageID = try #require(draft.messages.first?.id)
+            let assistantMessageID = try #require(draft.messages.last?.id)
+
+            viewModel.cancelRequest()
+
+            #expect(persistence.rejectedWriteCount == 1)
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+            let failedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(failedConversation.messages.map(\.id) == [userMessageID, assistantMessageID])
+            #expect(failedConversation.messages.last?.content == "Partial")
+            #expect(!fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.id == assistantMessageID
+            })
+
+            viewModel.retryFailedMessage()
+
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            #expect(aiService.capturedRequests.value.count == 1)
+            let promotedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(promotedConversation.messages.map(\.id) == [userMessageID, assistantMessageID])
+            #expect(promotedConversation.messages.last?.content == "Partial")
+            #expect(fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.id == assistantMessageID && $0.content == "Partial"
+            })
+        }
+
+        @Test
+        func `Cancellation flush failure retries full throttled content without another request`() throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                title: "Existing",
+                persistenceWriter: { persistence.write($0) }
+            )
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+            persistence.rejectNextWrite { data in
+                isDraftWrite(data, assistantContent: "First second")
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let request = try #require(aiService.capturedRequests.value.first)
+            let initialDraft = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            let userMessageID = try #require(initialDraft.messages.first?.id)
+            let assistantMessageID = try #require(initialDraft.messages.last?.id)
+            request.onChunk("First")
+            request.onChunk(" second")
+
+            viewModel.cancelRequest()
+
+            #expect(persistence.rejectedWriteCount == 1)
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+            #expect(aiService.capturedRequests.value.count == 1)
+            let failedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(failedConversation.messages.map(\.id) == [userMessageID, assistantMessageID])
+            #expect(failedConversation.messages.last?.content == "First")
+            #expect(!fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.id == assistantMessageID
+            })
+
+            viewModel.retryFailedMessage()
+
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            #expect(aiService.capturedRequests.value.count == 1)
+            let promotedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(promotedConversation.messages.map(\.id) == [userMessageID, assistantMessageID])
+            #expect(promotedConversation.messages.last?.content == "First second")
+            let assistantChanges = fixture.store.pendingMutationsForSync
+                .flatMap(\.messageChanges)
+                .filter { $0.id == assistantMessageID }
+            #expect(assistantChanges.count == 1)
+            #expect(assistantChanges.first?.content == "First second")
+        }
+
+        @Test
+        func `Provider error retry starts a new user turn after preserving partial output`() async throws {
+            let fixture = makeViewModelFixture(title: "Existing")
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let firstRequest = try #require(aiService.capturedRequests.value.first)
+            firstRequest.onChunk("Partial")
+            #expect(await waitUntil {
+                fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.content == "Partial"
+            })
+            firstRequest.onError(NSError(domain: "Provider", code: 1))
+            #expect(await waitUntil { !viewModel.isLoading })
+
+            let failedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(failedConversation.messages.map(\.role) == [
+                Message.Role.user.rawValue,
+                Message.Role.assistant.rawValue
+            ])
+            #expect(failedConversation.messages.last?.content == "Partial")
+
+            viewModel.retryFailedMessage()
+
+            #expect(aiService.capturedRequests.value.count == 2)
+            let retryRequest = try #require(aiService.capturedRequests.value.last)
+            #expect(retryRequest.messages.last?.role == .user)
+            #expect(retryRequest.messages.last?.content == "Prompt")
+            let retriedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(retriedConversation.messages.map(\.role) == [
+                Message.Role.user.rawValue,
+                Message.Role.assistant.rawValue,
+                Message.Role.user.rawValue,
+                Message.Role.assistant.rawValue
+            ])
+            #expect(retriedConversation.messages[0].id != retriedConversation.messages[2].id)
+        }
+
+        @Test
+        func `Provider error promotion failure retries the same partial draft`() async throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                title: "Existing",
+                persistenceWriter: { persistence.write($0) }
+            )
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+            persistence.rejectNextWrite { data in
+                isPromotionWrite(data, assistantContent: "Partial")
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let request = try #require(aiService.capturedRequests.value.first)
+            request.onChunk("Partial")
+            #expect(await waitUntil {
+                fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.content == "Partial"
+            })
+            let draft = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            let userMessageID = try #require(draft.messages.first?.id)
+            let assistantMessageID = try #require(draft.messages.last?.id)
+            request.onError(NSError(domain: "Provider", code: 1))
+
+            #expect(await waitUntil { !viewModel.isLoading })
+            #expect(persistence.rejectedWriteCount == 1)
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+            let failedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(failedConversation.messages.map(\.id) == [userMessageID, assistantMessageID])
+            #expect(failedConversation.messages.last?.content == "Partial")
+
+            viewModel.retryFailedMessage()
+
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            #expect(aiService.capturedRequests.value.count == 1)
+            let promotedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(promotedConversation.messages.map(\.id) == [userMessageID, assistantMessageID])
+            #expect(promotedConversation.messages.last?.content == "Partial")
+            #expect(fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.id == assistantMessageID && $0.content == "Partial"
+            })
+        }
+
+        @Test
+        func `Missing conversation during a tool callback surfaces retry state`() async throws {
+            let fixture = makeViewModelFixture(title: "Existing")
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let request = try #require(aiService.capturedRequests.value.first)
+            let onToolCallRequested = try #require(request.onToolCallRequested)
+            #expect(fixture.store.deleteConversation(fixture.conversation.id))
+
+            onToolCallRequested("missing-conversation", "unavailable_watch_tool", [:])
+
+            #expect(await waitUntil { !viewModel.isLoading })
+            #expect(viewModel.errorMessage == "Failed to update conversation. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+        }
+
+        @Test
+        func `Message persistence failure rejects the request`() {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(persistenceWriter: { persistence.write($0) })
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            var request: WatchChatViewModel.RequestConfiguration?
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService,
+                requestObserver: { request = $0 }
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+            persistence.rejectNextWrite { data in
+                isConversationMessageWrite(
+                    data,
+                    role: Message.Role.user.rawValue,
+                    content: "Prompt"
+                )
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .notConsumed)
+
+            #expect(request == nil)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.isEmpty == true)
+            #expect(viewModel.errorMessage != nil)
+
+            viewModel.retryFailedMessage()
+            #expect(request != nil)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.count {
+                $0.role == Message.Role.user.rawValue
+            } == 1)
+            viewModel.cancelRequest()
+        }
+
+        @Test
+        func `Assistant draft persistence failure rejects the request`() {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(persistenceWriter: { persistence.write($0) })
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            var request: WatchChatViewModel.RequestConfiguration?
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService,
+                requestObserver: { request = $0 }
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+            persistence.rejectNextWrite { data in
+                isDraftWrite(data, assistantContent: "")
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .consumed)
+
+            #expect(request == nil)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.map(\.role) == [
+                Message.Role.user.rawValue,
+            ])
+            #expect(viewModel.errorMessage != nil)
+
+            viewModel.retryFailedMessage()
+            #expect(request != nil)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.count {
+                $0.role == Message.Role.user.rawValue
+            } == 1)
+            viewModel.cancelRequest()
+        }
+
+        @Test
+        func `Final response promotion failure stays retryable without generating a title`() async throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                title: "New Chat",
+                persistenceWriter: { persistence.write($0) }
+            )
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+            persistence.rejectNextWrite { data in
+                isPromotionWrite(data, assistantContent: "Answer")
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let generationRequest = try #require(aiService.capturedRequests.value.first)
+            generationRequest.onChunk("Answer")
+            generationRequest.onComplete()
+
+            #expect(await waitUntil { !viewModel.isLoading })
+            #expect(persistence.rejectedWriteCount == 1)
+            #expect(aiService.capturedRequests.value.count == 1)
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+            let failedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(failedConversation.messages.map(\.role) == [
+                Message.Role.user.rawValue,
+                Message.Role.assistant.rawValue,
+            ])
+            #expect(failedConversation.messages.last?.content == "Answer")
+            #expect(!fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.role == Message.Role.assistant.rawValue
+            })
+
+            viewModel.retryFailedMessage()
+
+            #expect(await waitUntil { aiService.capturedRequests.value.count == 2 })
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            let promotedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(promotedConversation.messages.map(\.role) == [
+                Message.Role.user.rawValue,
+                Message.Role.assistant.rawValue,
+            ])
+            #expect(promotedConversation.messages.last?.content == "Answer")
+            #expect(fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.role == Message.Role.assistant.rawValue && $0.content == "Answer"
+            })
+        }
+
+        @Test
+        func `Failed final response promotion follows its conversation across switches`() async throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                title: "New Chat",
+                persistenceWriter: { persistence.write($0) }
+            )
+            let otherConversation = WatchConversation(
+                id: UUID(),
+                title: "Other",
+                model: fixture.conversation.model,
+                updatedAt: Date(timeIntervalSince1970: 2),
+                createdAt: Date(timeIntervalSince1970: 2)
+            )
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 2,
+                    conversations: [fixture.conversation, otherConversation],
+                    authoritativeConversationIDs: [fixture.conversation.id, otherConversation.id]
+                )
+            )
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            var generationRequests: [WatchChatViewModel.RequestConfiguration] = []
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService,
+                requestObserver: { generationRequests.append($0) }
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+            persistence.rejectNextWrite { data in
+                isPromotionWrite(data, assistantContent: "Answer")
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let generationRequest = try #require(aiService.capturedRequests.value.first)
+            generationRequest.onChunk("Answer")
+            generationRequest.onComplete()
+
+            #expect(await waitUntil { !viewModel.isLoading })
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+            #expect(generationRequests.count == 1)
+
+            viewModel.setConversation(otherConversation.id)
+
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+
+            viewModel.setConversation(fixture.conversation.id)
+
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+
+            viewModel.retryFailedMessage()
+
+            #expect(await waitUntil { aiService.capturedRequests.value.count == 2 })
+            #expect(generationRequests.count == 1)
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            let promotedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(promotedConversation.messages.map(\.role) == [
+                Message.Role.user.rawValue,
+                Message.Role.assistant.rawValue,
+            ])
+            #expect(promotedConversation.messages.last?.content == "Answer")
+
+            let titleRequest = try #require(aiService.capturedRequests.value.last)
+            titleRequest.onChunk("Recovered Title")
+            #expect(await waitUntil {
+                fixture.store.conversation(for: fixture.conversation.id)?.title == "Recovered Title"
+            })
+        }
+
+        @Test
+        func `Successful promotion retry clears only the selected conversation retry`() async throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                title: "First",
+                persistenceWriter: { persistence.write($0) }
+            )
+            let otherConversation = WatchConversation(
+                id: UUID(),
+                title: "Second",
+                model: fixture.conversation.model,
+                updatedAt: Date(timeIntervalSince1970: 2),
+                createdAt: Date(timeIntervalSince1970: 2)
+            )
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 2,
+                    conversations: [fixture.conversation, otherConversation],
+                    authoritativeConversationIDs: [fixture.conversation.id, otherConversation.id]
+                )
+            )
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            persistence.rejectNextWrite { data in
+                isPromotionWrite(data, assistantContent: "First answer")
+            }
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("First prompt") == .started)
+            let firstRequest = try #require(aiService.capturedRequests.value.first)
+            firstRequest.onChunk("First answer")
+            firstRequest.onComplete()
+            #expect(await waitUntil { !viewModel.isLoading })
+
+            viewModel.setConversation(otherConversation.id)
+            persistence.rejectNextWrite { data in
+                isPromotionWrite(data, assistantContent: "Second answer")
+            }
+            #expect(viewModel.sendMessage("Second prompt") == .started)
+            let secondRequest = try #require(aiService.capturedRequests.value.last)
+            secondRequest.onChunk("Second answer")
+            secondRequest.onComplete()
+            #expect(await waitUntil { !viewModel.isLoading })
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.failedMessage == "First prompt")
+            viewModel.retryFailedMessage()
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+
+            viewModel.setConversation(otherConversation.id)
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Second prompt")
+            viewModel.retryFailedMessage()
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            #expect(aiService.capturedRequests.value.count == 2)
+        }
+
+        @Test
+        func `Cancel and dismiss preserve durable promotion retry ownership`() async throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                title: "Existing",
+                persistenceWriter: { persistence.write($0) }
+            )
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.selectedModel = fixture.conversation.model
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+            persistence.rejectNextWrite { data in
+                isPromotionWrite(data, assistantContent: "Answer")
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let request = try #require(aiService.capturedRequests.value.first)
+            request.onChunk("Answer")
+            request.onComplete()
+            #expect(await waitUntil { !viewModel.isLoading })
+
+            viewModel.cancelRequest()
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+
+            viewModel.dismissError()
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+
+            let newConversationID = try #require(viewModel.createNewConversation())
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            #expect(fixture.store.conversation(for: newConversationID) != nil)
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+
+            viewModel.retryFailedMessage()
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            #expect(aiService.capturedRequests.value.count == 1)
+            #expect(fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.role == Message.Role.assistant.rawValue && $0.content == "Answer"
+            })
+        }
+
+        @Test
+        func `Fallback model persistence failure rejects the request`() {
+            let appleModel = "apple-intelligence"
+            let configuredModel = "configured-model"
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                model: appleModel,
+                persistenceWriter: { persistence.write($0) }
+            )
+            let aiService = configuredCapturingAIService(model: configuredModel)
+            aiService.customModels = [appleModel, configuredModel]
+            aiService.modelProviders = [
+                appleModel: .appleIntelligence,
+                configuredModel: .openai,
+            ]
+            aiService.modelEndpoints = [configuredModel: "http://localhost:11434"]
+            aiService.modelAPIKeys = [:]
+            var request: WatchChatViewModel.RequestConfiguration?
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService,
+                requestObserver: { request = $0 }
+            )
+            WatchConnectivityService.shared.availableModels = [configuredModel]
+            persistence.rejectNextWrite { data in
+                isConversationModelWrite(
+                    data,
+                    conversationID: fixture.conversation.id,
+                    model: configuredModel
+                )
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .consumed)
+
+            #expect(request == nil)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.model == appleModel)
+            #expect(viewModel.errorMessage != nil)
+        }
+
+        @Test
+        func `Apple Intelligence fallback skips unconfigured models`() {
+            let appleModel = "apple-intelligence"
+            let unconfiguredModel = "unconfigured-model"
+            let configuredModel = "configured-model"
+            let fixture = makeViewModelFixture(model: appleModel)
+            let aiService = configuredCapturingAIService(model: configuredModel)
+            aiService.customModels = [appleModel, unconfiguredModel, configuredModel]
+            aiService.modelProviders = [
+                appleModel: .appleIntelligence,
+                unconfiguredModel: .openai,
+                configuredModel: .openai,
+            ]
+            aiService.modelEndpoints = [configuredModel: "http://localhost:11434"]
+            aiService.modelAPIKeys = [:]
+            var request: WatchChatViewModel.RequestConfiguration?
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService,
+                requestObserver: { request = $0 }
+            )
+            WatchConnectivityService.shared.availableModels = [unconfiguredModel, configuredModel]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+
+            #expect(request?.model == configuredModel)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.model == configuredModel)
+            viewModel.cancelRequest()
+        }
+
+        @Test
+        func `Conversation creation persistence failure is surfaced without a phantom selection`() throws {
+            let persistence = PersistenceTestWriter()
+            persistence.rejectWrite(number: 1)
+            let suiteName = "WatchConversationCreationFailure.\(UUID().uuidString)"
+            let defaults = try #require(UserDefaults(suiteName: suiteName))
+            defaults.removePersistentDomain(forName: suiteName)
+            let store = WatchConversationStore(
+                userDefaults: defaults,
+                persistenceKey: "state",
+                persistenceWriter: { persistence.write($0) },
+                mutationEnqueuer: { _ in }
+            )
+            let model = "configured-model"
+            let aiService = configuredCapturingAIService(model: model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.selectedModel = model
+            WatchConnectivityService.shared.availableModels = [model]
+
+            let conversationID = viewModel.createNewConversation()
+
+            #expect(conversationID == nil)
+            #expect(store.conversations.isEmpty)
+            #expect(viewModel.errorMessage != nil)
+        }
+
+        @Test
+        func `Apple Intelligence conversation keeps its model when no fallback is configured`() {
+            let appleModel = "apple-intelligence"
+            let unconfiguredModel = "unconfigured-model"
+            let fixture = makeViewModelFixture(model: appleModel)
+            let aiService = configuredCapturingAIService(model: unconfiguredModel)
+            aiService.customModels = [appleModel, unconfiguredModel]
+            aiService.modelProviders = [
+                appleModel: .appleIntelligence,
+                unconfiguredModel: .openai,
+            ]
+            aiService.modelEndpoints = [:]
+            aiService.modelAPIKeys = [:]
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [unconfiguredModel]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .consumed)
+
+            #expect(aiService.capturedRequests.value.isEmpty)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.model == appleModel)
+        }
+
+        @Test
+        func `Tool continuation includes final throttled assistant content`() async throws {
+            let fixture = makeViewModelFixture()
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            var requests: [WatchChatViewModel.RequestConfiguration] = []
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService,
+                requestObserver: { requests.append($0) }
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let firstRequest = try #require(aiService.capturedRequests.value.first)
+            let onToolCallRequested = try #require(firstRequest.onToolCallRequested)
+            firstRequest.onChunk("First")
+            firstRequest.onChunk(" second")
+            onToolCallRequested("current-call", "unavailable_watch_tool", [:])
+            firstRequest.onComplete()
+
+            #expect(await waitUntil { requests.count == 2 })
+            let continuation = try #require(requests.last)
+            #expect(continuation.messages.first { $0.role == .assistant }?.content == "First second")
+            viewModel.cancelRequest()
+        }
+
+        @Test
+        func `Tool continuation flush failure retries full throttled content without another request`() async throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                title: "Existing",
+                persistenceWriter: { persistence.write($0) }
+            )
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            defer { viewModel.cancelOwnedRequest() }
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+            persistence.rejectNextWrite { data in
+                isDraftWrite(data, assistantContent: "First second")
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let firstRequest = try #require(aiService.capturedRequests.value.first)
+            let onToolCallRequested = try #require(firstRequest.onToolCallRequested)
+            let initialDraft = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            let userMessageID = try #require(initialDraft.messages.first?.id)
+            let assistantMessageID = try #require(initialDraft.messages.last?.id)
+            firstRequest.onChunk("First")
+            firstRequest.onChunk(" second")
+            onToolCallRequested("current-call", "unavailable_watch_tool", [:])
+            firstRequest.onComplete()
+
+            #expect(await waitUntil {
+                !viewModel.isLoading || aiService.capturedRequests.value.count > 1
+            })
+            #expect(persistence.rejectedWriteCount == 1)
+            #expect(!viewModel.isLoading)
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+            #expect(aiService.capturedRequests.value.count == 1)
+            let failedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(failedConversation.messages.map(\.id) == [userMessageID, assistantMessageID])
+            #expect(failedConversation.messages.last?.content == "First")
+            #expect(failedConversation.messages.last?.toolCalls?.map(\.id) == ["current-call"])
+            #expect(!failedConversation.messages.contains { $0.role == Message.Role.tool.rawValue })
+            #expect(!fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.id == assistantMessageID
+            })
+
+            viewModel.retryFailedMessage()
+
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            #expect(aiService.capturedRequests.value.count == 1)
+            let promotedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(promotedConversation.messages.map(\.id) == [userMessageID, assistantMessageID])
+            #expect(promotedConversation.messages.last?.content == "First second")
+            #expect(promotedConversation.messages.last?.toolCalls?.map(\.id) == ["current-call"])
+            #expect(!promotedConversation.messages.contains { $0.role == Message.Role.tool.rawValue })
+            let assistantChanges = fixture.store.pendingMutationsForSync
+                .flatMap(\.messageChanges)
+                .filter { $0.id == assistantMessageID }
+            #expect(assistantChanges.count == 1)
+            #expect(assistantChanges.first?.content == "First second")
+        }
+
+        @Test
+        func `Tool continuation persistence failure stops before another request`() async throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(persistenceWriter: { persistence.write($0) })
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            var requests: [WatchChatViewModel.RequestConfiguration] = []
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService,
+                requestObserver: { requests.append($0) }
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let firstRequest = try #require(aiService.capturedRequests.value.first)
+            let onToolCallRequested = try #require(firstRequest.onToolCallRequested)
+            firstRequest.onChunk("First")
+            firstRequest.onChunk(" second")
+            onToolCallRequested("current-call", "unavailable_watch_tool", [:])
+            #expect(await waitUntil {
+                fixture.store.conversation(for: fixture.conversation.id)?.messages.contains {
+                    $0.toolCalls?.contains(where: { $0.id == "current-call" }) == true
+                } == true
+            })
+            persistence.rejectWrite(number: persistence.writeCount + 2)
+
+            firstRequest.onComplete()
+
+            #expect(await waitUntil { !viewModel.isLoading })
+            #expect(requests.count == 1)
+            #expect(viewModel.errorMessage != nil)
+            let conversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(!conversation.messages.contains { $0.role == Message.Role.tool.rawValue })
+        }
+
+        @Test
+        func `Repeated tool callback ID executes only once`() async throws {
+            let fixture = makeViewModelFixture()
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            var requests: [WatchChatViewModel.RequestConfiguration] = []
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService,
+                requestObserver: { requests.append($0) }
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let firstRequest = try #require(aiService.capturedRequests.value.first)
+            let onToolCallRequested = try #require(firstRequest.onToolCallRequested)
+            onToolCallRequested("duplicate-call", "unavailable_watch_tool", [:])
+            onToolCallRequested("duplicate-call", "unavailable_watch_tool", [:])
+            firstRequest.onComplete()
+
+            #expect(await waitUntil { requests.count == 2 })
+            let continuation = try #require(requests.last)
+            #expect(continuation.messages.count { $0.role == .tool } == 1)
+            viewModel.cancelRequest()
+        }
+
+        @Test
+        func `Provider tool call IDs may be reused in later request rounds`() async throws {
+            let fixture = makeViewModelFixture()
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let firstRequest = try #require(aiService.capturedRequests.value.first)
+            let firstToolCallback = try #require(firstRequest.onToolCallRequested)
+            firstToolCallback("reused-call", "unavailable_watch_tool", ["round": 1])
+            firstRequest.onComplete()
+
+            #expect(await waitUntil { aiService.capturedRequests.value.count == 2 })
+            let secondRequest = try #require(aiService.capturedRequests.value.last)
+            let secondToolCallback = try #require(secondRequest.onToolCallRequested)
+            secondToolCallback("reused-call", "unavailable_watch_tool", ["round": 2])
+            secondRequest.onComplete()
+
+            #expect(await waitUntil { aiService.capturedRequests.value.count == 3 })
+            let continuation = try #require(aiService.capturedRequests.value.last)
+            let resultCalls = continuation.messages
+                .filter { $0.role == .tool }
+                .compactMap { $0.toolCalls?.first }
+            #expect(resultCalls.map(\.id) == ["reused-call", "reused-call"])
+            #expect(resultCalls.compactMap { $0.arguments["round"]?.value as? Int } == [1, 2])
+            viewModel.cancelRequest()
+        }
+
+        @Test
+        func `Multiple ID-less tool calls persist distinct ordered synthetic IDs`() async throws {
+            let fixture = makeViewModelFixture()
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let firstRequest = try #require(aiService.capturedRequests.value.first)
+            let onToolCallRequested = try #require(firstRequest.onToolCallRequested)
+            onToolCallRequested("", "unavailable_watch_tool", ["position": 1])
+            onToolCallRequested("   ", "unavailable_watch_tool", ["position": 2])
+            onToolCallRequested("", "unavailable_watch_tool", ["position": 1])
+            firstRequest.onComplete()
+
+            #expect(await waitUntil { aiService.capturedRequests.value.count == 2 })
+            let continuation = try #require(aiService.capturedRequests.value.last)
+            let resultCalls = continuation.messages
+                .filter { $0.role == .tool }
+                .compactMap { $0.toolCalls?.first }
+            let resultIDs = resultCalls.map(\.id)
+            #expect(resultCalls.compactMap { $0.arguments["position"]?.value as? Int } == [1, 2])
+            #expect(resultIDs.count == 2)
+            #expect(resultIDs.allSatisfy { !$0.isEmpty })
+            #expect(Set(resultIDs).count == 2)
+
+            let assistantIDs = continuation.messages
+                .filter { $0.role == .assistant }
+                .flatMap { $0.toolCalls ?? [] }
+                .map(\.id)
+            #expect(assistantIDs == resultIDs)
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            let reloadedIDs = reloaded.conversation(for: fixture.conversation.id)?.messages
+                .filter { $0.role == Message.Role.assistant.rawValue }
+                .flatMap { $0.toolCalls ?? [] }
+                .map(\.id)
+            #expect(reloadedIDs == resultIDs)
+            viewModel.cancelRequest()
+        }
+
+        @Test
+        func `Tool depth promotion failure retries the same partial draft`() async throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                title: "Existing",
+                persistenceWriter: { persistence.write($0) }
+            )
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            for round in 0 ..< 5 {
+                let requests = aiService.capturedRequests.value
+                try #require(requests.indices.contains(round))
+                let request = requests[round]
+                let onToolCallRequested = try #require(request.onToolCallRequested)
+                onToolCallRequested("call-\(round)", "unavailable_watch_tool", [:])
+                request.onComplete()
+                #expect(await waitUntil { aiService.capturedRequests.value.count == round + 2 })
+            }
+
+            let depthRequest = try #require(aiService.capturedRequests.value.last)
+            depthRequest.onChunk("Depth partial")
+            #expect(await waitUntil {
+                fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.content ==
+                    "Depth partial"
+            })
+            let draft = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            let messageIDs = draft.messages.map(\.id)
+            let assistantMessageID = try #require(draft.messages.last?.id)
+            persistence.rejectNextWrite { data in
+                isPromotionWrite(data, assistantContent: "Depth partial")
+            }
+
+            let onToolCallRequested = try #require(depthRequest.onToolCallRequested)
+            onToolCallRequested("depth-limit-call", "unavailable_watch_tool", [:])
+
+            #expect(await waitUntil { !viewModel.isLoading })
+            #expect(persistence.rejectedWriteCount == 1)
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.map(\.id) == messageIDs)
+
+            viewModel.retryFailedMessage()
+
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            #expect(aiService.capturedRequests.value.count == 6)
+            let promotedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(promotedConversation.messages.map(\.id) == messageIDs)
+            #expect(promotedConversation.messages.last?.content == "Depth partial")
+            #expect(fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.id == assistantMessageID && $0.content == "Depth partial"
+            })
+        }
+
+        @Test
+        func `Continuation failure preserves completed tool state without empty placeholder`() async throws {
+            let fixture = makeViewModelFixture()
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            viewModel.sendMessage("Prompt")
+            let firstRequest = try #require(aiService.capturedRequests.value.first)
+            let onToolCallRequested = try #require(firstRequest.onToolCallRequested)
+            onToolCallRequested("current-call", "unavailable_watch_tool", [:])
+            firstRequest.onComplete()
+
+            #expect(await waitUntil { aiService.capturedRequests.value.count == 2 })
+            let continuation = try #require(aiService.capturedRequests.value.last)
+            continuation.onError(NSError(domain: "WatchContinuation", code: 1))
+
+            #expect(await waitUntil { !viewModel.isLoading })
+            let conversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(conversation.messages.contains {
+                $0.toolCalls?.contains(where: { $0.id == "current-call" }) == true
+            })
+            #expect(conversation.messages.contains { $0.role == Message.Role.tool.rawValue })
+            #expect(conversation.messages.last?.role == Message.Role.tool.rawValue)
+            #expect(fixture.store.pendingMutationsForSync.first {
+                $0.conversationID == fixture.conversation.id
+            }?.revision == 2)
+        }
+
+        @Test
+        func `Detached generation callbacks preserve order and complete safely`() async throws {
+            let fixture = makeViewModelFixture()
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            viewModel.sendMessage("Prompt")
+            let request = try #require(aiService.capturedRequests.value.first)
+
+            await Task.detached {
+                request.onChunk("Detached")
+                request.onChunk(" callback")
+                request.onComplete()
+            }.value
+
+            #expect(await waitUntil { !viewModel.isLoading })
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.content ==
+                "Detached callback")
+            #expect(fixture.store.pendingMutationsForSync.first {
+                $0.conversationID == fixture.conversation.id
+            }?.revision == 2)
+        }
+
+        @Test
+        func `Later manual title edit wins over generated title callbacks`() async throws {
+            let fixture = makeViewModelFixture(title: "New Chat")
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let generationRequest = try #require(aiService.capturedRequests.value.first)
+            generationRequest.onChunk("Answer")
+            generationRequest.onComplete()
+
+            #expect(await waitUntil { aiService.capturedRequests.value.count == 2 })
+            let titleRequest = try #require(aiService.capturedRequests.value.last)
+            let manualTitle = "Manual Phone Title"
+            #expect(fixture.store.renameConversation(fixture.conversation.id, newTitle: manualTitle))
+
+            await Task.detached {
+                titleRequest.onChunk("Generated Title")
+                titleRequest.onError(NSError(domain: "Title", code: 1))
+            }.value
+
+            let titleWasOverwritten = await waitUntil(timeout: .milliseconds(100)) {
+                fixture.store.conversation(for: fixture.conversation.id)?.title != manualTitle
+            }
+            #expect(!titleWasOverwritten)
+            #expect(fixture.store.conversation(for: fixture.conversation.id)?.title == manualTitle)
+        }
+
+        @Test
+        func `Phone title ABA snapshots fence detached title callbacks`() async throws {
+            let fixture = makeViewModelFixture(title: "New Chat")
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let generationRequest = try #require(aiService.capturedRequests.value.first)
+            generationRequest.onChunk("Answer")
+            generationRequest.onComplete()
+
+            #expect(await waitUntil { aiService.capturedRequests.value.count == 2 })
+            let titleRequest = try #require(aiService.capturedRequests.value.last)
+            var phoneConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            let titleRequestRevision = phoneConversation.watchRevision
+            let titleRequestUpdatedAt = phoneConversation.updatedAt
+
+            phoneConversation.title = "Manual Phone Title"
+            phoneConversation.updatedAt = titleRequestUpdatedAt.addingTimeInterval(1)
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 2,
+                    conversations: [phoneConversation],
+                    authoritativeConversationIDs: [phoneConversation.id]
+                )
+            )
+            #expect(fixture.store.conversation(for: phoneConversation.id)?.title == "Manual Phone Title")
+
+            phoneConversation.title = "New Chat"
+            phoneConversation.updatedAt = titleRequestUpdatedAt.addingTimeInterval(2)
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 3,
+                    conversations: [phoneConversation],
+                    authoritativeConversationIDs: [phoneConversation.id]
+                )
+            )
+
+            let manuallyRestoredConversation = try #require(fixture.store.conversation(for: phoneConversation.id))
+            #expect(manuallyRestoredConversation.title == "New Chat")
+            #expect(manuallyRestoredConversation.watchRevision == titleRequestRevision)
+            #expect(manuallyRestoredConversation.updatedAt == phoneConversation.updatedAt)
+
+            await Task.detached {
+                titleRequest.onChunk("Generated Title")
+                titleRequest.onComplete()
+            }.value
+            viewModel.cancelOwnedRequest()
+            await Task.yield()
+
+            let fencedConversation = try #require(fixture.store.conversation(for: phoneConversation.id))
+            #expect(fencedConversation.title == "New Chat")
+            #expect(fencedConversation.updatedAt == phoneConversation.updatedAt)
+        }
+
+        @Test
+        func `Detached title callbacks hop safely to the main actor`() async throws {
+            let fixture = makeViewModelFixture(title: "New Chat")
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            viewModel.sendMessage("Prompt")
+            let generationRequest = try #require(aiService.capturedRequests.value.first)
+            await Task.detached {
+                generationRequest.onChunk("Answer")
+                generationRequest.onComplete()
+            }.value
+
+            #expect(await waitUntil { aiService.capturedRequests.value.count == 2 })
+            let titleRequest = try #require(aiService.capturedRequests.value.last)
+            await Task.detached {
+                titleRequest.onChunk("\"Detached Title\"\n")
+            }.value
+
+            #expect(await waitUntil {
+                fixture.store.conversation(for: fixture.conversation.id)?.title == "Detached Title"
+            })
+            await Task.detached {
+                titleRequest.onComplete()
+            }.value
+        }
+    }
+
+    @MainActor
+    private struct ViewModelFixture {
+        let defaults: UserDefaults
+        let key: String
+        let store: WatchConversationStore
+        let conversation: WatchConversation
+    }
+
+    @MainActor
+    private func makeViewModelFixture(
+        title: String = "Synced",
+        messages: [WatchMessage] = [],
+        model: String = "conversation-model",
+        persistenceWriter: ((Data) -> Bool)? = nil
+    ) -> ViewModelFixture {
+        let suiteName = "WatchChatViewModelNativeTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let key = "state"
+        let store = WatchConversationStore(
+            userDefaults: defaults,
+            persistenceKey: key,
+            now: { Date(timeIntervalSince1970: 100) },
+            persistenceWriter: persistenceWriter,
+            mutationEnqueuer: { _ in }
+        )
+        let date = Date(timeIntervalSince1970: 1)
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: title,
+            messages: messages,
+            model: model,
+            updatedAt: date,
+            createdAt: date,
+            temperature: 0.15,
+            resolvedSystemPrompt: "System prompt"
+        )
+        store.applySyncSnapshot(
+            WatchSyncSnapshot(
+                revision: 1,
+                conversations: [conversation],
+                authoritativeConversationIDs: [conversation.id]
+            )
+        )
+        return ViewModelFixture(
+            defaults: defaults,
+            key: key,
+            store: store,
+            conversation: conversation
+        )
+    }
+
+    @MainActor
+    private final class PersistenceTestWriter {
+        private(set) var writeCount = 0
+        private(set) var rejectedWriteCount = 0
+        private var rejectedWriteNumber: Int?
+        private var rejectedWritePredicate: ((Data) -> Bool)?
+
+        func rejectWrite(number: Int) {
+            rejectedWriteNumber = number
+        }
+
+        func rejectNextWrite(where predicate: @escaping (Data) -> Bool) {
+            rejectedWritePredicate = predicate
+        }
+
+        func write(_ data: Data) -> Bool {
+            writeCount += 1
+            let rejectsNumber = writeCount == rejectedWriteNumber
+            let rejectsPredicate = rejectedWritePredicate?(data) == true
+            guard !rejectsNumber, !rejectsPredicate else {
+                rejectedWriteCount += 1
+                if rejectsPredicate {
+                    rejectedWritePredicate = nil
+                }
+                return false
+            }
+            return true
+        }
+    }
+
+    private func isConversationMessageWrite(
+        _ data: Data,
+        role: String,
+        content: String
+    ) -> Bool {
+        guard let state = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let conversations = state["conversations"] as? [[String: Any]]
+        else {
+            return false
+        }
+        return conversations.contains { conversation in
+            guard let messages = conversation["messages"] as? [[String: Any]] else { return false }
+            return messages.contains { message in
+                message["role"] as? String == role && message["content"] as? String == content
+            }
+        }
+    }
+
+    private func isConversationModelWrite(
+        _ data: Data,
+        conversationID: UUID,
+        model: String
+    ) -> Bool {
+        guard let state = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let conversations = state["conversations"] as? [[String: Any]]
+        else {
+            return false
+        }
+        return conversations.contains { conversation in
+            conversation["id"] as? String == conversationID.uuidString
+                && conversation["model"] as? String == model
+        }
+    }
+
+    private func isDraftWrite(_ data: Data, assistantContent: String) -> Bool {
+        guard let state = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let pendingDrafts = state["pendingDrafts"] as? [[String: Any]]
+        else {
+            return false
+        }
+        return pendingDrafts.contains { draft in
+            guard let conversation = draft["conversation"] as? [String: Any],
+                  let messages = conversation["messages"] as? [[String: Any]]
+            else {
+                return false
+            }
+            return messages.contains { message in
+                message["role"] as? String == Message.Role.assistant.rawValue &&
+                    message["content"] as? String == assistantContent
+            }
+        }
+    }
+
+    private func isPromotionWrite(_ data: Data, assistantContent: String) -> Bool {
+        guard let state = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let pendingMutations = state["pendingMutations"] as? [[String: Any]]
+        else {
+            return false
+        }
+        return pendingMutations.contains { mutation in
+            guard let messageChanges = mutation["messageChanges"] as? [[String: Any]] else {
+                return false
+            }
+            return messageChanges.contains { message in
+                message["role"] as? String == Message.Role.assistant.rawValue &&
+                    message["content"] as? String == assistantContent
+            }
+        }
+    }
+
+    @MainActor
+    private func configuredAIService(
+        model: String,
+        responseSimulator: @escaping AIServiceResponseSimulator
+    ) -> AIService {
+        let service = AIService(responseSimulator: responseSimulator)
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-watch-test"
+        return service
+    }
+
+    @MainActor
+    private func configuredCapturingAIService(model: String) -> CallbackCapturingAIService {
+        let service = CallbackCapturingAIService()
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelAPIKeys[model] = "sk-watch-test"
+        return service
+    }
+
+    @MainActor
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        _ condition: @escaping @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !condition(), clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return condition()
+    }
+
+    private struct CapturedAIServiceRequest: @unchecked Sendable {
+        let messages: [Message]
+        let onChunk: @Sendable (String) -> Void
+        let onComplete: @Sendable () -> Void
+        let onError: @Sendable (Error) -> Void
+        let onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?
+    }
+
+    @MainActor
+    private final class CallbackCapturingAIService: AIService {
+        let capturedRequests = FlightTestBox<[CapturedAIServiceRequest]>([])
+
+        init() {
+            super.init(responseSimulator: { _, _ in })
+        }
+
+        override func sendMessage(
+            messages: [Message],
+            model: String?,
+            temperature: Double?,
+            stream: Bool,
+            tools: [[String: Any]]?,
+            conversationId: UUID?,
+            isMultiModelRequest: Bool,
+            onChunk: @escaping @Sendable (String) -> Void,
+            onComplete: @escaping @Sendable () -> Void,
+            onError: @escaping @Sendable (Error) -> Void,
+            onToolCall: (@Sendable (String, String, [String: Any]) async -> String)?,
+            onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?,
+            onReasoning: (@Sendable (String) -> Void)?,
+            preparedAPIKey: String?,
+            requestFlightID: RequestFlightID?
+        ) -> AITextRequest {
+            capturedRequests.update {
+                $0.append(
+                    CapturedAIServiceRequest(
+                        messages: messages,
+                        onChunk: onChunk,
+                        onComplete: onComplete,
+                        onError: onError,
+                        onToolCallRequested: onToolCallRequested
+                    )
+                )
+            }
+            return super.sendMessage(
+                messages: messages,
+                model: model,
+                temperature: temperature,
+                stream: stream,
+                tools: tools,
+                conversationId: conversationId,
+                isMultiModelRequest: isMultiModelRequest,
+                onChunk: onChunk,
+                onComplete: onComplete,
+                onError: onError,
+                onToolCall: onToolCall,
+                onToolCallRequested: onToolCallRequested,
+                onReasoning: onReasoning,
+                preparedAPIKey: preparedAPIKey,
+                requestFlightID: requestFlightID
+            )
+        }
+    }
+
+    // swiftlint:enable identifier_name type_body_length
+
+#endif

--- a/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
+++ b/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
@@ -1342,8 +1342,8 @@
                 titleRequest.onChunk("Generated Title")
                 titleRequest.onComplete()
             }.value
-            viewModel.cancelOwnedRequest()
             await Task.yield()
+            #expect(!viewModel.cancelOwnedRequest())
 
             let fencedConversation = try #require(fixture.store.conversation(for: phoneConversation.id))
             #expect(fencedConversation.title == "New Chat")

--- a/Tests/AynaTests/WatchSyncConversationStoreNativeTests.swift
+++ b/Tests/AynaTests/WatchSyncConversationStoreNativeTests.swift
@@ -1,0 +1,1354 @@
+#if os(watchOS) || WATCH_STORE_HOST_TESTING
+
+    // swiftlint:disable identifier_name
+
+    @testable import Ayna
+    import Combine
+    import Foundation
+    import Testing
+
+    @Suite("Watch sync conversation store native tests")
+    @MainActor
+    // swiftlint:disable:next type_body_length
+    struct WatchSyncConversationStoreNativeTests {
+        @Test
+        func `Watch-created conversation uses the synced default system prompt immediately`() throws {
+            let fixture = makeFixture()
+
+            let conversation = try #require(fixture.store.createConversation(
+                model: "model",
+                resolvedSystemPrompt: "Synced global prompt"
+            ))
+
+            #expect(conversation.resolvedSystemPrompt == "Synced global prompt")
+            #expect(conversation.effectiveHistory.first?.role == .system)
+            #expect(conversation.effectiveHistory.first?.content == "Synced global prompt")
+        }
+
+        @Test
+        func `Snapshot echo keeps a persisted local draft overlay`() throws {
+            let fixture = makeFixture()
+            let conversation = makeConversation(messages: [makeMessage(role: .user, content: "Prompt")])
+            fixture.store.applySyncSnapshot(snapshot(revision: 1, conversations: [conversation]))
+
+            var draft = conversation
+            draft.messages.append(makeMessage(role: .assistant, content: "Partial", model: conversation.model))
+            fixture.store.syncDraft(draft)
+            fixture.store.applySyncSnapshot(snapshot(revision: 2, conversations: [conversation]))
+
+            let visible = try #require(fixture.store.conversation(for: conversation.id))
+            #expect(visible.messages.map(\.content) == ["Prompt", "Partial"])
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(reloaded.conversation(for: conversation.id)?.messages.last?.content == "Partial")
+            #expect(reloaded.pendingMutationsForSync.first?.messageChanges.last?.content == "Partial")
+        }
+
+        @Test
+        func `Restart discards an empty assistant draft placeholder`() throws {
+            let fixture = makeFixture()
+            let conversation = makeConversation(messages: [makeMessage(role: .user, content: "Prompt")])
+            fixture.store.applySyncSnapshot(snapshot(revision: 1, conversations: [conversation]))
+
+            var draft = conversation
+            draft.messages.append(makeMessage(role: .assistant, content: "", model: conversation.model))
+            fixture.store.syncDraft(draft)
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            let restored = try #require(reloaded.conversation(for: conversation.id))
+            #expect(restored.messages.map(\.content) == ["Prompt"])
+            #expect(reloaded.pendingMutationsForSync.isEmpty)
+        }
+
+        @Test
+        func `Explicitly empty authoritative snapshot deletes remote-only conversations`() {
+            let fixture = makeFixture()
+            let conversation = makeConversation()
+            fixture.store.applySyncSnapshot(snapshot(revision: 1, conversations: [conversation]))
+
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 2,
+                    conversations: [],
+                    authoritativeConversationIDs: []
+                )
+            )
+
+            #expect(fixture.store.conversation(for: conversation.id) == nil)
+        }
+
+        @Test
+        func `Completed multi-page cycle prunes stale conversations and preserves Watch-owned work`() throws {
+            let fixture = makeFixture()
+            let sourceID = UUID()
+            let cycleID = UUID()
+            let retainedFirst = makeConversation(id: UUID())
+            let retainedSecond = makeConversation(id: UUID())
+            let stale = makeConversation(id: UUID())
+            let initial = WatchSyncSnapshot(
+                sourceID: sourceID,
+                revision: 1,
+                conversations: [retainedFirst, retainedSecond, stale],
+                authoritativeConversationIDs: [retainedFirst.id, retainedSecond.id, stale.id]
+            )
+            #expect(fixture.store.applySyncSnapshot(initial) == .applied)
+
+            let watchOwned = try #require(fixture.store.createConversation(model: "model"))
+            var draft = watchOwned
+            draft.messages.append(makeMessage(role: .assistant, content: "Watch draft", model: "model"))
+            #expect(fixture.store.syncDraft(draft))
+
+            let firstPage = WatchSyncSnapshot(
+                sourceID: sourceID,
+                revision: 2,
+                paginationCursor: 0,
+                conversations: [retainedFirst],
+                authoritativeConversationIDs: [retainedFirst.id],
+                authoritativeConversationIDsAreComplete: false
+            )
+            let firstMetadata = WatchSyncPageCycleMetadata(
+                cycleID: cycleID,
+                sourceID: sourceID,
+                snapshotRevision: firstPage.revision,
+                cursor: .initial,
+                manifest: WatchSyncPageSection(offset: 0, itemCount: 1, totalCount: 2),
+                configurations: WatchSyncPageSection(offset: 0, itemCount: 0, totalCount: 0),
+                tombstones: WatchSyncPageSection(offset: 0, itemCount: 0, totalCount: 0)
+            )
+            let secondCursor = try #require(firstMetadata.nextCursor)
+            let secondPage = WatchSyncSnapshot(
+                sourceID: sourceID,
+                revision: 3,
+                paginationCursor: 1,
+                conversations: [retainedSecond],
+                authoritativeConversationIDs: [retainedSecond.id],
+                authoritativeConversationIDsAreComplete: false
+            )
+            let secondMetadata = WatchSyncPageCycleMetadata(
+                cycleID: cycleID,
+                sourceID: sourceID,
+                snapshotRevision: secondPage.revision,
+                cursor: secondCursor,
+                manifest: WatchSyncPageSection(offset: 1, itemCount: 1, totalCount: 2),
+                configurations: WatchSyncPageSection(offset: 0, itemCount: 0, totalCount: 0),
+                tombstones: WatchSyncPageSection(offset: 0, itemCount: 0, totalCount: 0)
+            )
+
+            #expect(fixture.store.applySyncSnapshot(
+                firstPage,
+                pageCycleMetadata: firstMetadata
+            ) == .applied)
+            #expect(fixture.store.conversation(for: stale.id) != nil)
+
+            #expect(fixture.store.applySyncSnapshot(
+                secondPage,
+                pageCycleMetadata: secondMetadata
+            ) == .applied)
+
+            #expect(fixture.store.conversation(for: retainedFirst.id) != nil)
+            #expect(fixture.store.conversation(for: retainedSecond.id) != nil)
+            #expect(fixture.store.conversation(for: stale.id) == nil)
+            #expect(fixture.store.conversation(for: watchOwned.id)?.messages.last?.content == "Watch draft")
+            #expect(fixture.store.pendingMutationsForSync.contains { $0.conversationID == watchOwned.id })
+        }
+
+        @Test
+        func `Rejected snapshot is not published and can be retried`() throws {
+            let fixture = makeFixture()
+            let conversation = makeConversation()
+            fixture.store.applySyncSnapshot(snapshot(revision: 1, conversations: [conversation]))
+            var publishedTitles: [[String]] = []
+            let cancellable = fixture.store.$conversations.sink { conversations in
+                publishedTitles.append(conversations.map(\.title))
+            }
+            defer { cancellable.cancel() }
+            var updated = conversation
+            updated.title = "Phone edit"
+            updated.updatedAt = Date(timeIntervalSince1970: 30)
+            fixture.allowsPersistence = false
+
+            fixture.store.applySyncSnapshot(snapshot(revision: 2, conversations: [updated]))
+
+            #expect(publishedTitles == [["Synced"]])
+            #expect(try #require(fixture.store.conversation(for: conversation.id)).title == "Synced")
+
+            fixture.allowsPersistence = true
+            fixture.store.applySyncSnapshot(snapshot(revision: 2, conversations: [updated]))
+
+            #expect(publishedTitles == [["Synced"], ["Phone edit"]])
+            #expect(try #require(fixture.store.conversation(for: conversation.id)).title == "Phone edit")
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(try #require(reloaded.conversation(for: conversation.id)).title == "Phone edit")
+        }
+
+        @Test
+        func `Failed first page remains the exact retry until its snapshot is durable`() throws {
+            let fixture = makeFixture()
+            let conversation = makeConversation()
+            let sourceID = UUID()
+            let cycleID = UUID()
+            let deletedID = UUID()
+            let snapshot = WatchSyncSnapshot(
+                sourceID: sourceID,
+                revision: 1,
+                paginationCursor: 0,
+                conversations: [conversation],
+                authoritativeConversationIDs: [conversation.id],
+                authoritativeConversationIDsAreComplete: false,
+                conversationConfigurations: [
+                    WatchConversationRequestConfiguration(
+                        id: conversation.id,
+                        model: conversation.model,
+                        temperature: conversation.temperature,
+                        resolvedSystemPrompt: conversation.resolvedSystemPrompt
+                    )
+                ],
+                conversationConfigurationsAreComplete: false,
+                tombstones: [WatchConversationTombstone(conversationID: deletedID, revision: 1)]
+            )
+            let metadata = WatchSyncPageCycleMetadata(
+                cycleID: cycleID,
+                sourceID: sourceID,
+                snapshotRevision: snapshot.revision,
+                cursor: .initial,
+                manifest: WatchSyncPageSection(offset: 0, itemCount: 1, totalCount: 2),
+                configurations: WatchSyncPageSection(offset: 0, itemCount: 1, totalCount: 2),
+                tombstones: WatchSyncPageSection(offset: 0, itemCount: 1, totalCount: 2)
+            )
+            let initialRequest = WatchSyncPageCycleRequest(cycleID: cycleID, cursor: .initial)
+            let nextRequest = try WatchSyncPageCycleRequest(
+                cycleID: cycleID,
+                cursor: #require(metadata.nextCursor)
+            )
+            var coordinator = WatchPageCycleCoordinator()
+            fixture.allowsPersistence = false
+
+            let failedApply = fixture.store.applySyncSnapshot(snapshot)
+            let failedPage = coordinator.receive(metadata, after: failedApply)
+
+            #expect(failedApply == .persistenceFailed)
+            #expect(!failedPage.acceptedPage)
+            #expect(failedPage.retainedForRetry)
+            #expect(failedPage.pendingRequest == initialRequest)
+            #expect(fixture.store.conversation(for: conversation.id) == nil)
+
+            fixture.allowsPersistence = true
+            let durableApply = fixture.store.applySyncSnapshot(snapshot)
+            let durablePage = coordinator.receive(metadata, after: durableApply)
+
+            #expect(durableApply == .applied)
+            #expect(durablePage.acceptedPage)
+            #expect(!durablePage.retainedForRetry)
+            #expect(durablePage.pendingRequest == nextRequest)
+            #expect(fixture.store.conversation(for: conversation.id) != nil)
+
+            let repeatedApply = fixture.store.applySyncSnapshot(snapshot)
+            let repeatedPage = coordinator.receive(metadata, after: repeatedApply)
+
+            #expect(repeatedApply == .alreadyDurable)
+            #expect(!repeatedPage.acceptedPage)
+            #expect(repeatedPage.pendingRequest == nextRequest)
+        }
+
+        @Test
+        func `Legacy bounded bodies preserve a revisioned source across restart and empty lists`() throws {
+            let fixture = makeFixture()
+            let sourceID = try #require(UUID(uuidString: "11111111-1111-1111-1111-111111111111"))
+            let conversationA = makeConversation()
+            let conversationB = makeConversation()
+            let initialApply = fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    sourceID: sourceID,
+                    revision: 7,
+                    conversations: [conversationA, conversationB],
+                    authoritativeConversationIDs: [conversationA.id, conversationB.id]
+                )
+            )
+            var updatedA = conversationA
+            updatedA.title = "Updated by phone"
+            updatedA.updatedAt = Date(timeIntervalSince1970: 30)
+
+            fixture.store.updateConversations([updatedA])
+
+            #expect(initialApply == .applied)
+            #expect(try #require(fixture.store.conversation(for: conversationA.id)).title == "Updated by phone")
+            #expect(fixture.store.conversation(for: conversationB.id) == conversationB)
+
+            let restarted = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(try #require(restarted.conversation(for: conversationA.id)).title == "Updated by phone")
+            #expect(restarted.conversation(for: conversationB.id) == conversationB)
+
+            restarted.updateConversations([])
+
+            #expect(restarted.conversation(for: conversationA.id) != nil)
+            #expect(restarted.conversation(for: conversationB.id) == conversationB)
+
+            let restartedAfterEmptyList = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(restartedAfterEmptyList.conversation(for: conversationA.id) != nil)
+            #expect(restartedAfterEmptyList.conversation(for: conversationB.id) == conversationB)
+        }
+
+        @Test
+        func `Rotating authoritative bodies keep persisted Watch cache bounded across restart`() throws {
+            let fixture = makeFixture()
+            let bodies = (0 ..< 25).map { index in
+                makeConversation(
+                    id: UUID(),
+                    messages: [makeMessage(role: .assistant, content: "Body \(index)")]
+                )
+            }
+            let manifest = bodies.map(\.id)
+
+            for (index, body) in bodies.enumerated() {
+                let outcome = fixture.store.applySyncSnapshot(
+                    WatchSyncSnapshot(
+                        revision: WatchSyncRevision(index + 1),
+                        conversations: [body],
+                        authoritativeConversationIDs: manifest
+                    )
+                )
+                #expect(outcome == .applied)
+            }
+
+            let persisted = try persistedFixtureState(in: fixture)
+            #expect(persisted.conversations.count == 20)
+            #expect(fixture.store.conversations.count == 20)
+
+            let restarted = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(restarted.conversations.count == 20)
+        }
+
+        @Test
+        func `Restart compacts previously unbounded persisted bodies`() throws {
+            let fixture = makeFixture()
+            let bodies = (0 ..< 25).map { _ in makeConversation(id: UUID()) }
+            try persistFixtureState(
+                peerID: UUID(),
+                conversations: bodies,
+                in: fixture
+            )
+
+            #expect(fixture.store.conversations.count == 20)
+            #expect(try persistedFixtureState(in: fixture).conversations.count == 20)
+        }
+
+        @Test
+        func `Failed restart compaction keeps the previously durable cache visible`() throws {
+            let fixture = makeFixture()
+            let bodies = (0 ..< 25).map { _ in makeConversation(id: UUID()) }
+            try persistFixtureState(
+                peerID: UUID(),
+                conversations: bodies,
+                in: fixture
+            )
+            fixture.allowsPersistence = false
+
+            #expect(fixture.store.conversations.count == 25)
+            #expect(try persistedFixtureState(in: fixture).conversations.count == 25)
+        }
+
+        @Test
+        func `Bounded cache keeps a manifest-only body across persistence and restart`() throws {
+            let fixture = makeFixture(maximumCachedConversationBodies: 2)
+            let retained = makeConversation(id: UUID())
+            var updated = makeConversation(id: UUID())
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 1,
+                    conversations: [updated, retained],
+                    authoritativeConversationIDs: [updated.id, retained.id]
+                )
+            )
+            updated.title = "Updated body"
+
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 2,
+                    conversations: [updated],
+                    authoritativeConversationIDs: [updated.id, retained.id]
+                )
+            )
+
+            #expect(fixture.store.conversation(for: retained.id) == retained)
+            #expect(try persistedFixtureState(in: fixture).conversations.count == 2)
+
+            let restarted = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                maximumCachedConversationBodies: 2,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(restarted.conversation(for: retained.id) == retained)
+        }
+
+        @Test
+        func `Selected conversation access is durable before the next eviction`() throws {
+            let fixture = makeFixture(maximumCachedConversationBodies: 2)
+            let selected = makeConversation(id: UUID())
+            let evicted = makeConversation(id: UUID())
+            let newest = makeConversation(id: UUID())
+            let manifest = [selected.id, evicted.id, newest.id]
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 1,
+                    conversations: [selected, evicted],
+                    authoritativeConversationIDs: manifest
+                )
+            )
+            fixture.store.selectedConversationId = selected.id
+
+            let restarted = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                maximumCachedConversationBodies: 2,
+                mutationEnqueuer: { _ in }
+            )
+            restarted.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 2,
+                    conversations: [newest],
+                    authoritativeConversationIDs: manifest
+                )
+            )
+
+            #expect(restarted.conversation(for: selected.id) != nil)
+            #expect(restarted.conversation(for: newest.id) != nil)
+            #expect(restarted.conversation(for: evicted.id) == nil)
+            #expect(try persistedFixtureState(in: fixture).conversations.count == 2)
+        }
+
+        @Test
+        func `Current conversation read is durable before the next eviction`() {
+            let fixture = makeFixture(maximumCachedConversationBodies: 2)
+            let current = makeConversation(id: UUID())
+            let evicted = makeConversation(id: UUID())
+            let newest = makeConversation(id: UUID())
+            let manifest = [current.id, evicted.id, newest.id]
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 1,
+                    conversations: [current, evicted],
+                    authoritativeConversationIDs: manifest
+                )
+            )
+            _ = fixture.store.conversation(for: current.id)
+
+            let restarted = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                maximumCachedConversationBodies: 2,
+                mutationEnqueuer: { _ in }
+            )
+            restarted.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 2,
+                    conversations: [newest],
+                    authoritativeConversationIDs: manifest
+                )
+            )
+
+            #expect(restarted.conversation(for: current.id) != nil)
+            #expect(restarted.conversation(for: newest.id) != nil)
+            #expect(restarted.conversation(for: evicted.id) == nil)
+        }
+
+        @Test
+        func `Pending mutations may exceed the body target until acknowledged`() throws {
+            let fixture = makeFixture(maximumCachedConversationBodies: 1)
+            let first = try #require(fixture.store.createConversation(model: "model"))
+            let second = try #require(fixture.store.createConversation(model: "model"))
+
+            #expect(try persistedFixtureState(in: fixture).conversations.count == 2)
+
+            let restarted = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                maximumCachedConversationBodies: 1,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(restarted.conversation(for: first.id) != nil)
+            #expect(restarted.conversation(for: second.id) != nil)
+
+            #expect(restarted.acknowledgeWatchRevision(conversationID: first.id, revision: 1))
+            #expect(restarted.conversation(for: first.id) == nil)
+            #expect(restarted.conversation(for: second.id) != nil)
+            let compacted = try persistedFixtureState(in: fixture)
+            #expect(compacted.conversations.map(\.id) == [second.id])
+        }
+
+        @Test
+        func `Request draft body survives eviction restart and recovery`() throws {
+            let fixture = makeFixture(maximumCachedConversationBodies: 1)
+            let requestOwner = makeConversation(id: UUID())
+            let newest = makeConversation(id: UUID())
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 1,
+                    conversations: [requestOwner],
+                    authoritativeConversationIDs: [requestOwner.id]
+                )
+            )
+            var draft = try #require(fixture.store.conversations.first { $0.id == requestOwner.id })
+            draft.messages.append(makeMessage(role: .assistant, content: "Partial response"))
+            #expect(fixture.store.syncDraft(draft))
+
+            fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 2,
+                    conversations: [newest],
+                    authoritativeConversationIDs: [requestOwner.id, newest.id]
+                )
+            )
+
+            #expect(fixture.store.conversation(for: requestOwner.id)?.messages.last?.content == "Partial response")
+            #expect(fixture.store.conversation(for: newest.id) == nil)
+            #expect(try persistedFixtureState(in: fixture).conversations.map(\.id) == [requestOwner.id])
+
+            let restarted = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                maximumCachedConversationBodies: 1,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(restarted.conversation(for: requestOwner.id)?.messages.last?.content == "Partial response")
+            #expect(restarted.pendingMutationsForSync.first?.conversationID == requestOwner.id)
+        }
+
+        @Test
+        func `Outbox coalesces local operations and acknowledgement removes only covered revisions`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(title: "Original", model: "model-a"))
+            fixture.store.addMessage(makeMessage(role: .user, content: "Prompt"), to: conversation.id)
+            fixture.store.renameConversation(conversation.id, newTitle: "Renamed")
+            fixture.store.updateModel("model-b", for: conversation.id)
+
+            let pending = try #require(fixture.store.pendingMutationsForSync.first)
+            #expect(fixture.store.pendingMutationsForSync.count == 1)
+            #expect(pending.revision == 4)
+            #expect(pending.fields.contains(.create))
+            #expect(pending.fields.contains(.messages))
+            #expect(pending.fields.contains(.title))
+            #expect(pending.fields.contains(.configuration))
+            #expect(pending.conversation.title == "Renamed")
+            #expect(pending.conversation.model == "model-b")
+            #expect(pending.conversation.messages.isEmpty)
+            #expect(pending.messageChanges.map(\.content) == ["Prompt"])
+            #expect(pending.peerID == fixture.store.peerID)
+
+            fixture.store.acknowledgeWatchRevision(conversationID: conversation.id, revision: 3)
+            #expect(fixture.store.pendingMutationsForSync.count == 1)
+            fixture.store.acknowledgeWatchRevision(conversationID: conversation.id, revision: 4)
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+        }
+
+        @Test
+        func `Revision exhaustion preserves a message draft across restart coalescing and acknowledgement`() throws {
+            let fixture = makeFixture()
+            let peerID = UUID()
+            let conversationID = UUID()
+            var exhausted = makeConversation(
+                id: conversationID,
+                messages: [makeMessage(role: .user, content: "Existing")]
+            )
+            exhausted.title = "Exhausted"
+            exhausted.watchRevision = .max
+            let existingMutation = WatchConversationMutation(
+                peerID: peerID,
+                revision: .max,
+                conversation: exhausted,
+                fields: [.title]
+            )
+            let coverage = WatchMutationDeliveryCoverage(titleRevision: .max)
+            try persistFixtureState(
+                peerID: peerID,
+                conversations: [exhausted],
+                pendingMutations: [existingMutation],
+                legacyDeliveryCoverage: [conversationID: coverage],
+                in: fixture
+            )
+            let candidate = makeMessage(role: .user, content: "Preserve me")
+
+            let accepted = fixture.store.addMessage(candidate, to: conversationID)
+
+            #expect(!accepted)
+            #expect(fixture.store.peerID == peerID)
+            #expect(fixture.store.pendingMutationsForSync == [existingMutation])
+            #expect(fixture.store.durableLegacyDeliveryCoverage(for: conversationID) == coverage)
+            #expect(fixture.store.conversation(for: conversationID)?.messages.map(\.content) == [
+                "Existing",
+                "Preserve me"
+            ])
+            #expect(fixture.enqueued.isEmpty)
+
+            let restarted = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(restarted.peerID == peerID)
+            #expect(restarted.pendingMutationsForSync == [existingMutation])
+            #expect(restarted.conversation(for: conversationID)?.messages.map(\.content) == [
+                "Existing",
+                "Preserve me"
+            ])
+
+            #expect(restarted.acknowledgeWatchRevision(
+                conversationID: conversationID,
+                revision: .max
+            ))
+            #expect(restarted.pendingMutationsForSync.isEmpty)
+            #expect(restarted.finishDraft(conversationID: conversationID) == .persistenceFailed)
+            #expect(restarted.peerID == peerID)
+            #expect(restarted.pendingMutationsForSync.isEmpty)
+            #expect(restarted.conversation(for: conversationID)?.messages.map(\.content) == [
+                "Existing",
+                "Preserve me"
+            ])
+        }
+
+        @Test
+        func `Revision exhaustion preserves title configuration and delete intents locally`() throws {
+            let fixture = makeFixture()
+            let peerID = UUID()
+            var titled = makeConversation(id: UUID())
+            titled.title = "Original title"
+            titled.watchRevision = .max
+            var configured = makeConversation(id: UUID())
+            configured.model = "old-model"
+            configured.watchRevision = .max
+            var deleted = makeConversation(id: UUID())
+            deleted.watchRevision = .max
+            try persistFixtureState(
+                peerID: peerID,
+                conversations: [titled, configured, deleted],
+                in: fixture
+            )
+
+            let renamed = fixture.store.renameConversation(titled.id, newTitle: "Deferred title")
+            let changedModel = fixture.store.updateModel("deferred-model", for: configured.id)
+            let removed = fixture.store.deleteConversation(deleted.id)
+
+            #expect(!renamed)
+            #expect(!changedModel)
+            #expect(!removed)
+            #expect(fixture.store.peerID == peerID)
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+            #expect(fixture.store.conversation(for: titled.id)?.title == "Deferred title")
+            #expect(fixture.store.conversation(for: configured.id)?.model == "deferred-model")
+            #expect(fixture.store.conversation(for: deleted.id) == nil)
+            #expect(fixture.enqueued.isEmpty)
+
+            let restarted = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            let acknowledgedSnapshot = WatchSyncSnapshot(
+                sourceID: UUID(),
+                revision: 1,
+                conversations: [titled, configured, deleted],
+                authoritativeConversationIDs: [titled.id, configured.id, deleted.id],
+                acknowledgedPeerID: peerID,
+                acknowledgedWatchRevisions: [
+                    titled.id: .max,
+                    configured.id: .max,
+                    deleted.id: .max
+                ]
+            )
+
+            #expect(restarted.applySyncSnapshot(acknowledgedSnapshot) == .applied)
+            #expect(restarted.peerID == peerID)
+            #expect(restarted.pendingMutationsForSync.isEmpty)
+            #expect(restarted.conversation(for: titled.id)?.title == "Deferred title")
+            #expect(restarted.conversation(for: configured.id)?.model == "deferred-model")
+            #expect(restarted.conversation(for: deleted.id) == nil)
+        }
+
+        @Test
+        func `Offline message coalescing retains every explicit message delta`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model"))
+            for index in 0 ..< 25 {
+                fixture.store.addMessage(
+                    makeMessage(role: .user, content: "offline-\(index)"),
+                    to: conversation.id
+                )
+            }
+
+            let pending = try #require(fixture.store.pendingMutationsForSync.first)
+
+            #expect(pending.revision == 26)
+            #expect(pending.messageChanges.count == 25)
+            #expect(pending.messageChanges.map(\.content) == (0 ..< 25).map { "offline-\($0)" })
+            let firstChange = try #require(pending.messageChanges.first)
+            let lastChange = try #require(pending.messageChanges.last)
+            #expect(pending.messageChangeRevisions[firstChange.id] == 2)
+            #expect(pending.messageChangeRevisions[lastChange.id] == 26)
+        }
+
+        @Test
+        func `Disjoint bounded legacy echoes cumulatively acknowledge a durable mutation`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model"))
+            for index in 0 ..< 25 {
+                fixture.store.addMessage(
+                    makeMessage(role: .user, content: "offline-\(index)"),
+                    to: conversation.id
+                )
+            }
+            let firstMutation = try #require(fixture.store.pendingMutationsForSync.first)
+            var firstEcho = try #require(fixture.store.conversation(for: conversation.id))
+            firstEcho.messages = Array(firstEcho.messages.prefix(12))
+            let firstReconciliation = WatchLegacyEchoReconciler.reconcile(
+                firstMutation,
+                echoedConversations: [firstEcho]
+            )
+
+            #expect(!firstReconciliation.canAcknowledgeMutation)
+            #expect(fixture.store.markLegacyComponentsDelivered(
+                firstReconciliation.matchedComponents,
+                for: firstMutation
+            ))
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            let reloadedMutation = try #require(reloaded.pendingMutationsForSync.first)
+            let firstCoverage = try #require(reloaded.durableLegacyDeliveryCoverage(for: conversation.id))
+            #expect(reloadedMutation.messageChanges(
+                after: 0,
+                coverage: firstCoverage
+            ).count == 13)
+
+            var secondEcho = try #require(reloaded.conversation(for: conversation.id))
+            secondEcho.messages = Array(secondEcho.messages.suffix(13))
+            let secondReconciliation = WatchLegacyEchoReconciler.reconcile(
+                reloadedMutation,
+                echoedConversations: [secondEcho]
+            )
+            #expect(!secondReconciliation.canAcknowledgeMutation)
+            #expect(reloaded.markLegacyComponentsDelivered(
+                secondReconciliation.matchedComponents,
+                for: reloadedMutation
+            ))
+
+            #expect(WatchLegacyEchoReconciler.canAcknowledge(
+                reloadedMutation,
+                currentMatches: secondReconciliation.matchedComponents,
+                durableCoverage: reloaded.durableLegacyDeliveryCoverage(for: conversation.id)
+            ))
+            #expect(reloaded.acknowledgeWatchRevision(
+                conversationID: conversation.id,
+                revision: reloadedMutation.revision
+            ))
+            #expect(reloaded.pendingMutationsForSync.isEmpty)
+        }
+
+        @Test
+        func `counterpart reset clears durable legacy coverage across restart`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model"))
+            let message = makeMessage(role: .user, content: "Pending counterpart delivery")
+            #expect(fixture.store.addMessage(message, to: conversation.id))
+            let mutation = try #require(fixture.store.pendingMutationsForSync.first)
+            let component = WatchLegacyEchoComponent.message(
+                id: message.id,
+                revision: mutation.messageChangeRevisions[message.id] ?? mutation.revision
+            )
+            #expect(fixture.store.markLegacyComponentsDelivered([component], for: mutation))
+            #expect(fixture.store.durableLegacyDeliveryCoverage(for: conversation.id) != nil)
+
+            #expect(fixture.store.clearLegacyDeliveryCoverage())
+            #expect(fixture.store.durableLegacyDeliveryCoverage(for: conversation.id) == nil)
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(reloaded.durableLegacyDeliveryCoverage(for: conversation.id) == nil)
+            #expect(reloaded.pendingMutationsForSync == [mutation])
+        }
+
+        @Test
+        func `Deletion is durable and emits a revisioned deletion mutation`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model"))
+            fixture.store.acknowledgeWatchRevision(conversationID: conversation.id, revision: 1)
+
+            fixture.store.deleteConversation(conversation.id)
+
+            #expect(fixture.store.conversation(for: conversation.id) == nil)
+            let deletion = try #require(fixture.store.pendingMutationsForSync.first)
+            #expect(deletion.conversationID == conversation.id)
+            #expect(deletion.revision == 2)
+            #expect(deletion.fields.contains(.delete))
+            #expect(fixture.enqueued.last == deletion)
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(reloaded.conversation(for: conversation.id) == nil)
+            #expect(reloaded.pendingMutationsForSync == [deletion])
+        }
+
+        @Test
+        func `Failed persistence does not publish or enqueue an undurable title mutation`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(title: "Original", model: "model"))
+            fixture.store.acknowledgeWatchRevision(conversationID: conversation.id, revision: 1)
+            fixture.enqueued.removeAll()
+            var publishedTitles: [[String]] = []
+            let cancellable = fixture.store.$conversations.sink { conversations in
+                publishedTitles.append(conversations.map(\.title))
+            }
+            defer { cancellable.cancel() }
+            fixture.allowsPersistence = false
+
+            let renamed = fixture.store.renameConversation(conversation.id, newTitle: "Undurable")
+
+            #expect(renamed == false)
+            #expect(publishedTitles == [["Original"]])
+            #expect(fixture.store.conversation(for: conversation.id)?.title == "Original")
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+            #expect(fixture.enqueued.isEmpty)
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(try #require(reloaded.conversation(for: conversation.id)).title == "Original")
+        }
+
+        @Test
+        func `Failed message persistence does not publish the candidate message`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model"))
+            fixture.store.acknowledgeWatchRevision(conversationID: conversation.id, revision: 1)
+            fixture.enqueued.removeAll()
+            var publishedMessageContents: [[String]] = []
+            let cancellable = fixture.store.$conversations.sink { conversations in
+                publishedMessageContents.append(conversations.first?.messages.map(\.content) ?? [])
+            }
+            defer { cancellable.cancel() }
+            fixture.allowsPersistence = false
+
+            let added = fixture.store.addMessage(
+                makeMessage(role: .user, content: "Undurable"),
+                to: conversation.id
+            )
+
+            #expect(added == false)
+            #expect(publishedMessageContents == [[]])
+            #expect(fixture.store.conversation(for: conversation.id)?.messages.isEmpty == true)
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+            #expect(fixture.enqueued.isEmpty)
+        }
+
+        @Test
+        func `Failed model persistence does not publish the candidate configuration`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model-a"))
+            fixture.store.acknowledgeWatchRevision(conversationID: conversation.id, revision: 1)
+            fixture.enqueued.removeAll()
+            var publishedModels: [[String]] = []
+            let cancellable = fixture.store.$conversations.sink { conversations in
+                publishedModels.append(conversations.map(\.model))
+            }
+            defer { cancellable.cancel() }
+            fixture.allowsPersistence = false
+
+            let updated = fixture.store.updateModel("model-b", for: conversation.id)
+
+            #expect(updated == false)
+            #expect(publishedModels == [["model-a"]])
+            #expect(fixture.store.conversation(for: conversation.id)?.model == "model-a")
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+            #expect(fixture.enqueued.isEmpty)
+        }
+
+        @Test
+        func `Failed delete persistence publishes neither removal nor selection clearing`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(title: "Keep", model: "model"))
+            fixture.store.acknowledgeWatchRevision(conversationID: conversation.id, revision: 1)
+            fixture.store.selectedConversationId = conversation.id
+            fixture.enqueued.removeAll()
+            var publishedConversationIDs: [[UUID]] = []
+            var publishedSelections: [UUID?] = []
+            let conversationsCancellable = fixture.store.$conversations.sink { conversations in
+                publishedConversationIDs.append(conversations.map(\.id))
+            }
+            let selectionCancellable = fixture.store.$selectedConversationId.sink { selection in
+                publishedSelections.append(selection)
+            }
+            defer {
+                conversationsCancellable.cancel()
+                selectionCancellable.cancel()
+            }
+            fixture.allowsPersistence = false
+
+            let deleted = fixture.store.deleteConversation(conversation.id)
+
+            #expect(deleted == false)
+            #expect(publishedConversationIDs == [[conversation.id]])
+            #expect(publishedSelections == [conversation.id])
+            #expect(fixture.store.conversation(for: conversation.id)?.title == "Keep")
+            #expect(fixture.store.selectedConversationId == conversation.id)
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+            #expect(fixture.enqueued.isEmpty)
+        }
+
+        @Test
+        func `Failed draft persistence does not publish the draft overlay`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model"))
+            fixture.store.acknowledgeWatchRevision(conversationID: conversation.id, revision: 1)
+            var publishedMessageContents: [[String]] = []
+            let cancellable = fixture.store.$conversations.sink { conversations in
+                publishedMessageContents.append(conversations.first?.messages.map(\.content) ?? [])
+            }
+            defer { cancellable.cancel() }
+            fixture.allowsPersistence = false
+            var draft = try #require(fixture.store.conversation(for: conversation.id))
+            draft.messages.append(makeMessage(role: .assistant, content: "Undurable", model: "model"))
+
+            let persisted = fixture.store.syncDraft(draft)
+
+            #expect(persisted == false)
+            #expect(publishedMessageContents == [[]])
+            #expect(fixture.store.conversation(for: conversation.id)?.messages.isEmpty == true)
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+        }
+
+        @Test
+        func `Failed acknowledgement persistence does not publish the candidate revision`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model"))
+            var publishedRevisions: [WatchSyncRevision] = []
+            let cancellable = fixture.store.$conversations.sink { conversations in
+                publishedRevisions.append(conversations.first?.watchRevision ?? 0)
+            }
+            defer { cancellable.cancel() }
+            fixture.allowsPersistence = false
+
+            let acknowledged = fixture.store.acknowledgeWatchRevision(
+                conversationID: conversation.id,
+                revision: 2
+            )
+
+            #expect(acknowledged == false)
+            #expect(publishedRevisions == [1])
+            #expect(fixture.store.pendingMutationsForSync.count == 1)
+            #expect(fixture.store.pendingMutationsForSync.first?.revision == 1)
+            #expect(fixture.store.conversation(for: conversation.id)?.watchRevision == 1)
+        }
+
+        @Test
+        func `Echo-covered mutation retries failed local acknowledgement without retransmission`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(title: "A", model: "model"))
+            #expect(fixture.store.acknowledgeWatchRevision(
+                conversationID: conversation.id,
+                revision: 1
+            ))
+            #expect(fixture.store.renameConversation(conversation.id, newTitle: "B"))
+            let mutation = try #require(fixture.store.pendingMutationsForSync.first)
+            #expect(fixture.store.markLegacyComponentsDelivered(
+                [.title(revision: mutation.titleRevision ?? mutation.revision)],
+                for: mutation
+            ))
+            let coverage = try #require(
+                fixture.store.durableLegacyDeliveryCoverage(for: conversation.id)
+            )
+            #expect(WatchLegacyEchoReconciler.canAcknowledge(
+                mutation,
+                currentMatches: [.title(revision: mutation.titleRevision ?? mutation.revision)],
+                durableCoverage: coverage
+            ))
+            let deliveryTracker = WatchLegacyDeliveryTracker(
+                userDefaults: fixture.defaults,
+                persistenceKey: "legacy-delivery"
+            )
+            deliveryTracker.confirm(
+                WatchLegacyEchoComponent.title(revision: mutation.titleRevision ?? mutation.revision)
+                    .deliveryUserInfo(for: mutation)
+            )
+            let suppressedSend = try WatchLegacyMutationSender.prepare(
+                mutation,
+                tracker: deliveryTracker
+            )
+            #expect(suppressedSend.componentIDs.isEmpty)
+            #expect(suppressedSend.fullyRepresented)
+            let transportEnqueueCount = fixture.enqueued.count
+            let retryTracker = WatchLegacyAcknowledgementRetryTracker()
+            retryTracker.retain(mutation)
+            fixture.allowsPersistence = false
+
+            let failed = retryTracker.retry { conversationID, revision in
+                fixture.store.acknowledgeWatchRevision(
+                    conversationID: conversationID,
+                    revision: revision
+                )
+            }
+
+            #expect(failed.isEmpty)
+            #expect(retryTracker.contains(operationID: mutation.operationID))
+            #expect(fixture.store.pendingMutationsForSync == [mutation])
+            #expect(fixture.enqueued.count == transportEnqueueCount)
+
+            fixture.allowsPersistence = true
+            let succeeded = retryTracker.retry { conversationID, revision in
+                fixture.store.acknowledgeWatchRevision(
+                    conversationID: conversationID,
+                    revision: revision
+                )
+            }
+
+            #expect(succeeded.map(\.operationID) == [mutation.operationID])
+            #expect(!retryTracker.contains(operationID: mutation.operationID))
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+            #expect(fixture.enqueued.count == transportEnqueueCount)
+        }
+
+        @Test
+        func `Failed conversation creation returns no phantom conversation`() {
+            let fixture = makeFixture()
+            fixture.allowsPersistence = false
+
+            let conversation = fixture.store.createConversation(model: "model")
+
+            #expect(conversation == nil)
+            #expect(fixture.store.conversations.isEmpty)
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+            #expect(fixture.enqueued.isEmpty)
+        }
+
+        @Test
+        func `Failed draft promotion reports failure and keeps the durable draft retryable`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model"))
+            #expect(fixture.store.acknowledgeWatchRevision(
+                conversationID: conversation.id,
+                revision: 1
+            ))
+            fixture.enqueued.removeAll()
+
+            let assistant = makeMessage(role: .assistant, content: "Answer", model: "model")
+            var draft = try #require(fixture.store.conversation(for: conversation.id))
+            draft.messages.append(assistant)
+            #expect(fixture.store.syncDraft(draft))
+            fixture.allowsPersistence = false
+
+            let failed = fixture.store.finishDraft(conversationID: conversation.id)
+
+            #expect(failed == .persistenceFailed)
+            #expect(fixture.store.conversation(for: conversation.id)?.messages == [assistant])
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+            #expect(fixture.enqueued.isEmpty)
+
+            fixture.allowsPersistence = true
+            let retried = fixture.store.finishDraft(conversationID: conversation.id)
+
+            guard case let .promoted(promoted) = retried else {
+                Issue.record("Expected the same durable draft to promote on retry")
+                return
+            }
+            #expect(promoted.messages == [assistant])
+            #expect(fixture.store.pendingMutationsForSync.flatMap(\.messageChanges) == [assistant])
+            #expect(fixture.enqueued.count == 1)
+        }
+
+        @Test
+        func `Adding a message while a draft exists preserves unique message identities`() throws {
+            let fixture = makeFixture()
+            let messageID = UUID()
+            let original = WatchMessage(
+                id: messageID,
+                role: Message.Role.user.rawValue,
+                content: "Original",
+                timestamp: Date(timeIntervalSince1970: 10)
+            )
+            let conversation = makeConversation(messages: [original])
+            #expect(fixture.store.applySyncSnapshot(snapshot(revision: 1, conversations: [conversation])) == .applied)
+
+            let assistant = makeMessage(role: .assistant, content: "Draft", model: "model")
+            var draft = try #require(fixture.store.conversation(for: conversation.id))
+            draft.messages.append(assistant)
+            #expect(fixture.store.syncDraft(draft))
+
+            let replacement = WatchMessage(
+                id: messageID,
+                role: Message.Role.user.rawValue,
+                content: "Replacement",
+                timestamp: Date(timeIntervalSince1970: 20)
+            )
+            #expect(fixture.store.addMessage(replacement, to: conversation.id))
+
+            let visible = try #require(fixture.store.conversation(for: conversation.id))
+            #expect(visible.messages.map(\.id) == [messageID, assistant.id])
+            #expect(visible.messages.first?.content == "Replacement")
+            #expect(Set(visible.messages.map(\.id)).count == visible.messages.count)
+        }
+
+        @Test
+        func `Finishing a draft syncs it once while discard restores committed state`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model"))
+            fixture.store.acknowledgeWatchRevision(conversationID: conversation.id, revision: 1)
+
+            var draft = try #require(fixture.store.conversation(for: conversation.id))
+            draft.messages.append(makeMessage(role: .assistant, content: "Partial", model: "model"))
+            fixture.store.syncDraft(draft)
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+
+            _ = fixture.store.finishDraft(conversationID: conversation.id)
+            #expect(fixture.store.pendingMutationsForSync.count == 1)
+            #expect(fixture.store.pendingMutationsForSync.first?.revision == 2)
+            #expect(fixture.store.finishDraft(conversationID: conversation.id) == .noDraft)
+            #expect(fixture.store.pendingMutationsForSync.count == 1)
+
+            fixture.store.acknowledgeWatchRevision(conversationID: conversation.id, revision: 2)
+            var discarded = try #require(fixture.store.conversation(for: conversation.id))
+            discarded.messages.append(makeMessage(role: .assistant, content: "Discard me", model: "model"))
+            fixture.store.syncDraft(discarded)
+            fixture.store.discardDraft(conversationID: conversation.id)
+            #expect(fixture.store.conversation(for: conversation.id)?.messages.last?.content == "Partial")
+            #expect(fixture.store.pendingMutationsForSync.isEmpty)
+        }
+
+        @Test
+        func `Draft finish preserves phone edits and deletions outside request ownership`() throws {
+            let fixture = makeFixture()
+            let edited = makeMessage(role: .user, content: "Original")
+            let deleted = makeMessage(role: .user, content: "Delete remotely")
+            let conversation = makeConversation(messages: [edited, deleted])
+            fixture.store.applySyncSnapshot(snapshot(revision: 1, conversations: [conversation]))
+
+            let assistant = makeMessage(role: .assistant, content: "Partial", model: "model")
+            var draft = conversation
+            draft.messages.append(assistant)
+            fixture.store.syncDraft(draft)
+
+            var phone = conversation
+            phone.messages = [
+                WatchMessage(
+                    id: edited.id,
+                    role: edited.role,
+                    content: "Edited on phone",
+                    timestamp: edited.timestamp,
+                    model: edited.model
+                )
+            ]
+            fixture.store.applySyncSnapshot(snapshot(revision: 2, conversations: [phone]))
+            _ = fixture.store.finishDraft(conversationID: conversation.id)
+
+            let finished = try #require(fixture.store.conversation(for: conversation.id))
+            let pending = try #require(fixture.store.pendingMutationsForSync.first)
+            #expect(finished.messages.map(\.id) == [edited.id, assistant.id])
+            #expect(finished.messages.first?.content == "Edited on phone")
+            #expect(pending.messageChanges == [assistant])
+        }
+
+        @Test
+        func `Draft finish safely canonicalizes duplicate remote message identities`() throws {
+            let fixture = makeFixture()
+            let duplicateID = UUID()
+            let older = WatchMessage(
+                id: duplicateID,
+                role: Message.Role.user.rawValue,
+                content: "Older",
+                timestamp: Date(timeIntervalSince1970: 10)
+            )
+            let newer = WatchMessage(
+                id: duplicateID,
+                role: Message.Role.user.rawValue,
+                content: "Newer",
+                timestamp: Date(timeIntervalSince1970: 20)
+            )
+            let conversation = makeConversation(messages: [older, newer])
+            fixture.store.applySyncSnapshot(snapshot(revision: 1, conversations: [conversation]))
+            let assistant = makeMessage(role: .assistant, content: "Answer", model: "model")
+            var draft = try #require(fixture.store.conversation(for: conversation.id))
+            draft.messages.append(assistant)
+            fixture.store.syncDraft(draft)
+
+            _ = fixture.store.finishDraft(conversationID: conversation.id)
+
+            let finished = try #require(fixture.store.conversation(for: conversation.id))
+            #expect(finished.messages.map(\.id) == [duplicateID, assistant.id])
+            #expect(finished.messages.first?.content == "Newer")
+        }
+
+        @Test
+        func `Snapshot publication canonicalizes duplicate message identities immediately`() throws {
+            let fixture = makeFixture()
+            let duplicateID = UUID()
+            let older = WatchMessage(
+                id: duplicateID,
+                role: Message.Role.user.rawValue,
+                content: "Older",
+                timestamp: Date(timeIntervalSince1970: 10)
+            )
+            let newer = WatchMessage(
+                id: duplicateID,
+                role: Message.Role.user.rawValue,
+                content: "Newer",
+                timestamp: Date(timeIntervalSince1970: 20)
+            )
+            let conversation = makeConversation(messages: [older, newer])
+
+            fixture.store.applySyncSnapshot(snapshot(revision: 1, conversations: [conversation]))
+
+            let published = try #require(fixture.store.conversation(for: conversation.id))
+            #expect(published.messages.map(\.id) == [duplicateID])
+            #expect(published.messages.first?.content == "Newer")
+        }
+    }
+
+    private struct PersistedFixtureState: Codable {
+        var sourceID: UUID?
+        var peerID: UUID?
+        var lastSnapshotRevision: WatchSyncRevision
+        var conversations: [WatchConversation]
+        var pendingMutations: [WatchConversationMutation]
+        var pendingDrafts: [WatchConversationDraft]
+        var legacyDeliveryCoverage: [UUID: WatchMutationDeliveryCoverage]?
+    }
+
+    @MainActor
+    private func persistedFixtureState(in fixture: StoreFixture) throws -> PersistedFixtureState {
+        let data = try #require(fixture.defaults.data(forKey: fixture.key))
+        return try JSONDecoder().decode(PersistedFixtureState.self, from: data)
+    }
+
+    @MainActor
+    private func persistFixtureState(
+        peerID: UUID,
+        conversations: [WatchConversation],
+        pendingMutations: [WatchConversationMutation] = [],
+        pendingDrafts: [WatchConversationDraft] = [],
+        legacyDeliveryCoverage: [UUID: WatchMutationDeliveryCoverage] = [:],
+        in fixture: StoreFixture
+    ) throws {
+        let data = try JSONEncoder().encode(PersistedFixtureState(
+            sourceID: nil,
+            peerID: peerID,
+            lastSnapshotRevision: 0,
+            conversations: conversations,
+            pendingMutations: pendingMutations,
+            pendingDrafts: pendingDrafts,
+            legacyDeliveryCoverage: legacyDeliveryCoverage
+        ))
+        fixture.defaults.set(data, forKey: fixture.key)
+    }
+
+    @MainActor
+    private final class StoreFixture {
+        let defaults: UserDefaults
+        let key: String
+        var enqueued: [WatchConversationMutation] = []
+        var allowsPersistence = true
+        private let maximumCachedConversationBodies: Int
+        lazy var store = WatchConversationStore(
+            userDefaults: defaults,
+            persistenceKey: key,
+            maximumCachedConversationBodies: maximumCachedConversationBodies,
+            now: { Date(timeIntervalSince1970: 100) },
+            persistenceWriter: { [weak self] data in
+                guard let self, allowsPersistence else { return false }
+                defaults.set(data, forKey: key)
+                return true
+            },
+            mutationEnqueuer: { [weak self] mutation in self?.enqueued.append(mutation) }
+        )
+
+        init(maximumCachedConversationBodies: Int = 20) {
+            self.maximumCachedConversationBodies = maximumCachedConversationBodies
+            let suiteName = "WatchConversationStoreNativeTests.\(UUID().uuidString)"
+            defaults = UserDefaults(suiteName: suiteName)!
+            defaults.removePersistentDomain(forName: suiteName)
+            key = "state"
+        }
+    }
+
+    @MainActor
+    private func makeFixture(maximumCachedConversationBodies: Int = 20) -> StoreFixture {
+        StoreFixture(maximumCachedConversationBodies: maximumCachedConversationBodies)
+    }
+
+    private func snapshot(
+        revision: WatchSyncRevision,
+        conversations: [WatchConversation]
+    ) -> WatchSyncSnapshot {
+        WatchSyncSnapshot(
+            revision: revision,
+            conversations: conversations,
+            authoritativeConversationIDs: conversations.map(\.id)
+        )
+    }
+
+    private func makeConversation(
+        id: UUID = UUID(),
+        messages: [WatchMessage] = []
+    ) -> WatchConversation {
+        let date = Date(timeIntervalSince1970: 10)
+        return WatchConversation(
+            id: id,
+            title: "Synced",
+            messages: messages,
+            model: "model",
+            updatedAt: date,
+            createdAt: date,
+            temperature: 0.25,
+            resolvedSystemPrompt: "System prompt"
+        )
+    }
+
+    private func makeMessage(
+        role: Message.Role,
+        content: String,
+        model: String? = nil
+    ) -> WatchMessage {
+        WatchMessage(
+            id: UUID(),
+            role: role.rawValue,
+            content: content,
+            timestamp: Date(timeIntervalSince1970: 20),
+            model: model
+        )
+    }
+
+    // swiftlint:enable identifier_name
+
+#endif

--- a/Tests/AynaTests/WatchSyncConversationStoreNativeTests.swift
+++ b/Tests/AynaTests/WatchSyncConversationStoreNativeTests.swift
@@ -798,6 +798,51 @@
         }
 
         @Test
+        func `Rejected counterpart reset restores legacy coverage and clears durably on retry`() throws {
+            let fixture = makeFixture()
+            let conversation = try #require(fixture.store.createConversation(model: "model"))
+            let message = makeMessage(role: .user, content: "Pending counterpart delivery")
+            #expect(fixture.store.addMessage(message, to: conversation.id))
+            let mutation = try #require(fixture.store.pendingMutationsForSync.first)
+            let component = WatchLegacyEchoComponent.message(
+                id: message.id,
+                revision: mutation.messageChangeRevisions[message.id] ?? mutation.revision
+            )
+            #expect(fixture.store.markLegacyComponentsDelivered([component], for: mutation))
+            let coverage = try #require(
+                fixture.store.durableLegacyDeliveryCoverage(for: conversation.id)
+            )
+            fixture.allowsPersistence = false
+
+            #expect(!fixture.store.clearLegacyDeliveryCoverage())
+            #expect(fixture.store.durableLegacyDeliveryCoverage(for: conversation.id) == coverage)
+            #expect(fixture.store.pendingMutationsForSync == [mutation])
+            #expect(
+                try persistedFixtureState(in: fixture).legacyDeliveryCoverage?[conversation.id] == coverage
+            )
+
+            let restartedAfterFailure = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(restartedAfterFailure.durableLegacyDeliveryCoverage(for: conversation.id) == coverage)
+            #expect(restartedAfterFailure.pendingMutationsForSync == [mutation])
+
+            fixture.allowsPersistence = true
+            #expect(fixture.store.clearLegacyDeliveryCoverage())
+            #expect(fixture.store.durableLegacyDeliveryCoverage(for: conversation.id) == nil)
+
+            let restartedAfterRetry = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            #expect(restartedAfterRetry.durableLegacyDeliveryCoverage(for: conversation.id) == nil)
+            #expect(restartedAfterRetry.pendingMutationsForSync == [mutation])
+        }
+
+        @Test
         func `Deletion is durable and emits a revisioned deletion mutation`() throws {
             let fixture = makeFixture()
             let conversation = try #require(fixture.store.createConversation(model: "model"))

--- a/Tests/AynaTests/WatchSyncProtocolTests.swift
+++ b/Tests/AynaTests/WatchSyncProtocolTests.swift
@@ -1,0 +1,3009 @@
+// swiftlint:disable file_length identifier_name type_body_length
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Watch sync protocol tests", .tags(.fast))
+struct WatchSyncProtocolTests {
+    @Test
+    func `Mutation retry backoff is bounded and exponential`() {
+        #expect(WatchMutationRetryBackoff.seconds(forAttempt: 0) == 5)
+        #expect(WatchMutationRetryBackoff.seconds(forAttempt: 1) == 10)
+        #expect(WatchMutationRetryBackoff.seconds(forAttempt: 2) == 20)
+        #expect(WatchMutationRetryBackoff.seconds(forAttempt: 20) == 60)
+    }
+
+    @Test
+    func `Model fallback keeps every model referenced by mirrored conversations`() {
+        let models = WatchModelSyncSelection.models(
+            selectedModel: "selected",
+            availableModels: ["other-a", "other-b", "referenced-b"],
+            referencedModels: ["referenced-a", "referenced-b"],
+            limit: 2
+        )
+
+        #expect(models == ["selected", "referenced-a", "referenced-b"])
+        #expect(WatchModelSyncSelection.selectableModels(
+            selectedModel: "referenced-a",
+            availableModels: ["other-a", "other-b", "referenced-b"],
+            limit: 2
+        ) == ["other-a", "other-b"])
+    }
+
+    @Test
+    func `Long model identifiers remain exact through body build Codable and reconcile`() throws {
+        let maximumModelCharacters = 16
+        let model = "custom-provider/" + String(repeating: "long-model-segment-", count: 12)
+        #expect(model.count > maximumModelCharacters)
+        let message = Message(
+            role: .assistant,
+            content: "Response",
+            model: model
+        )
+        let phone = Conversation(
+            title: "Long model",
+            messages: [message],
+            model: model
+        )
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumModelCharacters = maximumModelCharacters
+
+        let payload = try WatchSyncPayloadBuilder.build(
+            conversations: [phone],
+            snapshotRevision: 1,
+            configuration: configuration
+        )
+        let decoded = try JSONDecoder().decode(WatchSyncSnapshot.self, from: payload.data)
+        let body = try #require(decoded.conversations.first)
+        let reconciled = try #require(
+            WatchSnapshotReconciler.reconcile(decoded, with: WatchSyncLocalState())
+                .state.conversations.first
+        )
+        let settingsByModel = [model: "exact-settings"]
+
+        #expect(body.model == model)
+        #expect(body.messages.first?.model == model)
+        #expect(settingsByModel[body.model] == "exact-settings")
+        #expect(reconciled.model == model)
+        #expect(reconciled.messages.first?.model == model)
+        #expect(settingsByModel[reconciled.model] == "exact-settings")
+    }
+
+    @Test
+    func `Long model identifiers remain exact through compact configuration build Codable and reconcile`() throws {
+        let maximumModelCharacters = 16
+        let model = "custom-provider/" + String(repeating: "configuration-segment-", count: 12)
+        #expect(model.count > maximumModelCharacters)
+        let phone = Conversation(
+            title: "Manifest only",
+            model: model,
+            temperature: 0.25
+        )
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumModelCharacters = maximumModelCharacters
+
+        let payload = try WatchSyncPayloadBuilder.build(
+            conversations: [phone],
+            snapshotRevision: 1,
+            configuration: configuration
+        )
+        let decoded = try JSONDecoder().decode(WatchSyncSnapshot.self, from: payload.data)
+        let compactConfiguration = try #require(decoded.conversationConfigurations.first)
+        let retainedMessage = WatchMessage(from: Message(role: .user, content: "Keep me"))
+        let retained = WatchConversation(
+            id: phone.id,
+            title: phone.title,
+            messages: [retainedMessage],
+            model: "old-model",
+            updatedAt: phone.updatedAt,
+            createdAt: phone.createdAt
+        )
+        let state = WatchSyncLocalState(conversations: [retained])
+        let reconciled = try #require(
+            WatchSnapshotReconciler.reconcile(decoded, with: state)
+                .state.conversations.first
+        )
+        let settingsByModel = [model: "exact-settings"]
+
+        #expect(decoded.conversations.isEmpty)
+        #expect(compactConfiguration.model == model)
+        #expect(settingsByModel[compactConfiguration.model] == "exact-settings")
+        #expect(reconciled.model == model)
+        #expect(reconciled.messages == [retainedMessage])
+        #expect(settingsByModel[reconciled.model] == "exact-settings")
+    }
+
+    @Test
+    func `Resolved prompt above the character threshold is delivered when the byte budget permits`() throws {
+        let prompt = String(repeating: "lossless-prompt-segment-", count: 240)
+        #expect(prompt.count > WatchSyncPayloadConfiguration.default.maximumSystemPromptCharacters)
+        let phone = Conversation(
+            title: "Oversized prompt",
+            model: "test-model",
+            systemPromptMode: .custom(prompt)
+        )
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumConversationConfigurations = 1
+        configuration.byteBudget = 32000
+
+        let payload = try WatchSyncPayloadBuilder.build(
+            conversations: [phone],
+            snapshotRevision: 1,
+            configuration: configuration,
+            resolvedSystemPrompt: { _ in prompt }
+        )
+
+        let compactConfiguration = try #require(payload.snapshot.conversationConfigurations.first)
+        #expect(payload.data.count <= configuration.byteBudget)
+        #expect(compactConfiguration.resolvedSystemPrompt == prompt)
+    }
+
+    @Test
+    func `Oversized model record is deferred rather than truncated to fit the snapshot budget`() throws {
+        let model = "custom-provider/" + String(repeating: "oversized-model-segment-", count: 200)
+        let phone = Conversation(title: "Oversized model", model: model)
+        let deferredSnapshot = WatchSyncSnapshot(
+            revision: 1,
+            conversations: [],
+            authoritativeConversationIDs: [],
+            authoritativeConversationIDsAreComplete: false,
+            conversationConfigurations: [],
+            conversationConfigurationsAreComplete: false
+        )
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumModelCharacters = 8
+        configuration.byteBudget = try WatchSyncPayloadBuilder.encode(deferredSnapshot).count
+
+        let payload = try WatchSyncPayloadBuilder.build(
+            conversations: [phone],
+            snapshotRevision: 1,
+            configuration: configuration
+        )
+
+        #expect(payload.data.count <= configuration.byteBudget)
+        #expect(payload.snapshot == deferredSnapshot)
+        #expect(payload.snapshot.conversations.isEmpty)
+        #expect(payload.snapshot.conversationConfigurations.isEmpty)
+    }
+
+    @Test
+    // swiftlint:disable:next function_body_length
+    func `Oversized prompt gate clears stale state and a later page cycle converges losslessly`() throws {
+        let oversizedID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000301"))
+        let laterID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000302"))
+        let peerID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000304"))
+        let sourceID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000305"))
+        let oversizedPrompt = String(repeating: "lossless-prompt-segment-", count: 260)
+        let oversized = Conversation(
+            id: oversizedID,
+            title: "Oversized",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 30),
+            model: "oversized-model",
+            systemPromptMode: .custom(oversizedPrompt)
+        )
+        let later = Conversation(
+            id: laterID,
+            title: "Later",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 20),
+            model: "later-model",
+            temperature: 0.25
+        )
+        let state = PhoneWatchSyncState(
+            peerID: peerID,
+            conversations: [later, oversized]
+        )
+        let availabilityGate = WatchConversationRequestConfiguration(
+            id: oversizedID,
+            model: oversized.model,
+            temperature: oversized.temperature,
+            resolvedSystemPrompt: nil
+        )
+        let laterConfiguration = WatchConversationRequestConfiguration(
+            id: laterID,
+            model: later.model,
+            temperature: later.temperature,
+            resolvedSystemPrompt: nil
+        )
+        let firstExpectedSnapshot = WatchSyncSnapshot(
+            snapshotRevision: 10,
+            sourceID: sourceID,
+            paginationCursor: 0,
+            conversations: [],
+            authoritativeConversationIDs: [oversizedID, laterID],
+            authoritativeConversationIDsAreComplete: true,
+            conversationConfigurations: [availabilityGate],
+            conversationConfigurationsAreComplete: false,
+            acknowledgedPeerID: peerID
+        )
+        let secondExpectedSnapshot = WatchSyncSnapshot(
+            snapshotRevision: 11,
+            sourceID: sourceID,
+            paginationCursor: 1,
+            conversations: [],
+            authoritativeConversationIDs: [],
+            authoritativeConversationIDsAreComplete: false,
+            conversationConfigurations: [laterConfiguration],
+            conversationConfigurationsAreComplete: false,
+            acknowledgedPeerID: peerID
+        )
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumManifestConversationIDs = 2
+        configuration.maximumConversationConfigurations = 1
+        configuration.maximumAcknowledgements = 0
+        configuration.maximumTombstones = 0
+        configuration.maximumSystemPromptCharacters = 8
+        configuration.byteBudget = try max(
+            WatchSyncPayloadBuilder.encode(firstExpectedSnapshot).count,
+            WatchSyncPayloadBuilder.encode(secondExpectedSnapshot).count
+        )
+        let cycleID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000306"))
+        let promptResolver: (Conversation) -> String? = { conversation in
+            conversation.id == oversizedID ? oversizedPrompt : nil
+        }
+
+        let first = try WatchSyncPayloadBuilder.buildPageCycle(
+            state: state,
+            sourceID: sourceID,
+            snapshotRevision: 10,
+            cycleID: cycleID,
+            cursor: .initial,
+            configuration: configuration,
+            resolvedSystemPrompt: promptResolver
+        )
+        let secondCursor = try #require(first.metadata.nextCursor)
+        let second = try WatchSyncPayloadBuilder.buildPageCycle(
+            state: state,
+            sourceID: sourceID,
+            snapshotRevision: 11,
+            cycleID: cycleID,
+            cursor: secondCursor,
+            configuration: configuration,
+            resolvedSystemPrompt: promptResolver
+        )
+
+        #expect(first.data.count <= configuration.byteBudget)
+        #expect(first.snapshot == firstExpectedSnapshot)
+        #expect(first.metadata.configurations == WatchSyncPageSection(
+            offset: 0,
+            itemCount: 1,
+            totalCount: 2,
+            containsUnavailablePromptGate: true
+        ))
+        #expect(!first.metadata.configurations.isLossless)
+        #expect(secondCursor == WatchSyncPageCycleCursor(
+            pageIndex: 1,
+            manifestOffset: 2,
+            configurationOffset: 1,
+            tombstoneOffset: 0,
+            precedingConfigurationsAreLossless: false
+        ))
+        #expect(second.data.count <= configuration.byteBudget)
+        #expect(second.snapshot == secondExpectedSnapshot)
+        #expect(second.metadata.nextCursor == nil)
+        #expect(!second.metadata.modelMetadataCycleIsAuthoritative)
+
+        let stale = WatchConversation(
+            id: oversizedID,
+            title: oversized.title,
+            model: oversized.model,
+            updatedAt: oversized.updatedAt,
+            createdAt: oversized.createdAt,
+            resolvedSystemPrompt: "stale instructions"
+        )
+        let gatedState = WatchSnapshotReconciler.reconcile(
+            first.snapshot,
+            with: WatchSyncLocalState(
+                sourceID: sourceID,
+                peerID: peerID,
+                lastSnapshotRevision: 9,
+                conversations: [stale]
+            )
+        ).state
+        #expect(gatedState.conversations.first?.resolvedSystemPrompt == nil)
+
+        configuration.byteBudget = 32000
+        let retried = try WatchSyncPayloadBuilder.buildPageCycle(
+            state: state,
+            sourceID: sourceID,
+            snapshotRevision: 12,
+            cycleID: #require(UUID(uuidString: "00000000-0000-0000-0000-000000000307")),
+            cursor: .initial,
+            configuration: configuration,
+            resolvedSystemPrompt: promptResolver
+        )
+        let retriedConfiguration = try #require(retried.snapshot.conversationConfigurations.first)
+        let convergedState = WatchSnapshotReconciler.reconcile(
+            retried.snapshot,
+            with: gatedState
+        ).state
+
+        #expect(retried.data.count <= configuration.byteBudget)
+        #expect(retriedConfiguration.id == oversizedID)
+        #expect(retriedConfiguration.resolvedSystemPrompt == oversizedPrompt)
+        #expect(retried.metadata.configurations.isLossless)
+        #expect(convergedState.conversations.first?.resolvedSystemPrompt == oversizedPrompt)
+    }
+
+    @Test
+    @MainActor
+    func `Default prompt fallbacks clear stale instructions and later converge without source loss`() throws {
+        let suiteName = "WatchDefaultPromptGateTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let oversizedPrompt = String(repeating: "global-prompt-segment-", count: 260)
+        defaults.set(oversizedPrompt, forKey: "globalSystemPrompt")
+        defer {
+            WatchDefaultSystemPromptPublicationGate.prepareForSnapshotBuild(defaults: defaults)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let attempts = WatchApplicationContextAttempt.fallbacks(
+            memoryFacts: WatchMemoryFactsPayload(data: nil, preservesAcrossFallbacks: false)
+        )
+        var retainedPrompt: String? = "stale instructions"
+        for attempt in attempts {
+            var configuration = WatchSyncPayloadConfiguration.default
+            configuration.byteBudget = attempt.snapshotBytes
+            #expect(WatchDefaultSystemPromptPublicationGate.maximumCharacters(
+                for: configuration
+            ) == attempt.maximumDefaultSystemPromptCharacters)
+            #expect(WatchDefaultSystemPromptPublicationGate.installIfNeeded(
+                configuration: configuration,
+                defaults: defaults,
+                schedulesAutomaticRestore: false
+            ))
+
+            let incoming = WatchPayloadStringLimiter.losslessRepresentation(
+                defaults.string(forKey: "globalSystemPrompt") ?? "",
+                maximumCharacters: attempt.maximumDefaultSystemPromptCharacters
+            )
+            #expect(incoming == "")
+            retainedPrompt = WatchDefaultSystemPromptReducer.value(
+                current: retainedPrompt,
+                incoming: incoming
+            )
+            #expect(retainedPrompt == nil)
+            #expect(defaults.persistentDomain(forName: suiteName)?["globalSystemPrompt"] as? String
+                == oversizedPrompt)
+        }
+
+        WatchDefaultSystemPromptPublicationGate.prepareForSnapshotBuild(defaults: defaults)
+        #expect(defaults.string(forKey: "globalSystemPrompt") == oversizedPrompt)
+        defaults.set("replacement instructions", forKey: "globalSystemPrompt")
+        var recoveryConfiguration = WatchSyncPayloadConfiguration.default
+        recoveryConfiguration.byteBudget = attempts[0].snapshotBytes
+        #expect(!WatchDefaultSystemPromptPublicationGate.installIfNeeded(
+            configuration: recoveryConfiguration,
+            defaults: defaults,
+            schedulesAutomaticRestore: false
+        ))
+        let recoveredPrompt = WatchPayloadStringLimiter.losslessRepresentation(
+            defaults.string(forKey: "globalSystemPrompt") ?? "",
+            maximumCharacters: attempts[0].maximumDefaultSystemPromptCharacters
+        )
+
+        #expect(recoveredPrompt == "replacement instructions")
+        #expect(WatchDefaultSystemPromptReducer.value(
+            current: retainedPrompt,
+            incoming: recoveredPrompt
+        ) == "replacement instructions")
+    }
+
+    @Test
+    func `Legacy page section decoding defaults prompt availability gates to absent`() throws {
+        let data = Data(
+            #"{"offset":0,"itemCount":1,"totalCount":1,"cursorAdvanceCount":1}"#.utf8
+        )
+
+        let section = try JSONDecoder().decode(WatchSyncPageSection.self, from: data)
+
+        #expect(!section.containsUnavailablePromptGate)
+        #expect(section.isLossless)
+    }
+
+    @Test
+    func `Application context prompt fallback emits only lossless values or explicit clears`() {
+        #expect(WatchPayloadStringLimiter.losslessRepresentation(
+            "abc",
+            maximumCharacters: 3
+        ) == "abc")
+        #expect(WatchPayloadStringLimiter.losslessRepresentation(
+            "abcdef",
+            maximumCharacters: 3
+        ) == nil)
+        #expect(WatchPayloadStringLimiter.losslessRepresentation(
+            "",
+            maximumCharacters: 0
+        ) == "")
+        #expect(WatchPayloadStringLimiter.losslessRepresentation(
+            "a",
+            maximumCharacters: 0
+        ) == nil)
+        #expect(WatchDefaultSystemPromptReducer.value(
+            current: "retained",
+            incoming: nil
+        ) == "retained")
+        #expect(WatchDefaultSystemPromptReducer.value(
+            current: "retained",
+            incoming: ""
+        ) == nil)
+        #expect(WatchDefaultSystemPromptReducer.value(
+            current: "retained",
+            incoming: "replacement"
+        ) == "replacement")
+    }
+
+    @Test
+    func `Revision decoder accepts only exact unsigned integers`() {
+        #expect(WatchSyncValueDecoder.revision(UInt64.max) == UInt64.max)
+        #expect(WatchSyncValueDecoder.revision(NSNumber(value: 42.0)) == 42)
+
+        #expect(WatchSyncValueDecoder.revision(true) == nil)
+        #expect(WatchSyncValueDecoder.revision(NSNumber(value: -1)) == nil)
+        #expect(WatchSyncValueDecoder.revision(NSNumber(value: 1.5)) == nil)
+        #expect(WatchSyncValueDecoder.revision(NSNumber(value: Double(UInt64.max))) == nil)
+        #expect(WatchSyncValueDecoder.revision(NSDecimalNumber(string: "18446744073709551616")) == nil)
+        #expect(WatchSyncValueDecoder.revision(NSDecimalNumber(string: "42.0000000000000000001")) == nil)
+    }
+
+    @Test
+    func `Revision map decoder merges UUID case aliases at the maximum revision`() throws {
+        let id = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE1"))
+        let data = try JSONSerialization.data(withJSONObject: [
+            id.uuidString: 2,
+            id.uuidString.lowercased(): 7
+        ], options: [.sortedKeys])
+
+        let decoded = WatchSyncMetadataCodec.decodeRevisionMap(data)
+
+        #expect(decoded == [id: 7])
+    }
+
+    @Test
+    func `Peer revision map decoder merges peer and conversation UUID aliases`() throws {
+        let peerID = try #require(UUID(uuidString: "ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEF01"))
+        let conversationID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE2"))
+        let otherConversationID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE3"))
+        let data = try JSONSerialization.data(withJSONObject: [
+            peerID.uuidString: [
+                conversationID.uuidString: 2,
+                conversationID.uuidString.lowercased(): 5
+            ],
+            peerID.uuidString.lowercased(): [
+                conversationID.uuidString: 7,
+                otherConversationID.uuidString.lowercased(): 4
+            ]
+        ], options: [.sortedKeys])
+
+        let decoded = WatchSyncMetadataCodec.decodePeerRevisionMaps(data)
+
+        #expect(decoded == [peerID: [conversationID: 7, otherConversationID: 4]])
+    }
+
+    @Test
+    func `Snapshot acknowledgement decoder merges UUID case aliases`() throws {
+        let conversationID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE4"))
+        let snapshot = WatchSyncSnapshot(
+            revision: 1,
+            conversations: [],
+            authoritativeConversationIDs: []
+        )
+        let encoded = try WatchSyncPayloadBuilder.encode(snapshot)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        object["acknowledgedWatchRevisions"] = [
+            conversationID.uuidString: 3,
+            conversationID.uuidString.lowercased(): 9
+        ]
+        let aliased = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+
+        let decoded = try JSONDecoder().decode(WatchSyncSnapshot.self, from: aliased)
+
+        #expect(decoded.acknowledgedWatchRevisions == [conversationID: 9])
+    }
+
+    @Test
+    func `Mutation message revision decoder normalizes UUID aliases`() throws {
+        let messageID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE5"))
+        let message = WatchMessage(
+            id: messageID,
+            role: Message.Role.user.rawValue,
+            content: "Changed",
+            timestamp: Date(timeIntervalSince1970: 10)
+        )
+        let mutation = WatchConversationMutation(
+            revision: 10,
+            conversation: makeWatchConversation(title: "Alias", revision: 10),
+            fields: [.messages],
+            messageChanges: [message]
+        )
+        let encoded = try WatchSyncPayloadBuilder.encodeMutation(mutation)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        object["messageChangeRevisions"] = [
+            messageID.uuidString: 3,
+            messageID.uuidString.lowercased(): 7
+        ]
+        let aliased = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+
+        let decoded = try JSONDecoder().decode(WatchConversationMutation.self, from: aliased)
+
+        #expect(decoded.messageChangeRevisions == [messageID: 7])
+        #expect(decoded.messageChanges(after: 6) == [message])
+    }
+
+    @Test
+    @MainActor
+    func `Legacy delivery tracker sends create and each incremental change once across restart`() throws {
+        let suiteName = "WatchLegacyDeliveryTrackerTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let key = "state"
+        let conversation = makeWatchConversation(title: "Initial", revision: 1)
+        let firstMessage = WatchMessage(from: Message(role: .user, content: "First"))
+        let firstMutation = WatchConversationMutation(
+            revision: 1,
+            conversation: conversation,
+            fields: [.create, .messages, .title],
+            messageChanges: [firstMessage]
+        )
+        let tracker = WatchLegacyDeliveryTracker(userDefaults: defaults, persistenceKey: key)
+
+        #expect(tracker.needsCreate(conversationID: conversation.id))
+        #expect(tracker.pendingMessages(from: firstMutation) == [firstMessage])
+        #expect(tracker.needsTitle(
+            conversationID: conversation.id,
+            title: "Initial",
+            revision: 1
+        ))
+        #expect(tracker.configurationIsRepresented(by: firstMutation, createWillBeSent: true))
+        tracker.confirm([
+            WatchMessageKeys.conversationId: conversation.id.uuidString,
+            WatchMessageKeys.legacyComponentKind: WatchMessageKeys.legacyComponentCreate,
+            WatchMessageKeys.configurationRevision: NSNumber(value: 1)
+        ])
+        tracker.confirm([
+            WatchMessageKeys.conversationId: conversation.id.uuidString,
+            WatchMessageKeys.legacyComponentKind: WatchMessageKeys.legacyComponentMessage,
+            WatchMessageKeys.messageId: firstMessage.id.uuidString,
+            WatchMessageKeys.mutationRevision: NSNumber(value: 1)
+        ])
+        tracker.confirm([
+            WatchMessageKeys.conversationId: conversation.id.uuidString,
+            WatchMessageKeys.legacyComponentKind: WatchMessageKeys.legacyComponentTitle,
+            WatchMessageKeys.title: "Initial",
+            WatchMessageKeys.mutationRevision: NSNumber(value: 1)
+        ])
+        #expect(!tracker.needsCreate(conversationID: conversation.id))
+        #expect(tracker.pendingMessages(from: firstMutation).isEmpty)
+        #expect(!tracker.needsTitle(
+            conversationID: conversation.id,
+            title: "Initial",
+            revision: 1
+        ))
+
+        let updatedMessage = WatchMessage(
+            id: firstMessage.id,
+            role: firstMessage.role,
+            content: "Updated",
+            timestamp: firstMessage.timestamp
+        )
+        let secondMessage = WatchMessage(from: Message(role: .assistant, content: "Second"))
+        let secondMutation = WatchConversationMutation(
+            revision: 2,
+            conversation: conversation,
+            fields: [.create, .messages, .title, .configuration],
+            messageChanges: [updatedMessage, secondMessage]
+        )
+        #expect(tracker.pendingMessages(from: secondMutation) == [updatedMessage, secondMessage])
+        #expect(!tracker.configurationIsRepresented(by: secondMutation, createWillBeSent: false))
+
+        let reloaded = WatchLegacyDeliveryTracker(userDefaults: defaults, persistenceKey: key)
+        #expect(!reloaded.needsCreate(conversationID: conversation.id))
+        #expect(reloaded.pendingMessages(from: secondMutation) == [updatedMessage, secondMessage])
+        #expect(reloaded.needsTitle(
+            conversationID: conversation.id,
+            title: "Initial",
+            revision: 2
+        ))
+        #expect(reloaded.needsTitle(
+            conversationID: conversation.id,
+            title: "Renamed",
+            revision: 2
+        ))
+    }
+
+    @Test
+    func `Revision metadata fences delayed legacy fallback`() {
+        let peerID = UUID()
+        let conversationID = UUID()
+        let metadata = WatchLegacyMutationMetadata(message: [
+            WatchMessageKeys.peerId: peerID.uuidString,
+            WatchMessageKeys.mutationRevision: NSNumber(value: 4)
+        ])
+
+        #expect(metadata.isCovered(
+            conversationID: conversationID,
+            activePeerID: peerID,
+            acknowledgements: [conversationID: 4]
+        ))
+        #expect(!metadata.isCovered(
+            conversationID: conversationID,
+            activePeerID: peerID,
+            acknowledgements: [conversationID: 3]
+        ))
+    }
+
+    @Test
+    @MainActor
+    func `Legacy operation completes only after every component succeeds`() {
+        let mutation = WatchConversationMutation(
+            revision: 3,
+            conversation: makeWatchConversation(title: "Legacy", revision: 3),
+            fields: [.create, .messages, .title]
+        )
+        let tracker = WatchLegacyOperationTracker()
+        tracker.begin(
+            mutation,
+            result: WatchLegacySendResult(
+                userInfos: ["create", "message", "title"].map {
+                    [WatchMessageKeys.legacyComponentId: $0]
+                },
+                fullyRepresented: true
+            )
+        )
+
+        #expect(tracker.completion(operationID: mutation.operationID, componentID: "create") == nil)
+        #expect(tracker.completion(operationID: mutation.operationID, componentID: "message") == nil)
+        let completion = tracker.completion(operationID: mutation.operationID, componentID: "title")
+        #expect(completion?.conversationID == mutation.conversationID)
+        #expect(completion?.revision == mutation.revision)
+    }
+
+    @Test
+    @MainActor
+    func `Mutation processing queue does not let a later callback overtake persistence`() async {
+        let queue = WatchMutationProcessingQueue()
+        let gate = TestGate()
+        var events: [String] = []
+
+        let newest = Task { @MainActor in
+            await queue.enqueue {
+                events.append("revision-2-start")
+                await gate.wait()
+                events.append("revision-2-finish")
+            }
+        }
+        await Task.yield()
+        let stale = Task { @MainActor in
+            await queue.enqueue {
+                events.append("revision-1")
+            }
+        }
+        await Task.yield()
+
+        #expect(events == ["revision-2-start"])
+        gate.open()
+        await newest.value
+        await stale.value
+        #expect(events == ["revision-2-start", "revision-2-finish", "revision-1"])
+    }
+
+    @Test
+    @MainActor
+    func `Session event queue drains receives before a later lifecycle event`() async {
+        let queue = WatchSessionEventQueue()
+        let gate = TestGate()
+        var events: [String] = []
+
+        queue.enqueue {
+            events.append("receive-start")
+            await gate.wait()
+            events.append("receive-finish")
+        }
+        queue.enqueue {
+            events.append("deactivate")
+        }
+        await Task.yield()
+
+        #expect(events == ["receive-start"])
+        gate.open()
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while events.count < 3, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(events == ["receive-start", "receive-finish", "deactivate"])
+    }
+
+    @Test
+    func `Phone state and reducer canonicalize duplicate conversation IDs using the newest state`() {
+        let conversationID = UUID()
+        let older = Conversation(
+            id: conversationID,
+            title: "Older",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 10),
+            model: "older-model"
+        )
+        let newer = Conversation(
+            id: conversationID,
+            title: "Newer",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 20),
+            model: "newer-model"
+        )
+
+        let initialized = PhoneWatchSyncState(conversations: [older, newer])
+        #expect(initialized.conversations.count == 1)
+        #expect(initialized.conversations.first?.title == "Newer")
+
+        var mutated = initialized
+        mutated.conversations = [older, newer]
+        let watchState = makeWatchConversation(
+            id: conversationID,
+            title: "Watch edit",
+            revision: 1,
+            updatedAt: 30
+        )
+        let reduced = PhoneWatchMutationReducer.reduce(
+            mutated,
+            mutation: WatchConversationMutation(
+                revision: 1,
+                conversation: watchState,
+                fields: [.title]
+            )
+        )
+
+        #expect(reduced.state.conversations.count == 1)
+        #expect(reduced.state.conversations.first?.title == "Watch edit")
+        #expect(reduced.state.conversations.first?.model == "newer-model")
+    }
+
+    @Test
+    func `Watch local state canonicalizes duplicate IDs using revision before timestamp`() {
+        let conversationID = UUID()
+        let newerTimestamp = makeWatchConversation(
+            id: conversationID,
+            title: "Newer timestamp",
+            revision: 4,
+            updatedAt: 40
+        )
+        let newerRevision = makeWatchConversation(
+            id: conversationID,
+            title: "Newer revision",
+            revision: 5,
+            updatedAt: 20
+        )
+
+        let state = WatchSyncLocalState(conversations: [newerTimestamp, newerRevision])
+
+        #expect(state.conversations.count == 1)
+        #expect(state.conversations.first?.title == "Newer revision")
+        #expect(state.conversations.first?.watchRevision == 5)
+    }
+
+    @Test
+    func `Phone reducer preserves phone-only state and merges messages by stable ID`() throws {
+        let conversationID = UUID()
+        let existingMessageID = UUID()
+        let newMessageID = UUID()
+        let timestamp = Date(timeIntervalSince1970: 100)
+        var phone = Conversation(
+            id: conversationID,
+            title: "Phone title",
+            messages: [
+                Message(
+                    id: existingMessageID,
+                    role: .user,
+                    content: "old",
+                    timestamp: timestamp
+                )
+            ],
+            createdAt: timestamp,
+            updatedAt: timestamp,
+            model: "phone-model",
+            systemPromptMode: .custom("phone-only prompt"),
+            temperature: 0.7
+        )
+        phone.pendingAutoSendPrompt = "pending phone prompt"
+
+        var watch = WatchConversation(
+            id: conversationID,
+            title: "Watch title",
+            messages: [
+                WatchMessage(
+                    id: existingMessageID,
+                    role: Message.Role.user.rawValue,
+                    content: "edited",
+                    timestamp: timestamp
+                ),
+                WatchMessage(
+                    id: newMessageID,
+                    role: Message.Role.assistant.rawValue,
+                    content: "answer",
+                    timestamp: timestamp.addingTimeInterval(1)
+                ),
+                WatchMessage(
+                    id: newMessageID,
+                    role: Message.Role.assistant.rawValue,
+                    content: "answer-final",
+                    timestamp: timestamp.addingTimeInterval(1)
+                )
+            ],
+            model: "watch-model",
+            updatedAt: timestamp.addingTimeInterval(2),
+            createdAt: timestamp,
+            temperature: 0.2,
+            resolvedSystemPrompt: "must not replace phone mode"
+        )
+        watch.watchRevision = 2
+        let mutation = WatchConversationMutation(
+            revision: 2,
+            conversation: watch,
+            fields: [.title, .messages],
+            messageChanges: watch.messages
+        )
+
+        let reduction = PhoneWatchMutationReducer.reduce(
+            PhoneWatchSyncState(conversations: [phone]),
+            mutation: mutation
+        )
+        let merged = try #require(reduction.state.conversations.first)
+
+        #expect(reduction.disposition == .applied)
+        #expect(merged.title == "Watch title")
+        #expect(merged.model == "phone-model")
+        #expect(merged.temperature == 0.7)
+        #expect(merged.systemPromptMode == .custom("phone-only prompt"))
+        #expect(merged.pendingAutoSendPrompt == "pending phone prompt")
+        #expect(merged.messages.map(\.id) == [existingMessageID, newMessageID])
+        #expect(merged.messages[0].content == "edited")
+        #expect(merged.messages[1].content == "answer-final")
+        #expect(reduction.state.acknowledgedWatchRevisions[conversationID] == 2)
+    }
+
+    @Test
+    func `Configuration mutation updates model and temperature without replacing phone prompt`() throws {
+        let conversationID = UUID()
+        var phone = Conversation(
+            id: conversationID,
+            title: "Phone",
+            model: "old-model",
+            systemPromptMode: .custom("phone prompt"),
+            temperature: 0.4
+        )
+        phone.pendingAutoSendPrompt = "pending"
+        let watch = WatchConversation(
+            id: conversationID,
+            title: "Phone",
+            model: "new-model",
+            updatedAt: Date(timeIntervalSince1970: 2),
+            createdAt: Date(timeIntervalSince1970: 1),
+            temperature: 0.9,
+            resolvedSystemPrompt: "stale resolved prompt",
+            watchRevision: 1
+        )
+        let mutation = WatchConversationMutation(
+            revision: 1,
+            conversation: watch,
+            fields: [.configuration]
+        )
+
+        let reduction = PhoneWatchMutationReducer.reduce(
+            PhoneWatchSyncState(conversations: [phone]),
+            mutation: mutation
+        )
+        let updated = try #require(reduction.state.conversations.first)
+
+        #expect(updated.model == "new-model")
+        #expect(updated.temperature == 0.9)
+        #expect(updated.systemPromptMode == .custom("phone prompt"))
+        #expect(updated.pendingAutoSendPrompt == "pending")
+    }
+
+    @Test
+    func `Message mutation preserves bounded phone history and appends only explicit Watch changes`() throws {
+        let conversationID = UUID()
+        let phoneMessageID = UUID()
+        let watchMessageID = UUID()
+        let originalContent = String(repeating: "phone-history-", count: 400)
+        let truncatedContent = String(originalContent.prefix(4000))
+        let timestamp = Date(timeIntervalSince1970: 100)
+        let phone = Conversation(
+            id: conversationID,
+            title: "History",
+            messages: [
+                Message(
+                    id: phoneMessageID,
+                    role: .user,
+                    content: originalContent,
+                    timestamp: timestamp
+                )
+            ],
+            createdAt: timestamp,
+            updatedAt: timestamp,
+            model: "model"
+        )
+        let newMessage = WatchMessage(
+            id: watchMessageID,
+            role: Message.Role.assistant.rawValue,
+            content: "Watch answer",
+            timestamp: timestamp.addingTimeInterval(1),
+            model: "model"
+        )
+        let boundedWatchState = WatchConversation(
+            id: conversationID,
+            title: "History",
+            messages: [
+                WatchMessage(
+                    id: phoneMessageID,
+                    role: Message.Role.user.rawValue,
+                    content: truncatedContent,
+                    timestamp: timestamp
+                ),
+                newMessage
+            ],
+            model: "model",
+            updatedAt: timestamp.addingTimeInterval(1),
+            createdAt: timestamp,
+            watchRevision: 1
+        )
+        let mutation = WatchConversationMutation(
+            revision: 1,
+            conversation: boundedWatchState,
+            fields: [.messages],
+            messageChanges: [newMessage]
+        )
+
+        let reduction = PhoneWatchMutationReducer.reduce(
+            PhoneWatchSyncState(conversations: [phone]),
+            mutation: mutation
+        )
+        let merged = try #require(reduction.state.conversations.first)
+
+        #expect(merged.messages.map(\.id) == [phoneMessageID, watchMessageID])
+        #expect(merged.messages.first?.content == originalContent)
+        #expect(merged.messages.last?.content == "Watch answer")
+    }
+
+    @Test
+    func `Acknowledged message delta is not replayed under a newer metadata revision`() throws {
+        let conversationID = UUID()
+        let messageID = UUID()
+        let timestamp = Date(timeIntervalSince1970: 1)
+        let phone = Conversation(
+            id: conversationID,
+            title: "Phone",
+            messages: [
+                Message(
+                    id: messageID,
+                    role: .assistant,
+                    content: "Edited on phone",
+                    timestamp: timestamp
+                )
+            ],
+            createdAt: timestamp,
+            updatedAt: timestamp,
+            model: "model"
+        )
+        let staleChange = WatchMessage(
+            id: messageID,
+            role: Message.Role.assistant.rawValue,
+            content: "Already acknowledged",
+            timestamp: timestamp,
+            model: "model"
+        )
+        let watch = WatchConversation(
+            id: conversationID,
+            title: "Renamed on Watch",
+            model: "model",
+            updatedAt: timestamp.addingTimeInterval(1),
+            createdAt: timestamp,
+            watchRevision: 2
+        )
+        let mutation = WatchConversationMutation(
+            revision: 2,
+            conversation: watch,
+            fields: [.title, .messages],
+            messageChanges: [staleChange],
+            messageChangeRevisions: [messageID: 1]
+        )
+        let state = PhoneWatchSyncState(
+            conversations: [phone],
+            acknowledgedWatchRevisions: [conversationID: 1]
+        )
+
+        let result = PhoneWatchMutationReducer.reduce(state, mutation: mutation)
+        let merged = try #require(result.state.conversations.first)
+
+        #expect(merged.title == "Renamed on Watch")
+        #expect(merged.messages.first?.content == "Edited on phone")
+        #expect(result.state.acknowledgedWatchRevisions[conversationID] == 2)
+    }
+
+    @Test
+    func `Acknowledged title is not replayed under a newer configuration revision`() throws {
+        let conversationID = UUID()
+        let phone = Conversation(
+            id: conversationID,
+            title: "Edited on phone",
+            model: "old-model"
+        )
+        let watch = WatchConversation(
+            id: conversationID,
+            title: "Already acknowledged",
+            model: "new-model",
+            updatedAt: Date(timeIntervalSince1970: 2),
+            createdAt: Date(timeIntervalSince1970: 1),
+            watchRevision: 2
+        )
+        let mutation = WatchConversationMutation(
+            revision: 2,
+            conversation: watch,
+            fields: [.title, .configuration],
+            titleRevision: 1,
+            configurationRevision: 2
+        )
+        let state = PhoneWatchSyncState(
+            conversations: [phone],
+            acknowledgedWatchRevisions: [conversationID: 1]
+        )
+
+        let result = PhoneWatchMutationReducer.reduce(state, mutation: mutation)
+        let merged = try #require(result.state.conversations.first)
+
+        #expect(merged.title == "Edited on phone")
+        #expect(merged.model == "new-model")
+    }
+
+    @Test
+    func `Locally delivered legacy mutation stays pending without overriding phone echo`() throws {
+        let conversationID = UUID()
+        let local = makeWatchConversation(id: conversationID, title: "Watch title", revision: 2)
+        let pending = WatchConversationMutation(
+            revision: 2,
+            conversation: local,
+            fields: [.title]
+        )
+        let remote = makeWatchConversation(id: conversationID, title: "Phone title", revision: 0)
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [local],
+            pendingMutations: [pending],
+            localDeliveryCoverage: [
+                conversationID: WatchMutationDeliveryCoverage(titleRevision: 2)
+            ]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [remote],
+            authoritativeConversationIDs: [conversationID]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+        let visible = try #require(result.state.conversations.first)
+
+        #expect(visible.title == "Phone title")
+        #expect(result.state.pendingMutations == [pending])
+        #expect(result.state.localDeliveryCoverage[conversationID]?.titleRevision == 2)
+    }
+
+    @Test
+    func `Partial legacy coverage suppresses delivered fields but retains unsupported configuration`() throws {
+        let conversationID = UUID()
+        let messageID = UUID()
+        let deliveredMessage = WatchMessage(
+            id: messageID,
+            role: Message.Role.user.rawValue,
+            content: "Watch message",
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+        let local = WatchConversation(
+            id: conversationID,
+            title: "Watch title",
+            messages: [deliveredMessage],
+            model: "watch-model",
+            updatedAt: Date(timeIntervalSince1970: 2),
+            createdAt: Date(timeIntervalSince1970: 1),
+            watchRevision: 2
+        )
+        let pending = WatchConversationMutation(
+            revision: 2,
+            conversation: local,
+            fields: [.title, .messages, .configuration],
+            titleRevision: 1,
+            configurationRevision: 2,
+            messageChanges: [deliveredMessage],
+            messageChangeRevisions: [messageID: 1]
+        )
+        let phoneMessage = WatchMessage(
+            id: messageID,
+            role: Message.Role.user.rawValue,
+            content: "Edited on phone",
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+        let remote = WatchConversation(
+            id: conversationID,
+            title: "Phone title",
+            messages: [phoneMessage],
+            model: "phone-model",
+            updatedAt: Date(timeIntervalSince1970: 3),
+            createdAt: Date(timeIntervalSince1970: 1)
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [local],
+            pendingMutations: [pending],
+            localDeliveryCoverage: [
+                conversationID: WatchMutationDeliveryCoverage(
+                    titleRevision: 1,
+                    messageRevisions: [messageID: 1]
+                )
+            ]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [remote],
+            authoritativeConversationIDs: [conversationID]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+        let visible = try #require(result.state.conversations.first)
+
+        #expect(visible.title == "Phone title")
+        #expect(visible.messages == [phoneMessage])
+        #expect(visible.model == "watch-model")
+        #expect(result.state.pendingMutations == [pending])
+    }
+
+    @Test
+    func `Acknowledged create does not replay a stale resolved system prompt`() throws {
+        let conversationID = UUID()
+        let pendingMessage = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "Pending message",
+            timestamp: Date(timeIntervalSince1970: 2)
+        )
+        var local = makeWatchConversation(
+            id: conversationID,
+            title: "Local",
+            revision: 2
+        )
+        local.messages = [pendingMessage]
+        local.resolvedSystemPrompt = "Stale create prompt"
+        let pending = WatchConversationMutation(
+            revision: 2,
+            conversation: local,
+            fields: [.create, .messages],
+            createRevision: 1,
+            messageChanges: [pendingMessage],
+            messageChangeRevisions: [pendingMessage.id: 2]
+        )
+        var remote = makeWatchConversation(
+            id: conversationID,
+            title: "Phone",
+            revision: 0
+        )
+        remote.resolvedSystemPrompt = "Phone-authoritative prompt"
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [local],
+            pendingMutations: [pending]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [remote],
+            authoritativeConversationIDs: [conversationID],
+            acknowledgedWatchRevisions: [conversationID: 1]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+        let visible = try #require(result.state.conversations.first)
+
+        #expect(visible.resolvedSystemPrompt == "Phone-authoritative prompt")
+        #expect(visible.messages == [pendingMessage])
+        #expect(result.state.pendingMutations == [pending])
+    }
+
+    @Test
+    func `Fully delivered legacy mutation does not recreate a phone-deleted conversation`() {
+        let local = makeWatchConversation(title: "Deleted on phone", revision: 2)
+        let pending = WatchConversationMutation(
+            revision: 2,
+            conversation: local,
+            fields: [.title],
+            titleRevision: 2
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [local],
+            pendingMutations: [pending],
+            localDeliveryCoverage: [
+                local.id: WatchMutationDeliveryCoverage(titleRevision: 2)
+            ]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [],
+            authoritativeConversationIDs: []
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+
+        #expect(result.state.conversations.isEmpty)
+        #expect(result.state.pendingMutations == [pending])
+    }
+
+    @Test
+    func `Deletion creates a tombstone and later mutations cannot resurrect the ID`() {
+        let conversation = makeWatchConversation(title: "Delete me", revision: 2)
+        let phone = conversation.toConversation()
+        let delete = WatchConversationMutation(
+            revision: 3,
+            conversation: conversation,
+            fields: [.delete]
+        )
+
+        let deleted = PhoneWatchMutationReducer.reduce(
+            PhoneWatchSyncState(conversations: [phone]),
+            mutation: delete
+        )
+        let recreate = WatchConversationMutation(
+            revision: 4,
+            conversation: makeWatchConversation(
+                id: conversation.id,
+                title: "Resurrected",
+                revision: 4
+            ),
+            fields: .fullState
+        )
+        let rejected = PhoneWatchMutationReducer.reduce(deleted.state, mutation: recreate)
+
+        #expect(deleted.disposition == .deleted)
+        #expect(deleted.state.conversations.isEmpty)
+        #expect(deleted.state.tombstoneRevisions[conversation.id] == 3)
+        #expect(rejected.disposition == .rejectedDeletedTombstone)
+        #expect(rejected.state.conversations.isEmpty)
+        #expect(rejected.state.acknowledgedWatchRevisions[conversation.id] == 4)
+        #expect(rejected.state.tombstoneRevisions[conversation.id] == 3)
+    }
+
+    @Test
+    func `Out-of-order mutations reject stale revisions and coalescing keeps latest full state`() throws {
+        let id = UUID()
+        let revisionOne = try WatchConversationMutation(
+            operationID: #require(UUID(uuidString: "00000000-0000-0000-0000-000000000001")),
+            revision: 1,
+            conversation: makeWatchConversation(id: id, title: "one", revision: 1),
+            fields: [.title]
+        )
+        var revisionTwoState = makeWatchConversation(id: id, title: "two", revision: 2)
+        revisionTwoState.messages = [WatchMessage(from: Message(role: .user, content: "latest"))]
+        let revisionTwo = try WatchConversationMutation(
+            operationID: #require(UUID(uuidString: "00000000-0000-0000-0000-000000000002")),
+            revision: 2,
+            conversation: revisionTwoState,
+            fields: [.messages],
+            messageChanges: revisionTwoState.messages
+        )
+
+        let coalesced = try #require(WatchConversationMutation.coalesced([revisionTwo, revisionOne]).first)
+        #expect(coalesced.revision == 2)
+        #expect(coalesced.operationID == revisionTwo.operationID)
+        #expect(coalesced.fields.contains(.title))
+        #expect(coalesced.fields.contains(.messages))
+        #expect(coalesced.conversation.title == "two")
+
+        let initial = PhoneWatchSyncState(
+            conversations: [makeWatchConversation(id: id, title: "base", revision: 0).toConversation()]
+        )
+        let newest = PhoneWatchMutationReducer.reduce(initial, mutation: revisionTwo)
+        let stale = PhoneWatchMutationReducer.reduce(newest.state, mutation: revisionOne)
+
+        #expect(stale.disposition == .rejectedStale)
+        #expect(stale.state.acknowledgedWatchRevisions[id] == 2)
+        #expect(stale.state.conversations.first?.messages.first?.content == "latest")
+    }
+
+    @Test
+    func `Stale snapshots are ignored without clearing pending work`() {
+        let local = makeWatchConversation(title: "Local", revision: 3)
+        let mutation = WatchConversationMutation(
+            revision: 4,
+            conversation: local,
+            fields: [.messages]
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 10,
+            conversations: [local],
+            pendingMutations: [mutation],
+            pendingDrafts: [local.id: WatchConversationDraft(conversation: local, ownedMessageIDs: Set(local.messages.map(\.id)))]
+        )
+        let stale = WatchSyncSnapshot(
+            revision: 9,
+            conversations: [],
+            authoritativeConversationIDs: []
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(stale, with: state)
+
+        #expect(result.disposition == .ignoredStale)
+        #expect(result.state == state)
+    }
+
+    @Test
+    func `New phone source applies revision one after the previous source reached a higher revision`() {
+        let oldSourceID = UUID()
+        let newSourceID = UUID()
+        let local = makeWatchConversation(title: "Old source", revision: 3)
+        let replacement = makeWatchConversation(id: local.id, title: "New source", revision: 0)
+        let state = WatchSyncLocalState(
+            sourceID: oldSourceID,
+            lastSnapshotRevision: 100,
+            conversations: [local]
+        )
+        let snapshot = WatchSyncSnapshot(
+            sourceID: newSourceID,
+            revision: 1,
+            conversations: [replacement],
+            authoritativeConversationIDs: [replacement.id]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+
+        #expect(result.disposition == .applied)
+        #expect(result.state.sourceID == newSourceID)
+        #expect(result.state.lastSnapshotRevision == 1)
+        #expect(result.state.conversations.first?.title == "New source")
+    }
+
+    @Test
+    func `New phone source retains an incomplete old base until the manifest cycle completes`() throws {
+        let oldSourceID = UUID()
+        let newSourceID = UUID()
+        let oldPhoneConversation = makeWatchConversation(title: "Old phone only", updatedAt: 30)
+        let newPhoneConversation = makeWatchConversation(title: "New phone page", updatedAt: 20)
+        let watchCreatedID = UUID()
+        let pendingUserMessage = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "Pending prompt",
+            timestamp: Date(timeIntervalSince1970: 10)
+        )
+        let pendingAssistantDraft = WatchMessage(
+            id: UUID(),
+            role: Message.Role.assistant.rawValue,
+            content: "Pending response",
+            timestamp: Date(timeIntervalSince1970: 11)
+        )
+        var watchCreated = makeWatchConversation(
+            id: watchCreatedID,
+            title: "Watch created",
+            revision: 4,
+            updatedAt: 11
+        )
+        watchCreated.messages = [pendingUserMessage, pendingAssistantDraft]
+        let pendingCreate = WatchConversationMutation(
+            revision: 4,
+            conversation: watchCreated,
+            fields: .fullState,
+            messageChanges: [pendingUserMessage]
+        )
+        let state = WatchSyncLocalState(
+            sourceID: oldSourceID,
+            lastSnapshotRevision: 100,
+            conversations: [oldPhoneConversation, watchCreated],
+            pendingMutations: [pendingCreate],
+            pendingDrafts: [
+                watchCreatedID: WatchConversationDraft(
+                    conversation: watchCreated,
+                    ownedMessageIDs: [pendingAssistantDraft.id]
+                )
+            ]
+        )
+        let snapshot = WatchSyncSnapshot(
+            sourceID: newSourceID,
+            revision: 1,
+            conversations: [newPhoneConversation],
+            authoritativeConversationIDs: [newPhoneConversation.id],
+            authoritativeConversationIDsAreComplete: false
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+        let created = try #require(
+            result.state.conversations.first { $0.id == watchCreatedID }
+        )
+
+        #expect(result.disposition == .applied)
+        #expect(Set(result.state.conversations.map(\.id)) == [
+            oldPhoneConversation.id,
+            newPhoneConversation.id,
+            watchCreatedID
+        ])
+        #expect(created.messages == [pendingUserMessage, pendingAssistantDraft])
+        #expect(result.state.pendingMutations == [pendingCreate])
+        #expect(result.state.pendingDrafts[watchCreatedID]?.conversation == created)
+
+        let completedSnapshot = WatchSyncSnapshot(
+            sourceID: newSourceID,
+            revision: 2,
+            conversations: [newPhoneConversation],
+            authoritativeConversationIDs: [newPhoneConversation.id],
+            authoritativeConversationIDsAreComplete: true
+        )
+        let completed = WatchSnapshotReconciler.reconcile(completedSnapshot, with: result.state)
+        #expect(Set(completed.state.conversations.map(\.id)) == [
+            newPhoneConversation.id,
+            watchCreatedID
+        ])
+    }
+
+    @Test
+    func `Source replacement preserves a manifest-listed cached body omitted by bounds`() throws {
+        let oldSourceID = UUID()
+        let newSourceID = UUID()
+        var cached = makeWatchConversation(title: "Cached body", updatedAt: 20)
+        cached.model = "old-model"
+        let stale = makeWatchConversation(title: "Old phone only", updatedAt: 10)
+        let state = WatchSyncLocalState(
+            sourceID: oldSourceID,
+            lastSnapshotRevision: 8,
+            conversations: [cached, stale]
+        )
+        let snapshot = WatchSyncSnapshot(
+            sourceID: newSourceID,
+            revision: 1,
+            conversations: [],
+            authoritativeConversationIDs: [cached.id],
+            authoritativeConversationIDsAreComplete: true,
+            conversationConfigurations: [
+                WatchConversationRequestConfiguration(
+                    id: cached.id,
+                    model: "new-model",
+                    temperature: 0.2,
+                    resolvedSystemPrompt: "new prompt"
+                )
+            ],
+            conversationConfigurationsAreComplete: true
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+        let retained = try #require(result.state.conversations.first)
+
+        #expect(result.state.conversations.count == 1)
+        #expect(retained.id == cached.id)
+        #expect(retained.title == "Cached body")
+        #expect(retained.model == "new-model")
+        #expect(retained.temperature == 0.2)
+        #expect(retained.resolvedSystemPrompt == "new prompt")
+    }
+
+    @Test
+    func `Acknowledgements from another Watch peer never clear local mutations`() {
+        let peerA = UUID()
+        let peerB = UUID()
+        let local = makeWatchConversation(title: "Peer B", revision: 3)
+        let pending = WatchConversationMutation(
+            peerID: peerB,
+            revision: 3,
+            conversation: local,
+            fields: [.title]
+        )
+        let state = WatchSyncLocalState(
+            peerID: peerB,
+            lastSnapshotRevision: 1,
+            conversations: [local],
+            pendingMutations: [pending]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [local],
+            authoritativeConversationIDs: [local.id],
+            acknowledgedPeerID: peerA,
+            acknowledgedWatchRevisions: [local.id: 99]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+
+        #expect(result.state.pendingMutations == [pending])
+    }
+
+    @Test
+    func `Mutation revisions are isolated by Watch peer`() {
+        let peerA = UUID()
+        let peerB = UUID()
+        let conversation = makeWatchConversation(title: "Updated by B", revision: 3)
+        let mutation = WatchConversationMutation(
+            peerID: peerB,
+            revision: 3,
+            conversation: conversation,
+            fields: [.title]
+        )
+        let state = PhoneWatchSyncState(
+            peerID: peerA,
+            conversations: [makeWatchConversation(id: conversation.id, title: "Phone", revision: 0).toConversation()],
+            acknowledgedWatchRevisions: [conversation.id: 10]
+        )
+
+        let result = PhoneWatchMutationReducer.reduce(state, mutation: mutation)
+
+        #expect(result.disposition == .applied)
+        #expect(result.state.peerID == peerB)
+        #expect(result.state.acknowledgedWatchRevisions[conversation.id] == 3)
+        #expect(result.state.conversations.first?.title == "Updated by B")
+    }
+
+    @Test
+    func `Future snapshot schema is ignored without mutating local state`() {
+        let local = makeWatchConversation(title: "Local", revision: 1)
+        let state = WatchSyncLocalState(lastSnapshotRevision: 4, conversations: [local])
+        let snapshot = WatchSyncSnapshot(
+            schemaVersion: WatchSyncSnapshot.currentSchemaVersion + 1,
+            revision: 5,
+            conversations: [],
+            authoritativeConversationIDs: []
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+
+        #expect(result.disposition == .ignoredUnsupportedSchema)
+        #expect(result.state == state)
+    }
+
+    @Test
+    func `Missing snapshot schema remains legacy v1 while nonpositive schemas are unsupported`() throws {
+        let body = makeWatchConversation(title: "Legacy body")
+        let snapshot = WatchSyncSnapshot(
+            revision: 1,
+            conversations: [body],
+            authoritativeConversationIDs: [body.id]
+        )
+        let encoded = try WatchSyncPayloadBuilder.encode(snapshot)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        for key in [
+            "schemaVersion",
+            "paginationCursor",
+            "authoritativeConversationIDsAreComplete",
+            "conversationConfigurations",
+            "conversationConfigurationsAreComplete",
+            "authoritativeConversationIDs"
+        ] {
+            object.removeValue(forKey: key)
+        }
+        let legacyData = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        let legacy = try JSONDecoder().decode(WatchSyncSnapshot.self, from: legacyData)
+        let state = WatchSyncLocalState()
+
+        #expect(legacy.schemaVersion == 1)
+        #expect(legacy.paginationCursor == 0)
+        #expect(legacy.authoritativeConversationIDs == [body.id])
+        #expect(legacy.authoritativeConversationIDsAreComplete)
+        #expect(legacy.conversationConfigurations.isEmpty)
+        #expect(!legacy.conversationConfigurationsAreComplete)
+        #expect(WatchSnapshotReconciler.reconcile(legacy, with: state).disposition == .applied)
+
+        for unsupportedVersion in [0, -1] {
+            var unsupported = legacy
+            unsupported.schemaVersion = unsupportedVersion
+            let result = WatchSnapshotReconciler.reconcile(unsupported, with: state)
+            #expect(result.disposition == .ignoredUnsupportedSchema)
+            #expect(result.state == state)
+        }
+    }
+
+    @Test
+    func `Schema two snapshot defaults to a complete manifest and no configuration page`() throws {
+        let body = makeWatchConversation(title: "Body")
+        let manifestOnly = makeWatchConversation(title: "Manifest only")
+        let snapshot = WatchSyncSnapshot(
+            schemaVersion: 2,
+            revision: 7,
+            conversations: [body],
+            authoritativeConversationIDs: [body.id, manifestOnly.id]
+        )
+        let encoded = try WatchSyncPayloadBuilder.encode(snapshot)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        for key in [
+            "paginationCursor",
+            "authoritativeConversationIDsAreComplete",
+            "conversationConfigurations",
+            "conversationConfigurationsAreComplete"
+        ] {
+            object.removeValue(forKey: key)
+        }
+        let legacyData = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        let decoded = try JSONDecoder().decode(WatchSyncSnapshot.self, from: legacyData)
+        let localManifestOnly = makeWatchConversation(
+            id: manifestOnly.id,
+            title: "Retained local body"
+        )
+        let result = WatchSnapshotReconciler.reconcile(
+            decoded,
+            with: WatchSyncLocalState(conversations: [localManifestOnly])
+        )
+
+        #expect(decoded.schemaVersion == 2)
+        #expect(decoded.paginationCursor == 6)
+        #expect(decoded.authoritativeConversationIDsAreComplete)
+        #expect(decoded.conversationConfigurations.isEmpty)
+        #expect(!decoded.conversationConfigurationsAreComplete)
+        #expect(result.state.conversations.contains { $0.id == manifestOnly.id })
+    }
+
+    @Test
+    func `Schema three without a completeness flag fails safe as an incomplete page`() throws {
+        let included = makeWatchConversation(title: "Included")
+        let omitted = makeWatchConversation(title: "Omitted")
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [included],
+            authoritativeConversationIDs: [included.id],
+            authoritativeConversationIDsAreComplete: false
+        )
+        let encoded = try WatchSyncPayloadBuilder.encode(snapshot)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        object.removeValue(forKey: "authoritativeConversationIDsAreComplete")
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        let decoded = try JSONDecoder().decode(WatchSyncSnapshot.self, from: data)
+        let result = WatchSnapshotReconciler.reconcile(
+            decoded,
+            with: WatchSyncLocalState(
+                lastSnapshotRevision: 1,
+                conversations: [included, omitted]
+            )
+        )
+
+        #expect(!decoded.authoritativeConversationIDsAreComplete)
+        #expect(result.state.conversations.contains { $0.id == omitted.id })
+    }
+
+    @Test
+    func `Empty complete manifest still clears retained conversations`() {
+        let local = makeWatchConversation(title: "Local")
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [],
+            authoritativeConversationIDs: [],
+            authoritativeConversationIDsAreComplete: true,
+            conversationConfigurations: [],
+            conversationConfigurationsAreComplete: true
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(
+            snapshot,
+            with: WatchSyncLocalState(
+                lastSnapshotRevision: 1,
+                conversations: [local]
+            )
+        )
+
+        #expect(result.state.conversations.isEmpty)
+    }
+
+    @Test
+    func `Bounded body omission is not deletion when the full manifest contains the ID`() {
+        let included = makeWatchConversation(title: "Included", updatedAt: 20)
+        let omitted = makeWatchConversation(title: "Omitted body", updatedAt: 10)
+        let remoteIncluded = makeWatchConversation(
+            id: included.id,
+            title: "Remote included",
+            updatedAt: 30
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [remoteIncluded],
+            authoritativeConversationIDs: [included.id, omitted.id]
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [included, omitted]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+
+        #expect(result.state.conversations.count == 2)
+        #expect(result.state.conversations.contains { $0.id == omitted.id && $0.title == "Omitted body" })
+        #expect(result.state.conversations.contains { $0.id == included.id && $0.title == "Remote included" })
+    }
+
+    @Test
+    func `Manifest-only custom configuration updates request settings without replacing messages`() throws {
+        let body = Conversation(
+            title: "Body",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 30),
+            model: "body-model"
+        )
+        let manifestOnly = Conversation(
+            title: "Manifest only",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 20),
+            model: "new-model",
+            systemPromptMode: .custom("New custom prompt"),
+            temperature: 0.2
+        )
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 1
+        let payload = try WatchSyncPayloadBuilder.build(
+            conversations: [manifestOnly, body],
+            snapshotRevision: 2,
+            configuration: configuration,
+            resolvedSystemPrompt: { conversation in
+                guard case let .custom(prompt) = conversation.systemPromptMode else { return nil }
+                return prompt
+            }
+        )
+        let retainedMessage = WatchMessage(from: Message(role: .user, content: "Keep me"))
+        let retained = WatchConversation(
+            id: manifestOnly.id,
+            title: manifestOnly.title,
+            messages: [retainedMessage],
+            model: "old-model",
+            updatedAt: manifestOnly.updatedAt,
+            createdAt: manifestOnly.createdAt,
+            temperature: 1.1,
+            resolvedSystemPrompt: "Old prompt"
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [retained]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(payload.snapshot, with: state)
+        let updated = try #require(result.state.conversations.first { $0.id == manifestOnly.id })
+
+        #expect(payload.snapshot.conversations.map(\.id) == [body.id])
+        #expect(payload.snapshot.conversationConfigurations.map(\.id) == [manifestOnly.id])
+        #expect(payload.snapshot.conversationConfigurationsAreComplete)
+        #expect(updated.model == "new-model")
+        #expect(updated.temperature == 0.2)
+        #expect(updated.resolvedSystemPrompt == "New custom prompt")
+        #expect(updated.messages == [retainedMessage])
+    }
+
+    @Test
+    func `Manifest-only inherited global prompt updates without replacing messages`() throws {
+        let phone = Conversation(
+            title: "Inherited prompt",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2),
+            model: "model",
+            systemPromptMode: .inheritGlobal
+        )
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        let payload = try WatchSyncPayloadBuilder.build(
+            conversations: [phone],
+            snapshotRevision: 2,
+            configuration: configuration,
+            resolvedSystemPrompt: { _ in "New global prompt" }
+        )
+        let retainedMessage = WatchMessage(from: Message(role: .user, content: "Keep me"))
+        let retained = WatchConversation(
+            id: phone.id,
+            title: phone.title,
+            messages: [retainedMessage],
+            model: phone.model,
+            updatedAt: phone.updatedAt,
+            createdAt: phone.createdAt,
+            resolvedSystemPrompt: "Old global prompt"
+        )
+        let result = WatchSnapshotReconciler.reconcile(
+            payload.snapshot,
+            with: WatchSyncLocalState(
+                lastSnapshotRevision: 1,
+                conversations: [retained]
+            )
+        )
+        let updated = try #require(result.state.conversations.first)
+
+        #expect(updated.resolvedSystemPrompt == "New global prompt")
+        #expect(updated.messages == [retainedMessage])
+    }
+
+    @Test
+    func `Configuration pages eventually update every manifest-only conversation`() throws {
+        let phoneConversations = (1 ... 3).map { index in
+            Conversation(
+                id: UUID(uuidString: "00000000-0000-0000-0000-00000000020\(index)")!,
+                title: "Conversation \(index)",
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(10 - index)),
+                model: "new-model-\(index)",
+                systemPromptMode: .custom("new-prompt-\(index)"),
+                temperature: Double(index) / 10
+            )
+        }
+        let retainedMessages = Dictionary(uniqueKeysWithValues: phoneConversations.map { conversation in
+            (
+                conversation.id,
+                WatchMessage(from: Message(role: .user, content: "message-\(conversation.id)"))
+            )
+        })
+        let localConversations = phoneConversations.map { conversation in
+            WatchConversation(
+                id: conversation.id,
+                title: conversation.title,
+                messages: [retainedMessages[conversation.id]!],
+                model: "old-model",
+                updatedAt: conversation.updatedAt,
+                createdAt: conversation.createdAt,
+                temperature: 1.0,
+                resolvedSystemPrompt: "old-prompt"
+            )
+        }
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumConversationConfigurations = 1
+        var state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: localConversations
+        )
+        var deliveredConfigurationIDs: Set<UUID> = []
+
+        for cursor in 0 ..< 3 {
+            let payload = try WatchSyncPayloadBuilder.build(
+                conversations: phoneConversations,
+                snapshotRevision: WatchSyncRevision(cursor + 2),
+                paginationCursor: WatchSyncRevision(cursor),
+                configuration: configuration,
+                resolvedSystemPrompt: { conversation in
+                    guard case let .custom(prompt) = conversation.systemPromptMode else { return nil }
+                    return prompt
+                }
+            )
+            deliveredConfigurationIDs.formUnion(payload.snapshot.conversationConfigurations.map(\.id))
+            #expect(!payload.snapshot.conversationConfigurationsAreComplete)
+            state = WatchSnapshotReconciler.reconcile(payload.snapshot, with: state).state
+        }
+
+        #expect(deliveredConfigurationIDs == Set(phoneConversations.map(\.id)))
+        for phone in phoneConversations {
+            let updated = try #require(state.conversations.first { $0.id == phone.id })
+            #expect(updated.model == phone.model)
+            #expect(updated.temperature == phone.temperature)
+            let expectedPrompt: String? = if case let .custom(prompt) = phone.systemPromptMode {
+                prompt
+            } else {
+                nil
+            }
+            #expect(updated.resolvedSystemPrompt == expectedPrompt)
+            #expect(try updated.messages == [#require(retainedMessages[phone.id])])
+        }
+    }
+
+    @Test
+    func `Incomplete manifest preserves omitted conversations while tombstones still delete`() {
+        let included = makeWatchConversation(title: "Included", updatedAt: 30)
+        var omitted = makeWatchConversation(title: "Omitted", updatedAt: 20)
+        let draftMessage = WatchMessage(from: Message(role: .assistant, content: "Draft"))
+        omitted.messages = [draftMessage]
+        let deleted = makeWatchConversation(title: "Deleted", updatedAt: 10)
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [included],
+            authoritativeConversationIDs: [included.id],
+            authoritativeConversationIDsAreComplete: false,
+            tombstones: [WatchConversationTombstone(conversationID: deleted.id, revision: 1)]
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [included, omitted, deleted],
+            pendingDrafts: [
+                omitted.id: WatchConversationDraft(
+                    conversation: omitted,
+                    ownedMessageIDs: [draftMessage.id]
+                )
+            ]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+        let ids = Set(result.state.conversations.map(\.id))
+
+        #expect(ids == [included.id, omitted.id])
+        #expect(result.state.pendingDrafts[omitted.id]?.conversation.messages == [draftMessage])
+    }
+
+    @Test
+    func `Bounded manifest preserves pending work until the phone acknowledges it`() {
+        let acknowledged = makeWatchConversation(title: "Acknowledged")
+        var pending = makeWatchConversation(title: "Pending", revision: 3)
+        let pendingMessage = WatchMessage(from: Message(role: .user, content: "Pending message"))
+        pending.messages = [pendingMessage]
+        let drafted = makeWatchConversation(title: "Drafted")
+        let clearedMutation = makeWatchConversation(title: "Already sent", revision: 2)
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [acknowledged, pending, drafted, clearedMutation],
+            pendingMutations: [
+                WatchConversationMutation(
+                    revision: 3,
+                    conversation: pending,
+                    fields: [.messages],
+                    messageChanges: [pendingMessage]
+                ),
+                WatchConversationMutation(
+                    revision: 2,
+                    conversation: clearedMutation,
+                    fields: [.title]
+                )
+            ],
+            pendingDrafts: [
+                drafted.id: WatchConversationDraft(
+                    conversation: drafted,
+                    ownedMessageIDs: Set(drafted.messages.map(\.id))
+                )
+            ]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [],
+            authoritativeConversationIDs: [],
+            acknowledgedWatchRevisions: [clearedMutation.id: 2]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+        let ids = Set(result.state.conversations.map(\.id))
+
+        #expect(result.disposition == .applied)
+        #expect(ids == [pending.id])
+        #expect(result.state.pendingMutations.map(\.conversationID) == [pending.id])
+        #expect(result.state.pendingDrafts.isEmpty)
+
+        let acknowledgedSnapshot = WatchSyncSnapshot(
+            revision: 3,
+            conversations: [],
+            authoritativeConversationIDs: [],
+            acknowledgedWatchRevisions: [pending.id: 3]
+        )
+        let acknowledgedResult = WatchSnapshotReconciler.reconcile(
+            acknowledgedSnapshot,
+            with: result.state
+        )
+        #expect(acknowledgedResult.state.conversations.isEmpty)
+        #expect(acknowledgedResult.state.pendingMutations.isEmpty)
+    }
+
+    @Test
+    func `Pending create replays explicit history when the snapshot omits its body`() throws {
+        let conversation = makeWatchConversation(title: "Watch-created", revision: 2)
+        let userMessage = WatchMessage(from: Message(role: .user, content: "Offline prompt"))
+        let mutation = WatchConversationMutation(
+            revision: 2,
+            conversation: conversation,
+            fields: [.create, .messages],
+            messageChanges: [userMessage]
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            pendingMutations: [mutation]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [],
+            authoritativeConversationIDs: []
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+        let replayed = try #require(result.state.conversations.first)
+
+        #expect(replayed.id == conversation.id)
+        #expect(replayed.messages == [userMessage])
+    }
+
+    @Test
+    func `Local assistant draft overlays an echoed phone body with the same conversation ID`() throws {
+        let conversationID = UUID()
+        let user = WatchMessage(from: Message(role: .user, content: "prompt"))
+        let assistant = WatchMessage(from: Message(role: .assistant, content: "partial"))
+        let remote = WatchConversation(
+            id: conversationID,
+            title: "Phone",
+            messages: [user],
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 2),
+            createdAt: Date(timeIntervalSince1970: 1)
+        )
+        let draft = WatchConversation(
+            id: conversationID,
+            title: "Watch",
+            messages: [user, assistant],
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 3),
+            createdAt: Date(timeIntervalSince1970: 1)
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [draft],
+            pendingDrafts: [conversationID: WatchConversationDraft(conversation: draft, ownedMessageIDs: [assistant.id])]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [remote],
+            authoritativeConversationIDs: [conversationID]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+        let merged = try #require(result.state.conversations.first)
+
+        #expect(merged.title == "Phone")
+        #expect(merged.messages.map(\.id) == [user.id, assistant.id])
+        #expect(merged.messages.last?.content == "partial")
+    }
+
+    @Test
+    func `Draft overlays only request-owned messages and preserves phone edits and deletions`() throws {
+        let conversationID = UUID()
+        let editedID = UUID()
+        let deletedID = UUID()
+        let assistantID = UUID()
+        let timestamp = Date(timeIntervalSince1970: 1)
+        let remote = WatchConversation(
+            id: conversationID,
+            title: "Phone",
+            messages: [
+                WatchMessage(
+                    id: editedID,
+                    role: Message.Role.user.rawValue,
+                    content: "phone edit",
+                    timestamp: timestamp
+                )
+            ],
+            model: "model",
+            updatedAt: timestamp.addingTimeInterval(2),
+            createdAt: timestamp
+        )
+        let staleDraft = WatchConversation(
+            id: conversationID,
+            title: "Phone",
+            messages: [
+                WatchMessage(
+                    id: editedID,
+                    role: Message.Role.user.rawValue,
+                    content: "stale Watch copy",
+                    timestamp: timestamp
+                ),
+                WatchMessage(
+                    id: deletedID,
+                    role: Message.Role.user.rawValue,
+                    content: "deleted on phone",
+                    timestamp: timestamp.addingTimeInterval(1)
+                ),
+                WatchMessage(
+                    id: assistantID,
+                    role: Message.Role.assistant.rawValue,
+                    content: "streaming",
+                    timestamp: timestamp.addingTimeInterval(2)
+                )
+            ],
+            model: "model",
+            updatedAt: timestamp.addingTimeInterval(3),
+            createdAt: timestamp
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [staleDraft],
+            pendingDrafts: [
+                conversationID: WatchConversationDraft(
+                    conversation: staleDraft,
+                    ownedMessageIDs: [assistantID]
+                )
+            ]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [remote],
+            authoritativeConversationIDs: [conversationID]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+        let merged = try #require(result.state.conversations.first)
+
+        #expect(merged.messages.map(\.id) == [editedID, assistantID])
+        #expect(merged.messages.first?.content == "phone edit")
+        #expect(!merged.messages.contains(where: { $0.id == deletedID }))
+        #expect(result.state.pendingDrafts[conversationID]?.conversation == merged)
+    }
+
+    @Test
+    func `Acknowledged create flag does not recreate a phone-deleted conversation`() {
+        let conversationID = UUID()
+        let pendingMessage = WatchMessage(
+            id: UUID(),
+            role: Message.Role.user.rawValue,
+            content: "Newer message",
+            timestamp: Date(timeIntervalSince1970: 2)
+        )
+        var local = makeWatchConversation(
+            id: conversationID,
+            title: "Stale create",
+            revision: 2
+        )
+        local.messages = [pendingMessage]
+        let mutation = WatchConversationMutation(
+            revision: 2,
+            conversation: local,
+            fields: [.create, .messages],
+            createRevision: 1,
+            messageChanges: [pendingMessage],
+            messageChangeRevisions: [pendingMessage.id: 2]
+        )
+        let state = PhoneWatchSyncState(
+            conversations: [],
+            acknowledgedWatchRevisions: [conversationID: 1]
+        )
+
+        let reduction = PhoneWatchMutationReducer.reduce(state, mutation: mutation)
+
+        #expect(reduction.disposition == .rejectedMissingCreate)
+        #expect(reduction.state.conversations.isEmpty)
+        #expect(reduction.state.acknowledgedWatchRevisions[conversationID] == 2)
+    }
+
+    @Test
+    func `Missing non-create mutation is acknowledged without resurrecting a phone deletion`() {
+        let conversation = makeWatchConversation(title: "Original metadata", revision: 2)
+        let messageMutation = WatchConversationMutation(
+            revision: 2,
+            conversation: conversation,
+            fields: [.messages],
+            messageChanges: conversation.messages
+        )
+        let olderCreate = WatchConversationMutation(
+            revision: 1,
+            conversation: makeWatchConversation(
+                id: conversation.id,
+                title: "stale",
+                revision: 1
+            ),
+            fields: .fullState
+        )
+
+        let created = PhoneWatchMutationReducer.reduce(PhoneWatchSyncState(), mutation: messageMutation)
+        let stale = PhoneWatchMutationReducer.reduce(created.state, mutation: olderCreate)
+
+        #expect(created.disposition == .rejectedMissingCreate)
+        #expect(created.state.conversations.isEmpty)
+        #expect(created.state.acknowledgedWatchRevisions[conversation.id] == 2)
+        #expect(stale.disposition == .rejectedStale)
+        #expect(stale.state.conversations.isEmpty)
+    }
+
+    @Test
+    func `Explicit tombstone revisions acknowledge and clear matching pending mutations`() {
+        let local = makeWatchConversation(title: "Deleted", revision: 5)
+        let pendingDelete = WatchConversationMutation(
+            revision: 5,
+            conversation: local,
+            fields: [.delete]
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [local],
+            pendingMutations: [pendingDelete]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [],
+            authoritativeConversationIDs: [],
+            tombstones: [WatchConversationTombstone(conversationID: local.id, revision: 5)]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+
+        #expect(result.state.conversations.isEmpty)
+        #expect(result.state.pendingMutations.isEmpty)
+    }
+
+    @Test
+    func `Phone tombstone always defeats higher local revisions and drafts`() {
+        let local = makeWatchConversation(title: "Deleted", revision: 99)
+        let pending = WatchConversationMutation(
+            revision: 99,
+            conversation: local,
+            fields: [.messages]
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [local],
+            pendingMutations: [pending],
+            pendingDrafts: [local.id: WatchConversationDraft(conversation: local, ownedMessageIDs: Set(local.messages.map(\.id)))]
+        )
+        let snapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [],
+            authoritativeConversationIDs: [],
+            tombstones: [WatchConversationTombstone(conversationID: local.id, revision: 2)]
+        )
+
+        let result = WatchSnapshotReconciler.reconcile(snapshot, with: state)
+
+        #expect(result.state.conversations.isEmpty)
+        #expect(result.state.pendingMutations.isEmpty)
+        #expect(result.state.pendingDrafts.isEmpty)
+    }
+
+    @Test
+    func `Tombstone pages are bounded deterministic and eventually deliver every deletion`() throws {
+        let activeID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000100"))
+        let tombstoneIDs = try (1 ... 5).map { index in
+            try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000020\(index)"))
+        }
+        let active = Conversation(
+            id: activeID,
+            title: "Active",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 10),
+            model: "model"
+        )
+        let tombstones = Dictionary(uniqueKeysWithValues: tombstoneIDs.enumerated().map { index, id in
+            (id, WatchSyncRevision(index + 1))
+        })
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumManifestConversationIDs = 0
+        configuration.maximumConversationConfigurations = 0
+        configuration.maximumTombstones = 2
+        configuration.byteBudget = 2000
+
+        let payloads = try (1 ... 3).map { revision in
+            try WatchSyncPayloadBuilder.build(
+                conversations: [active],
+                snapshotRevision: WatchSyncRevision(revision),
+                tombstoneRevisions: tombstones,
+                configuration: configuration
+            )
+        }
+        let repeatedFirst = try WatchSyncPayloadBuilder.build(
+            conversations: [active],
+            snapshotRevision: 1,
+            tombstoneRevisions: tombstones,
+            configuration: configuration
+        )
+
+        #expect(payloads[0].data == repeatedFirst.data)
+        #expect(payloads.map(\.snapshot.paginationCursor) == [0, 1, 2])
+        #expect(payloads.allSatisfy { $0.data.count <= configuration.byteBudget })
+        #expect(payloads.allSatisfy { !$0.snapshot.authoritativeConversationIDsAreComplete })
+        #expect(payloads.allSatisfy { $0.snapshot.tombstones.count <= 2 })
+        #expect(Set(payloads.flatMap(\.snapshot.tombstones).map(\.conversationID)) == Set(tombstoneIDs))
+
+        var localState = WatchSyncLocalState(
+            conversations: [
+                makeWatchConversation(id: activeID, title: "Retained active"),
+            ] + tombstoneIDs.map { makeWatchConversation(id: $0, title: "Deleted") }
+        )
+        for payload in payloads {
+            localState = WatchSnapshotReconciler.reconcile(payload.snapshot, with: localState).state
+        }
+
+        #expect(localState.conversations.map(\.id) == [activeID])
+    }
+
+    @Test
+    func `Byte-trimmed tombstone pages rotate every deletion into delivery`() throws {
+        let activeID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000300"))
+        let tombstoneIDs = try (1 ... 5).map { index in
+            try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000040\(index)"))
+        }
+        let active = Conversation(
+            id: activeID,
+            title: "Active",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 10),
+            model: "model"
+        )
+        let tombstones = Dictionary(uniqueKeysWithValues: tombstoneIDs.map { ($0, WatchSyncRevision(1)) })
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumManifestConversationIDs = 0
+        configuration.maximumConversationConfigurations = 0
+        configuration.maximumTombstones = 2
+        configuration.byteBudget = 10000
+        let untrimmed = try WatchSyncPayloadBuilder.build(
+            conversations: [active],
+            snapshotRevision: 1,
+            tombstoneRevisions: tombstones,
+            configuration: configuration
+        )
+        let firstTombstone = try #require(untrimmed.snapshot.tombstones.first)
+        var oneTombstone = untrimmed.snapshot
+        oneTombstone.tombstones = [firstTombstone]
+        configuration.byteBudget = try WatchSyncPayloadBuilder.encode(oneTombstone).count
+
+        let payloads = try (1 ... 5).map { revision in
+            try WatchSyncPayloadBuilder.build(
+                conversations: [active],
+                snapshotRevision: WatchSyncRevision(revision),
+                tombstoneRevisions: tombstones,
+                configuration: configuration
+            )
+        }
+
+        #expect(payloads.allSatisfy { $0.data.count <= configuration.byteBudget })
+        #expect(payloads.allSatisfy { $0.snapshot.tombstones.count == 1 })
+        #expect(Set(payloads.flatMap(\.snapshot.tombstones).map(\.conversationID)) == Set(tombstoneIDs))
+    }
+
+    @Test
+    func `Page cycle metadata exposes exact continuation offsets for every partial section`() throws {
+        let conversations = (0 ..< 80).map { index in
+            Conversation(
+                id: UUID(uuidString: String(
+                    format: "00000000-0000-0003-0000-%012d",
+                    index + 1
+                ))!,
+                title: "Conversation \(index)",
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(100 - index)),
+                model: "model-\(index)"
+            )
+        }
+        let tombstones = Dictionary(uniqueKeysWithValues: (0 ..< 70).map { index in
+            (
+                UUID(uuidString: String(
+                    format: "00000000-0000-0004-0000-%012d",
+                    index + 1
+                ))!,
+                WatchSyncRevision(index + 1)
+            )
+        })
+        let state = PhoneWatchSyncState(
+            conversations: conversations,
+            tombstoneRevisions: tombstones
+        )
+        let cycleID = UUID()
+        let sourceID = UUID()
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumManifestConversationIDs = 32
+        configuration.maximumConversationConfigurations = 32
+        configuration.maximumTombstones = 32
+        configuration.byteBudget = 30000
+
+        let page = try WatchSyncPayloadBuilder.buildPageCycle(
+            state: state,
+            sourceID: sourceID,
+            snapshotRevision: 10,
+            cycleID: cycleID,
+            cursor: .initial,
+            configuration: configuration
+        )
+
+        #expect(page.snapshot.paginationCursor == 0)
+        #expect(page.metadata.cycleID == cycleID)
+        #expect(page.metadata.sourceID == sourceID)
+        #expect(page.metadata.snapshotRevision == 10)
+        #expect(page.metadata.isValid(for: page.snapshot))
+        var staleSnapshot = page.snapshot
+        staleSnapshot.revision += 1
+        #expect(!page.metadata.isValid(for: staleSnapshot))
+        #expect(page.metadata.manifest == WatchSyncPageSection(
+            offset: 0,
+            itemCount: 32,
+            totalCount: 80
+        ))
+        #expect(page.metadata.configurations == WatchSyncPageSection(
+            offset: 0,
+            itemCount: 32,
+            totalCount: 80
+        ))
+        #expect(page.metadata.tombstones == WatchSyncPageSection(
+            offset: 0,
+            itemCount: 32,
+            totalCount: 70
+        ))
+        #expect(page.metadata.nextCursor == WatchSyncPageCycleCursor(
+            pageIndex: 1,
+            manifestOffset: 32,
+            configurationOffset: 32,
+            tombstoneOffset: 32
+        ))
+    }
+
+    @Test
+    func `Manifest pages are bounded deterministic and progress by cursor`() throws {
+        let conversations = (1 ... 5).map { index in
+            Conversation(
+                id: UUID(uuidString: "00000000-0000-0000-0000-00000000010\(index)")!,
+                title: "Conversation \(index)",
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(10 - index)),
+                model: "model"
+            )
+        }
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumManifestConversationIDs = 2
+        configuration.byteBudget = 2000
+
+        let first = try WatchSyncPayloadBuilder.build(
+            conversations: conversations,
+            snapshotRevision: 10,
+            paginationCursor: 0,
+            configuration: configuration
+        )
+        let repeated = try WatchSyncPayloadBuilder.build(
+            conversations: conversations.reversed(),
+            snapshotRevision: 10,
+            paginationCursor: 0,
+            configuration: configuration
+        )
+        let second = try WatchSyncPayloadBuilder.build(
+            conversations: conversations,
+            snapshotRevision: 11,
+            paginationCursor: 1,
+            configuration: configuration
+        )
+        let third = try WatchSyncPayloadBuilder.build(
+            conversations: conversations,
+            snapshotRevision: 12,
+            paginationCursor: 2,
+            configuration: configuration
+        )
+
+        #expect(first.data == repeated.data)
+        #expect(first.snapshot.paginationCursor == 0)
+        #expect(first.snapshot.authoritativeConversationIDs == Array(conversations[0 ... 1].map(\.id)))
+        #expect(second.snapshot.authoritativeConversationIDs == Array(conversations[2 ... 3].map(\.id)))
+        #expect(third.snapshot.authoritativeConversationIDs == [conversations[4].id])
+        #expect(!first.snapshot.authoritativeConversationIDsAreComplete)
+        #expect(!second.snapshot.authoritativeConversationIDsAreComplete)
+        #expect(!third.snapshot.authoritativeConversationIDsAreComplete)
+        #expect(
+            Set(
+                first.snapshot.authoritativeConversationIDs +
+                    second.snapshot.authoritativeConversationIDs +
+                    third.snapshot.authoritativeConversationIDs
+            ) == Set(conversations.map(\.id))
+        )
+    }
+
+    @Test
+    func `Body bounds do not change the selected manifest page`() throws {
+        let conversations = (1 ... 5).map { index in
+            Conversation(
+                id: UUID(uuidString: "00000000-0000-0000-0000-00000000020\(index)")!,
+                title: "Conversation \(index)",
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(10 - index)),
+                model: "model"
+            )
+        }
+        let expectedManifestPage = Array(conversations[2 ... 3].map(\.id))
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumManifestConversationIDs = 2
+        configuration.maximumConversationConfigurations = 0
+        configuration.byteBudget = 10000
+
+        for maximumBodies in [0, 1, conversations.count] {
+            configuration.maximumConversations = maximumBodies
+            let payload = try WatchSyncPayloadBuilder.build(
+                conversations: conversations,
+                snapshotRevision: 20,
+                paginationCursor: 1,
+                configuration: configuration
+            )
+
+            #expect(payload.snapshot.authoritativeConversationIDs == expectedManifestPage)
+            #expect(!payload.snapshot.authoritativeConversationIDsAreComplete)
+            #expect(payload.snapshot.conversations.count <= maximumBodies)
+        }
+    }
+
+    @Test
+    func `Realistic large history emits bounded progressing partial pages`() throws {
+        let conversations = (0 ..< 2000).map { index in
+            Conversation(
+                id: UUID(),
+                title: "Conversation \(index)",
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(2000 - index)),
+                model: "model"
+            )
+        }
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumConversationConfigurations = 1
+        configuration.byteBudget = 1800
+
+        let first = try WatchSyncPayloadBuilder.build(
+            conversations: conversations,
+            snapshotRevision: 1,
+            configuration: configuration
+        )
+        let second = try WatchSyncPayloadBuilder.build(
+            conversations: conversations,
+            snapshotRevision: 2,
+            configuration: configuration
+        )
+
+        #expect(first.data.count <= configuration.byteBudget)
+        #expect(second.data.count <= configuration.byteBudget)
+        #expect(!first.snapshot.authoritativeConversationIDsAreComplete)
+        #expect(!second.snapshot.authoritativeConversationIDsAreComplete)
+        #expect(!first.snapshot.authoritativeConversationIDs.isEmpty)
+        #expect(!second.snapshot.authoritativeConversationIDs.isEmpty)
+        #expect(first.snapshot.authoritativeConversationIDs != second.snapshot.authoritativeConversationIDs)
+        #expect(first.snapshot.conversationConfigurations.count <= 1)
+        #expect(second.snapshot.conversationConfigurations.count <= 1)
+    }
+
+    @Test
+    func `Body limit preserves the complete manifest and an omitted pending draft`() throws {
+        let newestID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000101"))
+        let middleID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000102"))
+        let omittedDraftID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000103"))
+        let draftMessageID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000201"))
+        let createdAt = Date(timeIntervalSince1970: 1)
+        let conversations = [
+            Conversation(
+                id: omittedDraftID,
+                title: "Omitted draft",
+                createdAt: createdAt,
+                updatedAt: Date(timeIntervalSince1970: 10),
+                model: "model"
+            ),
+            Conversation(
+                id: newestID,
+                title: "Newest",
+                createdAt: createdAt,
+                updatedAt: Date(timeIntervalSince1970: 30),
+                model: "model"
+            ),
+            Conversation(
+                id: middleID,
+                title: "Middle",
+                createdAt: createdAt,
+                updatedAt: Date(timeIntervalSince1970: 20),
+                model: "model"
+            )
+        ]
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 1
+        configuration.maximumMessagesPerConversation = 0
+        configuration.byteBudget = 10000
+
+        let payload = try WatchSyncPayloadBuilder.build(
+            conversations: conversations,
+            snapshotRevision: 2,
+            configuration: configuration
+        )
+        let reorderedPayload = try WatchSyncPayloadBuilder.build(
+            conversations: conversations.reversed(),
+            snapshotRevision: 2,
+            configuration: configuration
+        )
+        let expectedManifest = [newestID, middleID, omittedDraftID]
+
+        #expect(payload.data == reorderedPayload.data)
+        #expect(payload.snapshot.authoritativeConversationIDs == expectedManifest)
+        #expect(payload.snapshot.authoritativeConversationIDsAreComplete)
+        #expect(reorderedPayload.snapshot.authoritativeConversationIDsAreComplete)
+        #expect(payload.snapshot.conversations.map(\.id) == [newestID])
+
+        let draftMessage = WatchMessage(
+            id: draftMessageID,
+            role: Message.Role.assistant.rawValue,
+            content: "Pending response",
+            timestamp: Date(timeIntervalSince1970: 40)
+        )
+        let omittedDraft = WatchConversation(
+            id: omittedDraftID,
+            title: "Omitted draft",
+            messages: [draftMessage],
+            model: "model",
+            updatedAt: Date(timeIntervalSince1970: 40),
+            createdAt: createdAt
+        )
+        let state = WatchSyncLocalState(
+            lastSnapshotRevision: 1,
+            conversations: [omittedDraft],
+            pendingDrafts: [
+                omittedDraftID: WatchConversationDraft(
+                    conversation: omittedDraft,
+                    ownedMessageIDs: [draftMessageID]
+                )
+            ]
+        )
+
+        let reconciled = WatchSnapshotReconciler.reconcile(payload.snapshot, with: state)
+
+        #expect(reconciled.state.conversations.contains { $0.id == omittedDraftID })
+        #expect(reconciled.state.pendingDrafts[omittedDraftID]?.conversation.messages == [draftMessage])
+
+        let irreducibleSnapshot = WatchSyncSnapshot(
+            revision: 2,
+            conversations: [],
+            authoritativeConversationIDs: expectedManifest
+        )
+        configuration.byteBudget = try WatchSyncPayloadBuilder.encode(irreducibleSnapshot).count - 1
+
+        let paged = try WatchSyncPayloadBuilder.build(
+            conversations: conversations,
+            snapshotRevision: 2,
+            configuration: configuration
+        )
+
+        #expect(paged.data.count <= configuration.byteBudget)
+        #expect(!paged.snapshot.authoritativeConversationIDsAreComplete)
+        #expect(paged.snapshot.authoritativeConversationIDs.count < expectedManifest.count)
+    }
+
+    @Test
+    func `Payload builder canonicalizes duplicate conversation IDs and keeps the newest state`() throws {
+        let conversationID = UUID()
+        let olderMessage = Message(
+            role: .user,
+            content: "Older message",
+            timestamp: Date(timeIntervalSince1970: 10)
+        )
+        let newerMessage = Message(
+            role: .user,
+            content: "Newer message",
+            timestamp: Date(timeIntervalSince1970: 20)
+        )
+        let older = Conversation(
+            id: conversationID,
+            title: "Older",
+            messages: [olderMessage],
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 10),
+            model: "older-model"
+        )
+        let newer = Conversation(
+            id: conversationID,
+            title: "Newer",
+            messages: [newerMessage],
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 20),
+            model: "newer-model"
+        )
+
+        let first = try WatchSyncPayloadBuilder.build(
+            conversations: [older, newer],
+            snapshotRevision: 1
+        )
+        let second = try WatchSyncPayloadBuilder.build(
+            conversations: [newer, older],
+            snapshotRevision: 1
+        )
+
+        #expect(first.data == second.data)
+        #expect(first.snapshot.authoritativeConversationIDs == [conversationID])
+        #expect(first.snapshot.conversations.count == 1)
+        #expect(first.snapshot.conversations.first?.title == "Newer")
+        #expect(first.snapshot.conversations.first?.model == "newer-model")
+        #expect(first.snapshot.conversations.first?.messages.map(\.content) == ["Newer message"])
+    }
+
+    @Test
+    func `Payload builder is deterministic bounded sorted and keeps the complete manifest`() throws {
+        let base = Date(timeIntervalSince1970: 1000)
+        let conversations = (0 ..< 3).map { index -> Conversation in
+            let id = UUID(uuidString: "00000000-0000-0000-0000-00000000000\(index + 1)")!
+            let call = MCPToolCall(
+                id: String(repeating: "i", count: 500),
+                toolName: String(repeating: "tool", count: 200),
+                arguments: ["huge": AnyCodable(String(repeating: "argument", count: 1000))],
+                result: String(repeating: "result", count: 1000),
+                timestamp: base
+            )
+            let messages = (0 ..< 8).map { messageIndex in
+                Message(
+                    role: messageIndex.isMultiple(of: 2) ? .user : .assistant,
+                    content: String(repeating: "content-\(index)-\(messageIndex)", count: 100),
+                    timestamp: base.addingTimeInterval(Double(messageIndex)),
+                    toolCalls: [call]
+                )
+            }
+            return Conversation(
+                id: id,
+                title: String(repeating: "title-\(index)", count: 50),
+                messages: messages,
+                createdAt: base,
+                updatedAt: base.addingTimeInterval(Double(index)),
+                model: String(repeating: "model", count: 100),
+                systemPromptMode: .custom(String(repeating: "prompt", count: 500))
+            )
+        }
+        var configuration = WatchSyncPayloadConfiguration(
+            byteBudget: 2200,
+            maximumConversations: 2,
+            maximumMessagesPerConversation: 5,
+            maximumContentCharacters: 80
+        )
+        configuration.maximumTitleCharacters = 40
+        configuration.maximumModelCharacters = 30
+        configuration.maximumSystemPromptCharacters = 60
+        configuration.maximumToolCallsPerMessage = 1
+        configuration.maximumToolMetadataBytes = 180
+
+        let first = try WatchSyncPayloadBuilder.build(
+            conversations: conversations,
+            snapshotRevision: 9,
+            acknowledgedWatchRevisions: [conversations[0].id: 4],
+            configuration: configuration,
+            resolvedSystemPrompt: { conversation in
+                if case let .custom(prompt) = conversation.systemPromptMode {
+                    return prompt
+                }
+                return nil
+            }
+        )
+        let second = try WatchSyncPayloadBuilder.build(
+            conversations: conversations.reversed(),
+            snapshotRevision: 9,
+            acknowledgedWatchRevisions: [conversations[0].id: 4],
+            configuration: configuration,
+            resolvedSystemPrompt: { conversation in
+                if case let .custom(prompt) = conversation.systemPromptMode {
+                    return prompt
+                }
+                return nil
+            }
+        )
+        let decoded = try JSONDecoder().decode(WatchSyncSnapshot.self, from: first.data)
+
+        #expect(first.data.count <= configuration.byteBudget)
+        #expect(first.data == second.data)
+        #expect(first.snapshot == decoded)
+        let expectedManifest = conversations.sorted {
+            if $0.updatedAt != $1.updatedAt {
+                return $0.updatedAt > $1.updatedAt
+            }
+            return $0.id.uuidString < $1.id.uuidString
+        }.map(\.id)
+        let bodyIDs = first.snapshot.conversations.map(\.id)
+        #expect(first.snapshot.authoritativeConversationIDs == expectedManifest)
+        #expect(first.snapshot.conversations.count <= configuration.maximumConversations)
+        #expect(bodyIDs == Array(expectedManifest.prefix(bodyIDs.count)))
+        #expect(first.snapshot.conversations.map(\.updatedAt) == first.snapshot.conversations.map(\.updatedAt).sorted(by: >))
+        #expect(first.snapshot.conversations.allSatisfy { $0.title.count <= 40 })
+        #expect(first.snapshot.conversations.flatMap(\.messages).allSatisfy { $0.content.count <= 80 })
+        #expect(first.snapshot.conversations.flatMap(\.messages).flatMap { $0.toolCalls ?? [] }.allSatisfy {
+            (try? JSONEncoder().encode($0).count) ?? .max <= 180
+        })
+    }
+
+    @Test
+    func `Large durable acknowledgement and tombstone history still produces a bounded snapshot`() throws {
+        let conversations = (0 ..< 20).map { index in
+            Conversation(
+                id: UUID(),
+                title: "Conversation \(index)",
+                model: "model"
+            )
+        }
+        let acknowledged = Dictionary(uniqueKeysWithValues: (0 ..< 512).map { index in
+            (UUID(), WatchSyncRevision(index + 1))
+        })
+        let tombstones = Dictionary(uniqueKeysWithValues: (0 ..< 256).map { index in
+            (UUID(), WatchSyncRevision(index + 1))
+        })
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.byteBudget = 32000
+        configuration.maximumConversations = 10
+        let prioritizedAcknowledgementID = try #require(acknowledged.keys.first)
+
+        let payload = try WatchSyncPayloadBuilder.build(
+            conversations: conversations,
+            snapshotRevision: 10001,
+            acknowledgedWatchRevisions: acknowledged,
+            prioritizedAcknowledgementIDs: [prioritizedAcknowledgementID],
+            tombstoneRevisions: tombstones,
+            configuration: configuration
+        )
+
+        #expect(payload.data.count <= configuration.byteBudget)
+        #expect(Set(payload.snapshot.authoritativeConversationIDs) == Set(conversations.map(\.id)))
+        #expect(payload.snapshot.conversations.count <= configuration.maximumConversations)
+        #expect(payload.snapshot.acknowledgedWatchRevisions.count <= configuration.maximumAcknowledgements)
+        #expect(payload.snapshot.acknowledgedWatchRevisions[prioritizedAcknowledgementID] != nil)
+    }
+
+    @Test
+    func `Post-encoding trimming drops lowest-priority metadata first`() throws {
+        let lowAcknowledgementID = try #require(
+            UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE1")
+        )
+        let prioritizedAcknowledgementID = try #require(
+            UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE2")
+        )
+        let oldestTombstoneID = try #require(
+            UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE3")
+        )
+        let newestTombstoneID = try #require(
+            UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE4")
+        )
+        let acknowledgements: [UUID: WatchSyncRevision] = [
+            lowAcknowledgementID: 1,
+            prioritizedAcknowledgementID: 9
+        ]
+        let tombstones: [UUID: WatchSyncRevision] = [
+            oldestTombstoneID: 1,
+            newestTombstoneID: 9
+        ]
+        var configuration = WatchSyncPayloadConfiguration.default
+        configuration.maximumConversations = 0
+        configuration.maximumAcknowledgements = 2
+        configuration.maximumTombstones = 2
+        configuration.byteBudget = 10000
+        let full = try WatchSyncPayloadBuilder.build(
+            conversations: [],
+            snapshotRevision: 10,
+            acknowledgedWatchRevisions: acknowledgements,
+            prioritizedAcknowledgementIDs: [prioritizedAcknowledgementID],
+            tombstoneRevisions: tombstones,
+            configuration: configuration
+        )
+
+        var afterLowAcknowledgement = full.snapshot
+        afterLowAcknowledgement.acknowledgedWatchRevisions.removeValue(forKey: lowAcknowledgementID)
+        configuration.byteBudget = try WatchSyncPayloadBuilder.encode(afterLowAcknowledgement).count
+        let acknowledgementTrimmed = try WatchSyncPayloadBuilder.build(
+            conversations: [],
+            snapshotRevision: 10,
+            acknowledgedWatchRevisions: acknowledgements,
+            prioritizedAcknowledgementIDs: [prioritizedAcknowledgementID],
+            tombstoneRevisions: tombstones,
+            configuration: configuration
+        )
+
+        #expect(acknowledgementTrimmed.snapshot.acknowledgedWatchRevisions == [
+            prioritizedAcknowledgementID: 9
+        ])
+        #expect(Set(acknowledgementTrimmed.snapshot.tombstones.map(\.conversationID)) == [
+            oldestTombstoneID,
+            newestTombstoneID
+        ])
+
+        var afterOldestTombstone = afterLowAcknowledgement
+        afterOldestTombstone.tombstones.removeAll { $0.conversationID == oldestTombstoneID }
+        configuration.byteBudget = try WatchSyncPayloadBuilder.encode(afterOldestTombstone).count
+        let tombstoneTrimmed = try WatchSyncPayloadBuilder.build(
+            conversations: [],
+            snapshotRevision: 10,
+            acknowledgedWatchRevisions: acknowledgements,
+            prioritizedAcknowledgementIDs: [prioritizedAcknowledgementID],
+            tombstoneRevisions: tombstones,
+            configuration: configuration
+        )
+
+        #expect(tombstoneTrimmed.snapshot.acknowledgedWatchRevisions == [
+            prioritizedAcknowledgementID: 9
+        ])
+        #expect(tombstoneTrimmed.snapshot.tombstones == [
+            WatchConversationTombstone(conversationID: newestTombstoneID, revision: 9)
+        ])
+    }
+
+    @Test
+    func `Mutation payload preserves every offline message change`() throws {
+        let conversation = makeWatchConversation(title: "Offline", revision: 25)
+        let changes = (0 ..< 25).map { index in
+            WatchMessage(
+                id: UUID(),
+                role: Message.Role.user.rawValue,
+                content: "offline-\(index)",
+                timestamp: Date(timeIntervalSince1970: Double(index))
+            )
+        }
+        let mutation = WatchConversationMutation(
+            revision: 25,
+            conversation: conversation,
+            fields: [.messages],
+            messageChanges: changes
+        )
+
+        let payload = try WatchSyncPayloadBuilder.buildMutation(mutation)
+        let decoded = try JSONDecoder().decode(WatchConversationMutation.self, from: payload.data)
+
+        #expect(decoded.messageChanges == changes)
+        #expect(decoded.revision == 25)
+    }
+
+    @Test
+    func `Oversized mutation is rejected without truncating durable changes`() throws {
+        var conversation = makeWatchConversation(title: "Large mutation", revision: 7)
+        conversation.messages = (0 ..< 10).map { index in
+            WatchMessage(
+                id: UUID(),
+                role: Message.Role.assistant.rawValue,
+                content: String(repeating: "payload-\(index)", count: 1000),
+                timestamp: Date(timeIntervalSince1970: Double(index)),
+                toolCalls: [MCPToolCall(
+                    id: "tool-\(index)",
+                    toolName: "lookup",
+                    arguments: ["value": AnyCodable(String(repeating: "x", count: 5000))]
+                )]
+            )
+        }
+        let operationID = UUID()
+        let mutation = WatchConversationMutation(
+            operationID: operationID,
+            revision: 7,
+            conversation: conversation,
+            fields: [.messages],
+            messageChanges: conversation.messages
+        )
+
+        #expect(throws: WatchSyncPayloadBuilderError.self) {
+            try WatchSyncPayloadBuilder.buildMutation(mutation, byteBudget: 4000)
+        }
+        #expect(mutation.operationID == operationID)
+        #expect(mutation.messageChanges == conversation.messages)
+    }
+
+    @Test
+    func `An explicitly empty manifest survives Codable round trip`() throws {
+        let snapshot = WatchSyncSnapshot(
+            revision: 1,
+            conversations: [],
+            authoritativeConversationIDs: [],
+            acknowledgedWatchRevisions: [:],
+            tombstones: []
+        )
+
+        let data = try WatchSyncPayloadBuilder.encode(snapshot)
+        let decoded = try JSONDecoder().decode(WatchSyncSnapshot.self, from: data)
+
+        #expect(decoded.authoritativeConversationIDs.isEmpty)
+        #expect(decoded.conversations.isEmpty)
+    }
+}
+
+private func makeWatchConversation(
+    id: UUID = UUID(),
+    title: String,
+    revision: WatchSyncRevision = 0,
+    updatedAt: TimeInterval = 1
+) -> WatchConversation {
+    let date = Date(timeIntervalSince1970: updatedAt)
+    return WatchConversation(
+        id: id,
+        title: title,
+        messages: [],
+        model: "model",
+        updatedAt: date,
+        createdAt: date,
+        temperature: 0.7,
+        watchRevision: revision
+    )
+}
+
+@MainActor
+private final class TestGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+// swiftlint:enable identifier_name type_body_length

--- a/Tests/AynaTests/WebFetchTests.swift
+++ b/Tests/AynaTests/WebFetchTests.swift
@@ -9,7 +9,8 @@
 import Foundation
 import Testing
 
-@Suite("WebFetch Tests")
+// swiftformat:disable swiftTestingTestCaseNames
+@Suite("WebFetch Tests", .serialized)
 @MainActor
 struct WebFetchTests {
     private var webFetchService: WebFetchService!
@@ -17,6 +18,401 @@ struct WebFetchTests {
     init() {
         webFetchService = WebFetchService.shared
         webFetchService.isEnabled = true
+        WebFetchTestURLProtocol.reset()
+    }
+
+    // MARK: - Hostname Resolution Tests
+
+    @Test("Rejects a private address reported by the actual connection")
+    func rejectsPrivateActualConnectedAddress() throws {
+        let url = "https://public-looking.example/private"
+
+        #expect(throws: WebFetchError.self) {
+            try SSRFProtection.validateConnectedAddresses(
+                ["203.0.113.10", "127.0.0.1"],
+                reportedAs: url
+            )
+        }
+        #expect(throws: Never.self) {
+            try SSRFProtection.validateConnectedAddresses(
+                ["203.0.113.10", "2001:4860:4860::8888"],
+                reportedAs: url
+            )
+        }
+        #expect(throws: WebFetchError.self) {
+            try SSRFProtection.validateConnectedAddresses([], reportedAs: url)
+        }
+        #expect(throws: WebFetchError.self) {
+            try SSRFProtection.validateConnectedAddresses(
+                ["203.0.113.10"],
+                reportedAs: url,
+                isProxyConnection: true
+            )
+        }
+        #expect(!SSRFProtection.isPrivateHost("64:ff9b::808:808"))
+    }
+
+    @Test("Fails closed when hostname resolution fails")
+    func failsClosedWhenHostnameResolutionFails() async {
+        let url = "https://resolution-failure.example/content"
+        let session = makeSession(routes: [url: .success("should not be fetched")])
+        let resolver = HostResolver { _ in
+            throw WebFetchTestResolverError.lookupFailed
+        }
+
+        do {
+            _ = try await WebFetchRequestExecutor.fetchText(
+                from: url,
+                timeoutSeconds: 1,
+                maxResponseSize: 1024,
+                session: session,
+                resolver: resolver,
+                requiresConnectedEndpointVerification: false
+            )
+            Issue.record("Expected DNS resolution failure to stop the request")
+        } catch let error as WebFetchError {
+            guard case let .networkError(underlying) = error else {
+                Issue.record("Expected networkError, got \(error)")
+                return
+            }
+            #expect(underlying.contains("DNS resolution failed"))
+            #expect(underlying.contains("resolution-failure.example"))
+        } catch {
+            Issue.record("Expected WebFetchError, got \(error)")
+        }
+
+        #expect(WebFetchTestURLProtocol.requestedURLs.isEmpty)
+    }
+
+    @Test("Fails closed when hostname resolution returns no addresses")
+    func failsClosedWhenHostnameResolutionReturnsNoAddresses() async {
+        let url = "https://no-addresses.example/content"
+        let session = makeSession(routes: [url: .success("should not be fetched")])
+        let resolver = HostResolver { _ in [] }
+
+        do {
+            _ = try await WebFetchRequestExecutor.fetchText(
+                from: url,
+                timeoutSeconds: 1,
+                maxResponseSize: 1024,
+                session: session,
+                resolver: resolver,
+                requiresConnectedEndpointVerification: false
+            )
+            Issue.record("Expected an empty DNS result to stop the request")
+        } catch let error as WebFetchError {
+            guard case let .networkError(underlying) = error else {
+                Issue.record("Expected networkError, got \(error)")
+                return
+            }
+            #expect(underlying.contains("DNS resolution failed"))
+            #expect(underlying.contains("no-addresses.example"))
+            #expect(underlying.contains("No IP addresses returned"))
+        } catch {
+            Issue.record("Expected WebFetchError, got \(error)")
+        }
+
+        #expect(WebFetchTestURLProtocol.requestedURLs.isEmpty)
+    }
+
+    @Test("Request deadline bounds initial hostname resolution", .timeLimit(.minutes(1)))
+    func requestDeadlineBoundsInitialHostnameResolution() async {
+        let url = "https://stalled-resolution.example/content"
+        let session = makeSession(routes: [url: .success("should not be fetched")])
+        let resolverGate = WebFetchTestResolverGate()
+        let resolver = HostResolver { _ in
+            await resolverGate.resolve()
+        }
+        let fallbackRelease = Task {
+            do {
+                try await Task.sleep(for: .seconds(1))
+            } catch {
+                return
+            }
+            _ = await resolverGate.succeed(with: ["203.0.113.10"])
+        }
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        do {
+            _ = try await WebFetchRequestExecutor.fetchText(
+                from: url,
+                timeoutSeconds: 0.05,
+                maxResponseSize: 1024,
+                session: session,
+                resolver: resolver,
+                requiresConnectedEndpointVerification: false
+            )
+            Issue.record("Expected stalled initial DNS resolution to time out")
+        } catch let error as WebFetchError {
+            guard case let .networkError(underlying) = error else {
+                Issue.record("Expected networkError, got \(error)")
+                return
+            }
+            #expect(underlying.localizedCaseInsensitiveContains("timed out"))
+        } catch {
+            Issue.record("Expected WebFetchError, got \(error)")
+        }
+
+        let elapsed = start.duration(to: clock.now)
+        fallbackRelease.cancel()
+        if await resolverGate.succeed(with: ["203.0.113.10"]) {
+            await resolverGate.waitUntilCompleted()
+        }
+
+        #expect(elapsed < .milliseconds(500))
+        #expect(WebFetchTestURLProtocol.requestedURLs.isEmpty)
+    }
+
+    @Test("Blocks redirects whose hostname resolves to a private address")
+    func blocksRedirectResolvingToPrivateAddress() async throws {
+        let sourceURL = "https://public-source.example/start"
+        let redirectURL = "https://public-looking.example/private"
+        let session = try makeSession(routes: [
+            sourceURL: .redirect(#require(URL(string: redirectURL))),
+            redirectURL: .success("private response")
+        ])
+        let resolver = HostResolver { host in
+            switch host {
+            case "public-source.example":
+                ["203.0.113.10"]
+            case "public-looking.example":
+                ["127.0.0.1"]
+            default:
+                throw WebFetchTestResolverError.unexpectedHost(host)
+            }
+        }
+
+        do {
+            _ = try await WebFetchRequestExecutor.fetchText(
+                from: sourceURL,
+                timeoutSeconds: 1,
+                maxResponseSize: 1024,
+                session: session,
+                resolver: resolver,
+                requiresConnectedEndpointVerification: false
+            )
+            Issue.record("Expected redirect target to be SSRF-blocked")
+        } catch let error as WebFetchError {
+            guard case let .ssrfBlocked(url) = error else {
+                Issue.record("Expected ssrfBlocked, got \(error)")
+                return
+            }
+            #expect(url == redirectURL)
+        } catch {
+            Issue.record("Expected WebFetchError, got \(error)")
+        }
+
+        #expect(WebFetchTestURLProtocol.requestedURLs == [sourceURL])
+    }
+
+    @Test("Blocks hostnames resolving to private addresses", arguments: [
+        "127.0.0.1",
+        "169.254.20.1",
+        "192.168.1.20",
+        "::1",
+        "fe90::1",
+        "fd00::1",
+        "::ffff:127.0.0.1",
+        "64:ff9b::a00:1",
+        "64:ff9b:1::1"
+    ])
+    func blocksHostnamesResolvingToPrivateAddresses(privateAddress: String) async {
+        let url = "https://public-looking.example/content"
+        let session = makeSession(routes: [url: .success("private response")])
+        let resolver = HostResolver { _ in [privateAddress] }
+
+        do {
+            _ = try await WebFetchRequestExecutor.fetchText(
+                from: url,
+                timeoutSeconds: 1,
+                maxResponseSize: 1024,
+                session: session,
+                resolver: resolver,
+                requiresConnectedEndpointVerification: false
+            )
+            Issue.record("Expected resolved private address \(privateAddress) to be SSRF-blocked")
+        } catch let error as WebFetchError {
+            guard case let .ssrfBlocked(blockedURL) = error else {
+                Issue.record("Expected ssrfBlocked, got \(error)")
+                return
+            }
+            #expect(blockedURL == url)
+        } catch {
+            Issue.record("Expected WebFetchError, got \(error)")
+        }
+
+        #expect(WebFetchTestURLProtocol.requestedURLs.isEmpty)
+    }
+
+    @Test("Fails closed when redirect hostname resolution fails")
+    func failsClosedWhenRedirectHostnameResolutionFails() async throws {
+        let sourceURL = "https://public-source.example/start"
+        let redirectURL = "https://resolution-failure.example/content"
+        let session = try makeSession(routes: [
+            sourceURL: .redirect(#require(URL(string: redirectURL))),
+            redirectURL: .success("should not be fetched")
+        ])
+        let resolver = HostResolver { host in
+            if host == "public-source.example" {
+                return ["203.0.113.10"]
+            }
+            throw WebFetchTestResolverError.lookupFailed
+        }
+
+        do {
+            _ = try await WebFetchRequestExecutor.fetchText(
+                from: sourceURL,
+                timeoutSeconds: 1,
+                maxResponseSize: 1024,
+                session: session,
+                resolver: resolver,
+                requiresConnectedEndpointVerification: false
+            )
+            Issue.record("Expected redirect DNS resolution failure to stop the request")
+        } catch let error as WebFetchError {
+            guard case let .networkError(underlying) = error else {
+                Issue.record("Expected networkError, got \(error)")
+                return
+            }
+            #expect(underlying.contains("DNS resolution failed"))
+            #expect(underlying.contains("resolution-failure.example"))
+        } catch {
+            Issue.record("Expected WebFetchError, got \(error)")
+        }
+
+        #expect(WebFetchTestURLProtocol.requestedURLs == [sourceURL])
+    }
+
+    @Test("Request deadline bounds redirect hostname resolution", .timeLimit(.minutes(1)))
+    func requestDeadlineBoundsRedirectHostnameResolution() async throws {
+        let sourceURL = "https://public-source.example/start"
+        let redirectURL = "https://stalled-redirect.example/content"
+        let session = try makeSession(routes: [
+            sourceURL: .redirect(#require(URL(string: redirectURL))),
+            redirectURL: .success("should not be fetched")
+        ])
+        let resolverGate = WebFetchTestResolverGate()
+        let resolver = HostResolver { host in
+            switch host {
+            case "public-source.example":
+                ["203.0.113.10"]
+            case "stalled-redirect.example":
+                await resolverGate.resolve()
+            default:
+                throw WebFetchTestResolverError.unexpectedHost(host)
+            }
+        }
+        let fallbackRelease = Task {
+            do {
+                try await Task.sleep(for: .seconds(1))
+            } catch {
+                return
+            }
+            _ = await resolverGate.succeed(with: ["203.0.113.20"])
+        }
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        do {
+            _ = try await WebFetchRequestExecutor.fetchText(
+                from: sourceURL,
+                timeoutSeconds: 0.05,
+                maxResponseSize: 1024,
+                session: session,
+                resolver: resolver,
+                requiresConnectedEndpointVerification: false
+            )
+            Issue.record("Expected stalled redirect DNS resolution to time out")
+        } catch let error as WebFetchError {
+            guard case let .networkError(underlying) = error else {
+                Issue.record("Expected networkError, got \(error)")
+                return
+            }
+            #expect(underlying.localizedCaseInsensitiveContains("timed out"))
+        } catch {
+            Issue.record("Expected WebFetchError, got \(error)")
+        }
+
+        let elapsed = start.duration(to: clock.now)
+        fallbackRelease.cancel()
+        if await resolverGate.succeed(with: ["203.0.113.20"]) {
+            await resolverGate.waitUntilCompleted()
+        }
+
+        #expect(elapsed < .milliseconds(500))
+        #expect(WebFetchTestURLProtocol.requestedURLs == [sourceURL])
+    }
+
+    @Test("Follows redirects whose hostnames resolve only to public addresses")
+    func followsPublicRedirects() async throws {
+        let sourceURL = "https://public-source.example/start"
+        let redirectURL = "https://public-target.example/content"
+        let session = try makeSession(routes: [
+            sourceURL: .redirect(#require(URL(string: redirectURL))),
+            redirectURL: .success("public response")
+        ])
+        let resolver = HostResolver { host in
+            switch host {
+            case "public-source.example":
+                ["203.0.113.10"]
+            case "public-target.example":
+                ["203.0.113.20"]
+            default:
+                throw WebFetchTestResolverError.unexpectedHost(host)
+            }
+        }
+
+        let result = try await WebFetchRequestExecutor.fetchText(
+            from: sourceURL,
+            timeoutSeconds: 1,
+            maxResponseSize: 1024,
+            session: session,
+            resolver: resolver,
+            requiresConnectedEndpointVerification: false
+        )
+
+        #expect(result == "public response")
+        #expect(WebFetchTestURLProtocol.requestedURLs == [sourceURL, redirectURL])
+    }
+
+    @Test("Completes initial and redirect resolution within one request deadline")
+    func completesResolutionWithinRequestDeadline() async throws {
+        let sourceURL = "https://public-source.example/start"
+        let redirectURL = "https://public-target.example/content"
+        let session = try makeSession(routes: [
+            sourceURL: .redirect(#require(URL(string: redirectURL))),
+            redirectURL: .success("public response")
+        ])
+        let resolver = HostResolver { host in
+            try await Task.sleep(for: .milliseconds(10))
+            switch host {
+            case "public-source.example":
+                return ["203.0.113.10"]
+            case "public-target.example":
+                return ["203.0.113.20"]
+            default:
+                throw WebFetchTestResolverError.unexpectedHost(host)
+            }
+        }
+
+        let result = try await WebFetchRequestExecutor.fetchText(
+            from: sourceURL,
+            timeoutSeconds: 1,
+            maxResponseSize: 1024,
+            session: session,
+            resolver: resolver,
+            requiresConnectedEndpointVerification: false
+        )
+
+        #expect(result == "public response")
+        #expect(WebFetchTestURLProtocol.requestedURLs == [sourceURL, redirectURL])
+    }
+
+    @Test("System resolver resolves a numeric IPv4 address")
+    func systemResolverResolvesNumericIPv4Address() async throws {
+        let addresses = try await HostResolver.system.addresses(for: "127.0.0.1")
+        #expect(addresses.contains("127.0.0.1"))
     }
 
     // MARK: - Private IP Detection Tests (via fetch errors)
@@ -136,36 +532,17 @@ struct WebFetchTests {
     }
 
     // MARK: - IPv6 False Positive Tests
-    // These verify that domains starting with "fd" or "fc" are NOT blocked.
-    // The SSRF check should only block IPv6 addresses (containing ":"), not hostnames.
-    // Note: These are integration tests — they require network access. The fetch may
-    // fail with a network or HTTP error, but must NOT fail with .ssrfBlocked.
 
+    /// These verify that domains starting with "fd" or "fc" are NOT blocked.
+    /// The SSRF check should only block IPv6 addresses (containing ":"), not hostnames.
     @Test("Does not block fdic.gov (not an IPv6 address)")
-    func doesNotBlockFdicGov() async {
-        do {
-            _ = try await webFetchService.fetch(url: "https://fdic.gov")
-        } catch let error as WebFetchError {
-            if case .ssrfBlocked = error {
-                Issue.record("fdic.gov should not be SSRF-blocked")
-            }
-            // Other WebFetchErrors (network, HTTP) are acceptable
-        } catch {
-            // Non-WebFetchError exceptions are acceptable
-        }
+    func doesNotBlockFdicGov() {
+        #expect(!SSRFProtection.isPrivateHost("fdic.gov"))
     }
 
     @Test("Does not block fcc.gov (not an IPv6 address)")
-    func doesNotBlockFccGov() async {
-        do {
-            _ = try await webFetchService.fetch(url: "https://fcc.gov")
-        } catch let error as WebFetchError {
-            if case .ssrfBlocked = error {
-                Issue.record("fcc.gov should not be SSRF-blocked")
-            }
-        } catch {
-            // Non-WebFetchError exceptions are acceptable
-        }
+    func doesNotBlockFccGov() {
+        #expect(!SSRFProtection.isPrivateHost("fcc.gov"))
     }
 
     // MARK: - IPv6 Private Address Tests
@@ -201,4 +578,150 @@ struct WebFetchTests {
             _ = try await webFetchService.fetch(url: "https://example.com")
         }
     }
+
+    private func makeSession(routes: [String: WebFetchTestURLProtocol.Response]) -> URLSession {
+        WebFetchTestURLProtocol.install(routes: routes)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [WebFetchTestURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+}
+
+private enum WebFetchTestResolverError: LocalizedError, Sendable {
+    case lookupFailed
+    case unexpectedHost(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .lookupFailed:
+            "Synthetic DNS lookup failure"
+        case let .unexpectedHost(host):
+            "Unexpected host: \(host)"
+        }
+    }
+}
+
+private actor WebFetchTestResolverGate {
+    private var isStarted = false
+    private var isCompleted = false
+    private var pendingAddresses: [String]?
+    private var resolutionContinuation: CheckedContinuation<[String], Never>?
+    private var completionWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func resolve() async -> [String] {
+        isStarted = true
+        let addresses = await withCheckedContinuation { continuation in
+            if let pendingAddresses {
+                continuation.resume(returning: pendingAddresses)
+            } else {
+                resolutionContinuation = continuation
+            }
+        }
+
+        isCompleted = true
+        let pendingCompletionWaiters = completionWaiters
+        completionWaiters.removeAll()
+        for waiter in pendingCompletionWaiters {
+            waiter.resume()
+        }
+        return addresses
+    }
+
+    func waitUntilCompleted() async {
+        guard !isCompleted else { return }
+        await withCheckedContinuation { continuation in
+            completionWaiters.append(continuation)
+        }
+    }
+
+    func succeed(with addresses: [String]) -> Bool {
+        guard pendingAddresses == nil else { return isStarted }
+        pendingAddresses = addresses
+        resolutionContinuation?.resume(returning: addresses)
+        resolutionContinuation = nil
+        return isStarted
+    }
+}
+
+private final class WebFetchTestURLProtocol: URLProtocol, @unchecked Sendable {
+    enum Response: Sendable {
+        case success(String)
+        case redirect(URL)
+    }
+
+    private static let stateLock = NSLock()
+    private nonisolated(unsafe) static var routes: [String: Response] = [:]
+    private nonisolated(unsafe) static var recordedURLs: [String] = []
+
+    static var requestedURLs: [String] {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return recordedURLs
+    }
+
+    static func install(routes: [String: Response]) {
+        stateLock.lock()
+        self.routes = routes
+        recordedURLs = []
+        stateLock.unlock()
+    }
+
+    static func reset() {
+        install(routes: [:])
+    }
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        let response: Response?
+        Self.stateLock.lock()
+        Self.recordedURLs.append(url.absoluteString)
+        response = Self.routes[url.absoluteString]
+        Self.stateLock.unlock()
+
+        guard let response else {
+            client?.urlProtocol(self, didFailWithError: URLError(.resourceUnavailable))
+            return
+        }
+
+        switch response {
+        case let .success(content):
+            let httpResponse = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/plain"]
+            )!
+            client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(content.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        case let .redirect(target):
+            let httpResponse = HTTPURLResponse(
+                url: url,
+                statusCode: 302,
+                httpVersion: nil,
+                headerFields: ["Location": target.absoluteString]
+            )!
+            client?.urlProtocol(
+                self,
+                wasRedirectedTo: URLRequest(url: target),
+                redirectResponse: httpResponse
+            )
+            client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    override func stopLoading() {}
 }

--- a/Tests/AynaTests/WebFetchTests.swift
+++ b/Tests/AynaTests/WebFetchTests.swift
@@ -52,6 +52,32 @@ struct WebFetchTests {
         #expect(!SSRFProtection.isPrivateHost("64:ff9b::808:808"))
     }
 
+    @Test("Rejects multicast, broadcast, and reserved non-unicast addresses")
+    func rejectsNonUnicastAddresses() {
+        let blockedAddresses = [
+            "224.0.0.1",
+            "239.1.1.1",
+            "240.0.0.1",
+            "255.255.255.255",
+            "ff02::1",
+            "::ffff:239.1.1.1",
+            "64:ff9b::ef01:101",
+        ]
+
+        for address in blockedAddresses {
+            #expect(SSRFProtection.isPrivateHost(address))
+            #expect(throws: WebFetchError.self) {
+                try SSRFProtection.validateConnectedAddresses(
+                    [address],
+                    reportedAs: "http://\(address)/"
+                )
+            }
+        }
+
+        #expect(!SSRFProtection.isPrivateHost("223.255.255.255"))
+        #expect(!SSRFProtection.isPrivateHost("2001:4860:4860::8888"))
+    }
+
     @Test("Fails closed when hostname resolution fails")
     func failsClosedWhenHostnameResolutionFails() async {
         let url = "https://resolution-failure.example/content"

--- a/Tests/AynaTests/WebSearchCoordinatorTests.swift
+++ b/Tests/AynaTests/WebSearchCoordinatorTests.swift
@@ -5,15 +5,13 @@
 //  Tests for WebSearchCoordinator routing, fallback, and response formatting.
 //
 
+@testable import Ayna
 import Foundation
 import Testing
-
-@testable import Ayna
 
 @Suite("WebSearchCoordinator Tests", .tags(.async), .serialized)
 @MainActor
 struct WebSearchCoordinatorTests {
-
     // MARK: - Provider Routing Tests
 
     @Test("Routes to DuckDuckGo when Tavily not configured")
@@ -80,6 +78,39 @@ struct WebSearchCoordinatorTests {
         let result = await coordinator.executeToolCall(arguments: [:])
         #expect(result.contains("Error"))
         #expect(result.contains("query"))
+    }
+
+    @Test("Cancellation does not start a fallback provider", .timeLimit(.minutes(1)))
+    func cancellationDoesNotStartFallbackProvider() async {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FlightTestURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        let tavily = TavilyService(keychain: MockKeychainStorage(), urlSession: session)
+        tavily.apiKey = "tvly-test-key"
+        tavily.isEnabled = true
+        let ddg = DuckDuckGoSearchService(urlSession: session)
+        let coordinator = WebSearchCoordinator(tavilyService: tavily, ddgService: ddg)
+
+        let task = Task {
+            await coordinator.executeToolCallWithCitations(arguments: ["query": "cancel me"])
+        }
+
+        #expect(await server.waitForRequestCount(1))
+        let firstRequest = await server.exchange(at: 0)
+        task.cancel()
+
+        let clock = ContinuousClock()
+        let stopDeadline = clock.now.advanced(by: .seconds(1))
+        while !firstRequest.isStopped, clock.now < stopDeadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(firstRequest.isStopped)
+        _ = await task.value
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(server.requestCount == 1)
     }
 
     // MARK: - WebSearchResponse Formatting Tests

--- a/Tests/AynaWatchOSUITests/WatchSmokeUITests.swift
+++ b/Tests/AynaWatchOSUITests/WatchSmokeUITests.swift
@@ -32,8 +32,14 @@ final class WatchSmokeUITests: WatchUITestCase {
         tapNewChatButton()
 
         // Verify new chat view appears
-        let composerField = app.textFields["watch.newChat.composerTextField"]
-        XCTAssertTrue(composerField.waitForExistence(timeout: UITestTimeout.normal), "New chat composer should appear")
+        let composerField = app.descendants(matching: .any)["watch.newChat.composerTextField"]
+        let newChatTitle = app.descendants(matching: .any)["New Chat"].firstMatch
+        let hasComposer = composerField.waitForExistence(timeout: UITestTimeout.normal)
+        let hasTitle = newChatTitle.waitForExistence(timeout: UITestTimeout.immediate)
+        XCTAssertTrue(
+            hasComposer || hasTitle,
+            "New chat view should expose either its composer or navigation title"
+        )
     }
 
     func testNavigateToModelSelector() {

--- a/Tests/AynaWatchOSUITests/WatchSmokeUITests.swift
+++ b/Tests/AynaWatchOSUITests/WatchSmokeUITests.swift
@@ -33,12 +33,12 @@ final class WatchSmokeUITests: WatchUITestCase {
 
         // Verify new chat view appears
         let composerField = app.descendants(matching: .any)["watch.newChat.composerTextField"]
-        let newChatTitle = app.descendants(matching: .any)["New Chat"].firstMatch
+        let destinationMarker = app.descendants(matching: .any)["watch.newChat.view"].firstMatch
         let hasComposer = composerField.waitForExistence(timeout: UITestTimeout.normal)
-        let hasTitle = newChatTitle.waitForExistence(timeout: UITestTimeout.immediate)
+        let hasDestinationMarker = destinationMarker.waitForExistence(timeout: UITestTimeout.immediate)
         XCTAssertTrue(
-            hasComposer || hasTitle,
-            "New chat view should expose either its composer or navigation title"
+            hasComposer || hasDestinationMarker,
+            "New chat view should expose either its composer or model selector"
         )
     }
 
@@ -73,12 +73,12 @@ final class WatchSmokeUITests: WatchUITestCase {
         if !textField.waitForExistence(timeout: UITestTimeout.async) {
             // TextField may not appear in simulator without proper WatchConnectivity
             // Just verify navigation worked by checking for any new chat UI element
-            let newChatTitle = app.descendants(matching: .any)["New Chat"].firstMatch
-            if newChatTitle.waitForExistence(timeout: UITestTimeout.normal) {
+            let destinationMarker = app.descendants(matching: .any)["watch.newChat.view"].firstMatch
+            if destinationMarker.waitForExistence(timeout: UITestTimeout.normal) {
                 // Navigation worked, text field just isn't accessible - pass
                 return
             }
-            // If we got here, navigation may have worked but UI is different - skip gracefully
+            XCTFail("watchOS simulator did not expose the new-chat destination after tapping")
             return
         }
 
@@ -96,12 +96,14 @@ final class WatchSmokeUITests: WatchUITestCase {
 
         // Try multiple ways to verify we're in the new chat view
         let textField = app.textFields["watch.newChat.composerTextField"].firstMatch
-        let newChatTitle = app.descendants(matching: .any)["New Chat"].firstMatch
+        let destinationMarker = app.descendants(matching: .any)["watch.newChat.view"].firstMatch
 
         let hasTextField = textField.waitForExistence(timeout: UITestTimeout.async)
-        let hasTitle = newChatTitle.waitForExistence(timeout: UITestTimeout.normal)
+        let hasDestinationMarker = destinationMarker.waitForExistence(timeout: UITestTimeout.normal)
 
-        // Pass if we can see either the text field or the title - confirms navigation worked
-        XCTAssertTrue(hasTextField || hasTitle, "New chat view should be visible (either composer or title)")
+        XCTAssertTrue(
+            hasTextField || hasDestinationMarker,
+            "New chat view should be visible (either composer or model selector)"
+        )
     }
 }

--- a/docs/adr/0007-revisioned-watch-sync.md
+++ b/docs/adr/0007-revisioned-watch-sync.md
@@ -1,0 +1,71 @@
+# ADR-0007: Revisioned Durable Watch Sync
+
+**Date**: 2026-07-12
+**Status**: Accepted
+**Context**: Apple Watch conversations must remain correct across offline edits, bounded WatchConnectivity payloads, retries, deletions, app restarts, and mixed app versions.
+
+## Context
+
+The original Watch sync treated the phone application context as a bounded list of conversation bodies and sent Watch edits as independent best-effort messages. That model could not distinguish a body omitted for size from a deletion, could not represent an authoritative empty state, and allowed delayed snapshots or component deliveries to overwrite newer local work. Streaming and tool-call state also existed only in memory until completion, so termination could lose prompts or partial responses.
+
+WatchConnectivity offers transports with different delivery guarantees and strict practical payload limits. Both devices may be offline, callbacks may arrive out of order, and a transfer finishing does not prove that the receiver durably applied it. Model credentials, prompts, and memory add another omission problem: a value absent from a bounded page may mean “not represented yet” rather than “clear it.” The protocol therefore needs explicit identity, ordering, durability, authority, and compatibility rules rather than timestamp or array-position heuristics.
+
+## Decision
+
+Use a revisioned, phone-authoritative snapshot plus a durable Watch mutation outbox.
+
+- Every phone snapshot carries a stable source ID and monotonically increasing snapshot revision. Rotating the source ID resets revision ordering after overflow or source replacement.
+- A snapshot carries an explicit authoritative conversation-ID manifest. Conversation bodies are independently bounded; omission of a body is never interpreted as deletion.
+- Deletions are represented by revisioned tombstones, including authoritative empty state.
+- Each Watch installation has a durable peer ID. Watch-originated mutations carry per-conversation revisions and stable operation/message IDs.
+- The Watch persists committed conversations, pending mutations, and request-owned drafts before transport. Failed local persistence rolls the visible mutation back and leaves no false acknowledgement.
+- The phone reduces mutations by peer and revision while preserving phone-only fields. It acknowledges a mutation only after the resulting save/delete state is durably settled, including ID-only deletes for records omitted from memory. Competing proposed-save chains retain their pre-proposal durable state and compensate storage before a failed replacement receipt settles.
+- Phone snapshots are constructed from the durable storage snapshot rather than optimistic UI state. Successful later persistence advances a durable revision that retriggers Watch publication; superseded or failed reloads cannot replace that publication snapshot.
+- A phone conversation load is authoritative only when every encrypted record is readable. Partial or later failed reloads revoke authority before retry scheduling, so stale state cannot publish false deletions or acknowledgements.
+- Application-context payload construction is deterministic and byte-bounded. Conversation bodies, acknowledgements, tombstones, models, prompts, and memory data have explicit fallback priorities. An irreducible configuration is deferred without truncation while the page cursor advances; that cycle remains non-authoritative and a later cycle re-evaluates the record.
+- Snapshot-coupled settings apply only with a durably accepted snapshot page or a valid legacy fallback context. A standalone page-cycle retry retains the exact source/request identity of the in-flight cycle.
+- Model metadata is accumulated across a page cycle. A new metadata epoch remains provisional until a complete authoritative replacement arrives; only then is the epoch committed and stale metadata pruned.
+- Model-removal history is bounded and rotates with its epoch. Persistent SHA-256 field fingerprints revoke omitted providers, endpoints, OAuth flags, and API keys even when a bounded metadata cycle remains provisional. Selectable models come only from configured model metadata; conversation-referenced models remain transport-only fallbacks. Every advertised selectable model is included in the same publication's metadata coverage, even in reduced contexts.
+- Prompts are never truncated. Values larger than the old character cap are admitted when they fit the actual byte budget. If a prompt cannot fit, the page carries an explicit unavailable/empty gate that clears stale Watch instructions, remains non-authoritative, and is retried until a later lossless value fits. Watch-created conversations retain global-prompt inheritance; omission preserves an existing default prompt while an explicit empty value clears it.
+- Memory facts are published only when the phone has authoritative facts and the encrypted write or clear has succeeded. Writes are serialized by generation, and local edits racing the initial encrypted load are journaled and merged before persistence. Reduced/non-authoritative contexts omit memory rather than imply deletion; an authoritative empty list explicitly clears it. Enabling memory again retries a failed or not-yet-complete load without replacing optimistic facts from stale disk.
+- Oversized Watch mutations use file transfer rather than truncating message deltas. Ingress validates the active session and metadata before touching the file, enforces a shared 4 MiB ingress/egress bound, performs bounded reads, and verifies payload identity. A local enqueue or size failure schedules the same durable retry path, so the outbox cannot become stranded.
+- Interactive messages reduce latency, while user-info/file transfers and retry backoff provide durable delivery. Snapshot acknowledgements clear only matching-peer durable outbox entries.
+- During capability discovery, the Watch may dual-send legacy components and revisioned mutations. Once a supported revisioned snapshot is observed, the peer adopts revisioned mode; unsupported schemas do not change mode. Legacy operations awaiting phone authority use a separate retained FIFO so they cannot block later WCSession lifecycle or revisioned events. Legacy transfer markers and cumulative echo coverage survive ordinary activation together, while acknowledgement still requires fresh evidence from the current context; a known revisioned source transition resets both evidence classes.
+- Request-owned streaming/tool drafts are overlaid on phone snapshots by stable message identity. Cancellation, restart recovery, and title generation are fenced by request/conversation ownership. Tool-call duplicate IDs are scoped to one provider request round; ID-less calls receive deterministic round-local IDs so later rounds cannot suppress valid work.
+- Model selection persists the conversation change before updating global selection or dismissing the UI.
+- Persisted Watch conversation bodies use a 20-body recency soft limit. Bodies owned by pending mutations, request drafts, the current/selected conversation, or retained legacy delivery coverage are protected from eviction; manifest omission still never means deletion.
+- A native `Ayna-watchOSTests` target and shared-scheme test action run the Watch-only Swift Testing suites in CI, alongside the existing Watch UI smoke tests.
+- Watch mutation revisions never wrap. At revision exhaustion, transport mutation creation fails and the user's message/title/configuration/deletion intent remains durably deferred locally rather than being acknowledged as stale revision `1`.
+
+The same reliability increment hardens Watch-available web fetching. Redirect targets and connected remote endpoints are validated against private/local address policy. One absolute request deadline covers initial DNS, redirect DNS, and URLSession transfer; a stalled non-cancelable system resolver cannot hold the caller past that deadline. Proxied transactions are rejected because URLSession task metrics expose the proxy connection rather than a verifiable origin endpoint. Preflight DNS resolution plus post-connection validation reduces DNS-rebinding exposure, but does not pin the exact preflight address before the GET. Eliminating that remaining race requires a custom address-pinned HTTP/TLS transport and is intentionally outside this decision. `TavilyService` retains URLSession in production but exposes an injected async data loader so watchOS-native tests never depend on unsupported custom `URLProtocol` interception.
+
+## Consequences
+
+### Positive
+
+- Empty state, deletion, bounded omission, provisional metadata, and explicit clears have distinct meanings.
+- Offline Watch prompts, edits, tool results, and partial responses survive restart and retry without silent truncation; unavailable prompt gates prevent stale instructions from being used.
+- Delayed snapshots, duplicate callbacks, stale acknowledgements, and stale metadata epochs are idempotent and cannot overwrite newer state.
+- Phone-only conversation metadata remains authoritative while Watch-owned message deltas can merge safely.
+- Credentials, endpoints, prompts, and memory cannot be cleared merely because a bounded page omitted them, cannot be advertised without matching metadata, and cannot be published before their required persistence succeeds.
+- Payload and file-transfer behavior is deterministic and testable under strict byte/resource budgets.
+- Native Watch-only reliability tests execute automatically in CI instead of silently compiling out on macOS.
+- Mixed-version phone/watch pairs retain a bounded legacy compatibility path.
+- Web-fetch redirects and connected endpoints fail closed when they cannot be tied to an allowed public origin.
+
+### Negative
+
+- Sync state now includes source/peer identities, revisions, tombstones, acknowledgements, metadata epochs, invalidation fingerprints, prompt availability, draft overlays, body-recency metadata, and retry bookkeeping.
+- Both devices persist protocol metadata in addition to conversations, and Watch selection changes may write recency state even when conversation content is unchanged.
+- A mutation may remain pending after the phone already applied it if the acknowledgement cannot be persisted locally; retries must remain idempotent.
+- One unreadable encrypted conversation keeps phone state non-authoritative until the record is repaired or removed.
+- Revision-exhausted Watch intent remains visible and durable but cannot synchronize automatically until a future explicit epoch-rotation design is introduced.
+- Legacy compatibility temporarily duplicates transport work until peer capability is known; marker-less legacy model metadata is treated as a complete replacement, while explicit bounded metadata remains provisional.
+- Proxied web fetching is unavailable because the origin connection cannot be validated with the current URLSession metrics boundary.
+
+### Neutral
+
+- The phone remains authoritative for the complete conversation and configuration model; the Watch owns only explicit local mutations and request drafts.
+- Conversation bodies remain intentionally bounded on Watch. Full phone history is not guaranteed to be mirrored, and protected pending/draft bodies may temporarily exceed the ordinary 20-body soft limit.
+- Timestamps continue to drive display ordering, but never determine conflict resolution.
+- Completely closing the residual DNS preflight-to-connect race is deferred until a custom pinned transport is justified.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,7 @@ What trade-offs are we accepting?
 | [0004](0004-sparkle-auto-updates.md) | Sparkle Auto-Updates | Accepted |
 | [0005](0005-anthropic-provider.md) | Anthropic Provider Architecture | Accepted |
 | [0006](0006-native-agentic-tools.md) | Native Agentic Tools Architecture | Proposed |
+| [0007](0007-revisioned-watch-sync.md) | Revisioned Durable Watch Sync | Accepted |
 
 ## When to Create an ADR
 


### PR DESCRIPTION
## Summary

- restore reliable macOS, iOS, and watchOS builds and preserve legacy encrypted conversation decoding
- fix request and tool correctness across MCP arguments, OpenAI instructions, deep links, accessibility IDs, and model confirmation
- isolate request ownership and cancellation for streaming, multi-model, image generation, Apple Intelligence, and tool execution
- serialize conversation and memory persistence so failed, superseded, or overlapping operations cannot publish non-durable state
- replace best-effort Watch sync with revisioned snapshots, authoritative manifests, tombstones, acknowledgements, deterministic paging, bounded caches/files, and a durable mutation outbox
- harden web fetching with SSRF endpoint validation and one deadline across DNS, redirects, and transfer
- add native watchOS unit-test coverage to the shared scheme and CI

## Impact

The app now preserves user state and request ownership across cancellation, retries, offline operation, app restarts, bounded WatchConnectivity payloads, stale callbacks, and persistence failures. Reduced Watch contexts no longer retain stale credentials/instructions or advertise unusable models.

## Validation

- `swift test`: 1,002 tests / 89 suites passed
- focused reliability matrix: 354 tests / 24 suites passed
- native Watch tests: 177 tests / 11 suites passed
- Watch UI smoke: 6 tests passed
- macOS, iOS 26, and watchOS 26 SwiftPM builds passed
- native iOS and watchOS simulator builds passed
- paired iPhone 17 + Watch Ultra 3 live launch succeeded with no crash/fatal logs
- SwiftFormat clean on 35 files touched by the final increment
- SwiftLint strict: 0 violations on those files
- Xcode project, scheme XML, workflow YAML, and Git diff checks passed

## Architecture

See `docs/adr/0007-revisioned-watch-sync.md` for the Watch protocol decisions and accepted network-security tradeoffs.