### PR TITLE
fix(openai): preserve streamed tool names

### DIFF
--- a/Sources/Ayna/Chat/ToolCallRequestRoundCoordinator.swift
+++ b/Sources/Ayna/Chat/ToolCallRequestRoundCoordinator.swift
@@ -39,6 +39,9 @@ final class ToolCallRequestAdmissionGate: @unchecked Sendable {
         toolName: String,
         arguments: [String: Any]
     ) -> Bool {
+        let normalizedToolName = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedToolName.isEmpty else { return false }
+
         let normalizedProviderID = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
         if !normalizedProviderID.isEmpty {
             return admit(identity: .providerID(normalizedProviderID))
@@ -47,7 +50,7 @@ final class ToolCallRequestAdmissionGate: @unchecked Sendable {
         let codableArguments = arguments.mapValues(AnyCodable.init)
         return admit(
             identity: .idLess(
-                toolName: toolName,
+                toolName: normalizedToolName,
                 encodedArguments: ToolCallRequestRoundPolicy.canonicalArguments(codableArguments)
             )
         )

--- a/Sources/Ayna/Chat/ToolTranscriptSanitizer.swift
+++ b/Sources/Ayna/Chat/ToolTranscriptSanitizer.swift
@@ -42,7 +42,12 @@ enum ToolTranscriptSanitizer {
 
             var seenCallIDs: Set<String> = []
             let validCalls = toolCalls.filter { call in
-                resultByCallID[call.id] != nil && seenCallIDs.insert(call.id).inserted
+                let id = call.id.trimmingCharacters(in: .whitespacesAndNewlines)
+                let name = call.toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+                return !id.isEmpty &&
+                    !name.isEmpty &&
+                    resultByCallID[call.id] != nil &&
+                    seenCallIDs.insert(call.id).inserted
             }
 
             var sanitizedAssistant = message

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -3243,7 +3243,9 @@ class AIService: ObservableObject {
                                 currentToolCallBuffer = [:]
                             }
                             if let function = toolCall["function"] as? [String: Any] {
-                                if let name = function["name"] as? String {
+                                if let name = function["name"] as? String,
+                                   !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                {
                                     currentToolCallBuffer["name"] = name
                                 }
                                 if let args = function["arguments"] as? String {
@@ -3259,6 +3261,7 @@ class AIService: ObservableObject {
                 if let finishReason = firstChoice["finish_reason"] as? String {
                     if finishReason == "tool_calls",
                        let name = currentToolCallBuffer["name"] as? String,
+                       !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                        let argsString = currentToolCallBuffer["arguments"] as? String
                     {
                         if let argsData = argsString.data(using: .utf8),

--- a/Sources/Ayna/Services/OpenAIStreamParser.swift
+++ b/Sources/Ayna/Services/OpenAIStreamParser.swift
@@ -324,7 +324,9 @@ enum OpenAIStreamParser {
                 ids[index] = newId
             }
             if let function = toolCall["function"] as? [String: Any] {
-                if let name = function["name"] as? String {
+                if let name = function["name"] as? String,
+                   !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
                     buffer[ToolCallBufferKey.name] = name
                 }
                 if let argsChunk = function["arguments"] as? String {
@@ -364,6 +366,7 @@ enum OpenAIStreamParser {
         for index in toolCallBuffers.keys.sorted() {
             guard let toolCallBuffer = toolCallBuffers[index],
                   let toolName = toolCallBuffer[ToolCallBufferKey.name] as? String,
+                  !toolName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                   let argsData = toolArgumentsData(from: toolCallBuffer),
                   let arguments = try? JSONSerialization.jsonObject(with: argsData) as? [String: Any]
             else {

--- a/Tests/AynaTests/OpenAIStreamParserTests.swift
+++ b/Tests/AynaTests/OpenAIStreamParserTests.swift
@@ -51,6 +51,52 @@ struct OpenAIStreamParserTests {
         #expect(call?.query == "test")
     }
 
+    @Test("Empty streamed function names preserve the valid tool name")
+    func emptyStreamedFunctionNamePreservesValidToolName() async {
+        let recorder = ToolCallRecorder()
+        var buffers: [Int: [String: Any]] = [:]
+        var ids: [Int: String] = [:]
+
+        let firstChunk = #"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_vekil","function":{"name":"run_command","arguments":""}}]}}]}"#
+        let argumentsChunk = #"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"{\"command\":\"printf probe\"}"}}]}}]}"#
+        let completionChunk = #"data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#
+
+        var result = await OpenAIStreamParser.processStreamLine(
+            firstChunk,
+            toolCallBuffers: buffers,
+            toolCallIds: ids,
+            onToolCall: nil,
+            onToolCallRequested: nil
+        )
+        buffers = result.toolCallBuffers
+        ids = result.toolCallIds
+
+        result = await OpenAIStreamParser.processStreamLine(
+            argumentsChunk,
+            toolCallBuffers: buffers,
+            toolCallIds: ids,
+            onToolCall: nil,
+            onToolCallRequested: nil
+        )
+        buffers = result.toolCallBuffers
+        ids = result.toolCallIds
+
+        _ = await OpenAIStreamParser.processStreamLine(
+            completionChunk,
+            toolCallBuffers: buffers,
+            toolCallIds: ids,
+            onToolCall: nil,
+            onToolCallRequested: { id, name, arguments in
+                recorder.record(id: id, name: name, query: arguments["command"] as? String)
+            }
+        )
+
+        let call = recorder.firstCall()
+        #expect(call?.id == "call_vekil")
+        #expect(call?.name == "run_command")
+        #expect(call?.query == "printf probe")
+    }
+
     @Test("[DONE] marker completes the stream")
     func doneMarkerCompletesStream() async {
         let result = await OpenAIStreamParser.processStreamLine(

--- a/Tests/AynaTests/ToolCallRequestRoundCoordinatorTests.swift
+++ b/Tests/AynaTests/ToolCallRequestRoundCoordinatorTests.swift
@@ -58,6 +58,20 @@ struct ToolCallRequestRoundCoordinatorTests {
     }
 
     @Test
+    func `ingress gate rejects callbacks with empty tool names`() {
+        let gate = ToolCallRequestAdmissionGate()
+        let admittedTools = FlightTestBox<[String]>([])
+        let callback = gate.admittedCallback { _, toolName, _ in
+            admittedTools.update { $0.append(toolName) }
+        }
+
+        callback("call-empty", "", [:])
+        callback("call-whitespace", "   ", [:])
+
+        #expect(admittedTools.value.isEmpty)
+    }
+
+    @Test
     func `request round rejects tool fan out beyond the hard limit`() throws {
         let toolChainCoordinator = ToolChainCoordinator()
         let coordinator = Coordinator()

--- a/Tests/AynaTests/ToolTranscriptSanitizerTests.swift
+++ b/Tests/AynaTests/ToolTranscriptSanitizerTests.swift
@@ -52,6 +52,17 @@ struct ToolTranscriptSanitizerTests {
         #expect(ToolTranscriptSanitizer.sanitize([assistant]).isEmpty)
     }
 
+    @Test("Drops paired tool calls with empty names")
+    func dropsPairedToolCallsWithEmptyNames() {
+        let call = MCPToolCall(id: "call", toolName: "", arguments: [:])
+        var assistant = Message(role: .assistant, content: "")
+        assistant.toolCalls = [call]
+        var result = Message(role: .tool, content: "failed")
+        result.toolCalls = [MCPToolCall(id: call.id, toolName: call.toolName, arguments: [:], result: "failed")]
+
+        #expect(ToolTranscriptSanitizer.sanitize([assistant, result]).isEmpty)
+    }
+
     @Test("Preserves non-tool assistant content when orphan calls are stripped")
     func preservesMeaningfulAssistantContent() throws {
         let orphanCall = MCPToolCall(id: "orphan", toolName: "lookup", arguments: [:])


### PR DESCRIPTION
## Summary

- preserve a valid streamed function name when a later OpenAI-compatible delta supplies an empty name
- reject nameless tool callbacks and remove invalid tool-call rounds from persisted history
- add regression coverage for Vekil-style streaming deltas and the downstream safety gates

## Testing

- `swiftlint --strict`
- `swiftformat --lint --disable swiftTestingTestCaseNames` on touched files
- `swift test --no-parallel` (1,276 tests)
- `swift build`
- `swift build --triple arm64-apple-ios26.0`
- `swift build --triple arm64-apple-watchos26.0`