### PR TITLE
fix(ci): serialize release unit tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts
 
     - name: Run unit tests
-      run: swift test -q
+      run: swift test -q --no-parallel
 
     - name: Build app for UI tests
       env:


### PR DESCRIPTION
## Summary

- run release unit tests with `--no-parallel`
- match the main test workflow isolation required by shared process-wide state
- unblock the v0.4.0 release after run 31465647736 exposed parallel-test contamination

## Validation

- YAML parses successfully
- `swift test --help` confirms `--no-parallel` support
- the same serialized command is already green in the main Test Suite workflow
- actionlint reports only pre-existing SC2034 warnings in release-note generation

Signed-off-by: Sertac Ozercan <sozercan@gmail.com>