### PR TITLE
fix(ci): locate SwiftPM build products dynamically

### DIFF
--- a/Scripts/build-app.sh
+++ b/Scripts/build-app.sh
@@ -35,9 +35,18 @@ rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
 
 # Build for each architecture
+BUILD_PRODUCT_DIRS=()
 for ARCH in "${ARCH_LIST[@]}"; do
   echo "  → Building for $ARCH..."
-  swift build -c "$CONF" --arch "$ARCH"
+  SWIFT_BUILD_ARGS=(-c "$CONF" --arch "$ARCH")
+  if [[ ${#ARCH_LIST[@]} -gt 1 ]]; then
+    # SwiftPM's Swift Build engine can use one configuration output directory even
+    # when --arch changes. Keep universal-build slices isolated so a later
+    # build cannot overwrite an earlier architecture before lipo combines them.
+    SWIFT_BUILD_ARGS+=(--scratch-path "$ROOT/.build/architectures/$ARCH")
+  fi
+  swift build "${SWIFT_BUILD_ARGS[@]}"
+  BUILD_PRODUCT_DIRS+=("$(swift build "${SWIFT_BUILD_ARGS[@]}" --show-bin-path)")
 done
 
 # Create app bundle structure
@@ -46,14 +55,25 @@ mkdir -p "$APP_BUNDLE/Contents/MacOS"
 mkdir -p "$APP_BUNDLE/Contents/Resources"
 mkdir -p "$APP_BUNDLE/Contents/Frameworks"
 
-# Build path helper
+# Build path helpers. SwiftPM's output layout varies by build engine, so use
+# the paths it reported instead of assuming the legacy architecture layout.
+build_product_dir() {
+  local arch="$1"
+  local index
+  for index in "${!ARCH_LIST[@]}"; do
+    if [[ "${ARCH_LIST[$index]}" == "$arch" ]]; then
+      printf '%s\n' "${BUILD_PRODUCT_DIRS[$index]}"
+      return 0
+    fi
+  done
+  echo "ERROR: No build product directory recorded for $arch" >&2
+  return 1
+}
+
 build_product_path() {
   local name="$1"
   local arch="$2"
-  case "$arch" in
-    arm64|x86_64) echo ".build/${arch}-apple-macosx/$CONF/$name" ;;
-    *) echo ".build/$CONF/$name" ;;
-  esac
+  printf '%s/%s\n' "$(build_product_dir "$arch")" "$name"
 }
 
 # Verify binary architectures
@@ -251,8 +271,7 @@ fi
 # Embed Sparkle.framework
 SPARKLE_FRAMEWORK=""
 for arch in "${ARCH_LIST[@]}"; do
-  CANDIDATE=$(build_product_path "" "$arch")
-  CANDIDATE_DIR=$(dirname "$CANDIDATE")
+  CANDIDATE_DIR=$(build_product_dir "$arch")
   if [[ -d "$CANDIDATE_DIR/Sparkle.framework" ]]; then
     SPARKLE_FRAMEWORK="$CANDIDATE_DIR/Sparkle.framework"
     break
@@ -275,8 +294,7 @@ fi
 
 # SwiftPM resource bundles
 FIRST_ARCH="${ARCH_LIST[0]}"
-BINARY_PATH=$(build_product_path "$APP_NAME" "$FIRST_ARCH")
-PREFERRED_BUILD_DIR=$(dirname "$BINARY_PATH")
+PREFERRED_BUILD_DIR=$(build_product_dir "$FIRST_ARCH")
 shopt -s nullglob
 SWIFTPM_BUNDLES=("${PREFERRED_BUILD_DIR}/"*.bundle)
 shopt -u nullglob


### PR DESCRIPTION
## Summary

- resolve build artifacts using SwiftPM’s reported binary output path
- isolate per-architecture scratch directories for universal builds
- use resolved output directories for Ayna, Sparkle, and resource bundles

## Verification

- ./Scripts/compile_and_run.sh
- bash -n Scripts/build-app.sh Scripts/compile_and_run.sh
- git diff --check
- codesign --verify --deep --strict .build/app/Ayna.app