### PR TITLE
refactor(chat): centralize request and failure planning

### DIFF
--- a/Sources/Ayna/Chat/ChatTurnFailurePlan.swift
+++ b/Sources/Ayna/Chat/ChatTurnFailurePlan.swift
@@ -1,0 +1,115 @@
+//
+//  ChatTurnFailurePlan.swift
+//  Ayna
+//
+//  Plans transcript cleanup after a failed chat turn.
+//
+
+import Foundation
+
+/// Removes only UI-only assistant state while preserving durable failed-turn context.
+struct ChatTurnFailurePlan: Equatable, Sendable {
+    enum FailedUserMessagePolicy: Equatable, Sendable {
+        case preserve
+        case removeForRetry
+    }
+
+    let messagesAfterFailure: [Message]
+    let retryPrompt: String?
+
+    static func messagesBeforeFailedTurn(
+        in messages: [Message],
+        failedUserMessageId: UUID
+    ) -> [Message]? {
+        guard let failedUserIndex = messages.firstIndex(where: {
+            $0.id == failedUserMessageId && $0.role == .user
+        }) else {
+            return nil
+        }
+
+        return Array(messages.prefix(failedUserIndex))
+    }
+
+    static func hasSubstantiveText(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    init(
+        messages: [Message],
+        failedUserMessageId: UUID?,
+        assistantPlaceholderId: UUID?,
+        failedUserMessagePolicy: FailedUserMessagePolicy
+    ) {
+        let failedUserMessage = failedUserMessageId.flatMap { userId in
+            messages.first { $0.id == userId && $0.role == .user }
+        }
+        let assistantMessage = assistantPlaceholderId.flatMap { assistantId in
+            messages.first { $0.id == assistantId && $0.role == .assistant }
+        }
+
+        let shouldOfferRetry = failedUserMessagePolicy == .removeForRetry
+            && failedUserMessage.map(Self.canRecreateFromTextOnly) == true
+            && assistantMessage.map(Self.canRetryAfterAssistantState) == true
+
+        retryPrompt = shouldOfferRetry ? failedUserMessage?.content : nil
+        messagesAfterFailure = messages.filter { message in
+            guard let assistantPlaceholderId,
+                  message.id == assistantPlaceholderId,
+                  message.role == .assistant
+            else {
+                return true
+            }
+            return !Self.isRemovableAssistantPlaceholder(message)
+        }
+    }
+
+    private static func canRecreateFromTextOnly(_ message: Message) -> Bool {
+        let hasAttachments = !(message.attachments?.isEmpty ?? true)
+        return hasSubstantiveText(message.content)
+            && !hasAttachments
+            && message.mediaType == nil
+            && message.imageData == nil
+            && message.imagePath == nil
+    }
+
+    private static func isRemovableAssistantPlaceholder(_ message: Message) -> Bool {
+        isEmptyAssistantState(message, citationsPreventMatch: true)
+    }
+
+    /// Citations remain visible transcript metadata, but still allow retrying the
+    /// originating text-only request when no assistant text or reasoning arrived.
+    private static func canRetryAfterAssistantState(_ message: Message) -> Bool {
+        isEmptyAssistantState(message, citationsPreventMatch: false)
+    }
+
+    private static func isEmptyAssistantState(
+        _ message: Message,
+        citationsPreventMatch: Bool
+    ) -> Bool {
+        guard message.role == .assistant,
+              !hasSubstantiveText(message.content)
+        else {
+            return false
+        }
+
+        let hasAttachments = !(message.attachments?.isEmpty ?? true)
+        let hasReasoning = hasSubstantiveText(message.reasoning)
+        let hasCitations = !(message.citations?.isEmpty ?? true)
+        let hasToolCalls = !(message.toolCalls?.isEmpty ?? true)
+        #if os(watchOS)
+            let hasPendingToolCalls = false
+        #else
+            let hasPendingToolCalls = !(message.pendingToolCalls?.isEmpty ?? true)
+        #endif
+
+        return !hasAttachments
+            && !hasReasoning
+            && (!citationsPreventMatch || !hasCitations)
+            && !hasToolCalls
+            && !hasPendingToolCalls
+            && message.mediaType == nil
+            && message.imageData == nil
+            && message.imagePath == nil
+    }
+}

--- a/Sources/Ayna/Chat/ChatTurnFailurePlan.swift
+++ b/Sources/Ayna/Chat/ChatTurnFailurePlan.swift
@@ -47,10 +47,14 @@ struct ChatTurnFailurePlan: Equatable, Sendable {
         let assistantMessage = assistantPlaceholderId.flatMap { assistantId in
             messages.first { $0.id == assistantId && $0.role == .assistant }
         }
+        // Finalization only removes empty single-response placeholders, so an identified
+        // placeholder that is already absent still represents a retryable no-output failure.
+        let canRetryAfterAssistantState = assistantPlaceholderId != nil
+            && (assistantMessage.map(Self.canRetryAfterAssistantState) ?? true)
 
         let shouldOfferRetry = failedUserMessagePolicy == .removeForRetry
             && failedUserMessage.map(Self.canRecreateFromTextOnly) == true
-            && assistantMessage.map(Self.canRetryAfterAssistantState) == true
+            && canRetryAfterAssistantState
 
         retryPrompt = shouldOfferRetry ? failedUserMessage?.content : nil
         messagesAfterFailure = messages.filter { message in

--- a/Sources/Ayna/Chat/ChatTurnRequestPlan.swift
+++ b/Sources/Ayna/Chat/ChatTurnRequestPlan.swift
@@ -1,0 +1,79 @@
+//
+//  ChatTurnRequestPlan.swift
+//  Ayna
+//
+//  Plans the provider-visible history for a chat turn.
+//
+
+import Foundation
+
+/// Pure request-history construction shared by chat entry points.
+struct ChatTurnRequestPlan: Equatable, Sendable {
+    let messages: [Message]
+
+    init(history: [Message], systemPrompt: String?) {
+        messages = Self.messages(from: history, systemPrompt: systemPrompt)
+    }
+
+    init(
+        history: [Message],
+        systemPrompt: String?,
+        excludingAssistantPlaceholderId placeholderId: UUID?
+    ) {
+        self.init(
+            history: Self.history(
+                from: history,
+                excludingAssistantPlaceholderId: placeholderId
+            ),
+            systemPrompt: systemPrompt
+        )
+    }
+
+    init(
+        conversation: Conversation,
+        systemPrompt: String?,
+        excludingAssistantPlaceholderId placeholderId: UUID?
+    ) {
+        self.init(
+            history: conversation.getEffectiveHistory(),
+            systemPrompt: systemPrompt,
+            excludingAssistantPlaceholderId: placeholderId
+        )
+    }
+
+    static func messages(from history: [Message], systemPrompt: String?) -> [Message] {
+        guard let systemPrompt,
+              !systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return history
+        }
+
+        return [Message(role: .system, content: systemPrompt)] + history
+    }
+
+    static func effectiveMessages(
+        from conversation: Conversation,
+        systemPrompt: String?,
+        excludingResponseGroupId responseGroupId: UUID? = nil
+    ) -> [Message] {
+        var history = conversation.getEffectiveHistory()
+        if let responseGroupId {
+            history.removeAll { $0.responseGroupId == responseGroupId }
+        }
+        return messages(from: history, systemPrompt: systemPrompt)
+    }
+
+    private static func history(
+        from messages: [Message],
+        excludingAssistantPlaceholderId placeholderId: UUID?
+    ) -> [Message] {
+        guard let placeholderId else { return messages }
+
+        return messages.filter { message in
+            guard message.id == placeholderId, message.role == .assistant else {
+                return true
+            }
+            return !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+}

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -46,6 +46,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
 
     /// The last failed message content, stored for retry functionality
     @Published var failedMessage: String?
+    private var failedMessageId: UUID?
 
     /// Recovery suggestion for the current error (if available)
     @Published var errorRecoverySuggestion: String?
@@ -257,6 +258,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         errorMessage = nil
         errorRecoverySuggestion = nil
         failedMessage = nil
+        failedMessageId = nil
         cleanupAttachedFiles()
         attachedImages.removeAll()
         selectedModel = aiService.selectedModel
@@ -399,10 +401,26 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             metadata: ["messageLength": "\(message.count)"]
         )
 
+        let messageId = failedMessageId
+
         // Clear error state
         failedMessage = nil
+        failedMessageId = nil
         errorMessage = nil
         errorRecoverySuggestion = nil
+
+        if let messageId,
+           let conversation,
+           let messagesBeforeFailedTurn = ChatTurnFailurePlan.messagesBeforeFailedTurn(
+               in: conversation.messages,
+               failedUserMessageId: messageId
+           )
+        {
+            var updatedConversation = conversation
+            updatedConversation.messages = messagesBeforeFailedTurn
+            updatedConversation.updatedAt = Date()
+            conversationManager.updateConversation(updatedConversation)
+        }
 
         // Set message text and send
         messageText = message
@@ -412,6 +430,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     /// Dismiss the current error without retrying
     func dismissError() {
         failedMessage = nil
+        failedMessageId = nil
         errorMessage = nil
         errorRecoverySuggestion = nil
     }
@@ -739,6 +758,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         errorMessage = nil
         errorRecoverySuggestion = nil
         failedMessage = nil
+        failedMessageId = nil
 
         // Play message sent sound
         SoundEngine.messageSent()
@@ -789,15 +809,11 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             return
         }
 
-            // Linearize multi-model history and omit failed/empty placeholders. The newly added
-            // empty assistant is also excluded by effective-history filtering.
-            var messagesToSend = updatedConversation.getEffectiveHistory()
-
-        // Prepend system prompt if configured
-        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan(
+            conversation: updatedConversation,
+            systemPrompt: conversationManager.effectiveSystemPrompt(for: updatedConversation),
+            excludingAssistantPlaceholderId: assistantMessage.id
+        ).messages
 
         // Get available tools (Tavily web search on iOS)
         let tools = aiService.getAllAvailableTools()
@@ -838,6 +854,10 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         let toolsWrapper = UncheckedSendable(tools)
         let coordinator = toolChainCoordinator
         let roundCoordinator = toolCallRequestRoundCoordinator
+        let failedUserMessageId = messages.last(where: { $0.role == .user })?.id
+        let failedUserMessagePolicy: ChatTurnFailurePlan.FailedUserMessagePolicy = isNewChatMode
+            ? .preserve
+            : .removeForRetry
         let operationID = existingOperationID ?? coordinator.beginOperation(conversationID: conversationId)
         if existingOperationID == nil {
             activeMultiModelResponseGroupId = nil
@@ -942,7 +962,9 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                             error,
                             operationID: operationID,
                             assistantMessageId: assistantMessageId,
-                            conversationId: conversationId
+                            conversationId: conversationId,
+                            failedUserMessageId: failedUserMessageId,
+                            failedUserMessagePolicy: failedUserMessagePolicy
                         )
                     }
                 },
@@ -1203,12 +1225,11 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                                 return
                             }
 
-            var history = conversationWithAssistant
-            history.messages.removeAll { $0.id == continuationAssistantMessage.id }
-            var continuationMessages = history.getEffectiveHistory()
-            if let systemPrompt = conversationManager.effectiveSystemPrompt(for: conversationWithAssistant) {
-                continuationMessages.insert(Message(role: .system, content: systemPrompt), at: 0)
-            }
+            let continuationMessages = ChatTurnRequestPlan(
+                conversation: conversationWithAssistant,
+                systemPrompt: conversationManager.effectiveSystemPrompt(for: conversationWithAssistant),
+                excludingAssistantPlaceholderId: continuationAssistantMessage.id
+            ).messages
 
             currentToolName = nil
             sendMessageWithToolSupport(
@@ -1238,6 +1259,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             currentToolName = nil
             toolCallDepth = 0
             pendingUserMessage = nil
+            failedMessage = nil
+            failedMessageId = nil
             SoundEngine.messageReceived()
 
             if let finalConversation = conversationManager.conversation(byId: conversationId) {
@@ -1260,7 +1283,9 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             _ error: Error,
             operationID: ToolChainCoordinator.OperationID,
             assistantMessageId: UUID,
-            conversationId: UUID
+            conversationId: UUID,
+            failedUserMessageId: UUID?,
+            failedUserMessagePolicy: ChatTurnFailurePlan.FailedUserMessagePolicy
         ) {
             guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
                   activeAssistantMessageId == assistantMessageId
@@ -1305,20 +1330,23 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             toolCallDepth = 0
             errorMessage = ErrorPresenter.userMessage(for: error)
             errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
-            failedMessage = pendingUserMessage
             pendingUserMessage = nil
-            let assistantHasToolCalls = conversationManager
-                .conversation(byId: conversationId)?
-                .messages.first(where: { $0.id == assistantMessageId })?
-                .toolCalls?.isEmpty == false
-            if !assistantHasToolCalls {
-                conversationManager.removeMessage(
-                    conversationId: conversationId,
-                    messageId: assistantMessageId
+            if let current = conversationManager.conversation(byId: conversationId) {
+                let plan = ChatTurnFailurePlan(
+                    messages: current.messages,
+                    failedUserMessageId: failedUserMessageId,
+                    assistantPlaceholderId: assistantMessageId,
+                    failedUserMessagePolicy: failedUserMessagePolicy
                 )
-            }
-            if let updatedConversation = conversationManager.conversation(byId: conversationId) {
-                conversationManager.save(updatedConversation)
+                var updatedConversation = current
+                updatedConversation.messages = plan.messagesAfterFailure
+                updatedConversation.updatedAt = Date()
+                conversationManager.updateConversation(updatedConversation)
+                failedMessage = plan.retryPrompt
+                failedMessageId = plan.retryPrompt == nil ? nil : failedUserMessageId
+            } else {
+                failedMessage = nil
+                failedMessageId = nil
                         }
 
             if isNewChatMode {
@@ -1633,13 +1661,11 @@ extension IOSChatViewModel {
             )
             return
         }
-            var messagesToSend = updatedConversation.getEffectiveHistory()
-
-        // Prepend system prompt if configured
-        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan(
+            conversation: updatedConversation,
+            systemPrompt: conversationManager.effectiveSystemPrompt(for: updatedConversation),
+            excludingAssistantPlaceholderId: assistantMessage.id
+        ).messages
 
         // Get available tools and use helper method
         let tools = aiService.getAllAvailableTools()
@@ -1692,13 +1718,11 @@ extension IOSChatViewModel {
             )
             return
         }
-            var messagesToSend = refreshed.getEffectiveHistory()
-
-        // Prepend system prompt if configured
-        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: refreshed) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan(
+            conversation: refreshed,
+            systemPrompt: conversationManager.effectiveSystemPrompt(for: refreshed),
+            excludingAssistantPlaceholderId: assistantMessage.id
+        ).messages
 
         let tools = aiService.getAllAvailableTools()
         toolCallDepth = 0
@@ -1771,13 +1795,11 @@ extension IOSChatViewModel {
             )
             return
         }
-            var messagesToSend = updatedConversation.getEffectiveHistory()
-
-        // Prepend system prompt if configured
-        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan(
+            conversation: updatedConversation,
+            systemPrompt: conversationManager.effectiveSystemPrompt(for: updatedConversation),
+            excludingAssistantPlaceholderId: assistantMessage.id
+        ).messages
 
         // Get available tools and use helper method
         let tools = aiService.getAllAvailableTools()
@@ -1862,10 +1884,11 @@ extension IOSChatViewModel {
             isGenerating = false
             return
         }
-        var messagesToSend = updatedConversation.getEffectiveHistory().filter { $0.responseGroupId != responseGroupId }
-        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
-            messagesToSend.insert(Message(role: .system, content: systemPrompt), at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan.effectiveMessages(
+            from: updatedConversation,
+            systemPrompt: conversationManager.effectiveSystemPrompt(for: updatedConversation),
+            excludingResponseGroupId: responseGroupId
+        )
 
             // Send to all models under this view model's owner-specific operation.
             let coordinator = toolChainCoordinator

--- a/Sources/Ayna/ViewModels/WatchChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/WatchChatViewModel.swift
@@ -1104,9 +1104,7 @@ final class WatchToolCallRoundRegistry {
                 finalContent: message.content
             )
 
-            let hasAssistantState = !message.content.isEmpty ||
-                !(message.citations?.isEmpty ?? true) ||
-                !(message.toolCalls?.isEmpty ?? true)
+            let hasAssistantState = Self.hasSubstantiveAssistantState(message)
             let turnStartIndex = conversation.messages[...messageIndex].lastIndex {
                 $0.role == Message.Role.user.rawValue
             } ?? messageIndex
@@ -1134,6 +1132,12 @@ final class WatchToolCallRoundRegistry {
                 conversationStore.discardDraft(conversationID: conversationId)
                 return .discarded
             }
+        }
+
+        static func hasSubstantiveAssistantState(_ message: WatchMessage) -> Bool {
+            ChatTurnFailurePlan.hasSubstantiveText(message.content) ||
+                !(message.citations?.isEmpty ?? true) ||
+                !(message.toolCalls?.isEmpty ?? true)
         }
 
         private func makePendingResponsePromotion(

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
@@ -452,12 +452,10 @@ extension MacChatView {
 
         let messageIdsByModel = responsePlan.messageIDsByModel
 
-        // Prepare messages for API
-        var messagesToSend = updatedConversation.getEffectiveHistory()
-        if let systemPrompt = buildFullSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan.effectiveMessages(
+            from: updatedConversation,
+            systemPrompt: buildFullSystemPrompt(for: updatedConversation)
+        )
 
         // Capture necessary values for closures
         let conversationId = conversation.id

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
@@ -117,14 +117,10 @@ extension MacChatView {
             return
         }
 
-        let currentMessages = updatedConversation.messages
-
-        // Prepend system prompt if configured
-        var messagesToSend = currentMessages
-        if let systemPrompt = buildFullSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan.effectiveMessages(
+            from: updatedConversation,
+            systemPrompt: buildFullSystemPrompt(for: updatedConversation)
+        )
 
         // Add empty assistant message with current model
         let assistantMessage = Message(role: .assistant, content: "", model: updatedConversation.model)
@@ -142,7 +138,9 @@ extension MacChatView {
             temperature: updatedConversation.temperature,
             tools: tools,
             isInitialRequest: true,
-            assistantMessageID: assistantMessage.id
+            assistantMessageID: assistantMessage.id,
+            failedUserMessageId: nil,
+            failedUserMessagePolicy: .preserve
         )
     }
 
@@ -169,14 +167,10 @@ extension MacChatView {
             return
         }
 
-        let currentMessages = updatedConversation.messages
-
-        // Prepend system prompt if configured
-        var messagesToSend = currentMessages
-        if let systemPrompt = buildFullSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan.effectiveMessages(
+            from: updatedConversation,
+            systemPrompt: buildFullSystemPrompt(for: updatedConversation)
+        )
 
         // Add empty assistant message with the specified model
         let assistantMessage = Message(role: .assistant, content: "", model: model)
@@ -194,7 +188,9 @@ extension MacChatView {
             temperature: updatedConversation.temperature,
             tools: tools,
             isInitialRequest: true,
-            assistantMessageID: assistantMessage.id
+            assistantMessageID: assistantMessage.id,
+            failedUserMessageId: nil,
+            failedUserMessagePolicy: .preserve
         )
     }
 

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -145,6 +145,7 @@ struct MacChatView: View {
     @State var errorMessage: String?
     @State var errorRecoverySuggestion: String?
     @State private var failedMessage: String?
+    @State private var failedMessageId: UUID?
     @State private var selectedModel: String
     @State private var attachedFiles: [URL] = []
     @State var toolCallDepth = 0
@@ -475,12 +476,10 @@ struct MacChatView: View {
 
         isGenerating = true
 
-        // Build messages for API using the same pattern as sendMessage
-            var messagesToSend = currentConversation.getEffectiveHistory()
-        if let systemPrompt = buildFullSystemPrompt(for: currentConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan.effectiveMessages(
+            from: currentConversation,
+            systemPrompt: buildFullSystemPrompt(for: currentConversation)
+        )
 
         // Create assistant placeholder
         let assistantMessage = Message(role: .assistant, content: "", model: currentConversation.model)
@@ -495,8 +494,10 @@ struct MacChatView: View {
             model: currentConversation.model,
             temperature: currentConversation.temperature,
             tools: tools,
-                isInitialRequest: true,
-                assistantMessageID: assistantMessage.id
+            isInitialRequest: true,
+            assistantMessageID: assistantMessage.id,
+            failedUserMessageId: nil,
+            failedUserMessagePolicy: .preserve
         )
     }
 
@@ -701,10 +702,25 @@ struct MacChatView: View {
 
         logChat("🔄 Retrying failed message", level: .info, metadata: ["messageLength": "\(message.count)"])
 
+        let messageId = failedMessageId
+
         // Clear error state
         failedMessage = nil
+        failedMessageId = nil
         errorMessage = nil
         errorRecoverySuggestion = nil
+
+        if let messageId,
+           let messagesBeforeFailedTurn = ChatTurnFailurePlan.messagesBeforeFailedTurn(
+               in: currentConversation.messages,
+               failedUserMessageId: messageId
+           )
+        {
+            var updatedConversation = currentConversation
+            updatedConversation.messages = messagesBeforeFailedTurn
+            updatedConversation.updatedAt = Date()
+            conversationManager.updateConversation(updatedConversation)
+        }
 
         // Set message text and send
         messageText = message
@@ -714,6 +730,7 @@ struct MacChatView: View {
     /// Dismiss the current error without retrying
     private func dismissError() {
         failedMessage = nil
+        failedMessageId = nil
         errorMessage = nil
         errorRecoverySuggestion = nil
     }
@@ -1029,6 +1046,7 @@ struct MacChatView: View {
         errorMessage = nil
         errorRecoverySuggestion = nil
         failedMessage = promptText // Store for retry in case of failure
+        failedMessageId = userMessage.id
         logChat("🔄 isGenerating set to TRUE", level: .info)
 
         // Get updated messages after adding user message
@@ -1065,14 +1083,10 @@ struct MacChatView: View {
             return
         }
 
-            let currentMessages = updatedConversation.getEffectiveHistory()
-
-        // Prepend system prompt if configured
-        var messagesToSend = currentMessages
-        if let systemPrompt = buildFullSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan.effectiveMessages(
+            from: updatedConversation,
+            systemPrompt: buildFullSystemPrompt(for: updatedConversation)
+        )
 
         // Add empty assistant message with current model
         let assistantMessage = Message(role: .assistant, content: "", model: activeModel)
@@ -1148,12 +1162,14 @@ struct MacChatView: View {
             temperature: updatedConversation.temperature,
             tools: tools,
             isInitialRequest: true,
-            assistantMessageID: assistantMessage.id
+            assistantMessageID: assistantMessage.id,
+            failedUserMessageId: userMessage.id,
+            failedUserMessagePolicy: .removeForRetry
         )
     }
 
     // Helper function to send messages with automatic tool call handling
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length function_parameter_count
     func sendMessageWithToolSupport(
         messages: [Message],
         model: String,
@@ -1161,7 +1177,9 @@ struct MacChatView: View {
         tools: [[String: Any]]?,
         isInitialRequest _: Bool,
         assistantMessageID requestedAssistantMessageID: UUID? = nil,
-        operationID existingOperationID: ToolChainCoordinator.OperationID? = nil
+        operationID existingOperationID: ToolChainCoordinator.OperationID? = nil,
+        failedUserMessageId: UUID?,
+        failedUserMessagePolicy: ChatTurnFailurePlan.FailedUserMessagePolicy
     ) {
         let maxToolCallDepth = AgentSettingsStore.shared.settings.maxToolChainDepth
         let mcpManager = MCPServerManager.shared
@@ -1276,7 +1294,9 @@ struct MacChatView: View {
                             conversationID: conversationId,
                             model: model,
                             temperature: temperature,
-                            tools: toolsWrapper.value
+                            tools: toolsWrapper.value,
+                            failedUserMessageId: failedUserMessageId,
+                            failedUserMessagePolicy: failedUserMessagePolicy
                         )
                 }
             },
@@ -1285,7 +1305,8 @@ struct MacChatView: View {
                         guard activeAssistantMessageID == assistantMessageID else { return }
                         guard coordinator.owns(operationID, conversationID: conversationId) else { return }
                         abortOwnedTextGeneration(operationID: operationID, conversationID: conversationId)
-                        if !(error is CancellationError) {
+                        guard !(error is CancellationError) else { return }
+
                     logChat(
                         "❌ Stream error",
                         level: .error,
@@ -1293,7 +1314,24 @@ struct MacChatView: View {
                     )
                     errorMessage = ErrorPresenter.userMessage(for: error)
                     errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
-                }
+
+                        if let current = conversationManager.conversation(byId: conversationId) {
+                            let plan = ChatTurnFailurePlan(
+                                messages: current.messages,
+                                failedUserMessageId: failedUserMessageId,
+                                assistantPlaceholderId: assistantMessageID,
+                                failedUserMessagePolicy: failedUserMessagePolicy
+                            )
+                            var updatedConversation = current
+                            updatedConversation.messages = plan.messagesAfterFailure
+                            updatedConversation.updatedAt = Date()
+                            conversationManager.updateConversation(updatedConversation)
+                            failedMessage = plan.retryPrompt
+                            failedMessageId = plan.retryPrompt == nil ? nil : failedUserMessageId
+                        } else {
+                            failedMessage = nil
+                            failedMessageId = nil
+                        }
                     }
             },
             onToolCallRequested: toolCallAdmissionGate.admittedCallback { toolCallId, toolName, arguments in
@@ -1421,7 +1459,9 @@ struct MacChatView: View {
                                 conversationID: conversationId,
                                 model: model,
                                 temperature: temperature,
-                                tools: toolsWrapper.value
+                                tools: toolsWrapper.value,
+                                failedUserMessageId: failedUserMessageId,
+                                failedUserMessagePolicy: failedUserMessagePolicy
                             )
                         }
                     }
@@ -1437,7 +1477,9 @@ struct MacChatView: View {
             conversationID: UUID,
             model: String,
             temperature: Double,
-            tools: [[String: Any]]?
+            tools: [[String: Any]]?,
+            failedUserMessageId: UUID?,
+            failedUserMessagePolicy: ChatTurnFailurePlan.FailedUserMessagePolicy
         ) {
             switch resolution {
             case .pending:
@@ -1453,6 +1495,7 @@ struct MacChatView: View {
                 toolCallDepth = 0
                 isGenerating = false
                 failedMessage = nil
+                failedMessageId = nil
             case let .launchContinuation(continuation):
                 toolChainTimeoutTask?.cancel()
                 toolChainTimeoutTask = nil
@@ -1463,7 +1506,9 @@ struct MacChatView: View {
                     conversationID: conversationID,
                     model: model,
                     temperature: temperature,
-                    tools: tools
+                    tools: tools,
+                    failedUserMessageId: failedUserMessageId,
+                    failedUserMessagePolicy: failedUserMessagePolicy
                 )
             }
         }
@@ -1475,7 +1520,9 @@ struct MacChatView: View {
             conversationID: UUID,
             model: String,
             temperature: Double,
-            tools: [[String: Any]]?
+            tools: [[String: Any]]?,
+            failedUserMessageId: UUID?,
+            failedUserMessagePolicy: ChatTurnFailurePlan.FailedUserMessagePolicy
         ) {
             guard toolChainCoordinator.owns(operationID, conversationID: conversationID),
                   continuation.operationID == operationID,
@@ -1503,12 +1550,11 @@ struct MacChatView: View {
                 return
             }
 
-            var history = conversationWithAssistant
-            history.messages.removeAll { $0.id == continuationMessage.id }
-            var continuationMessages = history.getEffectiveHistory()
-            if let systemPrompt = buildFullSystemPrompt(for: conversationWithAssistant) {
-                continuationMessages.insert(Message(role: .system, content: systemPrompt), at: 0)
-            }
+            let continuationMessages = ChatTurnRequestPlan(
+                conversation: conversationWithAssistant,
+                systemPrompt: buildFullSystemPrompt(for: conversationWithAssistant),
+                excludingAssistantPlaceholderId: continuationMessage.id
+            ).messages
 
             currentToolName = nil
             sendMessageWithToolSupport(
@@ -1518,7 +1564,9 @@ struct MacChatView: View {
                 tools: tools,
                 isInitialRequest: false,
                 assistantMessageID: continuationMessage.id,
-                operationID: operationID
+                operationID: operationID,
+                failedUserMessageId: failedUserMessageId,
+                failedUserMessagePolicy: failedUserMessagePolicy
             )
         }
     }

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -585,11 +585,16 @@ struct MacNewChatView: View {
             metadata: ["conversationId": conversation.id.uuidString]
         )
 
-        let currentMessages = updatedConversation.messages
-
         // Add empty assistant message with current model
         let assistantMessage = Message(role: .assistant, content: "", model: activeModel)
         conversationManager.addMessage(to: conversation, message: assistantMessage)
+
+        let messagesToSend = ChatTurnRequestPlan(
+            conversation: updatedConversation,
+            systemPrompt: conversationManager.effectiveSystemPrompt(for: updatedConversation),
+            excludingAssistantPlaceholderId: assistantMessage.id
+        ).messages
+        let failedUserMessageId = updatedConversation.messages.last(where: { $0.role == .user })?.id
 
         // Get available tools (Tavily + MCP)
         let tools = aiService.getAllAvailableTools()
@@ -597,11 +602,13 @@ struct MacNewChatView: View {
 
         sendMessageWithToolSupport(
             conversation: conversation,
-            messages: currentMessages,
+            messages: messagesToSend,
             model: activeModel,
             temperature: updatedConversation.temperature,
                 tools: tools,
-                assistantMessageID: assistantMessage.id
+            assistantMessageID: assistantMessage.id,
+            failedUserMessageId: failedUserMessageId,
+            failedUserMessagePolicy: .preserve
         )
     }
 
@@ -891,12 +898,10 @@ struct MacNewChatView: View {
 
         let messageIdsByModel = responsePlan.messageIDsByModel
 
-        // Prepare messages for API
-        var messagesToSend = updatedConversation.getEffectiveHistory()
-        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
+        let messagesToSend = ChatTurnRequestPlan.effectiveMessages(
+            from: updatedConversation,
+            systemPrompt: conversationManager.effectiveSystemPrompt(for: updatedConversation)
+        )
 
             // Send to all models in parallel under this view's owner-specific operation.
             let coordinator = toolChainCoordinator
@@ -1017,7 +1022,7 @@ struct MacNewChatView: View {
             }
     }
 
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length function_parameter_count
     private func sendMessageWithToolSupport(
         conversation: Conversation,
         messages: [Message],
@@ -1025,7 +1030,9 @@ struct MacNewChatView: View {
         temperature: Double,
         tools: [[String: Any]]?,
         assistantMessageID requestedAssistantMessageID: UUID? = nil,
-        operationID existingOperationID: ToolChainCoordinator.OperationID? = nil
+        operationID existingOperationID: ToolChainCoordinator.OperationID? = nil,
+        failedUserMessageId: UUID?,
+        failedUserMessagePolicy: ChatTurnFailurePlan.FailedUserMessagePolicy
     ) {
         let maxToolCallDepth = AgentSettingsStore.shared.settings.maxToolChainDepth
         let conversationId = conversation.id
@@ -1104,7 +1111,9 @@ struct MacNewChatView: View {
                             conversationID: conversationId,
                             model: model,
                             temperature: temperature,
-                            tools: toolsWrapper.value
+                            tools: toolsWrapper.value,
+                            failedUserMessageId: failedUserMessageId,
+                            failedUserMessagePolicy: failedUserMessagePolicy
                         )
                 }
             },
@@ -1121,9 +1130,21 @@ struct MacNewChatView: View {
                             "error": error.localizedDescription
                         ]
                     )
-                        if !(error is CancellationError) {
-                    presentError(error)
-                }
+                        guard !(error is CancellationError) else { return }
+
+                        if let current = conversationManager.conversation(byId: conversationId) {
+                            let plan = ChatTurnFailurePlan(
+                                messages: current.messages,
+                                failedUserMessageId: failedUserMessageId,
+                                assistantPlaceholderId: assistantMessageID,
+                                failedUserMessagePolicy: failedUserMessagePolicy
+                            )
+                            var updatedConversation = current
+                            updatedConversation.messages = plan.messagesAfterFailure
+                            updatedConversation.updatedAt = Date()
+                            conversationManager.updateConversation(updatedConversation)
+                        }
+                        presentError(error)
                     }
             },
             onToolCallRequested: toolCallAdmissionGate.admittedCallback { toolCallId, toolName, arguments in
@@ -1242,7 +1263,9 @@ struct MacNewChatView: View {
                                 conversationID: conversationId,
                                     model: model,
                                     temperature: temperature,
-                                    tools: toolsWrapper.value
+                                tools: toolsWrapper.value,
+                                failedUserMessageId: failedUserMessageId,
+                                failedUserMessagePolicy: failedUserMessagePolicy
                                 )
                             }
                     }
@@ -1269,7 +1292,9 @@ struct MacNewChatView: View {
             conversationID: UUID,
             model: String,
             temperature: Double,
-            tools: [[String: Any]]?
+            tools: [[String: Any]]?,
+            failedUserMessageId: UUID?,
+            failedUserMessagePolicy: ChatTurnFailurePlan.FailedUserMessagePolicy
         ) {
             switch resolution {
             case .pending, .ignored:
@@ -1294,7 +1319,9 @@ struct MacNewChatView: View {
                     conversationID: conversationID,
                     model: model,
                     temperature: temperature,
-                    tools: tools
+                    tools: tools,
+                    failedUserMessageId: failedUserMessageId,
+                    failedUserMessagePolicy: failedUserMessagePolicy
                 )
             }
         }
@@ -1306,7 +1333,9 @@ struct MacNewChatView: View {
             conversationID: UUID,
             model: String,
             temperature: Double,
-            tools: [[String: Any]]?
+            tools: [[String: Any]]?,
+            failedUserMessageId: UUID?,
+            failedUserMessagePolicy: ChatTurnFailurePlan.FailedUserMessagePolicy
         ) {
             guard toolChainCoordinator.owns(operationID, conversationID: conversationID),
                   continuation.operationID == operationID,
@@ -1334,12 +1363,11 @@ struct MacNewChatView: View {
                 return
             }
 
-            var history = conversationWithAssistant
-            history.messages.removeAll { $0.id == continuationMessage.id }
-            var continuationMessages = history.getEffectiveHistory()
-            if let systemPrompt = conversationManager.effectiveSystemPrompt(for: conversationWithAssistant) {
-                continuationMessages.insert(Message(role: .system, content: systemPrompt), at: 0)
-            }
+            let continuationMessages = ChatTurnRequestPlan(
+                conversation: conversationWithAssistant,
+                systemPrompt: conversationManager.effectiveSystemPrompt(for: conversationWithAssistant),
+                excludingAssistantPlaceholderId: continuationMessage.id
+            ).messages
             currentToolName = nil
             sendMessageWithToolSupport(
                 conversation: conversationWithAssistant,
@@ -1348,9 +1376,11 @@ struct MacNewChatView: View {
                 temperature: temperature,
                 tools: tools,
                 assistantMessageID: continuationMessage.id,
-                operationID: operationID
-        )
-    }
+                operationID: operationID,
+                failedUserMessageId: failedUserMessageId,
+                failedUserMessagePolicy: failedUserMessagePolicy
+            )
+        }
 
     func presentError(_ error: Error) {
         errorMessage = ErrorPresenter.userMessage(for: error)

--- a/Tests/AynaTests/ChatTurnFailurePlanTests.swift
+++ b/Tests/AynaTests/ChatTurnFailurePlanTests.swift
@@ -1,0 +1,126 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("ChatTurnFailurePlan Tests", .tags(.fast))
+struct ChatTurnFailurePlanTests {
+    @Test
+    func `preserves the failed user and removes only its empty assistant placeholder`() {
+        let earlier = Message(role: .assistant, content: "Earlier")
+        let user = Message(role: .user, content: "Try this")
+        let placeholder = Message(role: .assistant, content: "")
+
+        let plan = ChatTurnFailurePlan(
+            messages: [earlier, user, placeholder],
+            failedUserMessageId: user.id,
+            assistantPlaceholderId: placeholder.id,
+            failedUserMessagePolicy: .preserve
+        )
+
+        #expect(plan.messagesAfterFailure == [earlier, user])
+        #expect(plan.retryPrompt == nil)
+    }
+
+    @Test
+    func `offers retry for a text-only user turn with no assistant output`() {
+        let user = Message(role: .user, content: "Retry me")
+        let placeholder = Message(role: .assistant, content: "")
+
+        let plan = ChatTurnFailurePlan(
+            messages: [user, placeholder],
+            failedUserMessageId: user.id,
+            assistantPlaceholderId: placeholder.id,
+            failedUserMessagePolicy: .removeForRetry
+        )
+
+        #expect(plan.messagesAfterFailure == [user])
+        #expect(plan.retryPrompt == user.content)
+    }
+
+    @Test
+    func `retry truncates the complete failed turn including tool continuations`() {
+        let earlier = Message(role: .assistant, content: "Earlier")
+        let user = Message(role: .user, content: "Search")
+        var toolRequest = Message(role: .assistant, content: "")
+        let toolResult = Message(role: .tool, content: "Result")
+        let continuation = Message(role: .assistant, content: "")
+        toolRequest.toolCalls = [MCPToolCall(toolName: "web_search", arguments: [:])]
+
+        let plan = ChatTurnFailurePlan(
+            messages: [earlier, user, toolRequest, toolResult, continuation],
+            failedUserMessageId: user.id,
+            assistantPlaceholderId: continuation.id,
+            failedUserMessagePolicy: .removeForRetry
+        )
+
+        #expect(plan.retryPrompt == user.content)
+        #expect(ChatTurnFailurePlan.messagesBeforeFailedTurn(
+            in: plan.messagesAfterFailure,
+            failedUserMessageId: user.id
+        ) == [earlier])
+    }
+
+    @Test
+    func `preserves partial text, reasoning, citations, and tool metadata`() {
+        let user = Message(role: .user, content: "Hello")
+        var toolAssistant = Message(role: .assistant, content: "")
+        toolAssistant.toolCalls = [MCPToolCall(toolName: "web_search", arguments: [:])]
+        let assistants = [
+            Message(role: .assistant, content: "Partial response"),
+            Message(role: .assistant, content: "", reasoning: "Thinking"),
+            Message(
+                role: .assistant,
+                content: "",
+                citations: [CitationReference(number: 1, title: "Source", url: "https://example.com")]
+            ),
+            toolAssistant,
+        ]
+
+        for assistant in assistants {
+            let plan = ChatTurnFailurePlan(
+                messages: [user, assistant],
+                failedUserMessageId: user.id,
+                assistantPlaceholderId: assistant.id,
+                failedUserMessagePolicy: .preserve
+            )
+            #expect(plan.messagesAfterFailure == [user, assistant])
+        }
+    }
+
+    @Test
+    func `treats whitespace-only content and reasoning as an empty placeholder`() {
+        let user = Message(role: .user, content: "Retry me")
+        let assistant = Message(role: .assistant, content: " \n ", reasoning: "\t")
+
+        let plan = ChatTurnFailurePlan(
+            messages: [user, assistant],
+            failedUserMessageId: user.id,
+            assistantPlaceholderId: assistant.id,
+            failedUserMessagePolicy: .removeForRetry
+        )
+
+        #expect(plan.messagesAfterFailure == [user])
+        #expect(plan.retryPrompt == user.content)
+    }
+
+    @Test
+    func `does not offer text-only retry for attachment prompts`() {
+        var user = Message(role: .user, content: "See attached")
+        user.attachments = [Message.FileAttachment(
+            fileName: "notes.txt",
+            mimeType: "text/plain",
+            data: Data([1, 2, 3])
+        )]
+        let placeholder = Message(role: .assistant, content: "")
+
+        let plan = ChatTurnFailurePlan(
+            messages: [user, placeholder],
+            failedUserMessageId: user.id,
+            assistantPlaceholderId: placeholder.id,
+            failedUserMessagePolicy: .removeForRetry
+        )
+
+        #expect(plan.messagesAfterFailure == [user])
+        #expect(plan.retryPrompt == nil)
+    }
+}

--- a/Tests/AynaTests/ChatTurnFailurePlanTests.swift
+++ b/Tests/AynaTests/ChatTurnFailurePlanTests.swift
@@ -38,6 +38,30 @@ struct ChatTurnFailurePlanTests {
     }
 
     @Test
+    func `immediate failure remains retryable after empty placeholder finalization`() {
+        let user = Message(role: .user, content: "Retry me")
+        let placeholder = Message(role: .assistant, content: "")
+        var conversation = Conversation(messages: [user, placeholder])
+
+        let finalization = ChatGenerationFinalizer.finalize(
+            conversation: &conversation,
+            activeAssistantMessageID: placeholder.id,
+            activeResponseGroupID: nil
+        )
+
+        let plan = ChatTurnFailurePlan(
+            messages: conversation.messages,
+            failedUserMessageId: user.id,
+            assistantPlaceholderId: placeholder.id,
+            failedUserMessagePolicy: .removeForRetry
+        )
+
+        #expect(finalization.removedAssistantMessageID == placeholder.id)
+        #expect(plan.messagesAfterFailure == [user])
+        #expect(plan.retryPrompt == user.content)
+    }
+
+    @Test
     func `retry truncates the complete failed turn including tool continuations`() {
         let earlier = Message(role: .assistant, content: "Earlier")
         let user = Message(role: .user, content: "Search")

--- a/Tests/AynaTests/ChatTurnRequestPlanTests.swift
+++ b/Tests/AynaTests/ChatTurnRequestPlanTests.swift
@@ -1,0 +1,121 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("ChatTurnRequestPlan Tests", .tags(.fast))
+struct ChatTurnRequestPlanTests {
+    @Test
+    func `prepends a non-empty system prompt`() {
+        let user = Message(role: .user, content: "Hello")
+
+        let plan = ChatTurnRequestPlan(history: [user], systemPrompt: "Be concise")
+
+        #expect(plan.messages.count == 2)
+        #expect(plan.messages[0].role == .system)
+        #expect(plan.messages[0].content == "Be concise")
+        #expect(plan.messages[1] == user)
+    }
+
+    @Test
+    func `ignores empty and whitespace-only system prompts`() {
+        let user = Message(role: .user, content: "Hello")
+
+        #expect(ChatTurnRequestPlan(history: [user], systemPrompt: "").messages == [user])
+        #expect(ChatTurnRequestPlan(history: [user], systemPrompt: "  \n ").messages == [user])
+    }
+
+    @Test
+    func `excludes only the matching assistant placeholder`() {
+        let user = Message(role: .user, content: "Hello")
+        let earlierAssistant = Message(role: .assistant, content: "Earlier")
+        let placeholder = Message(role: .assistant, content: "")
+        let conversation = Conversation(messages: [user, earlierAssistant, placeholder])
+
+        let plan = ChatTurnRequestPlan(
+            conversation: conversation,
+            systemPrompt: nil,
+            excludingAssistantPlaceholderId: placeholder.id
+        )
+
+        #expect(plan.messages == [user, earlierAssistant])
+    }
+
+    @Test
+    func `does not drop a user message when given the wrong placeholder identity`() {
+        let assistant = Message(role: .assistant, content: "Response")
+        let user = Message(role: .user, content: "Follow up")
+        let conversation = Conversation(messages: [assistant, user])
+
+        let plan = ChatTurnRequestPlan(
+            conversation: conversation,
+            systemPrompt: nil,
+            excludingAssistantPlaceholderId: user.id
+        )
+
+        #expect(plan.messages == [assistant, user])
+    }
+
+    @Test
+    func `uses effective history for selected multi-model responses`() {
+        let groupId = UUID()
+        let user = Message(role: .user, content: "Compare")
+        let unselected = Message(
+            role: .assistant,
+            content: "First response",
+            model: "model-a",
+            responseGroupId: groupId
+        )
+        let selected = Message(
+            role: .assistant,
+            content: "Selected response",
+            model: "model-b",
+            responseGroupId: groupId
+        )
+        let followUp = Message(role: .user, content: "Continue")
+        let placeholder = Message(role: .assistant, content: "")
+        let responseGroup = ResponseGroup(
+            id: groupId,
+            userMessageId: user.id,
+            responses: [
+                .init(id: unselected.id, modelName: "model-a", status: .completed),
+                .init(id: selected.id, modelName: "model-b", status: .selected),
+            ],
+            selectedResponseId: selected.id
+        )
+        let conversation = Conversation(
+            messages: [user, unselected, selected, followUp, placeholder],
+            responseGroups: [responseGroup]
+        )
+
+        let plan = ChatTurnRequestPlan(
+            conversation: conversation,
+            systemPrompt: nil,
+            excludingAssistantPlaceholderId: placeholder.id
+        )
+
+        #expect(plan.messages == [user, selected, followUp])
+    }
+
+    @Test
+    func `can exclude an in-flight response group`() {
+        let groupId = UUID()
+        let user = Message(role: .user, content: "Compare")
+        let grouped = Message(
+            role: .assistant,
+            content: "A",
+            model: "model-a",
+            responseGroupId: groupId
+        )
+        let conversation = Conversation(messages: [user, grouped])
+
+        let messages = ChatTurnRequestPlan.effectiveMessages(
+            from: conversation,
+            systemPrompt: "System",
+            excludingResponseGroupId: groupId
+        )
+
+        #expect(messages.count == 2)
+        #expect(messages[0].role == .system)
+        #expect(messages[1] == user)
+    }
+}

--- a/Tests/AynaTests/WatchChatViewModelNativeTests.swift
+++ b/Tests/AynaTests/WatchChatViewModelNativeTests.swift
@@ -151,6 +151,18 @@
             // Should not crash and state should remain unchanged
             #expect(!viewModel.isLoading)
         }
+
+        @Test
+        func `Whitespace-only assistant output is not substantive`() {
+            let message = WatchMessage(
+                id: UUID(),
+                role: Message.Role.assistant.rawValue,
+                content: " \n\t ",
+                timestamp: Date()
+            )
+
+            #expect(!WatchChatViewModel.hasSubstantiveAssistantState(message))
+        }
     }
 
     // swiftlint:enable identifier_name


### PR DESCRIPTION
## Summary

- centralize chat request-history and placeholder planning across macOS and iOS
- centralize failed-turn cleanup while preserving substantive partial output and metadata
- apply the shared substantive-output policy to watchOS retry handling
- fix macOS new-chat cleanup and treat cancellation as cancellation instead of a visible generation failure

## Why this is separate

This is the request/failure-planning portion of #95. It is stacked on #99 so reviewers can evaluate transcript planning first, then the request lifecycle changes independently.

## Validation

- `swiftlint --strict`
- focused `ChatTurnRequestPlanTests` and `ChatTurnFailurePlanTests` (12 tests)
- macOS build/test compile checks
- iOS compile check
- watchOS compile check

## Stack

- Base: #99
- Replaces part of: #95
