### PR TITLE
refactor(chat): centralize transcript and multi-model planning

### DIFF
--- a/Sources/Ayna/Chat/ChatTranscriptPlan.swift
+++ b/Sources/Ayna/Chat/ChatTranscriptPlan.swift
@@ -1,0 +1,221 @@
+//
+//  ChatTranscriptPlan.swift
+//  ayna
+//
+//  Plans the transcript items that chat views should render.
+//
+
+import Foundation
+
+/// How a visible message should be interpreted by transcript renderers.
+enum ChatTranscriptDisplayKind: Equatable, Sendable {
+    case text
+    case toolResult
+    case typingPlaceholder
+    case image
+    case citationsOnly
+}
+
+/// A visible transcript message plus the display semantics used to make it visible.
+struct ChatTranscriptMessage: Identifiable, Equatable, Sendable {
+    let message: Message
+    let displayKind: ChatTranscriptDisplayKind
+
+    var id: UUID {
+        message.id
+    }
+}
+
+/// A visible group of parallel model responses.
+struct ChatTranscriptResponseGroup: Identifiable, Equatable, Sendable {
+    let id: UUID
+    let responses: [ChatTranscriptMessage]
+    let selectedResponseId: UUID?
+    let defaultCandidateId: UUID?
+
+    var messages: [Message] {
+        responses.map(\.message)
+    }
+}
+
+/// Represents either a single visible message or one grouped set of parallel responses.
+enum ChatTranscriptItem: Identifiable, Equatable, Sendable {
+    case message(ChatTranscriptMessage)
+    case responseGroup(ChatTranscriptResponseGroup)
+
+    var id: String {
+        switch self {
+        case let .message(item):
+            item.id.uuidString
+        case let .responseGroup(group):
+            "group-\(group.id.uuidString)"
+        }
+    }
+}
+
+/// A response that should be auto-selected if the user continues from an unselected group.
+struct ChatTranscriptResponseSelection: Equatable, Sendable {
+    let groupId: UUID
+    let messageId: UUID
+}
+
+/// Pure display plan for a conversation transcript.
+struct ChatTranscriptPlan: Equatable, Sendable {
+    let visibleMessages: [ChatTranscriptMessage]
+    let items: [ChatTranscriptItem]
+    let pendingAutoSelection: ChatTranscriptResponseSelection?
+
+    init(conversation: Conversation, isGenerating: Bool) {
+        visibleMessages = conversation.messages.compactMap { message in
+            Self.visibleMessage(for: message, in: conversation, isGenerating: isGenerating)
+        }
+        items = Self.makeItems(from: visibleMessages, in: conversation)
+        pendingAutoSelection = Self.autoSelectionCandidate(in: conversation)
+    }
+
+    static func defaultCandidateId(
+        for responses: [Message],
+        in conversation: Conversation,
+        responseGroup: ResponseGroup? = nil
+    ) -> UUID? {
+        let selectableResponses = responses.filter { message in
+            guard let responseGroup,
+                  let entry = responseGroup.responses.first(where: { $0.id == message.id })
+            else {
+                return true
+            }
+            return entry.status != .streaming && entry.status != .failed
+        }
+        let candidates = selectableResponses.isEmpty ? responses : selectableResponses
+
+        if let match = candidates.first(where: { $0.model == conversation.model }) {
+            return match.id
+        }
+        return candidates.first?.id
+    }
+
+    static func autoSelectionCandidate(in conversation: Conversation) -> ChatTranscriptResponseSelection? {
+        guard let lastMessage = conversation.messages.last,
+              let groupId = lastMessage.responseGroupId,
+              let group = conversation.getResponseGroup(groupId),
+              group.selectedResponseId == nil
+        else {
+            return nil
+        }
+
+        let responses = conversation.messages.filter { $0.responseGroupId == groupId }
+        guard let messageId = defaultCandidateId(
+            for: responses,
+            in: conversation,
+            responseGroup: group
+        ) else {
+            return nil
+        }
+        return ChatTranscriptResponseSelection(groupId: groupId, messageId: messageId)
+    }
+
+    private static func visibleMessage(
+        for message: Message,
+        in conversation: Conversation,
+        isGenerating: Bool
+    ) -> ChatTranscriptMessage? {
+        guard let displayKind = displayKind(for: message, in: conversation, isGenerating: isGenerating) else {
+            return nil
+        }
+        return ChatTranscriptMessage(message: message, displayKind: displayKind)
+    }
+
+    private static func displayKind(
+        for message: Message,
+        in conversation: Conversation,
+        isGenerating: Bool
+    ) -> ChatTranscriptDisplayKind? {
+        if message.role == .system {
+            return nil
+        }
+
+        if message.role == .tool {
+            let isWebSearchResult = message.toolCalls?.contains(where: {
+                $0.toolName == WebSearchCoordinator.toolName
+            }) == true
+            guard !isWebSearchResult else { return nil }
+            return message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : .toolResult
+        }
+
+        if message.imageData != nil || message.imagePath != nil {
+            return .image
+        }
+
+        if message.mediaType == .image {
+            if message.responseGroupId != nil {
+                return .image
+            }
+
+            let hasContent = !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            if message.role == .assistant, !hasContent {
+                return message.id == conversation.messages.last?.id && isGenerating ? .image : nil
+            }
+            return hasContent ? .text : nil
+        }
+
+        if message.role == .assistant,
+           let reasoning = message.reasoning,
+           !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return .text
+        }
+
+        if message.role == .assistant, let citations = message.citations, !citations.isEmpty {
+            if message.content.isEmpty {
+                return message.id == conversation.messages.last?.id && isGenerating ? .typingPlaceholder : .citationsOnly
+            }
+            return .text
+        }
+
+        if message.role == .assistant, message.content.isEmpty {
+            #if !os(watchOS)
+                if let toolCalls = message.toolCalls, !toolCalls.isEmpty {
+                    return nil
+                }
+            #endif
+
+            if message.responseGroupId != nil {
+                return .typingPlaceholder
+            }
+
+            return message.id == conversation.messages.last?.id && isGenerating ? .typingPlaceholder : nil
+        }
+
+        return message.content.isEmpty ? nil : .text
+    }
+
+    private static func makeItems(
+        from visibleMessages: [ChatTranscriptMessage],
+        in conversation: Conversation
+    ) -> [ChatTranscriptItem] {
+        let messagesByID = visibleMessages.reduce(into: [UUID: ChatTranscriptMessage]()) { result, item in
+            result[item.id] = item
+        }
+
+        return DisplayableMessageGrouper.items(from: visibleMessages.map(\.message)).compactMap { groupedItem in
+            switch groupedItem {
+            case let .message(message):
+                guard let item = messagesByID[message.id] else { return nil }
+                return .message(item)
+            case let .responseGroup(groupId, responses):
+                let responseItems = responses.compactMap { messagesByID[$0.id] }
+                let responseGroup = conversation.getResponseGroup(groupId)
+                return .responseGroup(ChatTranscriptResponseGroup(
+                    id: groupId,
+                    responses: responseItems,
+                    selectedResponseId: responseGroup?.selectedResponseId,
+                    defaultCandidateId: defaultCandidateId(
+                        for: responses,
+                        in: conversation,
+                        responseGroup: responseGroup
+                    )
+                ))
+            }
+        }
+    }
+}

--- a/Sources/Ayna/Chat/ChatTranscriptPlan.swift
+++ b/Sources/Ayna/Chat/ChatTranscriptPlan.swift
@@ -66,10 +66,19 @@ struct ChatTranscriptPlan: Equatable, Sendable {
     let pendingAutoSelection: ChatTranscriptResponseSelection?
 
     init(conversation: Conversation, isGenerating: Bool) {
+        let responseGroupsByID = conversation.responseGroups.reduce(into: [UUID: ResponseGroup]()) { result, group in
+            if result[group.id] == nil {
+                result[group.id] = group
+            }
+        }
         visibleMessages = conversation.messages.compactMap { message in
             Self.visibleMessage(for: message, in: conversation, isGenerating: isGenerating)
         }
-        items = Self.makeItems(from: visibleMessages, in: conversation)
+        items = Self.makeItems(
+            from: visibleMessages,
+            in: conversation,
+            responseGroupsByID: responseGroupsByID
+        )
         pendingAutoSelection = Self.autoSelectionCandidate(in: conversation)
     }
 
@@ -78,15 +87,22 @@ struct ChatTranscriptPlan: Equatable, Sendable {
         in conversation: Conversation,
         responseGroup: ResponseGroup? = nil
     ) -> UUID? {
-        let selectableResponses = responses.filter { message in
-            guard let responseGroup,
-                  let entry = responseGroup.responses.first(where: { $0.id == message.id })
+        let responseEntriesByID = responseGroup?.responses.reduce(into: [UUID: ResponseGroupEntry]()) { result, entry in
+            if result[entry.id] == nil {
+                result[entry.id] = entry
+            }
+        } ?? [:]
+        let meaningfulResponses = responses.filter(\.hasMeaningfulHistoryContent)
+        let contentCandidates = meaningfulResponses.isEmpty ? responses : meaningfulResponses
+        let selectableResponses = contentCandidates.filter { message in
+            guard responseGroup != nil,
+                  let entry = responseEntriesByID[message.id]
             else {
                 return true
             }
             return entry.status != .streaming && entry.status != .failed
         }
-        let candidates = selectableResponses.isEmpty ? responses : selectableResponses
+        let candidates = selectableResponses.isEmpty ? contentCandidates : selectableResponses
 
         if let match = candidates.first(where: { $0.model == conversation.model }) {
             return match.id
@@ -191,7 +207,8 @@ struct ChatTranscriptPlan: Equatable, Sendable {
 
     private static func makeItems(
         from visibleMessages: [ChatTranscriptMessage],
-        in conversation: Conversation
+        in conversation: Conversation,
+        responseGroupsByID: [UUID: ResponseGroup]
     ) -> [ChatTranscriptItem] {
         let messagesByID = visibleMessages.reduce(into: [UUID: ChatTranscriptMessage]()) { result, item in
             result[item.id] = item
@@ -204,7 +221,7 @@ struct ChatTranscriptPlan: Equatable, Sendable {
                 return .message(item)
             case let .responseGroup(groupId, responses):
                 let responseItems = responses.compactMap { messagesByID[$0.id] }
-                let responseGroup = conversation.getResponseGroup(groupId)
+                let responseGroup = responseGroupsByID[groupId]
                 return .responseGroup(ChatTranscriptResponseGroup(
                     id: groupId,
                     responses: responseItems,

--- a/Sources/Ayna/Chat/MultiModelResponsePlan.swift
+++ b/Sources/Ayna/Chat/MultiModelResponsePlan.swift
@@ -1,0 +1,80 @@
+//
+//  MultiModelResponsePlan.swift
+//  ayna
+//
+//  Plans the placeholder messages and response group for a multi-model turn.
+//
+
+import Foundation
+
+/// Immutable setup for a multi-model response turn.
+struct MultiModelResponsePlan: Equatable, Sendable {
+    let responseGroup: ResponseGroup
+    let placeholderMessages: [Message]
+    let messageIDsByModel: [String: UUID]
+
+    var responseGroupId: UUID {
+        responseGroup.id
+    }
+
+    init(
+        models: [String],
+        userMessageId: UUID,
+        responseGroupId: UUID = UUID(),
+        mediaType: Message.MediaType? = nil
+    ) {
+        var messageIDsByModel: [String: UUID] = [:]
+        var entries: [ResponseGroup.ResponseEntry] = []
+        var placeholderMessages: [Message] = []
+
+        for model in models {
+            let messageId = UUID()
+            messageIDsByModel[model] = messageId
+            entries.append(ResponseGroup.ResponseEntry(
+                id: messageId,
+                modelName: model,
+                status: .streaming
+            ))
+            placeholderMessages.append(Message(
+                id: messageId,
+                role: .assistant,
+                content: "",
+                model: model,
+                responseGroupId: responseGroupId,
+                mediaType: mediaType
+            ))
+        }
+
+        self.messageIDsByModel = messageIDsByModel
+        self.placeholderMessages = placeholderMessages
+        self.responseGroup = ResponseGroup(
+            id: responseGroupId,
+            userMessageId: userMessageId,
+            responses: entries
+        )
+    }
+
+    func messageId(for model: String) -> UUID? {
+        messageIDsByModel[model]
+    }
+}
+
+/// Pure text-display state shared by multi-model response cards.
+struct MultiModelResponseContentPlan: Equatable, Sendable {
+    let reasoning: String?
+    let showsTypingIndicator: Bool
+
+    init(message: Message, responseStatus: ResponseGroupStatus?) {
+        if let reasoning = message.reasoning,
+           !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            self.reasoning = reasoning
+        } else {
+            self.reasoning = nil
+        }
+
+        showsTypingIndicator = responseStatus == .streaming
+            && message.content.isEmpty
+            && reasoning == nil
+    }
+}

--- a/Sources/Ayna/Utilities/StreamingChunkBuffer.swift
+++ b/Sources/Ayna/Utilities/StreamingChunkBuffer.swift
@@ -64,6 +64,7 @@ final class StreamingChunkBuffer {
 
     /// Add a chunk to the buffer. May trigger immediate or delayed delivery.
     func append(_ chunk: String) {
+        guard !chunk.isEmpty else { return }
         buffer += chunk
 
         // Track when we received the first chunk in this batch
@@ -82,13 +83,14 @@ final class StreamingChunkBuffer {
 
     /// Force delivery of any remaining buffered content.
     /// Call this when streaming completes.
-    func flush() {
+    @discardableResult
+    func flush() -> Bool {
         deliveryTask?.cancel()
         deliveryTask = nil
 
-        if !buffer.isEmpty {
-            deliverNow()
-        }
+        guard !buffer.isEmpty else { return false }
+        deliverNow()
+        return true
     }
 
     /// Cancel any pending delivery and clear the buffer.
@@ -146,36 +148,62 @@ final class StreamingChunkBuffer {
 // MARK: - Multi-Model Buffer Manager
 
 /// Manages multiple buffers for multi-model streaming scenarios.
-/// Each model gets its own buffer to prevent interference.
+/// Each response message gets its own buffer to prevent interference.
 @MainActor
 final class MultiModelStreamingBuffer {
-    private var buffers: [String: StreamingChunkBuffer] = [:]
+    private var buffers: [UUID: StreamingChunkBuffer] = [:]
     private let config: StreamingChunkBuffer.Config
+
+    var isEmpty: Bool {
+        buffers.isEmpty
+    }
 
     init(config: StreamingChunkBuffer.Config? = nil) {
         self.config = config ?? .multiModel
     }
 
-    /// Get or create a buffer for a specific model
-    func buffer(for model: String, onDeliver: @escaping (String) -> Void) -> StreamingChunkBuffer {
-        if let existing = buffers[model] {
+    /// Get or create a buffer for a specific response message.
+    func buffer(for messageID: UUID, onDeliver: @escaping (String) -> Void) -> StreamingChunkBuffer {
+        if let existing = buffers[messageID] {
             existing.onDeliver = onDeliver
             return existing
         }
 
         let newBuffer = StreamingChunkBuffer(config: config, onDeliver: onDeliver)
-        buffers[model] = newBuffer
+        buffers[messageID] = newBuffer
         return newBuffer
     }
 
-    /// Flush all buffers
-    func flushAll() {
+    /// Flush all buffers without ending their streams.
+    @discardableResult
+    func flushAll() -> Bool {
+        var delivered = false
         for buffer in buffers.values {
-            buffer.flush()
+            delivered = buffer.flush() || delivered
         }
+        return delivered
     }
 
-    /// Reset all buffers
+    /// Flush and remove a completed response buffer.
+    @discardableResult
+    func finish(for messageID: UUID) -> Bool {
+        guard let buffer = buffers.removeValue(forKey: messageID) else { return false }
+        return buffer.flush()
+    }
+
+    /// Flush and remove every response buffer owned by the current operation.
+    @discardableResult
+    func finishAll() -> Bool {
+        let activeBuffers = Array(buffers.values)
+        buffers.removeAll()
+        var delivered = false
+        for buffer in activeBuffers {
+            delivered = buffer.flush() || delivered
+        }
+        return delivered
+    }
+
+    /// Reset all buffers.
     func resetAll() {
         for buffer in buffers.values {
             buffer.reset()
@@ -183,9 +211,9 @@ final class MultiModelStreamingBuffer {
         buffers.removeAll()
     }
 
-    /// Reset buffer for a specific model
-    func reset(for model: String) {
-        buffers[model]?.reset()
-        buffers.removeValue(forKey: model)
+    /// Reset a response buffer without delivering it.
+    func reset(for messageID: UUID) {
+        buffers[messageID]?.reset()
+        buffers.removeValue(forKey: messageID)
     }
 }

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -1845,15 +1845,17 @@ extension IOSChatViewModel {
         isGenerating = true
         errorMessage = nil
 
-        let responseGroupId = UUID()
-        var messageIds: [String: UUID] = [:]
-        var placeholderMessages: [Message] = []
-        let responseGroup = createPlaceholderMessagesForMultiModel(
-            models: models, userMessageId: userMessage.id, responseGroupId: responseGroupId,
-            messageIds: &messageIds, placeholderMessages: &placeholderMessages
+        let responsePlan = createResponsePlanForMultiModel(
+            models: models,
+            userMessageId: userMessage.id
         )
-        let messageIdsByModel = messageIds
-        conversationManager.addMultiModelResponse(to: targetConversation, messages: placeholderMessages, responseGroup: responseGroup)
+        let responseGroupId = responsePlan.responseGroupId
+        let messageIdsByModel = responsePlan.messageIDsByModel
+        conversationManager.addMultiModelResponse(
+            to: targetConversation,
+            messages: responsePlan.placeholderMessages,
+            responseGroup: responsePlan.responseGroup
+        )
 
         guard let updatedConversation = conversation else {
             isGenerating = false
@@ -1945,7 +1947,21 @@ extension IOSChatViewModel {
                 }
             },
             onPendingToolCall: nil,
-            onReasoning: nil
+            onReasoning: { [weak self] model, reasoning in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
+                    guard let self,
+                          coordinator.owns(operationID, conversationID: conversationId),
+                          let messageId = messageIdsByModel[model]
+                    else {
+                        return
+                    }
+                    self.appendMultiModelReasoning(
+                        reasoning,
+                        to: messageId,
+                        conversationId: conversationId
+                    )
+                }
+            }
         )
             coordinator.onCancel(for: operationID) {
                 request.cancel()
@@ -1976,22 +1992,19 @@ extension IOSChatViewModel {
         return updatedConv
     }
 
-    /// Creates placeholder messages for each model in a multi-model request
-    func createPlaceholderMessagesForMultiModel(
+    /// Creates the immutable setup for a multi-model request.
+    func createResponsePlanForMultiModel(
         models: [String],
         userMessageId: UUID,
-        responseGroupId: UUID,
-        messageIds: inout [String: UUID],
-        placeholderMessages: inout [Message]
-    ) -> ResponseGroup {
-        var responseGroup = ResponseGroup(id: responseGroupId, userMessageId: userMessageId)
-        for model in models {
-            let messageId = UUID()
-            messageIds[model] = messageId
-            responseGroup.addResponse(messageId: messageId, modelName: model, status: .streaming)
-            placeholderMessages.append(Message(id: messageId, role: .assistant, content: "", model: model, responseGroupId: responseGroupId))
-        }
-        return responseGroup
+        responseGroupId: UUID = UUID(),
+        mediaType: Message.MediaType? = nil
+    ) -> MultiModelResponsePlan {
+        MultiModelResponsePlan(
+            models: models,
+            userMessageId: userMessageId,
+            responseGroupId: responseGroupId,
+            mediaType: mediaType
+        )
     }
 
     /// Processes a streaming chunk for a specific model in multi-model mode
@@ -2017,6 +2030,26 @@ extension IOSChatViewModel {
             model: model,
             chunk: chunk
         )
+    }
+
+    private func appendMultiModelReasoning(
+        _ reasoning: String,
+        to messageId: UUID,
+        conversationId: UUID
+    ) {
+        guard conversationManager.updateMessage(
+            conversationId: conversationId,
+            messageId: messageId,
+            update: { message in
+                message.reasoning = (message.reasoning ?? "") + reasoning
+            }
+        ) else {
+            return
+        }
+
+        if let conversation = conversationManager.conversation(byId: conversationId) {
+            conversationManager.save(conversation)
+        }
     }
 
     /// Processes completion for a specific model in multi-model mode
@@ -2333,40 +2366,19 @@ extension IOSChatViewModel {
         isGenerating = true
         errorMessage = nil
 
-        let responseGroupId = UUID()
-        var responseEntries: [ResponseGroup.ResponseEntry] = []
-        var messageIds: [String: UUID] = [:]
-
-        for model in models {
-            let messageId = UUID()
-            messageIds[model] = messageId
-
-            let placeholderMessage = Message(
-                id: messageId,
-                role: .assistant,
-                content: "",
-                model: model,
-                responseGroupId: responseGroupId,
-                mediaType: .image
-            )
-            conversationManager.addMessage(to: conversation, message: placeholderMessage)
-
-            responseEntries.append(ResponseGroup.ResponseEntry(
-                id: messageId,
-                modelName: model,
-                status: .streaming
-            ))
-        }
-
-        let responseGroup = ResponseGroup(
-            id: responseGroupId,
+        let responsePlan = createResponsePlanForMultiModel(
+            models: models,
             userMessageId: userMessage.id,
-            responses: responseEntries
+            mediaType: .image
         )
+        let responseGroupId = responsePlan.responseGroupId
+        let messageIds = responsePlan.messageIDsByModel
 
-        if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) {
-            conversationManager.conversations[index].responseGroups.append(responseGroup)
+        for placeholderMessage in responsePlan.placeholderMessages {
+            conversationManager.addMessage(to: conversation, message: placeholderMessage)
         }
+
+        conversationManager.addResponseGroup(to: conversation, group: responsePlan.responseGroup)
 
         let conversationManager = conversationManager
         let cancelledMessageIDs = Array(messageIds.values)

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -99,6 +99,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     private var pendingChunkBuffers: [StreamingChunkKey: PendingChunkBuffer] = [:]
     private let streamingChunkFlushInterval: Duration = .milliseconds(75)
     private let streamingChunkImmediateFlushThreshold = 256
+    private let multiModelReasoningBuffer = MultiModelStreamingBuffer()
 
     private struct ToolExecutionState {
         let token: ToolCallRequestRoundCoordinator<ToolExecutionResult>.ToolToken
@@ -1871,6 +1872,7 @@ extension IOSChatViewModel {
             activeAssistantMessageId = nil
             activeMultiModelResponseGroupId = responseGroupId
             let operationID = coordinator.beginOperation(conversationID: conversationId)
+            multiModelReasoningBuffer.resetAll()
             let request = aiService.sendToMultipleModels(
             messages: messagesToSend,
             models: models,
@@ -1914,24 +1916,9 @@ extension IOSChatViewModel {
             },
             onAllComplete: { [weak self] in
                     coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
-                        guard let self,
-                              coordinator.owns(operationID, conversationID: conversationId)
-                        else {
-                            return
-                        }
-
-                    self.flushAllStreamingChunks(conversationId: conversationId)
-                    self.isGenerating = false
-                    if let convIndex = self.conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) {
-                            self.conversationManager.saveImmediately(self.conversationManager.conversations[convIndex])
-                    }
-                        self.activeMultiModelResponseGroupId = nil
-                        guard coordinator.finishOperation(operationID) else { return }
-
-                    // Notify that conversation is ready (for new chat navigation)
-                    if self.isNewChatMode {
-                        self.onConversationCreated?(conversationId)
-                    }
+                        self?.finishMultiModelGeneration(
+                            operationID: operationID, conversationId: conversationId, coordinator: coordinator
+                        )
                 }
             },
             onError: { [weak self] model, error in
@@ -1949,23 +1936,48 @@ extension IOSChatViewModel {
             onPendingToolCall: nil,
             onReasoning: { [weak self] model, reasoning in
                 coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
-                    guard let self,
-                          coordinator.owns(operationID, conversationID: conversationId),
-                          let messageId = messageIdsByModel[model]
-                    else {
-                        return
-                    }
-                    self.appendMultiModelReasoning(
+                    guard let self, coordinator.owns(operationID, conversationID: conversationId) else { return }
+                    self.processMultiModelReasoning(
+                        model: model,
                         reasoning,
-                        to: messageId,
+                        messageIds: messageIdsByModel,
                         conversationId: conversationId
                     )
                 }
             }
         )
-            coordinator.onCancel(for: operationID) {
+            coordinator.onCancel(for: operationID) { [weak self] in
+                self?.finishAndPersistMultiModelReasoning(conversationId: conversationId)
                 request.cancel()
             }
+    }
+
+    private func finishMultiModelGeneration(
+        operationID: ToolChainCoordinator.OperationID,
+        conversationId: UUID,
+        coordinator: ToolChainCoordinator
+    ) {
+        guard coordinator.owns(operationID, conversationID: conversationId) else { return }
+
+        multiModelReasoningBuffer.finishAll()
+        flushAllStreamingChunks(conversationId: conversationId)
+        isGenerating = false
+        if let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) {
+            conversationManager.saveImmediately(conversationManager.conversations[conversationIndex])
+        }
+        activeMultiModelResponseGroupId = nil
+        guard coordinator.finishOperation(operationID) else { return }
+
+        if isNewChatMode {
+            onConversationCreated?(conversationId)
+        }
+    }
+
+    private func finishAndPersistMultiModelReasoning(conversationId: UUID) {
+        multiModelReasoningBuffer.finishAll()
+        if let conversation = conversationManager.conversation(byId: conversationId) {
+            conversationManager.saveImmediately(conversation)
+        }
     }
 
     /// Gets or creates a conversation configured for multi-model mode
@@ -2032,24 +2044,33 @@ extension IOSChatViewModel {
         )
     }
 
-    private func appendMultiModelReasoning(
+    func processMultiModelReasoning(
+        model: String,
         _ reasoning: String,
-        to messageId: UUID,
+        messageIds: [String: UUID],
         conversationId: UUID
     ) {
-        guard conversationManager.updateMessage(
-            conversationId: conversationId,
-            messageId: messageId,
-            update: { message in
-                message.reasoning = (message.reasoning ?? "") + reasoning
-            }
-        ) else {
+        guard !reasoning.isEmpty,
+              let messageId = messageIds[model]
+        else {
             return
         }
 
-        if let conversation = conversationManager.conversation(byId: conversationId) {
-            conversationManager.save(conversation)
-        }
+        let conversationManager = conversationManager
+        multiModelReasoningBuffer.buffer(for: messageId) { reasoningChunk in
+            guard conversationManager.updateMessage(
+                conversationId: conversationId,
+                messageId: messageId,
+                update: { message in
+                    message.reasoning = (message.reasoning ?? "") + reasoningChunk
+                }
+            ) else {
+                return
+            }
+            if let conversation = conversationManager.conversation(byId: conversationId) {
+                conversationManager.save(conversation)
+            }
+        }.append(reasoning)
     }
 
     /// Processes completion for a specific model in multi-model mode
@@ -2060,6 +2081,7 @@ extension IOSChatViewModel {
         responseGroupId: UUID
     ) {
         guard let messageId = messageIds[model] else { return }
+        multiModelReasoningBuffer.finish(for: messageId)
         flushStreamingChunks(
             conversationId: conversationId,
             messageId: messageId,
@@ -2092,6 +2114,7 @@ extension IOSChatViewModel {
         responseGroupId: UUID
     ) {
         guard let messageId = messageIds[model] else { return }
+        multiModelReasoningBuffer.finish(for: messageId)
         flushStreamingChunks(
             conversationId: conversationId,
             messageId: messageId,
@@ -2139,7 +2162,7 @@ extension IOSChatViewModel {
             let cancelledAutoSend = cancelPendingAutoSend()
             let cancelledPreparation = cancelSendPreparation()
             let hadActiveTextState = activeAssistantMessageId != nil || activeMultiModelResponseGroupId != nil
-            let hadBufferedText = !pendingChunkBuffers.isEmpty
+            let hadBufferedText = !pendingChunkBuffers.isEmpty || !multiModelReasoningBuffer.isEmpty
             let hadToolExecutions = !toolExecutionStates.isEmpty
             let cancelledToolChain = toolChainCoordinator.cancelCurrentOperation {
                 finalizePersistedTextGeneration()
@@ -2161,6 +2184,7 @@ extension IOSChatViewModel {
         private func finalizePersistedTextGeneration() {
             let assistantMessageId = activeAssistantMessageId
             let responseGroupId = activeMultiModelResponseGroupId
+            let flushedReasoning = multiModelReasoningBuffer.finishAll()
             guard let conversationId,
                   let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversationId })
             else {
@@ -2173,7 +2197,7 @@ extension IOSChatViewModel {
 
             let flushedText = flushAllStreamingChunks(conversationId: conversationId)
             let persistedTools = persistUnfinishedToolExecutions(conversationId: conversationId)
-            guard assistantMessageId != nil || responseGroupId != nil || flushedText || persistedTools else {
+            guard assistantMessageId != nil || responseGroupId != nil || flushedText || flushedReasoning || persistedTools else {
                 activeMultiModelResponseGroupId = nil
                 return
             }

--- a/Sources/Ayna/Views/iOS/IOSChatView.swift
+++ b/Sources/Ayna/Views/iOS/IOSChatView.swift
@@ -151,6 +151,17 @@ struct IOSChatView: View {
                             }
                         }
                     }
+                    .onChange(of: conversation.messages.last?.reasoning) {
+                        updateDisplayableItems()
+                        // Keep reasoning-only streams pinned just like answer content.
+                        if viewModel.isGenerating, let lastId = conversation.messages.last?.id {
+                            var transaction = Transaction()
+                            transaction.disablesAnimations = true
+                            withTransaction(transaction) {
+                                proxy.scrollTo(lastId, anchor: .bottom)
+                            }
+                        }
+                    }
                     .onChange(of: viewModel.isGenerating) { _, newValue in
                         updateDisplayableItems()
                         // Scroll to bottom when generation starts

--- a/Sources/Ayna/Views/iOS/IOSChatView.swift
+++ b/Sources/Ayna/Views/iOS/IOSChatView.swift
@@ -63,6 +63,8 @@ struct IOSChatView: View {
                                         IOSMessageView(
                                             message: message,
                                             displayKind: transcriptMessage.displayKind,
+                                            isGenerating: viewModel.isGenerating
+                                                && message.id == conversation.messages.last?.id,
                                             onRetry: message.role == .assistant && !viewModel.isGenerating ? {
                                                 viewModel.retryMessage(beforeMessage: message)
                                             } : nil,

--- a/Sources/Ayna/Views/iOS/IOSChatView.swift
+++ b/Sources/Ayna/Views/iOS/IOSChatView.swift
@@ -29,28 +29,11 @@ struct IOSChatView: View {
     @State private var isNearBottom = true
 
     /// Performance: Cached displayable items to avoid O(n) computation on every render
-    @State private var cachedDisplayableItems: [DisplayableItem] = []
+    @State private var cachedDisplayableItems: [ChatTranscriptItem] = []
 
     /// Get the conversation from the environment's conversation manager
     private var conversation: Conversation? {
         conversationManager.conversations.first { $0.id == conversationId }
-    }
-
-    // MARK: - Multi-Model Display
-
-    /// Represents either a single message or a group of parallel responses
-    private enum DisplayableItem: Identifiable {
-        case message(Message)
-        case responseGroup(groupId: UUID, responses: [Message])
-
-        var id: String {
-            switch self {
-            case let .message(msg):
-                msg.id.uuidString
-            case let .responseGroup(groupId, _):
-                "group-\(groupId.uuidString)"
-            }
-        }
     }
 
     /// Updates cached displayable items. Call when messages change or isGenerating changes.
@@ -60,50 +43,10 @@ struct IOSChatView: View {
             return
         }
 
-        let visibleMessages = conversation.messages.filter { message in
-            // Hide system messages entirely
-            if message.role == .system {
-                return false
-            }
-
-                // Web search results remain in model history but are presented as citations instead.
-            if message.role == .tool {
-                    if message.toolCalls?.contains(where: { $0.toolName == WebSearchCoordinator.toolName }) == true {
-                        return false
-                    }
-                return !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            }
-
-                if message.role == .assistant, let citations = message.citations, !citations.isEmpty {
-                    return true
-                }
-
-            // Don't show empty assistant messages unless we're actively generating
-            if message.role == .assistant && message.content.isEmpty && message.imageData == nil && message.imagePath == nil {
-                // Hide assistant messages that only have tool calls (intermediate steps)
-                // These are placeholders that triggered tool execution but have no response content
-                if let toolCalls = message.toolCalls, !toolCalls.isEmpty {
-                    return false
-                }
-                // Always show assistant messages in a response group (multi-model mode)
-                // They need to remain visible even after generation to show failed/empty states
-                if message.responseGroupId != nil {
-                    return true
-                }
-                // Only show empty assistant message if it's the last message and we're generating
-                return message.id == conversation.messages.last?.id && viewModel.isGenerating
-            }
-
-            return !message.content.isEmpty || message.imageData != nil || message.imagePath != nil || message.mediaType == .image
-        }
-
-        cachedDisplayableItems = DisplayableMessageGrouper.displayableItems(
-            from: visibleMessages,
-            makeMessage: { .message($0) },
-            makeResponseGroup: { groupId, responses in
-                .responseGroup(groupId: groupId, responses: responses)
-            }
-        )
+        cachedDisplayableItems = ChatTranscriptPlan(
+            conversation: conversation,
+            isGenerating: viewModel.isGenerating
+        ).items
     }
 
     var body: some View {
@@ -115,9 +58,11 @@ struct IOSChatView: View {
                             LazyVStack(spacing: 12) {
                                 ForEach(cachedDisplayableItems) { item in
                                     switch item {
-                                    case let .message(message):
+                                    case let .message(transcriptMessage):
+                                        let message = transcriptMessage.message
                                         IOSMessageView(
                                             message: message,
+                                            displayKind: transcriptMessage.displayKind,
                                             onRetry: message.role == .assistant && !viewModel.isGenerating ? {
                                                 viewModel.retryMessage(beforeMessage: message)
                                             } : nil,
@@ -138,24 +83,24 @@ struct IOSChatView: View {
                                         )
                                         .id(message.id)
                                         .accessibilityIdentifier(TestIdentifiers.ChatView.messageRow(for: message.id))
-                                    case let .responseGroup(groupId, responses):
+                                    case let .responseGroup(group):
                                         IOSMultiModelResponseView(
-                                            responseGroupId: groupId,
-                                            responses: responses,
+                                            responseGroupId: group.id,
+                                            responses: group.messages,
                                             conversation: conversation,
                                             onSelectResponse: { messageId in
                                                 // Use centralized haptic engine
                                                 HapticEngine.selection()
                                                 conversationManager.selectResponse(
                                                     in: conversation,
-                                                    groupId: groupId,
+                                                    groupId: group.id,
                                                     messageId: messageId
                                                 )
                                             },
                                             onRetry: viewModel.isGenerating ? nil : { message in
                                                 viewModel.retryMessage(beforeMessage: message)
                                             },
-                                            defaultCandidateId: defaultCandidateId(for: responses, in: conversation)
+                                            defaultCandidateId: group.defaultCandidateId
                                         )
                                         .id(item.id)
                                     }
@@ -400,45 +345,19 @@ struct IOSChatView: View {
 
     private func autoSelectResponseIfNeeded() {
         guard let conversation else { return }
-        guard let lastMessage = conversation.messages.last,
-              let groupId = lastMessage.responseGroupId,
-              let group = conversation.getResponseGroup(groupId),
-              group.selectedResponseId == nil
-        else {
-            return
-        }
+        guard let selection = ChatTranscriptPlan.autoSelectionCandidate(in: conversation) else { return }
 
-        let responses = conversation.messages.filter { $0.responseGroupId == groupId }
-        var candidateId: UUID?
-
-        // 1. Primary: conversation.model
-        if let match = responses.first(where: { $0.model == conversation.model }) {
-            candidateId = match.id
-        }
-        // 2. Fallback: First model
-        else if let first = responses.first {
-            candidateId = first.id
-        }
-
-        if let id = candidateId {
-            DiagnosticsLogger.log(
-                .chatView,
-                level: .info,
-                message: "🤖 Auto-selecting response before sending new message",
-                metadata: ["messageId": id.uuidString]
-            )
-            conversationManager.selectResponse(in: conversation, groupId: groupId, messageId: id)
-        }
-    }
-
-    /// Calculates which response would be auto-selected if user continues without choosing (for visual cue)
-    private func defaultCandidateId(for responses: [Message], in conversation: Conversation) -> UUID? {
-        // 1. Primary: conversation.model
-        if let match = responses.first(where: { $0.model == conversation.model }) {
-            return match.id
-        }
-        // 2. Fallback: First response
-        return responses.first?.id
+        DiagnosticsLogger.log(
+            .chatView,
+            level: .info,
+            message: "🤖 Auto-selecting response before sending new message",
+            metadata: ["messageId": selection.messageId.uuidString]
+        )
+        conversationManager.selectResponse(
+            in: conversation,
+            groupId: selection.groupId,
+            messageId: selection.messageId
+        )
     }
 
     private func scrollToBottom(proxy: ScrollViewProxy, conversation: Conversation) {

--- a/Sources/Ayna/Views/iOS/IOSContentView.swift
+++ b/Sources/Ayna/Views/iOS/IOSContentView.swift
@@ -156,29 +156,12 @@ struct IOSNewChatView: View {
     @State private var showModelSelector = false
 
     /// Cached displayable items to properly handle multi-model responses
-    @State private var cachedDisplayableItems: [DisplayableItem] = []
+    @State private var cachedDisplayableItems: [ChatTranscriptItem] = []
 
     /// Get the pending conversation from the environment's conversation manager
     private var pendingConversation: Conversation? {
         guard let id = viewModel.conversationId else { return nil }
         return conversationManager.conversations.first { $0.id == id }
-    }
-
-    // MARK: - Multi-Model Display
-
-    /// Represents either a single message or a group of parallel responses
-    private enum DisplayableItem: Identifiable {
-        case message(Message)
-        case responseGroup(groupId: UUID, responses: [Message])
-
-        var id: String {
-            switch self {
-            case let .message(msg):
-                msg.id.uuidString
-            case let .responseGroup(groupId, _):
-                "group-\(groupId.uuidString)"
-            }
-        }
     }
 
     /// Updates cached displayable items. Call when messages change or isGenerating changes.
@@ -188,56 +171,10 @@ struct IOSNewChatView: View {
             return
         }
 
-        let visibleMessages = conversation.messages.filter { message in
-            // Hide system messages entirely
-            if message.role == .system {
-                return false
-            }
-
-                // Web search results remain in model history but are presented as citations instead.
-            if message.role == .tool {
-                    if message.toolCalls?.contains(where: { $0.toolName == WebSearchCoordinator.toolName }) == true {
-                        return false
-                    }
-                return !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            }
-
-                if message.role == .assistant, let citations = message.citations, !citations.isEmpty {
-                    return true
-                }
-
-            // Don't show empty assistant messages unless we're actively generating
-            if message.role == .assistant && message.content.isEmpty && message.imageData == nil && message.imagePath == nil {
-                // Hide assistant messages that only have tool calls (intermediate steps)
-                if let toolCalls = message.toolCalls, !toolCalls.isEmpty {
-                    return false
-                }
-                // Always show assistant messages in a response group (multi-model mode)
-                if message.responseGroupId != nil {
-                    return true
-                }
-                // Only show empty assistant message if it's the last message and we're generating
-                return message.id == conversation.messages.last?.id && viewModel.isGenerating
-            }
-
-            return !message.content.isEmpty || message.imageData != nil || message.imagePath != nil || message.mediaType == .image
-        }
-
-        cachedDisplayableItems = DisplayableMessageGrouper.displayableItems(
-            from: visibleMessages,
-            makeMessage: { .message($0) },
-            makeResponseGroup: { groupId, responses in
-                .responseGroup(groupId: groupId, responses: responses)
-            }
-        )
-    }
-
-    /// Calculates which response would be auto-selected if user continues without choosing
-    private func defaultCandidateId(for responses: [Message], in conversation: Conversation) -> UUID? {
-        if let match = responses.first(where: { $0.model == conversation.model }) {
-            return match.id
-        }
-        return responses.first?.id
+        cachedDisplayableItems = ChatTranscriptPlan(
+            conversation: conversation,
+            isGenerating: viewModel.isGenerating
+        ).items
     }
 
     var body: some View {
@@ -257,9 +194,11 @@ struct IOSNewChatView: View {
                         LazyVStack(spacing: 12) {
                             ForEach(cachedDisplayableItems) { item in
                                 switch item {
-                                case let .message(message):
+                                case let .message(transcriptMessage):
+                                    let message = transcriptMessage.message
                                     IOSMessageView(
                                         message: message,
+                                        displayKind: transcriptMessage.displayKind,
                                         onRetry: message.role == .assistant ? {
                                             viewModel.retryMessage(beforeMessage: message)
                                         } : nil,
@@ -280,23 +219,23 @@ struct IOSNewChatView: View {
                                     )
                                     .id(message.id)
                                     .accessibilityIdentifier(TestIdentifiers.ChatView.messageRow(for: message.id))
-                                case let .responseGroup(groupId, responses):
+                                case let .responseGroup(group):
                                     IOSMultiModelResponseView(
-                                        responseGroupId: groupId,
-                                        responses: responses,
+                                        responseGroupId: group.id,
+                                        responses: group.messages,
                                         conversation: conversation,
                                         onSelectResponse: { messageId in
                                             HapticEngine.selection()
                                             conversationManager.selectResponse(
                                                 in: conversation,
-                                                groupId: groupId,
+                                                groupId: group.id,
                                                 messageId: messageId
                                             )
                                         },
                                         onRetry: { message in
                                             viewModel.retryMessage(beforeMessage: message)
                                         },
-                                        defaultCandidateId: defaultCandidateId(for: responses, in: conversation)
+                                        defaultCandidateId: group.defaultCandidateId
                                     )
                                     .id(item.id)
                                 }

--- a/Sources/Ayna/Views/iOS/IOSContentView.swift
+++ b/Sources/Ayna/Views/iOS/IOSContentView.swift
@@ -199,6 +199,8 @@ struct IOSNewChatView: View {
                                     IOSMessageView(
                                         message: message,
                                         displayKind: transcriptMessage.displayKind,
+                                        isGenerating: viewModel.isGenerating
+                                            && message.id == conversation.messages.last?.id,
                                         onRetry: message.role == .assistant ? {
                                             viewModel.retryMessage(beforeMessage: message)
                                         } : nil,

--- a/Sources/Ayna/Views/iOS/IOSContentView.swift
+++ b/Sources/Ayna/Views/iOS/IOSContentView.swift
@@ -262,6 +262,12 @@ struct IOSNewChatView: View {
                             proxy.scrollTo(lastId, anchor: .bottom)
                         }
                     }
+                    .onChange(of: conversation.messages.last?.reasoning) {
+                        updateDisplayableItems()
+                        if viewModel.isGenerating, let lastId = conversation.messages.last?.id {
+                            proxy.scrollTo(lastId, anchor: .bottom)
+                        }
+                    }
                     .onChange(of: viewModel.isGenerating) { _, _ in
                         updateDisplayableItems()
                     }

--- a/Sources/Ayna/Views/iOS/IOSMessageView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageView.swift
@@ -19,6 +19,7 @@ import UniformTypeIdentifiers
 struct IOSMessageView: View {
     let message: Message
     let displayKind: ChatTranscriptDisplayKind?
+    let isGenerating: Bool
     var onRetry: (() -> Void)?
     var onSwitchModel: ((String) -> Void)?
     var onEdit: ((String) -> Void)?
@@ -36,6 +37,7 @@ struct IOSMessageView: View {
     init(
         message: Message,
         displayKind: ChatTranscriptDisplayKind? = nil,
+        isGenerating: Bool = false,
         onRetry: (() -> Void)? = nil,
         onSwitchModel: ((String) -> Void)? = nil,
         onEdit: ((String) -> Void)? = nil,
@@ -43,6 +45,7 @@ struct IOSMessageView: View {
     ) {
         self.message = message
         self.displayKind = displayKind
+        self.isGenerating = isGenerating
         self.onRetry = onRetry
         self.onSwitchModel = onSwitchModel
         self.onEdit = onEdit
@@ -267,7 +270,8 @@ struct IOSMessageView: View {
                 if hasReasoning, let reasoning = message.reasoning {
                     IOSReasoningView(
                         reasoning: reasoning,
-                        initiallyExpanded: message.content.isEmpty
+                        initiallyExpanded: message.content.isEmpty,
+                        isStreaming: isGenerating
                     )
                 }
 
@@ -529,17 +533,18 @@ struct IOSMessageView: View {
 /// Collapsible reasoning content shared by single- and multi-model iOS responses.
 struct IOSReasoningView: View {
     let reasoning: String
+    let isStreaming: Bool
 
     @State private var isExpanded: Bool
     @State private var contentBlocks: [ContentBlock]
-    @State private var lastReasoningHash: Int
     @State private var parseTask: Task<Void, Never>?
+    @State private var parseGeneration = 0
 
-    init(reasoning: String, initiallyExpanded: Bool) {
+    init(reasoning: String, initiallyExpanded: Bool, isStreaming: Bool) {
         self.reasoning = reasoning
+        self.isStreaming = isStreaming
         _isExpanded = State(initialValue: initiallyExpanded)
-        _contentBlocks = State(initialValue: MarkdownRenderer.parse(reasoning))
-        _lastReasoningHash = State(initialValue: reasoning.hashValue)
+        _contentBlocks = State(initialValue: MarkdownRenderer.cachedBlocks(for: reasoning) ?? [])
     }
 
     var body: some View {
@@ -584,21 +589,43 @@ struct IOSReasoningView: View {
             }
         }
         .onChange(of: reasoning) { _, newReasoning in
-            let newHash = newReasoning.hashValue
-            guard newHash != lastReasoningHash else { return }
-            lastReasoningHash = newHash
-
-            parseTask?.cancel()
-            parseTask = Task.detached(priority: .userInitiated) {
-                let blocks = MarkdownRenderer.parse(newReasoning)
-                guard !Task.isCancelled else { return }
-                await MainActor.run {
-                    contentBlocks = blocks
-                }
+            scheduleParse(for: newReasoning)
+        }
+        .onChange(of: isStreaming) { wasStreaming, isStreaming in
+            if wasStreaming, !isStreaming {
+                scheduleParse(for: reasoning)
+            }
+        }
+        .task {
+            if contentBlocks.isEmpty {
+                scheduleParse(for: reasoning)
             }
         }
         .onDisappear {
             parseTask?.cancel()
+        }
+    }
+
+    private func scheduleParse(for reasoning: String) {
+        parseTask?.cancel()
+        parseGeneration += 1
+        let generation = parseGeneration
+        let shouldDebounce = isStreaming
+        let cachePolicy: MarkdownRenderer.CachePolicy = isStreaming ? .doNotCache : .useCache
+
+        parseTask = Task.detached(priority: .userInitiated) {
+            if shouldDebounce {
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+            guard !Task.isCancelled else { return }
+            let blocks = MarkdownRenderer.parse(reasoning, cachePolicy: cachePolicy)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard generation == parseGeneration, self.reasoning == reasoning else {
+                    return
+                }
+                contentBlocks = blocks
+            }
         }
     }
 }

--- a/Sources/Ayna/Views/iOS/IOSMessageView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageView.swift
@@ -18,6 +18,7 @@ import UniformTypeIdentifiers
 
 struct IOSMessageView: View {
     let message: Message
+    let displayKind: ChatTranscriptDisplayKind?
     var onRetry: (() -> Void)?
     var onSwitchModel: ((String) -> Void)?
     var onEdit: ((String) -> Void)?
@@ -34,12 +35,14 @@ struct IOSMessageView: View {
 
     init(
         message: Message,
+        displayKind: ChatTranscriptDisplayKind? = nil,
         onRetry: (() -> Void)? = nil,
         onSwitchModel: ((String) -> Void)? = nil,
         onEdit: ((String) -> Void)? = nil,
         availableModels: [String] = []
     ) {
         self.message = message
+        self.displayKind = displayKind
         self.onRetry = onRetry
         self.onSwitchModel = onSwitchModel
         self.onEdit = onEdit
@@ -57,7 +60,9 @@ struct IOSMessageView: View {
         // Pre-set hasAppeared to true for messages that are likely already in view
         // This prevents janky animations when scrolling through existing messages
         _hasAppeared = State(
-            initialValue: !message.content.isEmpty || !(message.citations?.isEmpty ?? true)
+            initialValue: !message.content.isEmpty
+                || !(message.citations?.isEmpty ?? true)
+                || !(message.reasoning?.isEmpty ?? true)
         )
     }
 
@@ -156,6 +161,25 @@ struct IOSMessageView: View {
 
     // MARK: - Regular Message View
 
+    private var shouldShowTypingIndicator: Bool {
+        guard !hasReasoning else { return false }
+
+        if let displayKind {
+            return displayKind == .typingPlaceholder
+        }
+
+        return message.role == .assistant
+            && message.content.isEmpty
+            && message.mediaType != .image
+            && (message.citations?.isEmpty ?? true)
+            && (message.toolCalls == nil || message.toolCalls?.isEmpty == true)
+    }
+
+    private var hasReasoning: Bool {
+        guard message.role == .assistant, let reasoning = message.reasoning else { return false }
+        return !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     /// Whether this message should be hidden (empty assistant message waiting for tool execution)
     private var shouldHideMessage: Bool {
         // Hide empty assistant messages that have pending tool calls
@@ -163,6 +187,7 @@ struct IOSMessageView: View {
         message.role == .assistant &&
             message.content.isEmpty &&
             message.mediaType != .image &&
+            !hasReasoning &&
             message.toolCalls != nil &&
             !(message.toolCalls?.isEmpty ?? true)
     }
@@ -239,12 +264,16 @@ struct IOSMessageView: View {
                     }
                 }
 
+                if hasReasoning, let reasoning = message.reasoning {
+                    IOSReasoningView(
+                        reasoning: reasoning,
+                        initiallyExpanded: message.content.isEmpty
+                    )
+                }
+
                 // Show typing indicator for empty assistant messages (waiting for response)
                 // Don't show if the message has tool calls (it's waiting for tool execution)
-                if message.role == .assistant, message.content.isEmpty, message.mediaType != .image,
-                   message.toolCalls == nil || message.toolCalls?.isEmpty == true,
-                   message.citations?.isEmpty ?? true
-                {
+                if shouldShowTypingIndicator {
                     IOSTypingIndicatorView()
                 } else if contentBlocks.isEmpty {
                     if !message.content.isEmpty {
@@ -493,6 +522,83 @@ struct IOSMessageView: View {
                     break
                 }
             }
+        }
+    }
+}
+
+/// Collapsible reasoning content shared by single- and multi-model iOS responses.
+struct IOSReasoningView: View {
+    let reasoning: String
+
+    @State private var isExpanded: Bool
+    @State private var contentBlocks: [ContentBlock]
+    @State private var lastReasoningHash: Int
+    @State private var parseTask: Task<Void, Never>?
+
+    init(reasoning: String, initiallyExpanded: Bool) {
+        self.reasoning = reasoning
+        _isExpanded = State(initialValue: initiallyExpanded)
+        _contentBlocks = State(initialValue: MarkdownRenderer.parse(reasoning))
+        _lastReasoningHash = State(initialValue: reasoning.hashValue)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Button {
+                withAnimation(Motion.easeStandard) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: Spacing.xs) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(Typography.caption)
+                    Text("Reasoning")
+                        .font(Typography.captionBold)
+                    Spacer(minLength: 0)
+                    Text("\(reasoning.count) chars")
+                        .font(Typography.micro)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(isExpanded ? "Hide reasoning" : "Show reasoning")
+            .accessibilityValue("\(reasoning.count) characters")
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: Spacing.sm) {
+                    if contentBlocks.isEmpty {
+                        Text(verbatim: reasoning)
+                    } else {
+                        ForEach(contentBlocks) { block in
+                            IOSContentBlockView(block: block)
+                        }
+                    }
+                }
+                .padding(Spacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    Theme.textSecondary.opacity(0.08),
+                    in: RoundedRectangle(cornerRadius: Spacing.CornerRadius.md)
+                )
+            }
+        }
+        .onChange(of: reasoning) { _, newReasoning in
+            let newHash = newReasoning.hashValue
+            guard newHash != lastReasoningHash else { return }
+            lastReasoningHash = newHash
+
+            parseTask?.cancel()
+            parseTask = Task.detached(priority: .userInitiated) {
+                let blocks = MarkdownRenderer.parse(newReasoning)
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    contentBlocks = blocks
+                }
+            }
+        }
+        .onDisappear {
+            parseTask?.cancel()
         }
     }
 }

--- a/Sources/Ayna/Views/iOS/IOSMultiModelResponseView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMultiModelResponseView.swift
@@ -350,7 +350,8 @@ struct IOSMultiModelResponseCard: View {
             if let reasoning = contentPlan.reasoning {
                 IOSReasoningView(
                     reasoning: reasoning,
-                    initiallyExpanded: message.content.isEmpty
+                    initiallyExpanded: message.content.isEmpty,
+                    isStreaming: isStreaming
                 )
             }
 

--- a/Sources/Ayna/Views/iOS/IOSMultiModelResponseView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMultiModelResponseView.swift
@@ -337,16 +337,34 @@ struct IOSMultiModelResponseCard: View {
 
     @ViewBuilder
     private var contentBody: some View {
+        let contentPlan = MultiModelResponseContentPlan(
+            message: message,
+            responseStatus: responseStatus
+        )
+
         if isImageGeneration {
             imageGenerationContent
-        } else if message.content.isEmpty, isStreaming {
-            IOSTypingIndicatorView()
-                .padding(.vertical, Spacing.lg)
         } else if hasFailed {
             failedStateView
         } else {
-            ForEach(contentBlocks) { block in
-                IOSContentBlockView(block: block)
+            if let reasoning = contentPlan.reasoning {
+                IOSReasoningView(
+                    reasoning: reasoning,
+                    initiallyExpanded: message.content.isEmpty
+                )
+            }
+
+            if contentPlan.showsTypingIndicator {
+                IOSTypingIndicatorView()
+                    .padding(.vertical, Spacing.lg)
+            } else if !message.content.isEmpty {
+                if contentBlocks.isEmpty {
+                    Text(verbatim: message.content)
+                } else {
+                    ForEach(contentBlocks) { block in
+                        IOSContentBlockView(block: block)
+                    }
+                }
             }
         }
     }

--- a/Sources/Ayna/Views/macOS/Chat/ChatMessageList.swift
+++ b/Sources/Ayna/Views/macOS/Chat/ChatMessageList.swift
@@ -8,24 +8,9 @@
 
 import SwiftUI
 
-/// Represents either a single message or a group of parallel responses
-enum DisplayableItem: Identifiable {
-    case message(Message)
-    case responseGroup(groupId: UUID, responses: [Message])
-
-    var id: String {
-        switch self {
-        case let .message(msg):
-            msg.id.uuidString
-        case let .responseGroup(groupId, _):
-            "group-\(groupId.uuidString)"
-        }
-    }
-}
-
 /// The scrollable message list area showing conversation messages
 struct ChatMessageList: View {
-    let displayableItems: [DisplayableItem]
+    let displayableItems: [ChatTranscriptItem]
     let conversation: Conversation
     let isGenerating: Bool
     @Binding var isToolSectionExpanded: Bool
@@ -50,7 +35,8 @@ struct ChatMessageList: View {
                 LazyVStack(spacing: 0) {
                     ForEach(displayableItems) { item in
                         switch item {
-                        case let .message(message):
+                        case let .message(transcriptMessage):
+                            let message = transcriptMessage.message
                             MacMessageView(
                                 message: message,
                                 modelName: message.model,
@@ -64,13 +50,14 @@ struct ChatMessageList: View {
                             )
                             .id(message.id)
 
-                        case let .responseGroup(groupId, responses):
+                        case let .responseGroup(group):
                             MultiModelResponseView(
-                                responseGroupId: groupId,
-                                responses: responses,
+                                responseGroupId: group.id,
+                                responses: group.messages,
                                 conversation: conversation,
+                                defaultCandidateId: group.defaultCandidateId,
                                 onSelectResponse: { messageId in
-                                    onSelectResponse(groupId, messageId)
+                                    onSelectResponse(group.id, messageId)
                                 },
                                 onRetry: { message in
                                     onRetryMessage(message)
@@ -129,6 +116,9 @@ struct ChatMessageList: View {
                 }
             }
             .onChange(of: conversation.messages) { _, _ in
+                onMessagesChange()
+            }
+            .onChange(of: conversation.responseGroups) { _, _ in
                 onMessagesChange()
             }
             .onChange(of: conversation.messages.last?.content) { _, _ in

--- a/Sources/Ayna/Views/macOS/Chat/ChatMessageList.swift
+++ b/Sources/Ayna/Views/macOS/Chat/ChatMessageList.swift
@@ -39,6 +39,7 @@ struct ChatMessageList: View {
                             let message = transcriptMessage.message
                             MacMessageView(
                                 message: message,
+                                displayKind: transcriptMessage.displayKind,
                                 modelName: message.model,
                                 onRetry: message.role == .assistant ? { onRetryMessage(message) } : nil,
                                 onSwitchModel: message.role == .assistant

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
@@ -172,45 +172,22 @@ extension MacChatView {
         // Find previous image path (cheap, no disk I/O)
         let previousImagePath = findPreviousImagePath()
 
-        // Create a response group for the multi-model comparison
-        let responseGroupId = UUID()
-        var responseEntries: [ResponseGroup.ResponseEntry] = []
-        var messageIds: [String: UUID] = [:]
-
-        // Create placeholder messages for each model
-        for model in models {
-            let messageId = UUID()
-            messageIds[model] = messageId
-
-            let placeholderMessage = Message(
-                id: messageId,
-                role: .assistant,
-                content: "",
-                model: model,
-                responseGroupId: responseGroupId,
-                mediaType: .image
-            )
-            conversationManager.addMessage(to: conversation, message: placeholderMessage)
-
-            responseEntries.append(ResponseGroup.ResponseEntry(
-                id: messageId,
-                modelName: model,
-                status: .streaming
-            ))
-        }
-
-        // Create response group
-        let userMessageId = conversation.messages.first(where: { $0.role == .user })?.id
-            ?? conversation.messages.last(where: { $0.role == .user })?.id ?? UUID()
-        let responseGroup = ResponseGroup(
-            id: responseGroupId,
+        let userMessageId = conversation.messages.last(where: { $0.role == .user })?.id ?? UUID()
+        let responsePlan = MultiModelResponsePlan(
+            models: models,
             userMessageId: userMessageId,
-            responses: responseEntries
+            mediaType: .image
         )
+        let responseGroupId = responsePlan.responseGroupId
+        let messageIds = responsePlan.messageIDsByModel
+
+        for placeholderMessage in responsePlan.placeholderMessages {
+            conversationManager.addMessage(to: conversation, message: placeholderMessage)
+        }
 
         // Add response group to conversation
         if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }) {
-            conversationManager.conversations[index].responseGroups.append(responseGroup)
+            conversationManager.conversations[index].responseGroups.append(responsePlan.responseGroup)
         }
 
         registerImageBatchCancellation(
@@ -464,30 +441,16 @@ extension MacChatView {
             return
         }
 
-        // Create response group
-        let responseGroupId = UUID()
-        var responseGroup = ResponseGroup(id: responseGroupId, userMessageId: userMessageId)
-
-        // Create placeholder messages for each model
-        let messageIds = Dictionary(uniqueKeysWithValues: models.map { ($0, UUID()) })
-        for model in models {
-            guard let messageId = messageIds[model] else { continue }
-            responseGroup.addResponse(messageId: messageId, modelName: model, status: .streaming)
-
-            let placeholderMessage = Message(
-                id: messageId,
-                role: .assistant,
-                content: "",
-                model: model,
-                responseGroupId: responseGroupId
-            )
+        let responsePlan = MultiModelResponsePlan(models: models, userMessageId: userMessageId)
+        let responseGroupId = responsePlan.responseGroupId
+        for placeholderMessage in responsePlan.placeholderMessages {
             conversationManager.addMessage(to: conversation, message: placeholderMessage)
         }
 
         // Add response group to conversation
-        conversationManager.addResponseGroup(to: conversation, group: responseGroup)
+        conversationManager.addResponseGroup(to: conversation, group: responsePlan.responseGroup)
 
-        let messageIdsByModel = messageIds
+        let messageIdsByModel = responsePlan.messageIDsByModel
 
         // Prepare messages for API
         var messagesToSend = updatedConversation.getEffectiveHistory()
@@ -615,7 +578,23 @@ extension MacChatView {
                     )
                 }
             },
-            onReasoning: nil
+            onReasoning: { model, reasoning in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                    guard let messageId = messageIdsByModel[model] else { return }
+                    guard conversationManager.updateMessage(
+                        conversationId: conversationId,
+                        messageId: messageId,
+                        update: { message in
+                            message.reasoning = (message.reasoning ?? "") + reasoning
+                        }
+                    ) else {
+                        return
+                    }
+                    if let conversation = conversationManager.conversation(byId: conversationId) {
+                        conversationManager.save(conversation)
+                    }
+                }
+            }
         )
         coordinator.onCancel(for: operationID) {
             request.cancel()

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
@@ -467,6 +467,7 @@ extension MacChatView {
         activeAssistantMessageID = nil
         activeMultiModelResponseGroupID = responseGroupId
         let operationID = coordinator.beginOperation(conversationID: conversationId)
+        multiModelReasoningBuffer.resetAll()
         let request = aiService.sendToMultipleModels(
             messages: messagesToSend,
             models: models,
@@ -490,6 +491,7 @@ extension MacChatView {
             onModelComplete: { model in
                 coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model] else { return }
+                    multiModelReasoningBuffer.finish(for: messageId)
 
                     // Update response group status
                     if let convIndex = conversationManager.conversations.firstIndex(where: {
@@ -511,6 +513,7 @@ extension MacChatView {
             onAllComplete: {
                 coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard coordinator.owns(operationID, conversationID: conversationId) else { return }
+                    multiModelReasoningBuffer.finishAll()
                     isGenerating = false
                     logChat("🏁 All models completed", level: .info)
 
@@ -527,6 +530,7 @@ extension MacChatView {
             onError: { model, error in
                 coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model] else { return }
+                    multiModelReasoningBuffer.finish(for: messageId)
 
                     // Update response group status to failed
                     if let convIndex = conversationManager.conversations.firstIndex(where: {
@@ -580,24 +584,47 @@ extension MacChatView {
             },
             onReasoning: { model, reasoning in
                 coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
-                    guard let messageId = messageIdsByModel[model] else { return }
-                    guard conversationManager.updateMessage(
-                        conversationId: conversationId,
-                        messageId: messageId,
-                        update: { message in
-                            message.reasoning = (message.reasoning ?? "") + reasoning
-                        }
-                    ) else {
-                        return
-                    }
-                    if let conversation = conversationManager.conversation(byId: conversationId) {
-                        conversationManager.save(conversation)
-                    }
+                    bufferMultiModelReasoning(reasoning, model: model, messageIdsByModel: messageIdsByModel, conversationId: conversationId)
                 }
             }
         )
         coordinator.onCancel(for: operationID) {
+            finishAndPersistMultiModelReasoning(conversationId: conversationId)
             request.cancel()
+        }
+    }
+
+    private func bufferMultiModelReasoning(
+        _ reasoning: String,
+        model: String,
+        messageIdsByModel: [String: UUID],
+        conversationId: UUID
+    ) {
+        guard !reasoning.isEmpty,
+              let messageId = messageIdsByModel[model]
+        else { return }
+
+        let conversationManager = conversationManager
+        multiModelReasoningBuffer.buffer(for: messageId) { reasoningChunk in
+            guard conversationManager.updateMessage(
+                conversationId: conversationId,
+                messageId: messageId,
+                update: { message in
+                    message.reasoning = (message.reasoning ?? "") + reasoningChunk
+                }
+            ) else {
+                return
+            }
+            if let conversation = conversationManager.conversation(byId: conversationId) {
+                conversationManager.save(conversation)
+            }
+        }.append(reasoning)
+    }
+
+    private func finishAndPersistMultiModelReasoning(conversationId: UUID) {
+        multiModelReasoningBuffer.finishAll()
+        if let conversation = conversationManager.conversation(byId: conversationId) {
+            conversationManager.saveImmediately(conversation)
         }
     }
 }

--- a/Sources/Ayna/Views/macOS/Chat/MacNewChatView+Lifecycle.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacNewChatView+Lifecycle.swift
@@ -39,7 +39,8 @@
         func finalizePersistedTextGeneration() {
             let assistantMessageID = activeAssistantMessageID
             let responseGroupID = activeMultiModelResponseGroupID
-            guard assistantMessageID != nil || responseGroupID != nil,
+            let flushedReasoning = multiModelReasoningBuffer.finishAll()
+            guard assistantMessageID != nil || responseGroupID != nil || flushedReasoning,
                   let conversationID = currentConversationId,
                   let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversationID })
             else {

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -159,6 +159,7 @@ struct MacChatView: View {
         @State var toolChainCoordinator = ToolChainCoordinator()
         @State private var toolCallRequestRoundCoordinator = ToolCallRequestRoundCoordinator<ToolExecutionResult>()
     @State var imageGenerationCoordinator = ImageGenerationCoordinator()
+    @State var multiModelReasoningBuffer = MultiModelStreamingBuffer()
     @State private var showingSystemPromptSheet = false
 
     // Multi-model support (unified selection - 1 model = single, 2+ = multi)
@@ -743,7 +744,8 @@ struct MacChatView: View {
 
             let assistantMessageID = activeAssistantMessageID
             let responseGroupID = activeMultiModelResponseGroupID
-            guard assistantMessageID != nil || responseGroupID != nil || !pendingText.isEmpty,
+            let flushedReasoning = multiModelReasoningBuffer.finishAll()
+            guard assistantMessageID != nil || responseGroupID != nil || !pendingText.isEmpty || flushedReasoning,
                   let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id })
             else {
                 activeMultiModelResponseGroupID = nil

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -179,9 +179,8 @@ struct MacChatView: View {
     // Performance optimizations
     @State private var pendingChunks: [String] = []
     @State private var batchUpdateTask: Task<Void, Never>?
-    @State private var visibleMessages: [Message] = []
     @State private var cachedConversationIndex: Int?
-    @State private var cachedDisplayableItems: [DisplayableItem] = []
+    @State private var cachedDisplayableItems: [ChatTranscriptItem] = []
     /// Cache the current conversation to avoid repeated lookups
     var currentConversation: Conversation {
         if let index = getConversationIndex() {
@@ -215,31 +214,12 @@ struct MacChatView: View {
         DiagnosticsLogger.log(.chatView, level: level, message: message, metadata: combinedMetadata)
     }
 
-    /// Helper to filter visible messages
-    private func updateVisibleMessages() {
-        visibleMessages = currentConversation.messages.filter { message in
-            MacChatMessagePresentation.isVisible(
-                message,
-                lastMessageID: currentConversation.messages.last?.id,
-                isGenerating: isGenerating
-            )
-        }
-
-        // Update displayable items after visible messages change
-        updateDisplayableItems()
-    }
-
-    // MARK: - Multi-Model Display
-
-    /// Updates cached displayable items. Call when messages change or isGenerating changes.
-    private func updateDisplayableItems() {
-        cachedDisplayableItems = DisplayableMessageGrouper.displayableItems(
-            from: visibleMessages,
-            makeMessage: { .message($0) },
-            makeResponseGroup: { groupId, responses in
-                .responseGroup(groupId: groupId, responses: responses)
-            }
-        )
+    /// Updates cached transcript items when messages, response groups, or generation state change.
+    private func updateTranscriptPlan() {
+        cachedDisplayableItems = ChatTranscriptPlan(
+            conversation: currentConversation,
+            isGenerating: isGenerating
+        ).items
     }
 
     private var normalizedSelectedModel: String {
@@ -306,21 +286,21 @@ struct MacChatView: View {
                         }
                     },
                     onAppearAction: {
-                        updateVisibleMessages()
+                        updateTranscriptPlan()
                         syncSelectedModelWithConversation()
                     },
                     onConversationChange: {
-                        updateVisibleMessages()
+                        updateTranscriptPlan()
                         syncSelectedModelWithConversation()
                     },
                     onMessagesChange: {
-                        updateVisibleMessages()
+                        updateTranscriptPlan()
                     },
                     onModelChange: {
                         syncSelectedModelWithConversation()
                     },
                     onGeneratingChange: {
-                        updateVisibleMessages()
+                        updateTranscriptPlan()
                     }
                 )
 
@@ -698,30 +678,17 @@ struct MacChatView: View {
 
     /// Auto-select response if we are continuing from a multi-model state without selection
     private func autoSelectResponseIfNeeded() {
-        guard let lastMessage = currentConversation.messages.last,
-              let groupId = lastMessage.responseGroupId,
-              let group = currentConversation.getResponseGroup(groupId),
-              group.selectedResponseId == nil
-        else {
-            return
-        }
+        guard let selection = ChatTranscriptPlan.autoSelectionCandidate(in: currentConversation) else { return }
 
-        let responses = currentConversation.messages.filter { $0.responseGroupId == groupId }
-        var candidateId: UUID?
-
-        // 1. Primary: conversation.model
-        if let match = responses.first(where: { $0.model == currentConversation.model }) {
-            candidateId = match.id
-        }
-        // 2. Fallback: First model
-        else if let first = responses.first {
-            candidateId = first.id
-        }
-
-        if let id = candidateId {
-            logChat("🤖 Auto-selecting response before sending new message", metadata: ["messageId": id.uuidString])
-            conversationManager.selectResponse(in: currentConversation, groupId: groupId, messageId: id)
-        }
+        logChat(
+            "🤖 Auto-selecting response before sending new message",
+            metadata: ["messageId": selection.messageId.uuidString]
+        )
+        conversationManager.selectResponse(
+            in: currentConversation,
+            groupId: selection.groupId,
+            messageId: selection.messageId
+        )
     }
 
     // MARK: - Error Handling

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -297,6 +297,7 @@ struct MacChatView: View {
                         updateTranscriptPlan()
                     },
                     onModelChange: {
+                        updateTranscriptPlan()
                         syncSelectedModelWithConversation()
                     },
                     onGeneratingChange: {

--- a/Sources/Ayna/Views/macOS/MacMessageView.swift
+++ b/Sources/Ayna/Views/macOS/MacMessageView.swift
@@ -18,6 +18,7 @@ import SwiftUI
 @MainActor
 struct MacMessageView: View {
     let message: Message
+    let displayKind: ChatTranscriptDisplayKind?
     var modelName: String?
     var onRetry: (() -> Void)?
     var onSwitchModel: ((String) -> Void)?
@@ -48,12 +49,14 @@ struct MacMessageView: View {
 
     init(
         message: Message,
+        displayKind: ChatTranscriptDisplayKind? = nil,
         modelName: String? = nil,
         onRetry: (() -> Void)? = nil,
         onSwitchModel: ((String) -> Void)? = nil,
         onEdit: ((String) -> Void)? = nil
     ) {
         self.message = message
+        self.displayKind = displayKind
         self.modelName = modelName
         self.onRetry = onRetry
         self.onSwitchModel = onSwitchModel
@@ -473,12 +476,16 @@ struct MacMessageView: View {
         // Check if message has meaningful reasoning content
         let hasReasoning = message.reasoning.map { !$0.isEmpty } ?? false
         let hasCitations = !(message.citations?.isEmpty ?? true)
+        let shouldShowTypingIndicator = if let displayKind {
+            displayKind == .typingPlaceholder
+        } else {
+            message.role == .assistant && message.content.isEmpty && message.mediaType != .image
+                && !hasReasoning && !hasCitations
+        }
 
         // Show typing indicator for empty assistant messages (waiting for response)
         // But not if we have reasoning content (model is thinking)
-        if message.role == .assistant, message.content.isEmpty, message.mediaType != .image,
-           !hasReasoning, !hasCitations
-        {
+        if shouldShowTypingIndicator {
             TypingIndicatorView()
         }
 

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -56,42 +56,9 @@ struct MacNewChatView: View {
 
     // MARK: - Multi-Model Display
 
-    /// Represents either a single message or a group of parallel responses
-    private enum DisplayableItem: Identifiable {
-        case message(Message)
-        case responseGroup(groupId: UUID, responses: [Message])
-
-        var id: String {
-            switch self {
-            case let .message(msg):
-                msg.id.uuidString
-            case let .responseGroup(groupId, _):
-                "group-\(groupId.uuidString)"
-            }
-        }
-    }
-
-    /// Get visible messages (filtering out system and tool messages)
-    private var visibleMessages: [Message] {
+    private var displayableItems: [ChatTranscriptItem] {
         guard let conversation = currentConversation else { return [] }
-        return conversation.messages.filter { message in
-            MacChatMessagePresentation.isVisible(
-                message,
-                lastMessageID: conversation.messages.last?.id,
-                isGenerating: isGenerating
-            )
-        }
-    }
-
-    /// Converts visible messages into displayable items, grouping multi-model responses together
-    private var displayableItems: [DisplayableItem] {
-        DisplayableMessageGrouper.displayableItems(
-            from: visibleMessages,
-            makeMessage: { .message($0) },
-            makeResponseGroup: { groupId, responses in
-                .responseGroup(groupId: groupId, responses: responses)
-            }
-        )
+        return ChatTranscriptPlan(conversation: conversation, isGenerating: isGenerating).items
     }
 
     private var needsModelSetup: Bool {
@@ -157,7 +124,8 @@ struct MacNewChatView: View {
                             LazyVStack(spacing: 0) {
                                 ForEach(displayableItems) { item in
                                     switch item {
-                                    case let .message(message):
+                                    case let .message(transcriptMessage):
+                                        let message = transcriptMessage.message
                                         MacMessageView(
                                             message: message,
                                             modelName: message.model,
@@ -178,16 +146,17 @@ struct MacNewChatView: View {
                                                 } : nil
                                         )
                                         .id(message.id)
-                                    case let .responseGroup(groupId, responses):
+                                    case let .responseGroup(group):
                                         if let conversation = currentConversation {
                                             MultiModelResponseView(
-                                                responseGroupId: groupId,
-                                                responses: responses,
+                                                responseGroupId: group.id,
+                                                responses: group.messages,
                                                 conversation: conversation,
+                                                defaultCandidateId: group.defaultCandidateId,
                                                 onSelectResponse: { messageId in
                                                     conversationManager.selectResponse(
                                                         in: conversation,
-                                                        groupId: groupId,
+                                                        groupId: group.id,
                                                         messageId: messageId
                                                     )
                                                 },
@@ -725,37 +694,21 @@ struct MacNewChatView: View {
             return
         }
 
-        let responseGroupId = UUID()
-        var responseEntries: [ResponseGroup.ResponseEntry] = []
-        var messageIds: [String: UUID] = [:]
+        let userMessageId = conversation.messages.last(where: { $0.role == .user })?.id ?? UUID()
+        let responsePlan = MultiModelResponsePlan(
+            models: models,
+            userMessageId: userMessageId,
+            mediaType: .image
+        )
+        let responseGroupId = responsePlan.responseGroupId
+        let messageIds = responsePlan.messageIDsByModel
 
-        for model in models {
-            let messageId = UUID()
-            messageIds[model] = messageId
-
-            let placeholderMessage = Message(
-                id: messageId,
-                role: .assistant,
-                content: "",
-                model: model,
-                responseGroupId: responseGroupId,
-                mediaType: .image
-            )
+        for placeholderMessage in responsePlan.placeholderMessages {
             conversationManager.addMessage(to: conversation, message: placeholderMessage)
-            responseEntries.append(ResponseGroup.ResponseEntry(
-                id: messageId,
-                modelName: model,
-                status: .streaming
-            ))
         }
 
-        let responseGroup = ResponseGroup(
-            id: responseGroupId,
-            userMessageId: conversation.messages.last(where: { $0.role == .user })?.id ?? UUID(),
-            responses: responseEntries
-        )
         if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }) {
-            conversationManager.conversations[index].responseGroups.append(responseGroup)
+            conversationManager.conversations[index].responseGroups.append(responsePlan.responseGroup)
         }
 
         registerNewChatImageBatchCancellation(
@@ -926,30 +879,16 @@ struct MacNewChatView: View {
             return
         }
 
-        // Create response group
-        let responseGroupId = UUID()
-        var responseGroup = ResponseGroup(id: responseGroupId, userMessageId: userMessageId)
-
-        // Create placeholder messages for each model
-        let messageIds = Dictionary(uniqueKeysWithValues: models.map { ($0, UUID()) })
-        for model in models {
-            guard let messageId = messageIds[model] else { continue }
-            responseGroup.addResponse(messageId: messageId, modelName: model, status: .streaming)
-
-            let placeholderMessage = Message(
-                id: messageId,
-                role: .assistant,
-                content: "",
-                model: model,
-                responseGroupId: responseGroupId
-            )
+        let responsePlan = MultiModelResponsePlan(models: models, userMessageId: userMessageId)
+        let responseGroupId = responsePlan.responseGroupId
+        for placeholderMessage in responsePlan.placeholderMessages {
             conversationManager.addMessage(to: updatedConversation, message: placeholderMessage)
         }
 
         // Add response group to conversation
-        conversationManager.addResponseGroup(to: updatedConversation, group: responseGroup)
+        conversationManager.addResponseGroup(to: updatedConversation, group: responsePlan.responseGroup)
 
-        let messageIdsByModel = messageIds
+        let messageIdsByModel = responsePlan.messageIDsByModel
 
         // Prepare messages for API
         var messagesToSend = updatedConversation.getEffectiveHistory()
@@ -1036,6 +975,24 @@ struct MacNewChatView: View {
                         errorMessage = "\"\(model)\" failed: \(safeMessage)"
                         errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
                         shouldOfferOpenSettings = ErrorPresenter.suggestedAction(for: error) == .openSettings
+                    }
+                }
+            },
+            onPendingToolCall: nil,
+            onReasoning: { model, reasoning in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                    guard let messageId = messageIdsByModel[model] else { return }
+                    guard conversationManager.updateMessage(
+                        conversationId: conversationId,
+                        messageId: messageId,
+                        update: { message in
+                            message.reasoning = (message.reasoning ?? "") + reasoning
+                        }
+                    ) else {
+                        return
+                    }
+                    if let conversation = conversationManager.conversation(byId: conversationId) {
+                        conversationManager.save(conversation)
                     }
                 }
             }

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 #if os(macOS)
 //
 //  MacNewChatView.swift
@@ -31,6 +30,7 @@ struct MacNewChatView: View {
         @State var toolChainCoordinator = ToolChainCoordinator()
         @State private var toolCallRequestRoundCoordinator = ToolCallRequestRoundCoordinator<ToolExecutionResult>()
         @State var imageGenerationCoordinator = ImageGenerationCoordinator()
+        @State var multiModelReasoningBuffer = MultiModelStreamingBuffer()
         @State private var sendPreparationTask: Task<Void, Never>?
         @State private var sendPreparationID: UUID?
 
@@ -903,6 +903,7 @@ struct MacNewChatView: View {
             activeAssistantMessageID = nil
             activeMultiModelResponseGroupID = responseGroupId
             let operationID = coordinator.beginOperation(conversationID: conversationId)
+            multiModelReasoningBuffer.resetAll()
             let request = aiService.sendToMultipleModels(
             messages: messagesToSend,
             models: models,
@@ -926,6 +927,7 @@ struct MacNewChatView: View {
             onModelComplete: { model in
                     coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model] else { return }
+                        multiModelReasoningBuffer.finish(for: messageId)
 
                         updateResponseGroupViaGroup(
                             conversationId: conversationId,
@@ -939,6 +941,7 @@ struct MacNewChatView: View {
             onAllComplete: {
                     coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                         guard coordinator.owns(operationID, conversationID: conversationId) else { return }
+                    multiModelReasoningBuffer.finishAll()
                     isGenerating = false
                     logNewChat("🏁 All models completed", level: .info)
 
@@ -958,6 +961,7 @@ struct MacNewChatView: View {
             onError: { model, error in
                     coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     guard let messageId = messageIdsByModel[model] else { return }
+                        multiModelReasoningBuffer.finish(for: messageId)
 
                         updateResponseGroupViaGroup(
                             conversationId: conversationId,
@@ -982,23 +986,33 @@ struct MacNewChatView: View {
             onPendingToolCall: nil,
             onReasoning: { model, reasoning in
                 coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
-                    guard let messageId = messageIdsByModel[model] else { return }
-                    guard conversationManager.updateMessage(
-                        conversationId: conversationId,
-                        messageId: messageId,
-                        update: { message in
-                            message.reasoning = (message.reasoning ?? "") + reasoning
+                    guard !reasoning.isEmpty,
+                          let messageId = messageIdsByModel[model]
+                    else { return }
+
+                    let conversationManager = conversationManager
+                    multiModelReasoningBuffer.buffer(for: messageId) { reasoningChunk in
+                        guard conversationManager.updateMessage(
+                            conversationId: conversationId,
+                            messageId: messageId,
+                            update: { message in
+                                message.reasoning = (message.reasoning ?? "") + reasoningChunk
+                            }
+                        ) else {
+                            return
                         }
-                    ) else {
-                        return
-                    }
-                    if let conversation = conversationManager.conversation(byId: conversationId) {
-                        conversationManager.save(conversation)
-                    }
+                        if let conversation = conversationManager.conversation(byId: conversationId) {
+                            conversationManager.save(conversation)
+                        }
+                    }.append(reasoning)
                 }
             }
         )
             coordinator.onCancel(for: operationID) {
+                multiModelReasoningBuffer.finishAll()
+                if let conversation = conversationManager.conversation(byId: conversationId) {
+                    conversationManager.saveImmediately(conversation)
+                }
                 request.cancel()
             }
     }

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -128,6 +128,7 @@ struct MacNewChatView: View {
                                         let message = transcriptMessage.message
                                         MacMessageView(
                                             message: message,
+                                            displayKind: transcriptMessage.displayKind,
                                             modelName: message.model,
                                             onRetry: nil,
                                             onSwitchModel: nil,

--- a/Sources/Ayna/Views/macOS/MultiModelResponseView.swift
+++ b/Sources/Ayna/Views/macOS/MultiModelResponseView.swift
@@ -122,6 +122,8 @@ struct MultiModelResponseCard: View {
     @State private var isHovered = false
     @State private var cachedContentBlocks: [ContentBlock]
     @State private var cachedReasoningBlocks: [ContentBlock]
+    @State private var reasoningParseTask: Task<Void, Never>?
+    @State private var reasoningParseGeneration = 0
     @State private var decodedImage: NSImage?
 
     init(
@@ -141,7 +143,9 @@ struct MultiModelResponseCard: View {
         self.onSelect = onSelect
         self.onRetry = onRetry
         _cachedContentBlocks = State(initialValue: MarkdownRenderer.parse(message.content))
-        _cachedReasoningBlocks = State(initialValue: MarkdownRenderer.parse(message.reasoning ?? ""))
+        _cachedReasoningBlocks = State(
+            initialValue: message.reasoning.flatMap { MarkdownRenderer.cachedBlocks(for: $0) } ?? []
+        )
     }
 
     private var modelName: String {
@@ -204,11 +208,11 @@ struct MultiModelResponseCard: View {
                 }
             }
             .onChange(of: message.reasoning) { _, newReasoning in
-                Task.detached(priority: .userInitiated) {
-                    let blocks = MarkdownRenderer.parse(newReasoning ?? "")
-                    await MainActor.run {
-                        cachedReasoningBlocks = blocks
-                    }
+                scheduleReasoningParse(for: newReasoning ?? "")
+            }
+            .onChange(of: isStreaming) { wasStreaming, isStreaming in
+                if wasStreaming, !isStreaming {
+                    scheduleReasoningParse(for: message.reasoning ?? "")
                 }
             }
             .onChange(of: message.imageData) { _, newImageData in
@@ -224,9 +228,15 @@ struct MultiModelResponseCard: View {
                 }
             }
             .task {
+                if cachedReasoningBlocks.isEmpty {
+                    scheduleReasoningParse(for: message.reasoning ?? "")
+                }
                 if message.mediaType == .image, decodedImage == nil {
                     loadImage()
                 }
+            }
+            .onDisappear {
+                reasoningParseTask?.cancel()
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel("Response from \(modelName)")
@@ -383,6 +393,31 @@ struct MultiModelResponseCard: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Reasoning")
+    }
+
+    private func scheduleReasoningParse(for reasoning: String) {
+        reasoningParseTask?.cancel()
+        reasoningParseGeneration += 1
+        let generation = reasoningParseGeneration
+        let shouldDebounce = isStreaming
+        let cachePolicy: MarkdownRenderer.CachePolicy = isStreaming ? .doNotCache : .useCache
+
+        reasoningParseTask = Task.detached(priority: .userInitiated) {
+            if shouldDebounce {
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+            guard !Task.isCancelled else { return }
+            let blocks = MarkdownRenderer.parse(reasoning, cachePolicy: cachePolicy)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard generation == reasoningParseGeneration,
+                      message.reasoning ?? "" == reasoning
+                else {
+                    return
+                }
+                cachedReasoningBlocks = blocks
+            }
+        }
     }
 
     private func loadImage() {

--- a/Sources/Ayna/Views/macOS/MultiModelResponseView.swift
+++ b/Sources/Ayna/Views/macOS/MultiModelResponseView.swift
@@ -15,6 +15,8 @@ struct MultiModelResponseView: View {
     let responseGroupId: UUID
     let responses: [Message]
     let conversation: Conversation
+    /// ID of the response that would be auto-selected if the user continues without choosing.
+    var defaultCandidateId: UUID?
     var onSelectResponse: ((UUID) -> Void)?
     var onRetry: ((Message) -> Void)?
 
@@ -30,15 +32,6 @@ struct MultiModelResponseView: View {
 
     private var isSelectionMade: Bool {
         selectedResponseId != nil
-    }
-
-    private var defaultCandidateId: UUID? {
-        // 1. Primary: conversation.model
-        if let match = responses.first(where: { $0.model == conversation.model }) {
-            return match.id
-        }
-        // 2. Fallback: First model
-        return responses.first?.id
     }
 
     /// Determines the grid layout based on number of responses
@@ -128,6 +121,7 @@ struct MultiModelResponseCard: View {
 
     @State private var isHovered = false
     @State private var cachedContentBlocks: [ContentBlock]
+    @State private var cachedReasoningBlocks: [ContentBlock]
     @State private var decodedImage: NSImage?
 
     init(
@@ -147,6 +141,7 @@ struct MultiModelResponseCard: View {
         self.onSelect = onSelect
         self.onRetry = onRetry
         _cachedContentBlocks = State(initialValue: MarkdownRenderer.parse(message.content))
+        _cachedReasoningBlocks = State(initialValue: MarkdownRenderer.parse(message.reasoning ?? ""))
     }
 
     private var modelName: String {
@@ -205,6 +200,14 @@ struct MultiModelResponseCard: View {
                     let blocks = MarkdownRenderer.parse(newContent)
                     await MainActor.run {
                         cachedContentBlocks = blocks
+                    }
+                }
+            }
+            .onChange(of: message.reasoning) { _, newReasoning in
+                Task.detached(priority: .userInitiated) {
+                    let blocks = MarkdownRenderer.parse(newReasoning ?? "")
+                    await MainActor.run {
+                        cachedReasoningBlocks = blocks
                     }
                 }
             }
@@ -286,7 +289,12 @@ struct MultiModelResponseCard: View {
     }
 
     private var contentScrollView: some View {
-        ScrollView {
+        let contentPlan = MultiModelResponseContentPlan(
+            message: message,
+            responseStatus: responseStatus
+        )
+
+        return ScrollView {
             VStack(alignment: .leading, spacing: Spacing.sm) {
                 if message.mediaType == .image {
                     // Image generation content
@@ -326,14 +334,24 @@ struct MultiModelResponseCard: View {
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, Spacing.xxl)
                     }
-                } else if message.content.isEmpty, isStreaming {
-                    TypingIndicatorView()
-                        .padding(.vertical, Spacing.sm)
                 } else if hasFailed {
                     failedContentView
                 } else {
-                    ForEach(cachedContentBlocks, id: \.id) { block in
-                        block.view
+                    if let reasoning = contentPlan.reasoning {
+                        reasoningView(reasoning)
+                    }
+
+                    if contentPlan.showsTypingIndicator {
+                        TypingIndicatorView()
+                            .padding(.vertical, Spacing.sm)
+                    } else if !message.content.isEmpty {
+                        if cachedContentBlocks.isEmpty {
+                            Text(verbatim: message.content)
+                        } else {
+                            ForEach(cachedContentBlocks, id: \.id) { block in
+                                block.view
+                            }
+                        }
                     }
                 }
             }
@@ -341,6 +359,30 @@ struct MultiModelResponseCard: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(minHeight: 120, maxHeight: 300)
+    }
+
+    private func reasoningView(_ reasoning: String) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Label("Reasoning", systemImage: "brain.head.profile")
+                .font(Typography.captionBold)
+                .foregroundStyle(Theme.textSecondary)
+
+            if cachedReasoningBlocks.isEmpty {
+                Text(verbatim: reasoning)
+            } else {
+                ForEach(cachedReasoningBlocks, id: \.id) { block in
+                    block.view
+                }
+            }
+        }
+        .padding(Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Theme.textSecondary.opacity(0.08),
+            in: RoundedRectangle(cornerRadius: Spacing.CornerRadius.md)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Reasoning")
     }
 
     private func loadImage() {
@@ -615,7 +657,8 @@ struct MultiModelSelector: View {
             return MultiModelResponseView(
                 responseGroupId: groupId,
                 responses: responses,
-                conversation: conversation
+                conversation: conversation,
+                defaultCandidateId: responses.first?.id
             )
             .frame(width: 800)
             .padding()

--- a/Tests/AynaTests/ChatTranscriptPlanTests.swift
+++ b/Tests/AynaTests/ChatTranscriptPlanTests.swift
@@ -1,0 +1,249 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("ChatTranscriptPlan Tests", .tags(.fast))
+struct ChatTranscriptPlanTests {
+    @Test
+    func `Plan hides system, web-search, and empty tool messages`() {
+        let system = Message(role: .system, content: "Hidden")
+        let emptyTool = Message(role: .tool, content: "  \n")
+        var webSearch = Message(role: .tool, content: "Search result")
+        webSearch.toolCalls = [MCPToolCall(toolName: WebSearchCoordinator.toolName, arguments: [:])]
+        let tool = Message(role: .tool, content: "Tool result")
+        let conversation = Conversation(messages: [system, emptyTool, webSearch, tool])
+
+        let plan = ChatTranscriptPlan(conversation: conversation, isGenerating: false)
+
+        #expect(plan.visibleMessages.map(\.id) == [tool.id])
+        #expect(plan.items == [.message(ChatTranscriptMessage(message: tool, displayKind: .toolResult))])
+    }
+
+    @Test
+    func `Plan hides empty assistant tool-call placeholders`() {
+        #if !os(watchOS)
+            var placeholder = Message(role: .assistant, content: "")
+            placeholder.toolCalls = [MCPToolCall(toolName: "web_search", arguments: [:])]
+            let visible = Message(role: .assistant, content: "Done")
+            let conversation = Conversation(messages: [placeholder, visible])
+
+            let plan = ChatTranscriptPlan(conversation: conversation, isGenerating: true)
+
+            #expect(plan.visibleMessages.map(\.id) == [visible.id])
+        #endif
+    }
+
+    @Test
+    func `Plan shows reasoning-only assistant messages`() {
+        let message = Message(role: .assistant, content: "", reasoning: "Thinking through this")
+        let conversation = Conversation(messages: [message])
+
+        let plan = ChatTranscriptPlan(conversation: conversation, isGenerating: false)
+
+        let expected = ChatTranscriptMessage(message: message, displayKind: .text)
+        #expect(plan.visibleMessages == [expected])
+        #expect(plan.items == [.message(expected)])
+    }
+
+    @Test
+    func `Plan shows citations-only assistant messages`() {
+        let message = Message(
+            role: .assistant,
+            content: "",
+            citations: [CitationReference(number: 1, title: "Source", url: "https://example.com")]
+        )
+        let conversation = Conversation(messages: [message])
+
+        let idlePlan = ChatTranscriptPlan(conversation: conversation, isGenerating: false)
+        let generatingPlan = ChatTranscriptPlan(conversation: conversation, isGenerating: true)
+
+        #expect(idlePlan.visibleMessages == [ChatTranscriptMessage(message: message, displayKind: .citationsOnly)])
+        #expect(generatingPlan.visibleMessages == [ChatTranscriptMessage(message: message, displayKind: .typingPlaceholder)])
+    }
+
+    @Test
+    func `Plan keeps empty response-group placeholders visible and grouped`() {
+        let groupId = UUID()
+        let first = Message(role: .assistant, content: "", model: "gpt-a", responseGroupId: groupId)
+        let second = Message(role: .assistant, content: "", model: "gpt-b", responseGroupId: groupId)
+        let group = ResponseGroup(
+            id: groupId,
+            userMessageId: UUID(),
+            responses: [
+                ResponseGroup.ResponseEntry(id: first.id, modelName: "gpt-a", status: .streaming),
+                ResponseGroup.ResponseEntry(id: second.id, modelName: "gpt-b", status: .streaming)
+            ]
+        )
+        let conversation = Conversation(messages: [first, second], responseGroups: [group])
+        let expectedResponses = [
+            ChatTranscriptMessage(message: first, displayKind: .typingPlaceholder),
+            ChatTranscriptMessage(message: second, displayKind: .typingPlaceholder)
+        ]
+
+        let plan = ChatTranscriptPlan(conversation: conversation, isGenerating: false)
+
+        #expect(plan.items == [.responseGroup(ChatTranscriptResponseGroup(
+            id: groupId,
+            responses: expectedResponses,
+            selectedResponseId: nil,
+            defaultCandidateId: first.id
+        ))])
+    }
+
+    @Test
+    func `Plan shows active image placeholders and completed images`() {
+        let placeholder = Message(role: .assistant, content: "", mediaType: .image)
+        let imagePath = Message(role: .assistant, content: "", imagePath: "images/generated.png")
+        let imageData = Message(role: .assistant, content: "", imageData: Data([1, 2, 3]))
+        let activeConversation = Conversation(messages: [imagePath, imageData, placeholder])
+        let idleConversation = Conversation(messages: [placeholder, imagePath, imageData])
+
+        let activePlan = ChatTranscriptPlan(conversation: activeConversation, isGenerating: true)
+        let idlePlan = ChatTranscriptPlan(conversation: idleConversation, isGenerating: false)
+
+        #expect(activePlan.visibleMessages.map(\.displayKind) == [.image, .image, .image])
+        #expect(idlePlan.visibleMessages.map(\.id) == [imagePath.id, imageData.id])
+    }
+
+    @Test
+    func `Plan keeps non-empty standalone image messages visible`() {
+        let failedAssistant = Message(role: .assistant, content: "Image generation failed", mediaType: .image)
+        let userImage = Message(role: .user, content: "Uploaded image context", mediaType: .image)
+        let oldPlaceholder = Message(role: .assistant, content: "", mediaType: .image)
+        let conversation = Conversation(messages: [failedAssistant, userImage, oldPlaceholder])
+
+        let plan = ChatTranscriptPlan(conversation: conversation, isGenerating: false)
+
+        #expect(plan.visibleMessages == [
+            ChatTranscriptMessage(message: failedAssistant, displayKind: .text),
+            ChatTranscriptMessage(message: userImage, displayKind: .text)
+        ])
+    }
+
+    @Test
+    func `Plan shows only the last empty assistant while generating`() {
+        let hidden = Message(role: .assistant, content: "")
+        let visible = Message(role: .assistant, content: "")
+        let conversation = Conversation(messages: [hidden, visible])
+
+        #expect(ChatTranscriptPlan(conversation: conversation, isGenerating: true).visibleMessages == [
+            ChatTranscriptMessage(message: visible, displayKind: .typingPlaceholder)
+        ])
+        #expect(ChatTranscriptPlan(conversation: conversation, isGenerating: false).visibleMessages.isEmpty)
+    }
+
+    @Test
+    func `Plan preserves response-group first occurrence order`() {
+        let groupId = UUID()
+        let user = Message(role: .user, content: "Question")
+        let groupedFirst = Message(role: .assistant, content: "A", model: "gpt-a", responseGroupId: groupId)
+        let standalone = Message(role: .assistant, content: "Interlude")
+        let groupedSecond = Message(role: .assistant, content: "B", model: "gpt-b", responseGroupId: groupId)
+        let group = ResponseGroup(
+            id: groupId,
+            userMessageId: user.id,
+            responses: [
+                ResponseGroup.ResponseEntry(id: groupedFirst.id, modelName: "gpt-a", status: .completed),
+                ResponseGroup.ResponseEntry(id: groupedSecond.id, modelName: "gpt-b", status: .completed)
+            ]
+        )
+        let conversation = Conversation(messages: [user, groupedFirst, standalone, groupedSecond], responseGroups: [group])
+
+        let plan = ChatTranscriptPlan(conversation: conversation, isGenerating: false)
+
+        #expect(plan.items.map(\.id) == [
+            user.id.uuidString,
+            "group-\(groupId.uuidString)",
+            standalone.id.uuidString
+        ])
+    }
+
+    @Test
+    func `Default candidate prefers completed conversation model`() {
+        let failed = Message(role: .assistant, content: "A", model: "gpt-a")
+        let streaming = Message(role: .assistant, content: "B", model: "gpt-b")
+        let completed = Message(role: .assistant, content: "C", model: "gpt-c")
+        let group = ResponseGroup(
+            userMessageId: UUID(),
+            responses: [
+                ResponseGroup.ResponseEntry(id: failed.id, modelName: "gpt-a", status: .failed),
+                ResponseGroup.ResponseEntry(id: streaming.id, modelName: "gpt-b", status: .streaming),
+                ResponseGroup.ResponseEntry(id: completed.id, modelName: "gpt-c", status: .completed)
+            ]
+        )
+        let conversation = Conversation(messages: [failed, streaming, completed], model: "gpt-a")
+
+        #expect(ChatTranscriptPlan.defaultCandidateId(
+            for: [failed, streaming, completed],
+            in: conversation,
+            responseGroup: group
+        ) == completed.id)
+    }
+
+    @Test
+    func `Default candidate falls back to original ordering when every response is unavailable`() {
+        let failed = Message(role: .assistant, content: "A", model: "gpt-a")
+        let streaming = Message(role: .assistant, content: "B", model: "gpt-b")
+        let group = ResponseGroup(
+            userMessageId: UUID(),
+            responses: [
+                ResponseGroup.ResponseEntry(id: failed.id, modelName: "gpt-a", status: .failed),
+                ResponseGroup.ResponseEntry(id: streaming.id, modelName: "gpt-b", status: .streaming)
+            ]
+        )
+
+        #expect(ChatTranscriptPlan.defaultCandidateId(
+            for: [failed, streaming],
+            in: Conversation(messages: [failed, streaming], model: "missing"),
+            responseGroup: group
+        ) == failed.id)
+    }
+
+    @Test
+    func `Response-group item includes selected and default metadata`() {
+        let groupId = UUID()
+        let user = Message(role: .user, content: "Compare")
+        let first = Message(role: .assistant, content: "A", model: "gpt-a", responseGroupId: groupId)
+        let second = Message(role: .assistant, content: "B", model: "gpt-b", responseGroupId: groupId)
+        let group = ResponseGroup(
+            id: groupId,
+            userMessageId: user.id,
+            responses: [
+                ResponseGroup.ResponseEntry(id: first.id, modelName: "gpt-a", status: .completed),
+                ResponseGroup.ResponseEntry(id: second.id, modelName: "gpt-b", status: .completed)
+            ],
+            selectedResponseId: first.id
+        )
+        let conversation = Conversation(messages: [user, first, second], model: "gpt-b", responseGroups: [group])
+        let plan = ChatTranscriptPlan(conversation: conversation, isGenerating: false)
+
+        guard case let .responseGroup(groupItem) = plan.items[1] else {
+            Issue.record("Expected response group")
+            return
+        }
+        #expect(groupItem.selectedResponseId == first.id)
+        #expect(groupItem.defaultCandidateId == second.id)
+    }
+
+    @Test
+    func `Auto-selection uses the last unselected response group`() {
+        let groupId = UUID()
+        let user = Message(role: .user, content: "Compare")
+        let first = Message(role: .assistant, content: "A", model: "gpt-a", responseGroupId: groupId)
+        let second = Message(role: .assistant, content: "B", model: "gpt-b", responseGroupId: groupId)
+        let group = ResponseGroup(
+            id: groupId,
+            userMessageId: user.id,
+            responses: [
+                ResponseGroup.ResponseEntry(id: first.id, modelName: "gpt-a", status: .completed),
+                ResponseGroup.ResponseEntry(id: second.id, modelName: "gpt-b", status: .completed)
+            ]
+        )
+        let conversation = Conversation(messages: [user, first, second], model: "gpt-b", responseGroups: [group])
+
+        #expect(ChatTranscriptPlan.autoSelectionCandidate(in: conversation) == ChatTranscriptResponseSelection(
+            groupId: groupId,
+            messageId: second.id
+        ))
+    }
+}

--- a/Tests/AynaTests/ChatTranscriptPlanTests.swift
+++ b/Tests/AynaTests/ChatTranscriptPlanTests.swift
@@ -181,6 +181,47 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
+    func `default candidate prefers meaningful content over an empty preferred-model response`() {
+        let groupId = UUID()
+        let user = Message(role: .user, content: "Compare")
+        let emptyPreferred = Message(
+            role: .assistant,
+            content: "",
+            model: "gpt-a",
+            responseGroupId: groupId
+        )
+        let meaningful = Message(
+            role: .assistant,
+            content: "Useful answer",
+            model: "gpt-b",
+            responseGroupId: groupId
+        )
+        let group = ResponseGroup(
+            id: groupId,
+            userMessageId: user.id,
+            responses: [
+                ResponseGroup.ResponseEntry(id: emptyPreferred.id, modelName: "gpt-a", status: .completed),
+                ResponseGroup.ResponseEntry(id: meaningful.id, modelName: "gpt-b", status: .completed)
+            ]
+        )
+        let conversation = Conversation(
+            messages: [user, emptyPreferred, meaningful],
+            model: "gpt-a",
+            responseGroups: [group]
+        )
+
+        let plan = ChatTranscriptPlan(conversation: conversation, isGenerating: false)
+
+        #expect(ChatTranscriptPlan.defaultCandidateId(
+            for: [emptyPreferred, meaningful],
+            in: conversation,
+            responseGroup: group
+        ) == meaningful.id)
+        #expect(plan.pendingAutoSelection?.messageId == meaningful.id)
+        #expect(conversation.getEffectiveHistory().map(\.id) == [user.id, meaningful.id])
+    }
+
+    @Test
     func `default candidate falls back to original ordering when every response is unavailable`() {
         let failed = Message(role: .assistant, content: "A", model: "gpt-a")
         let streaming = Message(role: .assistant, content: "B", model: "gpt-b")

--- a/Tests/AynaTests/ChatTranscriptPlanTests.swift
+++ b/Tests/AynaTests/ChatTranscriptPlanTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite("ChatTranscriptPlan Tests", .tags(.fast))
 struct ChatTranscriptPlanTests {
     @Test
-    func `Plan hides system, web-search, and empty tool messages`() {
+    func `plan hides system, web-search, and empty tool messages`() {
         let system = Message(role: .system, content: "Hidden")
         let emptyTool = Message(role: .tool, content: "  \n")
         var webSearch = Message(role: .tool, content: "Search result")
@@ -20,7 +20,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Plan hides empty assistant tool-call placeholders`() {
+    func `plan hides empty assistant tool-call placeholders`() {
         #if !os(watchOS)
             var placeholder = Message(role: .assistant, content: "")
             placeholder.toolCalls = [MCPToolCall(toolName: "web_search", arguments: [:])]
@@ -34,7 +34,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Plan shows reasoning-only assistant messages`() {
+    func `plan shows reasoning-only assistant messages`() {
         let message = Message(role: .assistant, content: "", reasoning: "Thinking through this")
         let conversation = Conversation(messages: [message])
 
@@ -46,7 +46,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Plan shows citations-only assistant messages`() {
+    func `plan shows citations-only assistant messages`() {
         let message = Message(
             role: .assistant,
             content: "",
@@ -62,7 +62,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Plan keeps empty response-group placeholders visible and grouped`() {
+    func `plan keeps empty response-group placeholders visible and grouped`() {
         let groupId = UUID()
         let first = Message(role: .assistant, content: "", model: "gpt-a", responseGroupId: groupId)
         let second = Message(role: .assistant, content: "", model: "gpt-b", responseGroupId: groupId)
@@ -91,7 +91,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Plan shows active image placeholders and completed images`() {
+    func `plan shows active image placeholders and completed images`() {
         let placeholder = Message(role: .assistant, content: "", mediaType: .image)
         let imagePath = Message(role: .assistant, content: "", imagePath: "images/generated.png")
         let imageData = Message(role: .assistant, content: "", imageData: Data([1, 2, 3]))
@@ -106,7 +106,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Plan keeps non-empty standalone image messages visible`() {
+    func `plan keeps non-empty standalone image messages visible`() {
         let failedAssistant = Message(role: .assistant, content: "Image generation failed", mediaType: .image)
         let userImage = Message(role: .user, content: "Uploaded image context", mediaType: .image)
         let oldPlaceholder = Message(role: .assistant, content: "", mediaType: .image)
@@ -121,7 +121,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Plan shows only the last empty assistant while generating`() {
+    func `plan shows only the last empty assistant while generating`() {
         let hidden = Message(role: .assistant, content: "")
         let visible = Message(role: .assistant, content: "")
         let conversation = Conversation(messages: [hidden, visible])
@@ -133,7 +133,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Plan preserves response-group first occurrence order`() {
+    func `plan preserves response-group first occurrence order`() {
         let groupId = UUID()
         let user = Message(role: .user, content: "Question")
         let groupedFirst = Message(role: .assistant, content: "A", model: "gpt-a", responseGroupId: groupId)
@@ -159,7 +159,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Default candidate prefers completed conversation model`() {
+    func `default candidate prefers completed conversation model`() {
         let failed = Message(role: .assistant, content: "A", model: "gpt-a")
         let streaming = Message(role: .assistant, content: "B", model: "gpt-b")
         let completed = Message(role: .assistant, content: "C", model: "gpt-c")
@@ -181,7 +181,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Default candidate falls back to original ordering when every response is unavailable`() {
+    func `default candidate falls back to original ordering when every response is unavailable`() {
         let failed = Message(role: .assistant, content: "A", model: "gpt-a")
         let streaming = Message(role: .assistant, content: "B", model: "gpt-b")
         let group = ResponseGroup(
@@ -200,7 +200,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Response-group item includes selected and default metadata`() {
+    func `response-group item includes selected and default metadata`() {
         let groupId = UUID()
         let user = Message(role: .user, content: "Compare")
         let first = Message(role: .assistant, content: "A", model: "gpt-a", responseGroupId: groupId)
@@ -226,7 +226,7 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
-    func `Auto-selection uses the last unselected response group`() {
+    func `auto-selection uses the last unselected response group`() {
         let groupId = UUID()
         let user = Message(role: .user, content: "Compare")
         let first = Message(role: .assistant, content: "A", model: "gpt-a", responseGroupId: groupId)

--- a/Tests/AynaTests/IOSChatViewModelStreamingCoalescingTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelStreamingCoalescingTests.swift
@@ -80,6 +80,36 @@ import Testing
             #expect(fixture.viewModel.messageContentRevision == 1)
         }
 
+        @Test(.timeLimit(.minutes(1)))
+        func `model completion coalesces and flushes pending reasoning exactly once`() async throws {
+            let fixture = try await makeFixture()
+
+            fixture.viewModel.processMultiModelReasoning(
+                model: fixture.model,
+                "first ",
+                messageIds: fixture.messageIds,
+                conversationId: fixture.conversationId
+            )
+            fixture.viewModel.processMultiModelReasoning(
+                model: fixture.model,
+                "second",
+                messageIds: fixture.messageIds,
+                conversationId: fixture.conversationId
+            )
+
+            #expect(fixture.manager.conversations.first?.messages.first?.reasoning == nil)
+
+            fixture.viewModel.processMultiModelCompletion(
+                model: fixture.model,
+                messageIds: fixture.messageIds,
+                conversationId: fixture.conversationId,
+                responseGroupId: fixture.responseGroupId
+            )
+
+            #expect(fixture.manager.conversations.first?.messages.first?.reasoning == "first second")
+            #expect(fixture.manager.conversations.first?.responseGroups.first?.responses.first?.status == .completed)
+        }
+
         @Test
         func `ordered callback queue preserves stream event order`() async {
             let queue = OrderedMainActorEventQueue()
@@ -125,6 +155,21 @@ import Testing
                 messageIds: [firstResponse.modelName: firstResponse.id],
                 conversationId: conversation.id
             )
+            viewModel.processMultiModelReasoning(
+                model: firstResponse.modelName,
+                "buffered ",
+                messageIds: [firstResponse.modelName: firstResponse.id],
+                conversationId: conversation.id
+            )
+            viewModel.processMultiModelReasoning(
+                model: firstResponse.modelName,
+                "reasoning",
+                messageIds: [firstResponse.modelName: firstResponse.id],
+                conversationId: conversation.id
+            )
+            #expect(
+                manager.conversations.first?.messages.first(where: { $0.id == firstResponse.id })?.reasoning == nil
+            )
 
             viewModel.cancelGeneration()
             let responseGroupAfterCancel = try #require(manager.conversations.first?.getResponseGroup(responseGroupId))
@@ -132,6 +177,7 @@ import Testing
                 manager.conversations.first?.messages.first(where: { $0.id == firstResponse.id })
             )
             #expect(messageAfterCancel.content == "buffered partial")
+            #expect(messageAfterCancel.reasoning == "buffered reasoning")
             #expect(responseGroupAfterCancel.isComplete)
             #expect(responseGroupAfterCancel.responses.allSatisfy { $0.status == .failed })
 
@@ -139,6 +185,7 @@ import Testing
             let persisted = try #require(try await store.loadConversation(id: conversation.id))
             #expect(persisted.getResponseGroup(responseGroupId)?.isComplete == true)
             #expect(persisted.messages.first(where: { $0.id == firstResponse.id })?.content == "buffered partial")
+            #expect(persisted.messages.first(where: { $0.id == firstResponse.id })?.reasoning == "buffered reasoning")
         }
 
         @Test

--- a/Tests/AynaTests/IOSChatViewModelTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelTests.swift
@@ -94,6 +94,70 @@
             viewModel.cancelOwnedOperations()
         }
 
+        @Test(.timeLimit(.minutes(1)))
+        func `multi-model reasoning routes by model and rejects stale operation callbacks`() async throws {
+            let models = ["model-a", "model-b"]
+            let conversation = Conversation(
+                model: models[0],
+                systemPromptMode: .disabled,
+                multiModelEnabled: true,
+                activeModels: models
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = MultiModelReasoningCapturingAIService()
+            configure(aiService, models: models)
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            viewModel.selectedModels = Set(models)
+            viewModel.messageText = "First comparison"
+
+            viewModel.sendMessage()
+            #expect(aiService.reasoningCallbackCount == 1)
+            let firstGroup = try #require(manager.conversation(byId: conversation.id)?.responseGroups.last)
+            let firstA = try #require(firstGroup.responses.first(where: { $0.modelName == models[0] }))
+            let firstB = try #require(firstGroup.responses.first(where: { $0.modelName == models[1] }))
+
+            aiService.emitReasoning(requestIndex: 0, model: models[0], reasoning: "first-a")
+            aiService.emitReasoning(requestIndex: 0, model: models[1], reasoning: "first-b")
+            #expect(await waitUntil {
+                let messages = manager.conversation(byId: conversation.id)?.messages ?? []
+                return messages.first(where: { $0.id == firstA.id })?.reasoning == "first-a"
+                    && messages.first(where: { $0.id == firstB.id })?.reasoning == "first-b"
+            })
+
+            viewModel.cancelGeneration()
+            viewModel.messageText = "Replacement comparison"
+            viewModel.sendMessage()
+            #expect(aiService.reasoningCallbackCount == 2)
+            let secondGroup = try #require(manager.conversation(byId: conversation.id)?.responseGroups.last)
+            #expect(secondGroup.id != firstGroup.id)
+            let secondA = try #require(secondGroup.responses.first(where: { $0.modelName == models[0] }))
+            let secondB = try #require(secondGroup.responses.first(where: { $0.modelName == models[1] }))
+
+            aiService.emitReasoning(requestIndex: 0, model: models[0], reasoning: "-stale")
+            aiService.emitReasoning(requestIndex: 1, model: models[0], reasoning: "second-a")
+            #expect(await waitUntil {
+                manager.conversation(byId: conversation.id)?.messages.first(where: { $0.id == secondA.id })?.reasoning
+                    == "second-a"
+            })
+
+            let messages = try #require(manager.conversation(byId: conversation.id)?.messages)
+            #expect(messages.first(where: { $0.id == firstA.id })?.reasoning == "first-a")
+            #expect(messages.first(where: { $0.id == firstB.id })?.reasoning == "first-b")
+            #expect(messages.first(where: { $0.id == secondB.id })?.reasoning == nil)
+            viewModel.cancelOwnedOperations()
+        }
+
         @Test
         func `hydrated conversation send remains synchronous`() throws {
             let conversation = Conversation(model: "model-a", systemPromptMode: .disabled)
@@ -571,6 +635,51 @@
                 onPendingToolCall: onPendingToolCall,
                 onReasoning: onReasoning
             )
+        }
+    }
+
+    @MainActor
+    private final class MultiModelReasoningCapturingAIService: AIService {
+        private typealias ReasoningCallback = @Sendable (String, String) -> Void
+
+        private var reasoningCallbacks: [ReasoningCallback?] = []
+
+        var reasoningCallbackCount: Int {
+            reasoningCallbacks.count
+        }
+
+        init() {
+            super.init(responseSimulator: { _, _ in })
+        }
+
+        override func sendToMultipleModels(
+            messages: [Message],
+            models: [String],
+            temperature: Double?,
+            onChunk: @escaping @Sendable (String, String) -> Void,
+            onModelComplete: @escaping @Sendable (String) -> Void,
+            onAllComplete: @escaping @Sendable () -> Void,
+            onError: @escaping @Sendable (String, Error) -> Void,
+            onPendingToolCall: (@Sendable (String, String, String, [String: Any]) -> Void)?,
+            onReasoning: (@Sendable (String, String) -> Void)?
+        ) -> AITextBatchRequest {
+            reasoningCallbacks.append(onReasoning)
+            return super.sendToMultipleModels(
+                messages: messages,
+                models: [],
+                temperature: temperature,
+                onChunk: { _, _ in },
+                onModelComplete: { _ in },
+                onAllComplete: {},
+                onError: { _, _ in },
+                onPendingToolCall: nil,
+                onReasoning: nil
+            )
+        }
+
+        func emitReasoning(requestIndex: Int, model: String, reasoning: String) {
+            guard reasoningCallbacks.indices.contains(requestIndex) else { return }
+            reasoningCallbacks[requestIndex]?(model, reasoning)
         }
     }
 

--- a/Tests/AynaTests/MultiModelResponsePlanTests.swift
+++ b/Tests/AynaTests/MultiModelResponsePlanTests.swift
@@ -1,0 +1,69 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("MultiModelResponsePlan Tests", .tags(.fast))
+struct MultiModelResponsePlanTests {
+    @Test
+    func `text plan creates streaming placeholders sharing one response group`() throws {
+        let userMessageId = UUID()
+        let responseGroupId = UUID()
+        let models = ["gpt-5", "claude-sonnet"]
+
+        let plan = MultiModelResponsePlan(
+            models: models,
+            userMessageId: userMessageId,
+            responseGroupId: responseGroupId
+        )
+
+        #expect(plan.responseGroup.id == responseGroupId)
+        #expect(plan.responseGroup.userMessageId == userMessageId)
+        #expect(plan.responseGroup.responses.map(\.modelName) == models)
+        #expect(plan.responseGroup.responses.allSatisfy { $0.status == .streaming })
+        #expect(plan.placeholderMessages.count == models.count)
+
+        for placeholder in plan.placeholderMessages {
+            let model = try #require(placeholder.model)
+            #expect(placeholder.role == .assistant)
+            #expect(placeholder.content.isEmpty)
+            #expect(placeholder.responseGroupId == responseGroupId)
+            #expect(placeholder.mediaType == nil)
+            #expect(plan.messageId(for: model) == placeholder.id)
+            #expect(plan.responseGroup.responses.contains { $0.id == placeholder.id && $0.modelName == model })
+        }
+    }
+
+    @Test
+    func `image plan marks placeholders as image responses`() {
+        let plan = MultiModelResponsePlan(
+            models: ["dall-e", "gpt-image"],
+            userMessageId: UUID(),
+            mediaType: .image
+        )
+
+        #expect(plan.placeholderMessages.allSatisfy { $0.mediaType == .image })
+        #expect(plan.placeholderMessages.allSatisfy { $0.imageData == nil && $0.imagePath == nil })
+        #expect(Set(plan.messageIDsByModel.keys) == Set(["dall-e", "gpt-image"]))
+    }
+
+    @Test
+    func `reasoning-only response renders reasoning instead of a typing indicator`() {
+        let message = Message(role: .assistant, content: "", reasoning: "Compare the constraints first.")
+
+        let plan = MultiModelResponseContentPlan(message: message, responseStatus: .streaming)
+
+        #expect(plan.reasoning == message.reasoning)
+        #expect(!plan.showsTypingIndicator)
+    }
+
+    @Test
+    func `empty streaming response renders a typing indicator`() {
+        let plan = MultiModelResponseContentPlan(
+            message: Message(role: .assistant, content: ""),
+            responseStatus: .streaming
+        )
+
+        #expect(plan.reasoning == nil)
+        #expect(plan.showsTypingIndicator)
+    }
+}

--- a/Tests/AynaTests/StreamingChunkBufferTests.swift
+++ b/Tests/AynaTests/StreamingChunkBufferTests.swift
@@ -1,0 +1,81 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Streaming Chunk Buffer Tests", .tags(.fast, .async))
+@MainActor
+struct StreamingChunkBufferTests {
+    private let deferredConfig = StreamingChunkBuffer.Config(
+        minDeliveryInterval: 60,
+        maxBufferSize: 1000,
+        maxWaitTime: 60
+    )
+
+    @Test
+    func `threshold delivers accumulated chunks immediately`() {
+        var deliveries: [String] = []
+        let buffer = StreamingChunkBuffer(
+            config: .init(minDeliveryInterval: 60, maxBufferSize: 4, maxWaitTime: 60)
+        ) { deliveries.append($0) }
+
+        buffer.append("ab")
+        #expect(deliveries.isEmpty)
+
+        buffer.append("cd")
+        #expect(deliveries == ["abcd"])
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `scheduled delivery flushes a small chunk`() async {
+        var deliveries: [String] = []
+        let buffer = StreamingChunkBuffer(
+            config: .init(minDeliveryInterval: 0.01, maxBufferSize: 1000, maxWaitTime: 60)
+        ) { deliveries.append($0) }
+
+        buffer.append("delayed")
+        #expect(deliveries.isEmpty)
+
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(deliveries == ["delayed"])
+    }
+
+    @Test
+    func `finish isolates messages flushes once and removes the completed buffer`() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let buffers = MultiModelStreamingBuffer(config: deferredConfig)
+        var deliveries: [UUID: String] = [:]
+
+        buffers.buffer(for: firstID) { deliveries[firstID, default: ""] += $0 }.append("first-")
+        buffers.buffer(for: firstID) { deliveries[firstID, default: ""] += $0 }.append("response")
+        buffers.buffer(for: secondID) { deliveries[secondID, default: ""] += $0 }.append("second")
+
+        #expect(deliveries.isEmpty)
+        #expect(buffers.finish(for: firstID))
+        #expect(deliveries[firstID] == "first-response")
+        #expect(deliveries[secondID] == nil)
+        #expect(!buffers.isEmpty)
+        #expect(!buffers.finish(for: firstID))
+
+        #expect(buffers.finishAll())
+        #expect(deliveries[secondID] == "second")
+        #expect(buffers.isEmpty)
+        #expect(!buffers.finishAll())
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `reset drops pending data and cancels scheduled delivery`() async {
+        let messageID = UUID()
+        let buffers = MultiModelStreamingBuffer(
+            config: .init(minDeliveryInterval: 0.01, maxBufferSize: 1000, maxWaitTime: 60)
+        )
+        var deliveries: [String] = []
+
+        buffers.buffer(for: messageID) { deliveries.append($0) }.append("discard me")
+        buffers.reset(for: messageID)
+
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(deliveries.isEmpty)
+        #expect(buffers.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Centralizes transcript visibility, grouping, and default-selection planning.
- Centralizes multi-model response-group and placeholder planning.
- Adopts the planners across macOS and iOS, including reasoning-only rendering.
- Preserves O(n) message grouping/caching and existing reliability coordinators.

## Validation

- `swift test --filter "ChatTranscriptPlanTests|MultiModelResponsePlanTests"` — 17 tests passed
- `swift build`
- `swift build --triple arm64-apple-ios26.0`
- `swift build --triple arm64-apple-watchos26.0`

This replaces the transcript and multi-model planning portion of #95. It does not close #95.