### PR TITLE
ci: lint production Swift sources

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,9 +10,7 @@ excluded:
 
 # Paths to include in linting (optional, defaults to all Swift files)
 included:
-  - App
-  - Core
-  - Views
+  - Sources/Ayna
   - Tests
 
 # Disable some rules that may be too strict

--- a/Sources/Ayna/Services/ConversationPersistenceCoordinator.swift
+++ b/Sources/Ayna/Services/ConversationPersistenceCoordinator.swift
@@ -5,6 +5,9 @@
 //  Created on 11/24/25.
 //
 
+// This legacy coordinator remains in one file while its persistence state machine is stabilized.
+// swiftlint:disable file_length
+
 import Foundation
 import OSLog
 
@@ -36,6 +39,8 @@ extension EncryptedConversationStore: ConversationStoreAdapter {
     }
 }
 
+// The full name distinguishes manager reconciliation state from store transaction state.
+// swiftlint:disable:next type_name
 struct ConversationPersistenceReconciliationState: Sendable {
     let dirtyIds: Set<UUID>
     let deletingIds: Set<UUID>
@@ -96,6 +101,8 @@ private final class OperationOverridingConversationStore: ConversationStoreAdapt
     }
 }
 
+// The full name identifies the compatibility boundary that erases concrete store errors.
+// swiftlint:disable:next type_name
 private struct ConversationPersistenceCompatibilityError: LocalizedError {
     let message: String
 
@@ -861,6 +868,8 @@ final class ConversationPersistenceCoordinator {
         }
 
         ensureRewriteScheduled()
+        // The tuple is local transition state and is destructured immediately below.
+        // swiftlint:disable:next large_tuple
         let pendingIntents = dirty.compactMap { id, intent -> (UUID, UInt64, DesiredState)? in
             guard proposedSaves[id] == nil,
                   !intent.isScheduled,

--- a/Sources/Ayna/Services/EncryptedConversationStore.swift
+++ b/Sources/Ayna/Services/EncryptedConversationStore.swift
@@ -5,6 +5,9 @@
 //  Created on 11/14/25.
 //
 
+// This legacy store remains in one file while migration and transaction helpers are extracted incrementally.
+// swiftlint:disable file_length
+
 import CryptoKit
 import Foundation
 import os.log
@@ -120,6 +123,8 @@ private struct PrivacyCleanupMarkerState: Codable {
     }
 }
 
+// The store remains monolithic while migration and transaction helpers are extracted incrementally.
+// swiftlint:disable:next type_body_length
 final class EncryptedConversationStore: Sendable {
     nonisolated static let shared = EncryptedConversationStore()
 
@@ -222,6 +227,8 @@ final class EncryptedConversationStore: Sendable {
         static let maximumEntryCost = 4 * 1024 * 1024
         static let maximumTotalCost = 32 * 1024 * 1024
 
+        // Keeping the cache entry private to its owning cache avoids widening the file's API.
+        // swiftlint:disable:next nesting
         struct Entry: Sendable {
             let fileVersion: FileVersion
             let searchableFields: [String]
@@ -299,6 +306,8 @@ final class EncryptedConversationStore: Sendable {
     }
 
     private final class OperationGenerationRegistry: @unchecked Sendable {
+        // The generation token is meaningful only within its owning registry.
+        // swiftlint:disable:next nesting
         struct Generation: Equatable, Sendable {
             let global: UInt64
             let conversation: UInt64
@@ -1238,6 +1247,8 @@ final class EncryptedConversationStore: Sendable {
         }.value
     }
 
+    // Metadata loading also owns one-time legacy migration and sidecar repair.
+    // swiftlint:disable:next function_body_length
     func loadConversationMetadata() async throws -> [ConversationMetadata] {
         try ensureClearRecoveryResolved()
         let directoryURL = directoryURL
@@ -1619,6 +1630,8 @@ final class EncryptedConversationStore: Sendable {
         }
     }
 
+    // Search validation, index repair, and one retry are intentionally kept atomic.
+    // swiftlint:disable:next cyclomatic_complexity function_body_length function_parameter_count
     private nonisolated static func fullTextSearchMatches(
         query: String,
         conversationId: UUID,
@@ -2052,14 +2065,14 @@ final class EncryptedConversationStore: Sendable {
     }
 
     private nonisolated static func symbolicLinkPath(in urls: [URL]) -> String? {
-        for url in urls {
-            if (try? FileManager.default.destinationOfSymbolicLink(atPath: url.path)) != nil {
-                return url.path
-            }
+        for url in urls where (try? FileManager.default.destinationOfSymbolicLink(atPath: url.path)) != nil {
+            return url.path
         }
         return nil
     }
 
+    // Clear is a transactional sequence whose rollback steps must remain adjacent.
+    // swiftlint:disable:next function_body_length
     func clear(attachmentCleanupSnapshot: AttachmentCleanupSnapshot? = nil) throws {
         let parentDirectory = directoryURL.deletingLastPathComponent()
         let transactionId = UUID().uuidString
@@ -2235,6 +2248,8 @@ final class EncryptedConversationStore: Sendable {
         operationGenerations: OperationGenerationRegistry
     ) async throws -> [Conversation] {
         let fileURLsById = try conversationFileURLsById(in: directory)
+        // The tuple is local task-group state and is destructured immediately after loading.
+        // swiftlint:disable:next large_tuple
         let snapshots = fileURLsById.compactMap { id, url -> (
             UUID,
             URL,
@@ -2411,6 +2426,8 @@ final class EncryptedConversationStore: Sendable {
         return try operation(stagedWrite)
     }
 
+    // Migration keeps explicit path and generation dependencies to enforce atomic replacement.
+    // swiftlint:disable:next function_parameter_count
     private nonisolated static func migrateLegacyConversation(
         _ conversation: Conversation,
         keyData: Data,
@@ -2645,6 +2662,8 @@ final class EncryptedConversationStore: Sendable {
         return nil
     }
 
+    // Metadata commit keeps explicit paths and generation guards to prevent stale sidecars.
+    // swiftlint:disable:next function_parameter_count
     private nonisolated static func commitMetadataCandidate(
         _ metadata: ConversationMetadata,
         sourceVersion: FileVersion,

--- a/Sources/Ayna/Services/PathValidator.swift
+++ b/Sources/Ayna/Services/PathValidator.swift
@@ -21,10 +21,13 @@ struct PathValidator {
     let protectedPaths: [String]
     let sensitiveFilenames: Set<String>
 
-    private static let environmentVariableRegex = try! NSRegularExpression(
-        pattern: #"\$([A-Za-z_][A-Za-z0-9_]*)"#,
-        options: []
-    )
+    private static let environmentVariableRegex: NSRegularExpression = {
+        let pattern = #"\$([A-Za-z_][A-Za-z0-9_]*)"#
+        guard let expression = try? NSRegularExpression(pattern: pattern) else {
+            preconditionFailure("Invalid static environment-variable regular expression: \(pattern)")
+        }
+        return expression
+    }()
 
     // MARK: - Default Protected Paths
 

--- a/Sources/Ayna/Services/WebSearchCoordinator.swift
+++ b/Sources/Ayna/Services/WebSearchCoordinator.swift
@@ -94,7 +94,6 @@ final class WebSearchCoordinator: ObservableObject {
         ]
     }
 
-    /// The tool name used in function calling
     // MARK: - Execution
 
     /// Executes a web search tool call and returns formatted results

--- a/Sources/Ayna/Utilities/MarkdownRenderer.swift
+++ b/Sources/Ayna/Utilities/MarkdownRenderer.swift
@@ -37,13 +37,21 @@ enum MarkdownRenderer {
     }()
 
     private static let horizontalRuleCharacters = CharacterSet(charactersIn: "-_* ")
+
+    private static func makeRegularExpression(pattern: String) -> NSRegularExpression {
+        guard let expression = try? NSRegularExpression(pattern: pattern) else {
+            preconditionFailure("Invalid static markdown regular expression: \(pattern)")
+        }
+        return expression
+    }
+
     private static let unorderedListRegex =
-        try! NSRegularExpression(pattern: #"^\s*[-*+]\s+"#)
+        makeRegularExpression(pattern: #"^\s*[-*+]\s+"#)
     private static let orderedListRegex =
-        try! NSRegularExpression(pattern: #"^\s*(\d+)\.\s+"#)
+        makeRegularExpression(pattern: #"^\s*(\d+)\.\s+"#)
     #if !os(watchOS)
     private static let tableDividerRegex =
-        try! NSRegularExpression(pattern: #"^\s*:?-+:?\s*$"#)
+        makeRegularExpression(pattern: #"^\s*:?-+:?\s*$"#)
     #endif
 
     nonisolated static func parse(

--- a/Sources/Ayna/Utilities/WatchMarkdownRenderer.swift
+++ b/Sources/Ayna/Utilities/WatchMarkdownRenderer.swift
@@ -20,7 +20,13 @@
             return options
         }()
 
-        private static let linkRegex = try! NSRegularExpression(pattern: #"\[([^\]]+)\]\([^\)]+\)"#)
+        private static let linkRegex: NSRegularExpression = {
+            let pattern = #"\[([^\]]+)\]\([^\)]+\)"#
+            guard let expression = try? NSRegularExpression(pattern: pattern) else {
+                preconditionFailure("Invalid static watch markdown regular expression: \(pattern)")
+            }
+            return expression
+        }()
 
         /// Render markdown string to AttributedString for Watch display
         /// Uses system AttributedString markdown support for inline elements only

--- a/Sources/Ayna/ViewModels/ConversationManager.swift
+++ b/Sources/Ayna/ViewModels/ConversationManager.swift
@@ -5,6 +5,9 @@
 //  Created on 11/2/25.
 //
 
+// This legacy coordinator remains in one file while persistence responsibilities are extracted incrementally.
+// swiftlint:disable file_length
+
 import Combine
 #if !os(watchOS)
     import CoreSpotlight
@@ -44,6 +47,8 @@ private struct AttachmentCleanupFencePreparation: Sendable {
 }
 
 @MainActor
+// The manager remains monolithic while persistence responsibilities are extracted incrementally.
+// swiftlint:disable:next type_body_length
 final class ConversationManager: ObservableObject {
     private static let searchIndexWarmupLimit = 16
 
@@ -207,6 +212,8 @@ final class ConversationManager: ObservableObject {
         }
     }
 
+    // Dependency wiring remains centralized until the manager is split into smaller collaborators.
+    // swiftlint:disable:next function_body_length
     init(
         store: (any ConversationStoreAdapter)? = nil,
         saveDebounceDuration: Duration = .milliseconds(200),
@@ -1030,6 +1037,8 @@ final class ConversationManager: ObservableObject {
         registerManagerDeletionTask(task, for: conversationId, version: deletionVersion)
     }
 
+    // Loading reconciles legacy, metadata-only, and durable snapshots in one transaction.
+    // swiftlint:disable:next function_body_length
     private func loadConversations(
         allowingActiveClearGeneration allowedClearGeneration: UInt64? = nil
     ) async {
@@ -1637,7 +1646,8 @@ final class ConversationManager: ObservableObject {
     }
 
     @discardableResult
-    func clearAllConversations() -> Task<Void, Never> {
+    // Clearing coordinates storage, attachments, summaries, and Spotlight rollback.
+    func clearAllConversations() -> Task<Void, Never> { // swiftlint:disable:this function_body_length
         persistenceErrorMessage = nil
         let previousClearTask = clearConversationsTask
         let clearWasAlreadyActive = previousClearTask != nil

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 #if os(macOS)
 //
 //  MacNewChatView.swift

--- a/Sources/Ayna/Views/macOS/MacSettingsView.swift
+++ b/Sources/Ayna/Views/macOS/MacSettingsView.swift
@@ -8,8 +8,8 @@
 
 import SwiftUI
 
-// swiftlint:disable:next superfluous_disable_command
-// swiftlint:disable file_length type_body_length
+// This legacy settings surface is split into sections but remains in one source file.
+// swiftlint:disable file_length
 
 struct MacSettingsView: View {
     @ObservedObject private var aiService = AIService.shared
@@ -2581,5 +2581,4 @@ struct AnthropicConfigurationView: View {
     MacSettingsView()
 }
 
-// swiftlint:enable file_length type_body_length
 #endif


### PR DESCRIPTION
## Summary

- replace obsolete SwiftLint include paths with `Sources/Ayna`
- expand strict lint coverage from 98 to 264 Swift files
- fix trivial violations exposed in production sources
- add narrow, documented suppressions for existing structural length/complexity debt without weakening global rules

## Why this is separate

This is the lint-scope correction from #95, isolated from the chat and provider refactors so CI coverage can be reviewed independently.

## Validation

- `swiftlint --strict` — 0 violations across 264 files
- `swiftlint lint --strict --reporter github-actions-logging`
- `swift build`
- `git diff --check`

Focused tests compiled but could not launch in the fresh worktree because `Sparkle.framework` was absent from the test runpath; the production build completed successfully.

Replaces part of #95.
