### PR TITLE
docs: describe Ayna as an agentic AI client

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,7 +347,7 @@ jobs:
 
           url "https://github.com/sozercan/ayna/releases/download/v#{version}/ayna-v#{version}.dmg"
           name "Ayna"
-          desc "Native macOS/iOS/watchOS ChatGPT client"
+          desc "A native agentic AI client for macOS, iOS, and watchOS, built with SwiftUI"
           homepage "https://github.com/sozercan/ayna"
 
           auto_updates true
@@ -401,7 +401,7 @@ jobs:
             <channel>
                 <title>Ayna Updates</title>
                 <link>https://github.com/sozercan/ayna/releases</link>
-                <description>Most recent updates for Ayna, a native macOS/iOS/watchOS ChatGPT client.</description>
+                <description>Most recent updates for Ayna, a native agentic AI client for macOS, iOS, and watchOS, built with SwiftUI.</description>
                 <language>en</language>
         APPCAST_EOF
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Ayna
 
-Native macOS/iOS/watchOS ChatGPT client. Swift 6.0+, macOS 26.0+, iOS 26.0+, watchOS 26.0+.
+A native agentic AI client for macOS, iOS, and watchOS, built with SwiftUI. Swift 6.0+, macOS 26.0+, iOS 26.0+, watchOS 26.0+.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ayna
 
-A native macOS, iOS, and watchOS ChatGPT client built for speed and simplicity.
+A native agentic AI client for macOS, iOS, and watchOS, built with SwiftUI.
 
 ## Features
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,7 +3,7 @@
     <channel>
         <title>Ayna Updates</title>
         <link>https://github.com/sozercan/ayna/releases</link>
-        <description>Most recent updates for Ayna, a native macOS/iOS/watchOS ChatGPT client.</description>
+        <description>Most recent updates for Ayna, a native agentic AI client for macOS, iOS, and watchOS, built with SwiftUI.</description>
         <language>en</language>
 
         <!-- New releases will be added here by CI -->


### PR DESCRIPTION
## Summary
- replace the product tagline with provider-neutral agentic AI language
- keep the README, contributor guidance, Homebrew cask metadata, and Sparkle appcast descriptions consistent
- retain implementation-specific ChatGPT references in source comments where they describe behavior rather than branding

## Why
Ayna supports multiple AI providers and agentic tooling, so the previous ChatGPT-specific description no longer represented the product accurately.

## Impact
Documentation and release metadata now describe Ayna as a native agentic AI client for macOS, iOS, and watchOS built with SwiftUI. There are no runtime changes.

## Validation
- `git diff --cached --check`
- `xmllint --noout appcast.xml`