### PR TITLE
feat(watchos): support reasoning-only responses

### DIFF
--- a/Sources/Ayna/Models/WatchDataModels.swift
+++ b/Sources/Ayna/Models/WatchDataModels.swift
@@ -421,6 +421,7 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
     let id: UUID
     var role: String
     var content: String
+    var reasoning: String?
     var timestamp: Date
     var model: String?
     var toolCalls: [MCPToolCall]?
@@ -430,6 +431,7 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
         id: UUID,
         role: String,
         content: String,
+        reasoning: String? = nil,
         timestamp: Date,
         model: String? = nil,
         toolCalls: [MCPToolCall]? = nil,
@@ -438,6 +440,7 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
         self.id = id
         self.role = role
         self.content = content
+        self.reasoning = reasoning
         self.timestamp = timestamp
         self.model = model
         self.toolCalls = toolCalls
@@ -448,6 +451,7 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
         id = message.id
         role = message.role.rawValue
         content = message.content
+        reasoning = message.reasoning
         timestamp = message.timestamp
         model = message.model
         toolCalls = message.toolCalls
@@ -475,8 +479,22 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
             timestamp: timestamp,
             toolCalls: toolCalls,
             model: model,
+            reasoning: reasoning,
             citations: citations
         )
+    }
+
+    /// Text shown when a reasoning-only response has no final answer content.
+    var visibleContent: String {
+        if !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return content
+        }
+        guard let reasoning,
+              !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return ""
+        }
+        return reasoning
     }
 }
 

--- a/Sources/Ayna/Services/WatchSyncProtocol.swift
+++ b/Sources/Ayna/Services/WatchSyncProtocol.swift
@@ -2296,6 +2296,9 @@ enum WatchSyncPayloadBuilder {
     ) -> WatchMessage {
         var result = message
         result.content = bounded(message.content, maximum: configuration.maximumContentCharacters)
+        result.reasoning = message.reasoning.map {
+            bounded($0, maximum: configuration.maximumContentCharacters)
+        }
         result.toolCalls = message.toolCalls.map { calls in
             Array(calls.prefix(max(0, configuration.maximumToolCallsPerMessage))).compactMap {
                 boundedToolCall($0, configuration: configuration)

--- a/Sources/Ayna/ViewModels/WatchChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/WatchChatViewModel.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 //
 //  WatchChatViewModel.swift
 //  Ayna Watch App
@@ -105,6 +106,7 @@ final class WatchToolCallRoundRegistry {
             let isFirstMessage: Bool
             let userContent: String
             let finalContent: String
+            let finalReasoning: String
         }
 
         private enum DraftFinalizationOutcome: Equatable {
@@ -147,6 +149,7 @@ final class WatchToolCallRoundRegistry {
         private var lastUIUpdateTime: Date = .distantPast
         private let uiUpdateInterval: TimeInterval = 0.1 // 100ms throttle
         private var pendingContent = ""
+        private var pendingReasoning = ""
 
         init(
             conversationStore: WatchConversationStore = .shared,
@@ -175,6 +178,7 @@ final class WatchToolCallRoundRegistry {
             failedMessage = nil
             pendingUserMessageId = nil
             pendingContent = ""
+            pendingReasoning = ""
             restorePendingResponsePromotionState(for: id)
         }
 
@@ -212,6 +216,7 @@ final class WatchToolCallRoundRegistry {
             isStreaming = false
             streamingContent = ""
             pendingContent = ""
+            pendingReasoning = ""
             currentToolName = nil
             toolCallDepth = 0
             lastUIUpdateTime = .distantPast
@@ -375,13 +380,11 @@ final class WatchToolCallRoundRegistry {
 
                         let now = Date()
                         if now.timeIntervalSince(self.lastUIUpdateTime) >= self.uiUpdateInterval {
-                            self.streamingContent = self.pendingContent
-                            self.updateAssistantMessage(
-                                assistantMessageId,
-                                in: conversationId,
-                                content: self.streamingContent
+                            self.publishPendingResponse(
+                                assistantMessageId: assistantMessageId,
+                                conversationId: conversationId,
+                                at: now
                             )
-                            self.lastUIUpdateTime = now
                         }
                         self.currentToolName = nil
                     }
@@ -507,7 +510,26 @@ final class WatchToolCallRoundRegistry {
                         )
                     }
                 },
-                onReasoning: nil
+                onReasoning: { [weak self] reasoning in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId),
+                              self.activeAssistantMessageId == assistantMessageId
+                        else {
+                            return
+                        }
+                        self.isStreaming = true
+                        self.pendingReasoning += reasoning
+                        let now = Date()
+                        if now.timeIntervalSince(self.lastUIUpdateTime) >= self.uiUpdateInterval {
+                            self.publishPendingResponse(
+                                assistantMessageId: assistantMessageId,
+                                conversationId: conversationId,
+                                at: now
+                            )
+                        }
+                    }
+                }
             )
             coordinator.onCancel(for: operationID) {
                 request.cancel()
@@ -649,7 +671,7 @@ final class WatchToolCallRoundRegistry {
                 return
             }
 
-            guard flushPendingContent(
+            guard flushPendingResponse(
                 assistantMessageId: assistantMessageId,
                 conversationId: conversationId
             ) else {
@@ -659,7 +681,8 @@ final class WatchToolCallRoundRegistry {
                         assistantMessageId: assistantMessageId,
                         conversationId: conversationId,
                         userContent: userContent,
-                        finalContent: pendingContent
+                        finalContent: pendingContent,
+                        finalReasoning: pendingReasoning
                     ),
                     retryPromotion: true
                 )
@@ -716,6 +739,7 @@ final class WatchToolCallRoundRegistry {
             let continuationMessages = Array(updatedConversation.effectiveHistory.dropLast())
             streamingContent = ""
             pendingContent = ""
+            pendingReasoning = ""
             currentToolName = nil
             lastUIUpdateTime = .distantPast
             sendMessageWithToolSupport(
@@ -751,17 +775,19 @@ final class WatchToolCallRoundRegistry {
                     userMessageID: pendingUserMessageId,
                     isFirstMessage: isFirstMessage,
                     userContent: userContent,
-                    finalContent: pendingContent
+                    finalContent: pendingContent,
+                    finalReasoning: pendingReasoning
                 )
             )
         }
 
         @discardableResult
         private func attemptResponsePromotion(_ pending: PendingResponsePromotion) -> Bool {
-            guard flushPendingContent(
+            guard flushPendingResponse(
                 assistantMessageId: pending.assistantMessageID,
                 conversationId: pending.conversationID,
-                finalContent: pending.finalContent
+                finalContent: pending.finalContent,
+                finalReasoning: pending.finalReasoning
             ) else {
                 failResponsePromotion(pending, retryPromotion: true)
                 return false
@@ -793,6 +819,8 @@ final class WatchToolCallRoundRegistry {
             toolCallDepth = 0
             errorMessage = nil
             failedMessage = nil
+            pendingContent = ""
+            pendingReasoning = ""
             playHaptic(.success)
 
             if pending.isFirstMessage, conversation.title == "New Chat" {
@@ -865,7 +893,7 @@ final class WatchToolCallRoundRegistry {
                 return
             }
             toolChainCoordinator.cancelCurrentOperation()
-            guard flushPendingContent(
+            guard flushPendingResponse(
                 assistantMessageId: assistantMessageId,
                 conversationId: conversationId
             ) else {
@@ -874,7 +902,8 @@ final class WatchToolCallRoundRegistry {
                         assistantMessageId: assistantMessageId,
                         conversationId: conversationId,
                         userContent: userContent,
-                        finalContent: pendingContent
+                        finalContent: pendingContent,
+                        finalReasoning: pendingReasoning
                     ),
                     retryPromotion: true
                 )
@@ -939,21 +968,37 @@ final class WatchToolCallRoundRegistry {
                 message: "⌚ Max tool call depth reached"
             )
             toolChainCoordinator.cancelCurrentOperation()
-            activeAssistantMessageId = nil
-            isLoading = false
-            isStreaming = false
-            currentToolName = nil
-            toolCallDepth = 0
-            errorMessage = "Tool call limit reached. Please try again."
+            guard flushPendingResponse(
+                assistantMessageId: assistantMessageId,
+                conversationId: conversationId
+            ) else {
+                failResponsePromotion(
+                    makePendingResponsePromotion(
+                        assistantMessageId: assistantMessageId,
+                        conversationId: conversationId,
+                        userContent: userContent,
+                        finalContent: pendingContent,
+                        finalReasoning: pendingReasoning
+                    ),
+                    retryPromotion: true
+                )
+                return
+            }
             let finalizationOutcome = finalizeDraftIfNeeded(
                 assistantMessageId: assistantMessageId,
                 conversationId: conversationId,
                 userContent: userContent
             )
+            activeAssistantMessageId = nil
+            isLoading = false
+            isStreaming = false
+            currentToolName = nil
+            toolCallDepth = 0
             if finalizationOutcome != .promotionPending {
                 pendingUserMessageId = nil
+                errorMessage = "Tool call limit reached. Please try again."
+                playHaptic(.failure)
             }
-            playHaptic(.failure)
         }
 
         private func stopToolChainForMissingConversation(
@@ -979,6 +1024,7 @@ final class WatchToolCallRoundRegistry {
             currentToolName = nil
             toolCallDepth = 0
             pendingContent = ""
+            pendingReasoning = ""
             if finalizationOutcome != .promotionPending {
                 errorMessage = "Failed to update conversation. Please try again."
                 failedMessage = userContent
@@ -1008,15 +1054,39 @@ final class WatchToolCallRoundRegistry {
         private func updateAssistantMessage(
             _ messageId: UUID,
             in conversationId: UUID,
-            content: String
+            content: String? = nil,
+            reasoning: String? = nil
         ) -> Bool {
+            guard content != nil || reasoning != nil else { return true }
             guard var conversation = conversationStore.conversation(for: conversationId),
                   let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId })
             else {
                 return false
             }
-            conversation.messages[messageIndex].content = content
+            if let content {
+                conversation.messages[messageIndex].content = content
+            }
+            if let reasoning {
+                conversation.messages[messageIndex].reasoning = reasoning
+            }
             return conversationStore.replaceConversation(conversation)
+        }
+
+        private func publishPendingResponse(
+            assistantMessageId: UUID,
+            conversationId: UUID,
+            at updateTime: Date
+        ) {
+            if !pendingContent.isEmpty {
+                streamingContent = pendingContent
+            }
+            updateAssistantMessage(
+                assistantMessageId,
+                in: conversationId,
+                content: pendingContent.isEmpty ? nil : pendingContent,
+                reasoning: pendingReasoning.isEmpty ? nil : pendingReasoning
+            )
+            lastUIUpdateTime = updateTime
         }
 
         /// Cancel active request work without discarding a completed response promotion retry.
@@ -1032,6 +1102,7 @@ final class WatchToolCallRoundRegistry {
             toolCallDepth = 0
             if !hasPendingResponsePromotionForCurrentConversation {
                 pendingContent = ""
+                pendingReasoning = ""
                 playHaptic(.click)
             }
         }
@@ -1051,6 +1122,7 @@ final class WatchToolCallRoundRegistry {
             toolCallDepth = 0
             if !hasPendingResponsePromotionForCurrentConversation {
                 pendingContent = ""
+                pendingReasoning = ""
             }
             return true
         }
@@ -1065,7 +1137,7 @@ final class WatchToolCallRoundRegistry {
             else {
                 return
             }
-            guard flushPendingContent(
+            guard flushPendingResponse(
                 assistantMessageId: assistantMessageId,
                 conversationId: conversationId
             ) else {
@@ -1073,7 +1145,8 @@ final class WatchToolCallRoundRegistry {
                     makePendingResponsePromotion(
                         assistantMessageId: assistantMessageId,
                         conversationId: conversationId,
-                        finalContent: pendingContent
+                        finalContent: pendingContent,
+                        finalReasoning: pendingReasoning
                     ),
                     retryPromotion: true
                 )
@@ -1101,10 +1174,12 @@ final class WatchToolCallRoundRegistry {
                 assistantMessageId: assistantMessageId,
                 conversationId: conversationId,
                 userContent: userContent,
-                finalContent: message.content
+                finalContent: message.content,
+                finalReasoning: message.reasoning ?? ""
             )
 
             let hasAssistantState = !message.content.isEmpty ||
+                !(message.reasoning?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true) ||
                 !(message.citations?.isEmpty ?? true) ||
                 !(message.toolCalls?.isEmpty ?? true)
             let turnStartIndex = conversation.messages[...messageIndex].lastIndex {
@@ -1140,7 +1215,8 @@ final class WatchToolCallRoundRegistry {
             assistantMessageId: UUID,
             conversationId: UUID,
             userContent: String? = nil,
-            finalContent: String
+            finalContent: String,
+            finalReasoning: String
         ) -> PendingResponsePromotion {
             let conversation = conversationStore.conversation(for: conversationId)
             let messageIndex = conversation?.messages.firstIndex { $0.id == assistantMessageId }
@@ -1155,34 +1231,43 @@ final class WatchToolCallRoundRegistry {
                 userMessageID: userMessageID,
                 isFirstMessage: isFirstMessage,
                 userContent: userContent ?? userMessage?.content ?? failedMessage ?? "",
-                finalContent: finalContent
+                finalContent: finalContent,
+                finalReasoning: finalReasoning
             )
         }
 
         @discardableResult
-        private func flushPendingContent(
+        private func flushPendingResponse(
             assistantMessageId: UUID? = nil,
             conversationId: UUID? = nil,
-            finalContent: String? = nil
+            finalContent: String? = nil,
+            finalReasoning: String? = nil
         ) -> Bool {
             let content = finalContent ?? pendingContent
-            guard !content.isEmpty else { return true }
+            let reasoning = finalReasoning ?? pendingReasoning
+            guard !content.isEmpty || !reasoning.isEmpty else { return true }
             guard let conversationId = conversationId ?? currentConversationId,
                   let assistantMessageId = assistantMessageId ?? activeAssistantMessageId
             else {
                 return false
             }
 
-            streamingContent = content
+            if !content.isEmpty {
+                streamingContent = content
+            }
             guard updateAssistantMessage(
                 assistantMessageId,
                 in: conversationId,
-                content: content
+                content: content.isEmpty ? nil : content,
+                reasoning: reasoning.isEmpty ? nil : reasoning
             ) else {
                 return false
             }
             if pendingContent == content {
                 pendingContent = ""
+            }
+            if pendingReasoning == reasoning {
+                pendingReasoning = ""
             }
             return true
         }

--- a/Sources/Ayna/ViewModels/WatchConversationStore.swift
+++ b/Sources/Ayna/ViewModels/WatchConversationStore.swift
@@ -787,8 +787,9 @@
 
         func previewText(for conversation: WatchConversation) -> String {
             guard let lastMessage = conversation.messages.last else { return "No messages" }
-            let preview = lastMessage.content.prefix(50)
-            return preview.count < lastMessage.content.count ? "\(preview)..." : String(preview)
+            let visibleContent = lastMessage.visibleContent
+            let preview = visibleContent.prefix(50)
+            return preview.count < visibleContent.count ? "\(preview)..." : String(preview)
         }
 
         // MARK: - Private state management
@@ -1135,6 +1136,7 @@
 
         private func isMeaningfulDraftMessage(_ message: WatchMessage) -> Bool {
             !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                !(message.reasoning?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true) ||
                 !(message.citations?.isEmpty ?? true) ||
                 !(message.toolCalls?.isEmpty ?? true) ||
                 message.role == Message.Role.tool.rawValue

--- a/Sources/Ayna/Views/watchOS/WatchChatView.swift
+++ b/Sources/Ayna/Views/watchOS/WatchChatView.swift
@@ -34,7 +34,7 @@
                                         }) == true
                                     // Keep web-search output in provider history but present citations instead.
                                     if !isWebSearchToolResult,
-                                       !message.content.isEmpty ||
+                                       !message.visibleContent.isEmpty ||
                                        message.role.lowercased() == "user" ||
                                        !(message.citations?.isEmpty ?? true)
                                     {

--- a/Sources/Ayna/Views/watchOS/WatchConversationListView.swift
+++ b/Sources/Ayna/Views/watchOS/WatchConversationListView.swift
@@ -122,7 +122,7 @@
 
             private var previewText: String {
                 if let lastMessage = conversation.messages.last {
-                    let stripped = WatchMarkdownRenderer.stripMarkdown(lastMessage.content)
+                    let stripped = WatchMarkdownRenderer.stripMarkdown(lastMessage.visibleContent)
                     return stripped.isEmpty ? "..." : stripped
                 }
                 return "No messages"

--- a/Sources/Ayna/Views/watchOS/WatchMessageView.swift
+++ b/Sources/Ayna/Views/watchOS/WatchMessageView.swift
@@ -25,7 +25,7 @@
         init(message: WatchMessage, showTimestamp: Bool = false) {
             self.message = message
             self.showTimestamp = showTimestamp
-            _renderedContent = State(initialValue: WatchMarkdownRenderer.render(message.content))
+            _renderedContent = State(initialValue: WatchMarkdownRenderer.render(message.visibleContent))
         }
 
         private static let timeFormatter: DateFormatter = {
@@ -47,7 +47,7 @@
 
                     // Message content and web-search sources.
                     VStack(alignment: .leading, spacing: Spacing.xxs) {
-                        if !message.content.isEmpty {
+                        if !message.visibleContent.isEmpty {
                     Text(renderedContent)
                         .font(Typography.body)
                         .foregroundStyle(isUser ? Theme.userBubbleText : .primary)
@@ -87,7 +87,7 @@
                         .padding(.horizontal, Spacing.xxs)
                 }
             }
-            .onChange(of: message.content) { _, newContent in
+            .onChange(of: message.visibleContent) { _, newContent in
                 renderedContent = WatchMarkdownRenderer.render(newContent)
             }
         }

--- a/Tests/AynaTests/WatchDataModelHostTests.swift
+++ b/Tests/AynaTests/WatchDataModelHostTests.swift
@@ -23,6 +23,7 @@ struct WatchDataModelHostTests {
             timestamp: timestamp,
             toolCalls: [call],
             model: "gpt-test",
+            reasoning: "Checked the source first.",
             citations: [CitationReference(number: 1, title: "Source", url: "https://example.com")]
         )
 
@@ -36,7 +37,30 @@ struct WatchDataModelHostTests {
         #expect(restored.timestamp == timestamp)
         #expect(restored.model == "gpt-test")
         #expect(restored.toolCalls == [call])
+        #expect(restored.reasoning == "Checked the source first.")
         #expect(restored.citations == original.citations)
+    }
+
+    @Test
+    func `Watch message exposes reasoning when final content is empty`() {
+        let reasoningOnly = WatchMessage(
+            id: UUID(),
+            role: Message.Role.assistant.rawValue,
+            content: "",
+            reasoning: "Compare the constraints.",
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+        var completed = reasoningOnly
+        completed.content = "Use the smaller option."
+        var whitespaceContent = reasoningOnly
+        whitespaceContent.content = " \n"
+        var whitespaceReasoning = reasoningOnly
+        whitespaceReasoning.reasoning = " \n"
+
+        #expect(reasoningOnly.visibleContent == "Compare the constraints.")
+        #expect(completed.visibleContent == "Use the smaller option.")
+        #expect(whitespaceContent.visibleContent == "Compare the constraints.")
+        #expect(whitespaceReasoning.visibleContent.isEmpty)
     }
 
     @Test

--- a/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
+++ b/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
@@ -57,7 +57,7 @@
         }
 
         @Test
-        func `Reasoning-only response streams promotes and survives reload`() async throws {
+        func `Reasoning-only response streams, promotes, and survives reload`() async throws {
             let expectedReasoning = "Compare the constraints first."
             let fixture = makeViewModelFixture(title: "Existing")
             let aiService = configuredCapturingAIService(model: fixture.conversation.model)

--- a/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
+++ b/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
@@ -57,6 +57,47 @@
         }
 
         @Test
+        func `Reasoning-only response streams promotes and survives reload`() async throws {
+            let expectedReasoning = "Compare the constraints first."
+            let fixture = makeViewModelFixture(title: "Existing")
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Think carefully") == .started)
+            let request = try #require(aiService.capturedRequests.value.first)
+            let onReasoning = try #require(request.onReasoning)
+
+            onReasoning("Compare the ")
+            onReasoning("constraints first.")
+            request.onComplete()
+
+            #expect(await waitUntil { !viewModel.isLoading })
+            let assistant = try #require(
+                fixture.store.conversation(for: fixture.conversation.id)?.messages.last
+            )
+            #expect(assistant.content.isEmpty)
+            #expect(assistant.reasoning == expectedReasoning)
+            #expect(fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.id == assistant.id && $0.reasoning == expectedReasoning
+            })
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            let reloadedConversation = try #require(reloaded.conversation(for: fixture.conversation.id))
+            #expect(reloadedConversation.messages.last?.reasoning == expectedReasoning)
+            #expect(reloaded.previewText(for: reloadedConversation) == expectedReasoning)
+        }
+
+        @Test
         func `Re-selecting the same conversation preserves generation and cancellation syncs partial once`() throws {
             let fixture = makeViewModelFixture()
             let callbacks = FlightTestBox<AIServiceResponseSimulationCallbacks?>(nil)
@@ -262,6 +303,64 @@
             #expect(promotedConversation.messages.last?.content == "Partial")
             #expect(fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
                 $0.id == assistantMessageID && $0.content == "Partial"
+            })
+        }
+
+        @Test
+        func `Cancelled reasoning-only promotion failure retries the same draft`() async throws {
+            let persistence = PersistenceTestWriter()
+            let fixture = makeViewModelFixture(
+                title: "Existing",
+                persistenceWriter: { persistence.write($0) }
+            )
+            let aiService = configuredCapturingAIService(model: fixture.conversation.model)
+            let viewModel = WatchChatViewModel(
+                conversationStore: fixture.store,
+                connectivityService: .shared,
+                aiService: aiService
+            )
+            WatchConnectivityService.shared.availableModels = [fixture.conversation.model]
+            persistence.rejectNextWrite { data in
+                isPromotionWrite(data, assistantReasoning: "Compare the constraints first.")
+            }
+
+            viewModel.setConversation(fixture.conversation.id)
+            #expect(viewModel.sendMessage("Prompt") == .started)
+            let request = try #require(aiService.capturedRequests.value.first)
+            let onReasoning = try #require(request.onReasoning)
+            onReasoning("Compare the constraints first.")
+            #expect(await waitUntil {
+                fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.reasoning ==
+                    "Compare the constraints first."
+            })
+            let draft = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            let userMessageID = try #require(draft.messages.first?.id)
+            let assistantMessageID = try #require(draft.messages.last?.id)
+
+            viewModel.cancelRequest()
+
+            #expect(persistence.rejectedWriteCount == 1)
+            #expect(viewModel.errorMessage == "Failed to save response. Please try again.")
+            #expect(viewModel.failedMessage == "Prompt")
+            let failedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(failedConversation.messages.map(\.id) == [userMessageID, assistantMessageID])
+            #expect(failedConversation.messages.last?.content.isEmpty == true)
+            #expect(failedConversation.messages.last?.reasoning == "Compare the constraints first.")
+            #expect(!fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.id == assistantMessageID
+            })
+
+            viewModel.retryFailedMessage()
+
+            #expect(viewModel.errorMessage == nil)
+            #expect(viewModel.failedMessage == nil)
+            #expect(aiService.capturedRequests.value.count == 1)
+            let promotedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
+            #expect(promotedConversation.messages.map(\.id) == [userMessageID, assistantMessageID])
+            #expect(promotedConversation.messages.last?.content.isEmpty == true)
+            #expect(promotedConversation.messages.last?.reasoning == "Compare the constraints first.")
+            #expect(fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
+                $0.id == assistantMessageID && $0.reasoning == "Compare the constraints first."
             })
         }
 
@@ -1131,7 +1230,9 @@
         }
 
         @Test
-        func `Tool depth promotion failure retries the same partial draft`() async throws {
+        func `Tool depth flushes multi-chunk response before promotion retry`() async throws {
+            let expectedContent = "Depth partial"
+            let expectedReasoning = "Depth reasoning"
             let persistence = PersistenceTestWriter()
             let fixture = makeViewModelFixture(
                 title: "Existing",
@@ -1158,19 +1259,23 @@
             }
 
             let depthRequest = try #require(aiService.capturedRequests.value.last)
-            depthRequest.onChunk("Depth partial")
-            #expect(await waitUntil {
-                fixture.store.conversation(for: fixture.conversation.id)?.messages.last?.content ==
-                    "Depth partial"
-            })
             let draft = try #require(fixture.store.conversation(for: fixture.conversation.id))
             let messageIDs = draft.messages.map(\.id)
             let assistantMessageID = try #require(draft.messages.last?.id)
             persistence.rejectNextWrite { data in
-                isPromotionWrite(data, assistantContent: "Depth partial")
+                isPromotionWrite(
+                    data,
+                    assistantContent: expectedContent,
+                    assistantReasoning: expectedReasoning
+                )
             }
 
+            let onReasoning = try #require(depthRequest.onReasoning)
             let onToolCallRequested = try #require(depthRequest.onToolCallRequested)
+            depthRequest.onChunk("Depth ")
+            depthRequest.onChunk("partial")
+            onReasoning("Depth ")
+            onReasoning("reasoning")
             onToolCallRequested("depth-limit-call", "unavailable_watch_tool", [:])
 
             #expect(await waitUntil { !viewModel.isLoading })
@@ -1186,9 +1291,12 @@
             #expect(aiService.capturedRequests.value.count == 6)
             let promotedConversation = try #require(fixture.store.conversation(for: fixture.conversation.id))
             #expect(promotedConversation.messages.map(\.id) == messageIDs)
-            #expect(promotedConversation.messages.last?.content == "Depth partial")
+            #expect(promotedConversation.messages.last?.content == expectedContent)
+            #expect(promotedConversation.messages.last?.reasoning == expectedReasoning)
             #expect(fixture.store.pendingMutationsForSync.flatMap(\.messageChanges).contains {
-                $0.id == assistantMessageID && $0.content == "Depth partial"
+                $0.id == assistantMessageID &&
+                    $0.content == expectedContent &&
+                    $0.reasoning == expectedReasoning
             })
         }
 
@@ -1519,7 +1627,11 @@
         }
     }
 
-    private func isPromotionWrite(_ data: Data, assistantContent: String) -> Bool {
+    private func isPromotionWrite(
+        _ data: Data,
+        assistantContent: String? = nil,
+        assistantReasoning: String? = nil
+    ) -> Bool {
         guard let state = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let pendingMutations = state["pendingMutations"] as? [[String: Any]]
         else {
@@ -1530,8 +1642,12 @@
                 return false
             }
             return messageChanges.contains { message in
-                message["role"] as? String == Message.Role.assistant.rawValue &&
-                    message["content"] as? String == assistantContent
+                guard message["role"] as? String == Message.Role.assistant.rawValue else {
+                    return false
+                }
+                let contentMatches = assistantContent.map { message["content"] as? String == $0 } ?? true
+                let reasoningMatches = assistantReasoning.map { message["reasoning"] as? String == $0 } ?? true
+                return contentMatches && reasoningMatches
             }
         }
     }
@@ -1578,6 +1694,7 @@
         let onComplete: @Sendable () -> Void
         let onError: @Sendable (Error) -> Void
         let onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?
+        let onReasoning: (@Sendable (String) -> Void)?
     }
 
     @MainActor
@@ -1613,7 +1730,8 @@
                         onChunk: onChunk,
                         onComplete: onComplete,
                         onError: onError,
-                        onToolCallRequested: onToolCallRequested
+                        onToolCallRequested: onToolCallRequested,
+                        onReasoning: onReasoning
                     )
                 )
             }

--- a/Tests/AynaTests/WatchSyncConversationStoreNativeTests.swift
+++ b/Tests/AynaTests/WatchSyncConversationStoreNativeTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 #if os(watchOS) || WATCH_STORE_HOST_TESTING
 
     // swiftlint:disable identifier_name
@@ -66,6 +67,37 @@
             let restored = try #require(reloaded.conversation(for: conversation.id))
             #expect(restored.messages.map(\.content) == ["Prompt"])
             #expect(reloaded.pendingMutationsForSync.isEmpty)
+        }
+
+        @Test
+        func `Restart recovers and previews a reasoning-only assistant draft`() throws {
+            let fixture = makeFixture()
+            let conversation = makeConversation(messages: [makeMessage(role: .user, content: "Prompt")])
+            fixture.store.applySyncSnapshot(snapshot(revision: 1, conversations: [conversation]))
+
+            var draft = conversation
+            draft.messages.append(
+                makeMessage(
+                    role: .assistant,
+                    content: "",
+                    reasoning: "Compare the constraints first.",
+                    model: conversation.model
+                )
+            )
+            #expect(fixture.store.syncDraft(draft))
+
+            let reloaded = WatchConversationStore(
+                userDefaults: fixture.defaults,
+                persistenceKey: fixture.key,
+                mutationEnqueuer: { _ in }
+            )
+            let restored = try #require(reloaded.conversation(for: conversation.id))
+
+            #expect(restored.messages.last?.content.isEmpty == true)
+            #expect(restored.messages.last?.reasoning == "Compare the constraints first.")
+            #expect(restored.messages.last?.visibleContent == "Compare the constraints first.")
+            #expect(reloaded.previewText(for: restored) == "Compare the constraints first.")
+            #expect(reloaded.pendingMutationsForSync.first?.messageChanges.last?.reasoning == "Compare the constraints first.")
         }
 
         @Test
@@ -1383,12 +1415,14 @@
     private func makeMessage(
         role: Message.Role,
         content: String,
+        reasoning: String? = nil,
         model: String? = nil
     ) -> WatchMessage {
         WatchMessage(
             id: UUID(),
             role: role.rawValue,
             content: content,
+            reasoning: reasoning,
             timestamp: Date(timeIntervalSince1970: 20),
             model: model
         )

--- a/Tests/AynaTests/WatchSyncProtocolTests.swift
+++ b/Tests/AynaTests/WatchSyncProtocolTests.swift
@@ -2775,10 +2775,43 @@ struct WatchSyncProtocolTests {
         #expect(bodyIDs == Array(expectedManifest.prefix(bodyIDs.count)))
         #expect(first.snapshot.conversations.map(\.updatedAt) == first.snapshot.conversations.map(\.updatedAt).sorted(by: >))
         #expect(first.snapshot.conversations.allSatisfy { $0.title.count <= 40 })
-        #expect(first.snapshot.conversations.flatMap(\.messages).allSatisfy { $0.content.count <= 80 })
+        let retainedMessages = first.snapshot.conversations.flatMap(\.messages)
+        #expect(retainedMessages.allSatisfy { $0.content.count <= 80 })
         #expect(first.snapshot.conversations.flatMap(\.messages).flatMap { $0.toolCalls ?? [] }.allSatisfy {
             (try? JSONEncoder().encode($0).count) ?? .max <= 180
         })
+    }
+
+    @Test
+    func `Payload builder bounds reasoning with the content limit`() throws {
+        let reasoning = String(repeating: "reasoning", count: 20)
+        let conversation = Conversation(
+            id: UUID(),
+            title: "Reasoning",
+            messages: [
+                Message(
+                    role: .assistant,
+                    content: "",
+                    reasoning: reasoning
+                ),
+            ],
+            model: "model"
+        )
+        let configuration = WatchSyncPayloadConfiguration(
+            byteBudget: 100_000,
+            maximumConversations: 1,
+            maximumMessagesPerConversation: 1,
+            maximumContentCharacters: 32
+        )
+
+        let result = try WatchSyncPayloadBuilder.build(
+            conversations: [conversation],
+            snapshotRevision: 1,
+            configuration: configuration
+        )
+        let message = try #require(result.snapshot.conversations.first?.messages.first)
+
+        #expect(message.reasoning == String(reasoning.prefix(32)))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Stream provider reasoning through the current Watch request and tool-chain lifecycle.
- Persist, sync, bound, reload, and render reasoning-only assistant responses and conversation previews.
- Preserve reasoning across cancellation, tool-depth finalization, and failed promotion retries.

## Testing

- swift test -q --filter WatchDataModelHostTests (11 passed)
- swift test -q --filter WatchSyncProtocolTests (72 passed)
- Focused Ayna-watchOSTests native suites (74 passed)
- swiftlint lint --strict on all 11 changed files (0 violations)
- swift build -q
- swift build -q --triple arm64-apple-ios26.0
- swift build -q --triple arm64-apple-watchos26.0

Supersedes the watchOS reasoning-response portion of #95. This PR does not close #95.