### PR TITLE
fix(chat): persist terminal conversation mutations

### DIFF
--- a/Sources/Ayna/ViewModels/ConversationManager.swift
+++ b/Sources/Ayna/ViewModels/ConversationManager.swift
@@ -2499,17 +2499,11 @@ final class ConversationManager: ObservableObject {
         messageId: UUID,
         update: (inout Message) -> Void
     ) -> Bool {
-        guard let convIndex = getConversationIndex(for: conversation.id),
-              let msgIndex = conversations[convIndex].messages.firstIndex(where: { $0.id == messageId })
-        else {
-            return false
-        }
-        var message = conversations[convIndex].messages[msgIndex]
-        update(&message)
-        conversations[convIndex].messages[msgIndex] = message
-        conversations[convIndex].updatedAt = Date()
-        save(conversations[convIndex])
-        return true
+        updateMessageAndPersist(
+            conversationId: conversation.id,
+            messageId: messageId,
+            update: update
+        )
     }
 
     // MARK: - Safe ID-Based Access
@@ -2526,11 +2520,46 @@ final class ConversationManager: ObservableObject {
         return nil
     }
 
-    /// Safely update a message by IDs. Returns true if update succeeded.
+    /// Safely updates a message in memory without scheduling persistence.
+    ///
+    /// Use this for streaming chunks such as reasoning deltas, then call an
+    /// explicit terminal persistence API when the response finishes.
     @discardableResult
     func updateMessage(
         conversationId: UUID,
         messageId: UUID,
+        update: (inout Message) -> Void
+    ) -> Bool {
+        mutateMessage(
+            conversationId: conversationId,
+            messageId: messageId,
+            shouldPersist: false,
+            update: update
+        )
+    }
+
+    /// Safely applies a completed message mutation and persists the conversation.
+    ///
+    /// The saved snapshot also includes any chunks or reasoning accumulated by
+    /// prior non-persisting streaming updates.
+    @discardableResult
+    func updateMessageAndPersist(
+        conversationId: UUID,
+        messageId: UUID,
+        update: (inout Message) -> Void
+    ) -> Bool {
+        mutateMessage(
+            conversationId: conversationId,
+            messageId: messageId,
+            shouldPersist: true,
+            update: update
+        )
+    }
+
+    private func mutateMessage(
+        conversationId: UUID,
+        messageId: UUID,
+        shouldPersist: Bool,
         update: (inout Message) -> Void
     ) -> Bool {
         guard let convIndex = getConversationIndex(for: conversationId),
@@ -2541,8 +2570,19 @@ final class ConversationManager: ObservableObject {
         var message = conversations[convIndex].messages[msgIndex]
         update(&message)
         conversations[convIndex].messages[msgIndex] = message
-        conversations[convIndex].updatedAt = Date()
+        if shouldPersist {
+            persistTerminalMutation(at: convIndex)
+        } else {
+            conversations[convIndex].updatedAt = Date()
+        }
         return true
+    }
+
+    /// Persists a completed conversation mutation that should survive reloads.
+    /// Streaming writes bypass this path so callers can choose one save point.
+    private func persistTerminalMutation(at conversationIndex: Int) {
+        conversations[conversationIndex].updatedAt = Date()
+        save(conversations[conversationIndex])
     }
 
     /// Safely append content to a message. Returns true if update succeeded.
@@ -2574,7 +2614,7 @@ final class ConversationManager: ObservableObject {
             return false
         }
         conversations[convIndex].messages.remove(at: msgIndex)
-        conversations[convIndex].updatedAt = Date()
+        persistTerminalMutation(at: convIndex)
         return true
     }
 
@@ -2587,12 +2627,19 @@ final class ConversationManager: ObservableObject {
         status: ResponseGroupStatus
     ) -> Bool {
         guard let convIndex = getConversationIndex(for: conversationId),
-              var group = conversations[convIndex].getResponseGroup(responseGroupId)
+              var group = conversations[convIndex].getResponseGroup(responseGroupId),
+              group.responses.contains(where: { $0.id == messageId })
         else {
             return false
         }
         group.updateStatus(for: messageId, status: status)
         conversations[convIndex].updateResponseGroup(group)
+        switch status {
+        case .streaming:
+            break
+        case .completed, .failed, .selected:
+            persistTerminalMutation(at: convIndex)
+        }
         return true
     }
 

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -2303,7 +2303,7 @@ extension IOSChatViewModel {
                         return
                     }
 
-                    let messageUpdated = self.conversationManager.updateMessage(
+                    let messageUpdated = self.conversationManager.updateMessageAndPersist(
                         conversationId: conversation.id,
                         messageId: assistantMessageId
                     ) { message in
@@ -2556,7 +2556,7 @@ extension IOSChatViewModel {
             }
             return
         }
-        let messageUpdated = conversationManager.updateMessage(
+        let messageUpdated = conversationManager.updateMessageAndPersist(
             conversationId: conversation.id,
             messageId: messageId
         ) { message in
@@ -2635,15 +2635,12 @@ extension IOSChatViewModel {
         messageId: UUID,
         status: ResponseGroup.ResponseStatus
     ) {
-        if let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
-           let groupIndex = conversationManager.conversations[conversationIndex].responseGroups.firstIndex(where: {
-               $0.id == responseGroupId
-           }),
-           let entryIndex = conversationManager.conversations[conversationIndex].responseGroups[groupIndex]
-           .responses.firstIndex(where: { $0.id == messageId })
-        {
-            conversationManager.conversations[conversationIndex].responseGroups[groupIndex].responses[entryIndex].status = status
-        }
+        conversationManager.updateResponseGroupStatus(
+            conversationId: conversationId,
+            responseGroupId: responseGroupId,
+            messageId: messageId,
+            status: status
+        )
     }
 
     /// Finalizes a batch of image generation requests

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
@@ -186,9 +186,7 @@ extension MacChatView {
         }
 
         // Add response group to conversation
-        if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }) {
-            conversationManager.conversations[index].responseGroups.append(responsePlan.responseGroup)
-        }
+        conversationManager.addResponseGroup(to: conversation, group: responsePlan.responseGroup)
 
         registerImageBatchCancellation(
             coordinator: coordinator,
@@ -378,16 +376,12 @@ extension MacChatView {
         messageId: UUID,
         status: ResponseGroup.ResponseStatus
     ) {
-        guard let conversationIndex = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }),
-              let groupIndex = conversationManager.conversations[conversationIndex].responseGroups.firstIndex(where: {
-                  $0.id == responseGroupId
-              }),
-              let entryIndex = conversationManager.conversations[conversationIndex].responseGroups[groupIndex]
-              .responses.firstIndex(where: { $0.id == messageId })
-        else {
-            return
-        }
-        conversationManager.conversations[conversationIndex].responseGroups[groupIndex].responses[entryIndex].status = status
+        conversationManager.updateResponseGroupStatus(
+            conversationId: conversation.id,
+            responseGroupId: responseGroupId,
+            messageId: messageId,
+            status: status
+        )
     }
 
     private func loadImageData(at path: String?) async -> Data? {
@@ -492,14 +486,12 @@ extension MacChatView {
                     multiModelReasoningBuffer.finish(for: messageId)
 
                     // Update response group status
-                    if let convIndex = conversationManager.conversations.firstIndex(where: {
-                        $0.id == conversationId
-                    }),
-                        var group = conversationManager.conversations[convIndex].getResponseGroup(responseGroupId)
-                    {
-                        group.updateStatus(for: messageId, status: .completed)
-                        conversationManager.conversations[convIndex].updateResponseGroup(group)
-                    }
+                    conversationManager.updateResponseGroupStatus(
+                        conversationId: conversationId,
+                        responseGroupId: responseGroupId,
+                        messageId: messageId,
+                        status: .completed
+                    )
 
                     logChat(
                         "✅ Model completed in multi-model",
@@ -531,14 +523,12 @@ extension MacChatView {
                     multiModelReasoningBuffer.finish(for: messageId)
 
                     // Update response group status to failed
-                    if let convIndex = conversationManager.conversations.firstIndex(where: {
-                        $0.id == conversationId
-                    }),
-                        var group = conversationManager.conversations[convIndex].getResponseGroup(responseGroupId)
-                    {
-                        group.updateStatus(for: messageId, status: .failed)
-                        conversationManager.conversations[convIndex].updateResponseGroup(group)
-                    }
+                    conversationManager.updateResponseGroupStatus(
+                        conversationId: conversationId,
+                        responseGroupId: responseGroupId,
+                        messageId: messageId,
+                        status: .failed
+                    )
 
                     logChat(
                         "❌ Model failed in multi-model",

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -365,21 +365,21 @@ struct MacNewChatView: View {
     }
 
     func updateResponseGroupStatus(conversationId: UUID, responseGroupId: UUID, messageId: UUID, status: ResponseGroup.ResponseStatus) {
-        if let ci = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
-           let gi = conversationManager.conversations[ci].responseGroups.firstIndex(where: { $0.id == responseGroupId }),
-           let ei = conversationManager.conversations[ci].responseGroups[gi].responses.firstIndex(where: { $0.id == messageId })
-        {
-            conversationManager.conversations[ci].responseGroups[gi].responses[ei].status = status
-        }
+        conversationManager.updateResponseGroupStatus(
+            conversationId: conversationId,
+            responseGroupId: responseGroupId,
+            messageId: messageId,
+            status: status
+        )
     }
 
     func updateResponseGroupViaGroup(conversationId: UUID, responseGroupId: UUID, messageId: UUID, status: ResponseGroup.ResponseStatus) {
-        if let ci = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
-           var group = conversationManager.conversations[ci].getResponseGroup(responseGroupId)
-        {
-            group.updateStatus(for: messageId, status: status)
-            conversationManager.conversations[ci].updateResponseGroup(group)
-        }
+        conversationManager.updateResponseGroupStatus(
+            conversationId: conversationId,
+            responseGroupId: responseGroupId,
+            messageId: messageId,
+            status: status
+        )
     }
 
     private func saveImageData(_ imageData: Data) async -> String? {
@@ -715,9 +715,7 @@ struct MacNewChatView: View {
             conversationManager.addMessage(to: conversation, message: placeholderMessage)
         }
 
-        if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }) {
-            conversationManager.conversations[index].responseGroups.append(responsePlan.responseGroup)
-        }
+        conversationManager.addResponseGroup(to: conversation, group: responsePlan.responseGroup)
 
         registerNewChatImageBatchCancellation(
             coordinator: coordinator,

--- a/Tests/AynaTests/ConversationManagerTerminalPersistenceTests.swift
+++ b/Tests/AynaTests/ConversationManagerTerminalPersistenceTests.swift
@@ -20,19 +20,12 @@ struct TerminalPersistenceTests {
         return manager
     }
 
-    @MainActor
-    private func reloadConversation(
+    private func loadPersistedConversation(
         _ conversationID: UUID,
         from store: EncryptedConversationStore
     ) async throws -> Conversation {
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            searchIndexWarmupEnabled: false,
-            spotlightIndexingEnabled: false
-        )
-        _ = await manager.loadingTask?.value
-        return try #require(await manager.ensureConversationLoaded(conversationID))
+        let conversation = try await store.loadConversation(id: conversationID)
+        return try #require(conversation)
     }
 
     @Test
@@ -56,7 +49,7 @@ struct TerminalPersistenceTests {
         })
 
         await manager.flushPendingSaves()
-        let beforeTerminalSave = try await reloadConversation(original.id, from: store)
+        let beforeTerminalSave = try await loadPersistedConversation(original.id, from: store)
         let originalAssistant = try #require(beforeTerminalSave.messages.first(where: { $0.id == assistant.id }))
         #expect(originalAssistant.content.isEmpty)
         #expect(originalAssistant.reasoning == nil)
@@ -69,7 +62,7 @@ struct TerminalPersistenceTests {
         })
         await manager.flushPendingSaves()
 
-        let reloaded = try await reloadConversation(original.id, from: store)
+        let reloaded = try await loadPersistedConversation(original.id, from: store)
         let reloadedAssistant = try #require(reloaded.messages.first(where: { $0.id == assistant.id }))
         #expect(reloadedAssistant.content == "Hello world")
         #expect(reloadedAssistant.reasoning == "Thinking")
@@ -94,7 +87,7 @@ struct TerminalPersistenceTests {
         ))
         await manager.flushPendingSaves()
 
-        let reloaded = try await reloadConversation(original.id, from: store)
+        let reloaded = try await loadPersistedConversation(original.id, from: store)
         #expect(!reloaded.messages.contains(where: { $0.id == removedMessageID }))
     }
 
@@ -147,7 +140,7 @@ struct TerminalPersistenceTests {
         ))
         await manager.flushPendingSaves()
 
-        let reloaded = try await reloadConversation(original.id, from: store)
+        let reloaded = try await loadPersistedConversation(original.id, from: store)
         let reloadedAssistant = try #require(reloaded.messages.first(where: { $0.id == assistant.id }))
         let reloadedGroup = try #require(reloaded.getResponseGroup(groupID))
         #expect(reloadedAssistant.content == "Completed response")

--- a/Tests/AynaTests/ConversationManagerTerminalPersistenceTests.swift
+++ b/Tests/AynaTests/ConversationManagerTerminalPersistenceTests.swift
@@ -1,0 +1,156 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Conversation Manager Terminal Persistence", .tags(.viewModel, .persistence))
+struct TerminalPersistenceTests {
+    @MainActor
+    private func makeEditingManager(
+        store: EncryptedConversationStore,
+        conversation: Conversation
+    ) -> ConversationManager {
+        let manager = ConversationManager(
+            store: store,
+            saveDebounceDuration: .seconds(30),
+            searchIndexWarmupEnabled: false,
+            spotlightIndexingEnabled: false,
+            startsLoadingImmediately: false
+        )
+        manager.conversations = [conversation]
+        return manager
+    }
+
+    @MainActor
+    private func reloadConversation(
+        _ conversationID: UUID,
+        from store: EncryptedConversationStore
+    ) async throws -> Conversation {
+        let manager = ConversationManager(
+            store: store,
+            saveDebounceDuration: .milliseconds(0),
+            searchIndexWarmupEnabled: false,
+            spotlightIndexingEnabled: false
+        )
+        _ = await manager.loadingTask?.value
+        return try #require(await manager.ensureConversationLoaded(conversationID))
+    }
+
+    @Test
+    @MainActor
+    func `streaming mutations wait for an explicit terminal save point`() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let store = TestHelpers.makeTestStore(directory: directory)
+        let assistant = Message(role: .assistant, content: "", model: AIService.shared.selectedModel)
+        var original = Conversation(title: "Deferred stream", model: AIService.shared.selectedModel)
+        original.addMessage(assistant)
+        try await store.save(original)
+        let manager = makeEditingManager(store: store, conversation: original)
+
+        #expect(manager.appendToMessage(
+            conversationId: original.id,
+            messageId: assistant.id,
+            chunk: "Hello"
+        ))
+        #expect(manager.updateMessage(conversationId: original.id, messageId: assistant.id) { message in
+            message.reasoning = "Thinking"
+        })
+
+        await manager.flushPendingSaves()
+        let beforeTerminalSave = try await reloadConversation(original.id, from: store)
+        let originalAssistant = try #require(beforeTerminalSave.messages.first(where: { $0.id == assistant.id }))
+        #expect(originalAssistant.content.isEmpty)
+        #expect(originalAssistant.reasoning == nil)
+
+        #expect(manager.updateMessageAndPersist(
+            conversationId: original.id,
+            messageId: assistant.id
+        ) { message in
+            message.content += " world"
+        })
+        await manager.flushPendingSaves()
+
+        let reloaded = try await reloadConversation(original.id, from: store)
+        let reloadedAssistant = try #require(reloaded.messages.first(where: { $0.id == assistant.id }))
+        #expect(reloadedAssistant.content == "Hello world")
+        #expect(reloadedAssistant.reasoning == "Thinking")
+    }
+
+    @Test
+    @MainActor
+    func `message removal survives reload`() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let store = TestHelpers.makeTestStore(directory: directory)
+        let original = TestHelpers.sampleConversation(
+            title: "Remove terminal placeholder",
+            model: AIService.shared.selectedModel
+        )
+        let removedMessageID = try #require(original.messages.last?.id)
+        try await store.save(original)
+        let manager = makeEditingManager(store: store, conversation: original)
+
+        #expect(manager.removeMessage(
+            conversationId: original.id,
+            messageId: removedMessageID
+        ))
+        await manager.flushPendingSaves()
+
+        let reloaded = try await reloadConversation(original.id, from: store)
+        #expect(!reloaded.messages.contains(where: { $0.id == removedMessageID }))
+    }
+
+    @Test
+    @MainActor
+    func `terminal response status persists accumulated chunks`() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let store = TestHelpers.makeTestStore(directory: directory)
+        let groupID = UUID()
+        let user = Message(role: .user, content: "Compare")
+        let assistant = Message(
+            role: .assistant,
+            content: "",
+            model: AIService.shared.selectedModel,
+            responseGroupId: groupID
+        )
+        let responseGroup = ResponseGroup(
+            id: groupID,
+            userMessageId: user.id,
+            responses: [
+                .init(id: assistant.id, modelName: AIService.shared.selectedModel, status: .streaming),
+            ]
+        )
+        var original = Conversation(
+            title: "Terminal response group",
+            messages: [user, assistant],
+            model: AIService.shared.selectedModel,
+            responseGroups: [responseGroup]
+        )
+        original.updatedAt = Date()
+        try await store.save(original)
+        let manager = makeEditingManager(store: store, conversation: original)
+
+        #expect(manager.appendToMessage(
+            conversationId: original.id,
+            messageId: assistant.id,
+            chunk: "Completed response"
+        ))
+        #expect(!manager.updateResponseGroupStatus(
+            conversationId: original.id,
+            responseGroupId: groupID,
+            messageId: UUID(),
+            status: .completed
+        ))
+        #expect(manager.updateResponseGroupStatus(
+            conversationId: original.id,
+            responseGroupId: groupID,
+            messageId: assistant.id,
+            status: .completed
+        ))
+        await manager.flushPendingSaves()
+
+        let reloaded = try await reloadConversation(original.id, from: store)
+        let reloadedAssistant = try #require(reloaded.messages.first(where: { $0.id == assistant.id }))
+        let reloadedGroup = try #require(reloaded.getResponseGroup(groupID))
+        #expect(reloadedAssistant.content == "Completed response")
+        #expect(reloadedGroup.responses.first?.status == .completed)
+    }
+}


### PR DESCRIPTION
## Summary

- add an explicit terminal message-update path that persists completed mutations without saving every streaming chunk
- persist message removals and terminal response-group status changes
- validate response-group membership before accepting status updates
- route image-generation completion through the persisting terminal APIs
- cover reload durability for completed message and response-group mutations

## Why this is separate

This is the terminal-persistence portion of #95. It remains deliberately narrow: streaming updates stay in-memory for performance, while completed mutations are saved explicitly.

## Validation

- `swiftlint --strict`
- focused terminal-persistence tests (3 tests)
- `swift build`
- `swift build --triple arm64-apple-ios26.0`
- `swift build --triple arm64-apple-watchos26.0`

## Stack

- Base: #102
- Replaces part of: #95
