### PR TITLE
ci(watchos): run native unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,56 @@ jobs:
     - name: Compile for watchOS
       run: swift build --triple arm64-apple-watchos26.0 --sdk "$(xcrun --sdk watchos --show-sdk-path)"
 
+  watchos_unit_tests:
+    name: watchOS Unit Tests
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+    - name: Select Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+    - name: Resolve watchOS Simulator
+      id: watch_destination
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        destination_id="$(
+          xcrun simctl list devices available | \
+            sed -nE '/^[[:space:]]+Apple Watch /{s/.*\(([[:xdigit:]-]{36})\).*/\1/p;}' | \
+            sed -n '1p'
+        )"
+        test -n "$destination_id"
+        echo "id=$destination_id" >> "$GITHUB_OUTPUT"
+
+    - name: Run native watchOS unit tests
+      run: |
+        set -o pipefail
+        xcodebuild \
+          -project AynaMobile.xcodeproj \
+          -scheme Ayna-watchOS \
+          -destination "id=${{ steps.watch_destination.outputs.id }}" \
+          -destination-timeout 120 \
+          -derivedDataPath ./build/watchos-unit \
+          -configuration Debug \
+          -resultBundlePath ./TestResults-watchOS-Unit.xcresult \
+          -parallel-testing-enabled NO \
+          CODE_SIGN_IDENTITY="" \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGNING_ALLOWED=NO \
+          test
+
+    - name: Upload test results on failure
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: watchOS-Unit-TestResults
+        path: TestResults-watchOS-Unit.xcresult
+        retention-days: 7
+
   macos_ui_tests:
     name: macOS UI Tests
     runs-on: macos-26
@@ -278,7 +328,7 @@ jobs:
         xcrun simctl shutdown "$DEVICE_UDID" 2>/dev/null || true
         sleep 3
 
-    - name: Run watchOS unit tests
+    - name: Build watchOS app
       run: |
         set -o pipefail
         xcodebuild \
@@ -287,12 +337,10 @@ jobs:
           -destination "id=$DEVICE_UDID" \
           -derivedDataPath ./build \
           -configuration Debug \
-          -resultBundlePath ./build/TestResults-watchOS-Unit.xcresult \
-          -parallel-testing-enabled NO \
           CODE_SIGN_IDENTITY="" \
           CODE_SIGNING_REQUIRED=NO \
           CODE_SIGNING_ALLOWED=NO \
-          test
+          build
 
     - name: Install watchOS app on simulator
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,8 +111,13 @@ jobs:
 
         destination_id="$(
           xcrun simctl list devices available | \
-            sed -nE '/^[[:space:]]+Apple Watch /{s/.*\(([[:xdigit:]-]{36})\).*/\1/p;}' | \
-            sed -n '1p'
+            awk '
+              /^-- watchOS 26\./ { compatible_runtime = 1; next }
+              /^-- / { compatible_runtime = 0 }
+              compatible_runtime && /^[[:space:]]+Apple Watch / { print }
+            ' | \
+            sed -nE 's/.*\(([[:xdigit:]-]{36})\).*/\1/p' | \
+            tail -n 1
         )"
         test -n "$destination_id"
         echo "id=$destination_id" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- add a dedicated watchOS unit-test job on macOS 26 with Xcode 26.2
- resolve an available Apple Watch simulator and run the `Ayna-watchOS` scheme tests natively
- upload the watchOS result bundle when the unit-test job fails
- keep the paired watchOS UI-test job focused on building and installing the app

## Validation

- `actionlint .github/workflows/tests.yml`
- YAML syntax parse with Ruby/Psych
- `xcodebuild ... build-for-testing` for the `Ayna-watchOS` scheme on a watchOS simulator target

Supersedes the watchOS CI/testing portion of #95.