### PR TITLE
fix(ci): publish appcast through protected branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,6 +349,8 @@ jobs:
 
     - name: Update Appcast
       if: success()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Fetch and checkout the default branch
         git fetch origin ${{ github.event.repository.default_branch }}
@@ -402,8 +404,39 @@ jobs:
           sed -i '' 's/^        //' appcast.xml
 
           git add appcast.xml
-          git diff --cached --quiet || git commit -s -m "chore: update appcast to ${{ steps.artifact.outputs.tag }}"
-          git push origin ${{ github.event.repository.default_branch }}
+          if git diff --cached --quiet; then
+            echo "Appcast is already up to date"
+          else
+            APPCAST_BRANCH="automation/appcast-${TAG}-${{ github.run_id }}"
+            git switch -c "$APPCAST_BRANCH"
+            git commit -s -m "chore: update appcast to ${{ steps.artifact.outputs.tag }}"
+            git push origin "$APPCAST_BRANCH"
+
+            PR_URL=$(gh pr create \
+              --base "${{ github.event.repository.default_branch }}" \
+              --head "$APPCAST_BRANCH" \
+              --title "chore: update appcast to ${{ steps.artifact.outputs.tag }}" \
+              --body "Publish the signed Sparkle appcast for ${{ steps.artifact.outputs.tag }}.")
+
+            for attempt in 1 2 3; do
+              if gh pr merge "$PR_URL" \
+                --squash \
+                --delete-branch \
+                --subject "chore: update appcast to ${{ steps.artifact.outputs.tag }}" \
+                --body "Publish the signed Sparkle appcast for ${{ steps.artifact.outputs.tag }}.
+
+        Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"; then
+                break
+              fi
+
+              if [ "$attempt" -eq 3 ]; then
+                echo "Error: Could not merge appcast pull request"
+                exit 1
+              fi
+
+              sleep 5
+            done
+          fi
         fi
 
     - name: Checkout Homebrew tap repo

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,7 +6,19 @@
         <description>Most recent updates for Ayna, a native agentic AI client for macOS, iOS, and watchOS, built with SwiftUI.</description>
         <language>en</language>
 
-        <!-- New releases will be added here by CI -->
+        <item>
+            <title>Version 0.4.0</title>
+            <sparkle:releaseNotesLink>https://github.com/sozercan/ayna/releases/tag/v0.4.0</sparkle:releaseNotesLink>
+            <pubDate>Tue, 11 Aug 2026 07:09:40 +0000</pubDate>
+            <enclosure
+                url="https://github.com/sozercan/ayna/releases/download/v0.4.0/ayna-v0.4.0.dmg"
+                sparkle:version="40"
+                sparkle:shortVersionString="0.4.0"
+                length="12386028"
+                type="application/octet-stream"
+                sparkle:edSignature="GhD11CKHvm7igjYnfuhhpzD3X5IaqyGweYuSj0pPAkwCdAdGRhNAsp9cWzhV3gps3L3RJa9Q3vtw5WzZFfFaBQ=="/>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+        </item>
 
     </channel>
 </rss>


### PR DESCRIPTION
Summary:
- publish the signed v0.4.0 Sparkle appcast
- create and merge appcast updates through pull requests to satisfy branch protection
- retry transient mergeability checks

Validation:
- actionlint .github/workflows/release.yml
- xmllint --noout appcast.xml
- verified the Ed25519 appcast signature against the immutable v0.4.0 DMG and embedded public key
- confirmed appcast build 40 matches the DMG CFBundleVersion