### PR TITLE
feat(chat): support pasting images into chat

### DIFF
--- a/Sources/Ayna/Chat/ChatDraftContent.swift
+++ b/Sources/Ayna/Chat/ChatDraftContent.swift
@@ -45,6 +45,23 @@ enum ChatDraftContent {
         return messages + [userMessage]
     }
 
+    static func effectiveHistory(
+        byEditingUserMessage messageID: UUID,
+        newContent: String,
+        in conversation: Conversation
+    ) -> [Message]? {
+        guard let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageID }),
+              conversation.messages[messageIndex].role == .user
+        else {
+            return nil
+        }
+
+        var candidateConversation = conversation
+        candidateConversation.messages = Array(conversation.messages.prefix(through: messageIndex))
+        candidateConversation.messages[messageIndex].content = newContent
+        return candidateConversation.getEffectiveHistory()
+    }
+
     static func isImageFile(_ fileURL: URL) -> Bool {
         guard !fileURL.pathExtension.isEmpty,
               let contentType = UTType(filenameExtension: fileURL.pathExtension.lowercased())

--- a/Sources/Ayna/Chat/ChatDraftContent.swift
+++ b/Sources/Ayna/Chat/ChatDraftContent.swift
@@ -29,6 +29,14 @@ enum ChatDraftContent {
             || attachments.contains(where: isProviderImageAttachment)
     }
 
+    static func remainingImageCapacity(
+        fileURLs: [URL],
+        inMemoryImageCount: Int
+    ) -> Int {
+        let imageFileCount = fileURLs.count(where: isImageFile)
+        return max(0, maximumImageCount - imageFileCount - max(0, inMemoryImageCount))
+    }
+
     static func messagesByIncludingUserMessageIfNeeded(
         _ userMessage: Message,
         in messages: [Message]

--- a/Sources/Ayna/Chat/ChatDraftContent.swift
+++ b/Sources/Ayna/Chat/ChatDraftContent.swift
@@ -1,0 +1,44 @@
+//
+//  ChatDraftContent.swift
+//  Ayna
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+/// Shared rules for deciding whether a composer draft can form a provider request.
+enum ChatDraftContent {
+    static func isSendable(
+        text: String,
+        fileURLs: [URL],
+        inMemoryImageCount: Int
+    ) -> Bool {
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || fileURLs.contains(where: isImageFile)
+            || inMemoryImageCount > 0
+    }
+
+    static func isSendable(
+        text: String,
+        attachments: [Message.FileAttachment]
+    ) -> Bool {
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || attachments.contains(where: isProviderImageAttachment)
+    }
+
+    static func isImageFile(_ fileURL: URL) -> Bool {
+        guard !fileURL.pathExtension.isEmpty,
+              let contentType = UTType(filenameExtension: fileURL.pathExtension.lowercased())
+        else {
+            return false
+        }
+
+        return [.jpeg, .png, .gif, .webP].contains { supportedType in
+            contentType.conforms(to: supportedType)
+        }
+    }
+
+    private static func isProviderImageAttachment(_ attachment: Message.FileAttachment) -> Bool {
+        ["image/jpeg", "image/png", "image/gif", "image/webp"].contains(attachment.mimeType.lowercased())
+    }
+}

--- a/Sources/Ayna/Chat/ChatDraftContent.swift
+++ b/Sources/Ayna/Chat/ChatDraftContent.swift
@@ -8,6 +8,9 @@ import UniformTypeIdentifiers
 
 /// Shared rules for deciding whether a composer draft can form a provider request.
 enum ChatDraftContent {
+    /// Matches the strictest supported provider limit (Anthropic: 20 images per request).
+    static let maximumImageCount = 20
+
     static func isSendable(
         text: String,
         fileURLs: [URL],

--- a/Sources/Ayna/Chat/ChatDraftContent.swift
+++ b/Sources/Ayna/Chat/ChatDraftContent.swift
@@ -29,6 +29,14 @@ enum ChatDraftContent {
             || attachments.contains(where: isProviderImageAttachment)
     }
 
+    static func messagesByIncludingUserMessageIfNeeded(
+        _ userMessage: Message,
+        in messages: [Message]
+    ) -> [Message] {
+        guard !messages.contains(where: { $0.id == userMessage.id }) else { return messages }
+        return messages + [userMessage]
+    }
+
     static func isImageFile(_ fileURL: URL) -> Bool {
         guard !fileURL.pathExtension.isEmpty,
               let contentType = UTType(filenameExtension: fileURL.pathExtension.lowercased())

--- a/Sources/Ayna/Chat/ChatMessageBuilder.swift
+++ b/Sources/Ayna/Chat/ChatMessageBuilder.swift
@@ -74,7 +74,7 @@
 
                 if saveToStorage {
                     let pathExtension = fileURL.pathExtension
-                    localPath = try? attachmentStorage.save(
+                    localPath = try? await attachmentStorage.saveData(
                         data: fileData,
                         extension: pathExtension,
                         generation: attachmentGeneration
@@ -93,7 +93,7 @@
             for pastedImage in pastedImages {
                 var localPath: String?
                 if saveToStorage {
-                    localPath = try? attachmentStorage.save(
+                    localPath = try? await attachmentStorage.saveData(
                         data: pastedImage.data,
                         extension: pastedImage.fileExtension,
                         generation: attachmentGeneration

--- a/Sources/Ayna/Chat/ChatMessageBuilder.swift
+++ b/Sources/Ayna/Chat/ChatMessageBuilder.swift
@@ -49,6 +49,7 @@
         /// - Returns: Array of file attachments
         static func buildAttachments(
             from fileURLs: [URL],
+            pastedImages: [PastedImage] = [],
             saveToStorage: Bool = false,
             attachmentStorage: AttachmentStorage = .shared,
             fileDataLoader: @escaping @Sendable (URL) async -> Data? = { fileURL in
@@ -89,6 +90,24 @@
                 attachments.append(attachment)
             }
 
+            for pastedImage in pastedImages {
+                var localPath: String?
+                if saveToStorage {
+                    localPath = try? attachmentStorage.save(
+                        data: pastedImage.data,
+                        extension: pastedImage.fileExtension,
+                        generation: attachmentGeneration
+                    )
+                }
+
+                attachments.append(Message.FileAttachment(
+                    fileName: pastedImage.fileName,
+                    mimeType: pastedImage.mimeType,
+                    data: localPath == nil ? pastedImage.data : nil,
+                    localPath: localPath
+                ))
+            }
+
             return attachments
         }
 
@@ -105,10 +124,17 @@
             text: String,
             appContent: AppContent?,
             fileURLs: [URL],
-            saveToStorage: Bool = false
+            pastedImages: [PastedImage] = [],
+            saveToStorage: Bool = false,
+            attachmentStorage: AttachmentStorage = .shared
         ) async -> Message {
             let content = formatContent(text: text, appContent: appContent)
-            let attachments = await buildAttachments(from: fileURLs, saveToStorage: saveToStorage)
+            let attachments = await buildAttachments(
+                from: fileURLs,
+                pastedImages: pastedImages,
+                saveToStorage: saveToStorage,
+                attachmentStorage: attachmentStorage
+            )
 
             return Message(
                 role: .user,

--- a/Sources/Ayna/Chat/ChatTranscriptPlan.swift
+++ b/Sources/Ayna/Chat/ChatTranscriptPlan.swift
@@ -162,6 +162,10 @@ struct ChatTranscriptPlan: Equatable, Sendable {
             return .image
         }
 
+        if message.role == .user, message.attachments?.isEmpty == false {
+            return .text
+        }
+
         if message.mediaType == .image {
             if message.responseGroupId != nil {
                 return .image

--- a/Sources/Ayna/Chat/ConversationSendPreflight.swift
+++ b/Sources/Ayna/Chat/ConversationSendPreflight.swift
@@ -2,6 +2,11 @@ import Foundation
 
 @MainActor
 enum ConversationSendPreflight {
+    struct Failure {
+        let message: String
+        let recoverySuggestion: String
+    }
+
     static func loadConversationHistory(
         conversationId: UUID,
         manager: ConversationManager
@@ -15,5 +20,85 @@ enum ConversationSendPreflight {
             return nil
         }
         return conversation
+    }
+
+    static func attachmentRuleFailure(
+        models: [String],
+        messages: [Message],
+        aiService: AIService
+    ) -> Failure? {
+        if let message = aiService.attachmentHistorySupportError(
+            for: models,
+            messages: messages
+        ) {
+            return Failure(
+                message: message,
+                recoverySuggestion: "Choose a vision-capable chat model or start a new conversation."
+            )
+        }
+
+        if let message = aiService.attachmentImageLimitError(
+            for: models,
+            messages: messages
+        ) {
+            return Failure(
+                message: message,
+                recoverySuggestion: "Remove images or start a new conversation."
+            )
+        }
+
+        return nil
+    }
+
+    static func attachmentDataFailure(
+        models: [String],
+        messages: [Message],
+        aiService: AIService,
+        loadAttachmentData: @Sendable (String) async -> Data?
+    ) async -> Failure? {
+        guard hasImageAttachments(in: messages) else { return nil }
+        guard let message = await aiService.attachmentImageValidationError(
+            for: models,
+            in: messages,
+            loadAttachmentData: loadAttachmentData
+        ) else {
+            return nil
+        }
+
+        return Failure(
+            message: message,
+            recoverySuggestion: "Remove the image or choose a different model."
+        )
+    }
+
+    static func attachmentFailure(
+        models: [String],
+        messages: [Message],
+        aiService: AIService,
+        loadAttachmentData: @Sendable (String) async -> Data?
+    ) async -> Failure? {
+        if let failure = attachmentRuleFailure(
+            models: models,
+            messages: messages,
+            aiService: aiService
+        ) {
+            return failure
+        }
+
+        return await attachmentDataFailure(
+            models: models,
+            messages: messages,
+            aiService: aiService,
+            loadAttachmentData: loadAttachmentData
+        )
+    }
+
+    static func hasImageAttachments(in messages: [Message]) -> Bool {
+        messages.contains { message in
+            guard message.role == .user else { return false }
+            return message.attachments?.contains(where: {
+                $0.mimeType.lowercased().hasPrefix("image/")
+            }) == true
+        }
     }
 }

--- a/Sources/Ayna/Models/AppContent.swift
+++ b/Sources/Ayna/Models/AppContent.swift
@@ -60,6 +60,23 @@
             }
         }
 
+        static func hasSamePayload(_ lhs: AppContent?, _ rhs: AppContent?) -> Bool {
+            switch (lhs, rhs) {
+            case (nil, nil):
+                true
+            case let (lhs?, rhs?):
+                lhs.appName == rhs.appName &&
+                    lhs.bundleIdentifier == rhs.bundleIdentifier &&
+                    lhs.windowTitle == rhs.windowTitle &&
+                    lhs.content == rhs.content &&
+                    lhs.contentType == rhs.contentType &&
+                    lhs.isTruncated == rhs.isTruncated &&
+                    lhs.originalLength == rhs.originalLength
+            default:
+                false
+            }
+        }
+
         /// Creates a truncated version of this content.
         /// For terminal output, keeps the END (most recent output).
         /// For other content types, keeps the START.

--- a/Sources/Ayna/Models/Conversation.swift
+++ b/Sources/Ayna/Models/Conversation.swift
@@ -272,10 +272,9 @@ struct Conversation: Identifiable, Equatable, Sendable {
         return nil
     }
 
-    /// Add a response group for multi-model responses
-    mutating func addResponseGroup(_ group: ResponseGroup) {
+    mutating func removeFailedResponseGroups(for userMessageId: UUID) {
         let failedGroupIDs = Set<UUID>(responseGroups.compactMap { existingGroup in
-            guard existingGroup.userMessageId == group.userMessageId,
+            guard existingGroup.userMessageId == userMessageId,
                   !existingGroup.responses.isEmpty,
                   existingGroup.responses.allSatisfy({ $0.status == .failed })
             else {
@@ -283,14 +282,18 @@ struct Conversation: Identifiable, Equatable, Sendable {
             }
             return existingGroup.id
         })
-        if !failedGroupIDs.isEmpty {
-            messages.removeAll { message in
-                guard let responseGroupId = message.responseGroupId else { return false }
-                return failedGroupIDs.contains(responseGroupId)
-            }
-            responseGroups.removeAll { failedGroupIDs.contains($0.id) }
-        }
+        guard !failedGroupIDs.isEmpty else { return }
 
+        messages.removeAll { message in
+            guard let responseGroupId = message.responseGroupId else { return false }
+            return failedGroupIDs.contains(responseGroupId)
+        }
+        responseGroups.removeAll { failedGroupIDs.contains($0.id) }
+        updatedAt = Date()
+    }
+
+    /// Add a response group for multi-model responses.
+    mutating func addResponseGroup(_ group: ResponseGroup) {
         responseGroups.append(group)
         updatedAt = Date()
     }

--- a/Sources/Ayna/Models/Conversation.swift
+++ b/Sources/Ayna/Models/Conversation.swift
@@ -274,6 +274,23 @@ struct Conversation: Identifiable, Equatable, Sendable {
 
     /// Add a response group for multi-model responses
     mutating func addResponseGroup(_ group: ResponseGroup) {
+        let failedGroupIDs = Set<UUID>(responseGroups.compactMap { existingGroup in
+            guard existingGroup.userMessageId == group.userMessageId,
+                  !existingGroup.responses.isEmpty,
+                  existingGroup.responses.allSatisfy({ $0.status == .failed })
+            else {
+                return nil
+            }
+            return existingGroup.id
+        })
+        if !failedGroupIDs.isEmpty {
+            messages.removeAll { message in
+                guard let responseGroupId = message.responseGroupId else { return false }
+                return failedGroupIDs.contains(responseGroupId)
+            }
+            responseGroups.removeAll { failedGroupIDs.contains($0.id) }
+        }
+
         responseGroups.append(group)
         updatedAt = Date()
     }

--- a/Sources/Ayna/Models/Message.swift
+++ b/Sources/Ayna/Models/Message.swift
@@ -62,11 +62,41 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
         case image
     }
 
-    struct FileAttachment: Codable, Equatable, Sendable {
+    struct FileAttachment: Identifiable, Codable, Equatable, Sendable {
+        let id: UUID
         let fileName: String
         let mimeType: String
         var data: Data?
         var localPath: String? // Path relative to AttachmentStorage
+
+        init(
+            id: UUID = UUID(),
+            fileName: String,
+            mimeType: String,
+            data: Data? = nil,
+            localPath: String? = nil
+        ) {
+            self.id = id
+            self.fileName = fileName
+            self.mimeType = mimeType
+            self.data = data
+            self.localPath = localPath
+        }
+
+        // FileAttachment is already nested in Message; Codable requires one further key type.
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case id, fileName, mimeType, data, localPath
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+            fileName = try container.decode(String.self, forKey: .fileName)
+            mimeType = try container.decode(String.self, forKey: .mimeType)
+            data = try container.decodeIfPresent(Data.self, forKey: .data)
+            localPath = try container.decodeIfPresent(String.self, forKey: .localPath)
+        }
 
         /// Helper to get data regardless of storage method
         @MainActor

--- a/Sources/Ayna/Models/PastedImage.swift
+++ b/Sources/Ayna/Models/PastedImage.swift
@@ -1,0 +1,220 @@
+//
+//  PastedImage.swift
+//  Ayna
+//
+
+#if !os(watchOS)
+
+    import CoreGraphics
+    import CoreTransferable
+    import Foundation
+    import ImageIO
+    import UniformTypeIdentifiers
+
+    /// An image imported from the clipboard and normalized for vision-capable providers.
+    struct PastedImage: Identifiable, Equatable, Sendable {
+        enum ImportError: LocalizedError {
+            case invalidImage
+            case conversionFailed
+            case imageTooLarge
+
+            var errorDescription: String? {
+                switch self {
+                case .invalidImage:
+                    "The clipboard does not contain a valid image."
+                case .conversionFailed:
+                    "The clipboard image could not be converted."
+                case .imageTooLarge:
+                    "The clipboard image is too large to attach."
+                }
+            }
+        }
+
+        /// Matches the strictest supported provider limit (Anthropic: 3.75 MiB).
+        static let maximumByteCount = 3_932_160
+        static let maximumDimension = 2048
+
+        let id: UUID
+        let data: Data
+        let mimeType: String
+        let fileExtension: String
+
+        init(
+            id: UUID = UUID(),
+            data: Data,
+            mimeType: String,
+            fileExtension: String
+        ) {
+            self.id = id
+            self.data = data
+            self.mimeType = mimeType
+            self.fileExtension = fileExtension.lowercased()
+        }
+
+        var fileName: String {
+            "pasted-image-\(id.uuidString.lowercased()).\(fileExtension)"
+        }
+
+        /// Validates clipboard bytes and converts formats that providers cannot consume directly.
+        static func importing(data: Data, contentType: UTType) throws -> PastedImage {
+            guard !data.isEmpty,
+                  let source = CGImageSourceCreateWithData(data as CFData, nil),
+                  CGImageSourceGetCount(source) > 0
+            else {
+                throw ImportError.invalidImage
+            }
+
+            guard let sourceImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+                throw ImportError.invalidImage
+            }
+
+            if let format = providerFormat(for: contentType),
+               data.count <= maximumByteCount,
+               max(sourceImage.width, sourceImage.height) <= maximumDimension
+            {
+                return PastedImage(
+                    data: data,
+                    mimeType: format.mimeType,
+                    fileExtension: format.fileExtension
+                )
+            }
+
+            return try convertedImage(from: sourceImage)
+        }
+
+        private static func providerFormat(for contentType: UTType) -> (mimeType: String, fileExtension: String)? {
+            if contentType.conforms(to: .jpeg) {
+                return ("image/jpeg", "jpg")
+            }
+            if contentType.conforms(to: .png) {
+                return ("image/png", "png")
+            }
+            if contentType.conforms(to: .gif) {
+                return ("image/gif", "gif")
+            }
+            if contentType.conforms(to: .webP) {
+                return ("image/webp", "webp")
+            }
+            return nil
+        }
+
+        private static func convertedImage(from sourceImage: CGImage) throws -> PastedImage {
+            let outputType: UTType = hasAlpha(sourceImage) ? .png : .jpeg
+            var image = resized(sourceImage, maximumDimension: maximumDimension) ?? sourceImage
+
+            while true {
+                let qualityValues: [CGFloat] = outputType == .jpeg
+                    ? [0.85, 0.7, 0.55, 0.4, 0.25]
+                    : [1.0]
+
+                for quality in qualityValues {
+                    guard let encoded = encode(image, as: outputType, quality: quality) else {
+                        continue
+                    }
+                    if encoded.count <= maximumByteCount {
+                        return PastedImage(
+                            data: encoded,
+                            mimeType: outputType == .png ? "image/png" : "image/jpeg",
+                            fileExtension: outputType == .png ? "png" : "jpg"
+                        )
+                    }
+                }
+
+                let largestDimension = max(image.width, image.height)
+                guard largestDimension > 64 else {
+                    throw ImportError.imageTooLarge
+                }
+                guard let smallerImage = resized(
+                    image,
+                    maximumDimension: max(64, Int(Double(largestDimension) * 0.75))
+                ) else {
+                    throw ImportError.conversionFailed
+                }
+                image = smallerImage
+            }
+        }
+
+        private static func encode(_ image: CGImage, as contentType: UTType, quality: CGFloat) -> Data? {
+            let output = NSMutableData()
+            guard let destination = CGImageDestinationCreateWithData(
+                output,
+                contentType.identifier as CFString,
+                1,
+                nil
+            ) else {
+                return nil
+            }
+
+            let properties: CFDictionary? = if contentType == .jpeg {
+                [kCGImageDestinationLossyCompressionQuality: quality] as CFDictionary
+            } else {
+                nil
+            }
+            CGImageDestinationAddImage(destination, image, properties)
+            guard CGImageDestinationFinalize(destination) else { return nil }
+            return output as Data
+        }
+
+        private static func resized(_ image: CGImage, maximumDimension: Int) -> CGImage? {
+            let largestDimension = max(image.width, image.height)
+            guard largestDimension > maximumDimension else { return image }
+
+            let scale = CGFloat(maximumDimension) / CGFloat(largestDimension)
+            let width = max(1, Int((CGFloat(image.width) * scale).rounded()))
+            let height = max(1, Int((CGFloat(image.height) * scale).rounded()))
+            let colorSpace = CGColorSpaceCreateDeviceRGB()
+            let bitmapInfo = CGBitmapInfo.byteOrder32Big.rawValue
+                | CGImageAlphaInfo.premultipliedLast.rawValue
+            guard let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: bitmapInfo
+            ) else {
+                return nil
+            }
+
+            context.interpolationQuality = .high
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return context.makeImage()
+        }
+
+        private static func hasAlpha(_ image: CGImage) -> Bool {
+            switch image.alphaInfo {
+            case .alphaOnly, .first, .last, .premultipliedFirst, .premultipliedLast:
+                true
+            case .none, .noneSkipFirst, .noneSkipLast:
+                false
+            @unknown default:
+                false
+            }
+        }
+    }
+
+    extension PastedImage: Transferable {
+        static var transferRepresentation: some TransferRepresentation {
+            DataRepresentation(importedContentType: .png) { data in
+                try importing(data: data, contentType: .png)
+            }
+            DataRepresentation(importedContentType: .jpeg) { data in
+                try importing(data: data, contentType: .jpeg)
+            }
+            DataRepresentation(importedContentType: .gif) { data in
+                try importing(data: data, contentType: .gif)
+            }
+            DataRepresentation(importedContentType: .webP) { data in
+                try importing(data: data, contentType: .webP)
+            }
+            DataRepresentation(importedContentType: .tiff) { data in
+                try importing(data: data, contentType: .tiff)
+            }
+            DataRepresentation(importedContentType: .heic) { data in
+                try importing(data: data, contentType: .heic)
+            }
+        }
+    }
+
+#endif

--- a/Sources/Ayna/Models/PastedImage.swift
+++ b/Sources/Ayna/Models/PastedImage.swift
@@ -59,19 +59,21 @@
         static func importing(data: Data, contentType: UTType) throws -> PastedImage {
             guard !data.isEmpty,
                   let source = CGImageSourceCreateWithData(data as CFData, nil),
-                  CGImageSourceGetCount(source) > 0
+                  CGImageSourceGetCount(source) > 0,
+                  let dimensions = pixelDimensions(of: source)
             else {
                 throw ImportError.invalidImage
             }
 
-            guard let sourceImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
-                throw ImportError.invalidImage
-            }
-
-            if let format = providerFormat(for: contentType),
+            let decodedContentType = CGImageSourceGetType(source)
+                .flatMap { UTType($0 as String) }
+            if let format = providerFormat(for: decodedContentType ?? contentType),
                data.count <= maximumByteCount,
-               max(sourceImage.width, sourceImage.height) <= maximumDimension
+               max(dimensions.width, dimensions.height) <= maximumDimension
             {
+                guard CGImageSourceCreateImageAtIndex(source, 0, nil) != nil else {
+                    throw ImportError.invalidImage
+                }
                 return PastedImage(
                     data: data,
                     mimeType: format.mimeType,
@@ -79,7 +81,32 @@
                 )
             }
 
+            guard let sourceImage = transformedThumbnail(from: source) else {
+                throw ImportError.invalidImage
+            }
             return try convertedImage(from: sourceImage)
+        }
+
+        private static func pixelDimensions(of source: CGImageSource) -> (width: Int, height: Int)? {
+            guard let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as NSDictionary?,
+                  let width = (properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
+                  let height = (properties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
+                  width > 0,
+                  height > 0
+            else {
+                return nil
+            }
+            return (width, height)
+        }
+
+        private static func transformedThumbnail(from source: CGImageSource) -> CGImage? {
+            let options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceThumbnailMaxPixelSize: maximumDimension,
+                kCGImageSourceShouldCacheImmediately: true,
+            ]
+            return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
         }
 
         private static func providerFormat(for contentType: UTType) -> (mimeType: String, fileExtension: String)? {

--- a/Sources/Ayna/Models/WatchDataModels.swift
+++ b/Sources/Ayna/Models/WatchDataModels.swift
@@ -450,7 +450,17 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
     init(from message: Message) {
         id = message.id
         role = message.role.rawValue
-        content = message.content
+        let imageCount = message.attachments?.count(where: {
+            $0.mimeType.starts(with: "image/")
+        }) ?? 0
+        if message.role == .user,
+           message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           imageCount > 0
+        {
+            content = imageCount == 1 ? "[Image]" : "[\(imageCount) images]"
+        } else {
+            content = message.content
+        }
         reasoning = message.reasoning
         timestamp = message.timestamp
         model = message.model

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -917,12 +917,7 @@ class AIService: ObservableObject {
 
     /// Returns a user-facing reason when an Anthropic request would exceed its image limit.
     func attachmentImageLimitError(for models: [String], messages: [Message]) -> String? {
-        let usesAnthropic = models.contains { model in
-            let normalizedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !normalizedModel.isEmpty else { return false }
-            return (modelProviders[normalizedModel] ?? provider) == .anthropic
-        }
-        guard usesAnthropic else { return nil }
+        guard usesAnthropicModel(models) else { return nil }
 
         let supportedTypes = Set(AnthropicRequestBuilder.supportedImageTypes)
         let imageCount = messages.reduce(into: 0) { count, message in
@@ -934,6 +929,56 @@ class AIService: ObservableObject {
         guard imageCount > AnthropicRequestBuilder.maxImagesPerRequest else { return nil }
 
         return "Anthropic supports at most \(AnthropicRequestBuilder.maxImagesPerRequest) images per request. Remove some images or start a new conversation."
+    }
+
+    func attachmentImageValidationError(
+        for models: [String],
+        inMemoryAttachments attachments: [Message.FileAttachment]
+    ) -> String? {
+        guard usesAnthropicModel(models) else { return nil }
+
+        for attachment in anthropicImageAttachments(in: attachments) {
+            guard let data = attachment.data else {
+                return "Unable to load image attachment \"\(attachment.fileName)\". Remove it and try again."
+            }
+            if let validationError = AnthropicRequestBuilder.imageValidationError(data: data) {
+                return "\(attachment.fileName): \(validationError)"
+            }
+        }
+        return nil
+    }
+
+    func attachmentImageValidationError(
+        for models: [String],
+        loading attachments: [Message.FileAttachment]
+    ) async -> String? {
+        guard usesAnthropicModel(models) else { return nil }
+
+        for attachment in anthropicImageAttachments(in: attachments) {
+            guard !Task.isCancelled else { return nil }
+            guard let data = await attachment.loadContent() else {
+                return "Unable to load image attachment \"\(attachment.fileName)\". Remove it and try again."
+            }
+            if let validationError = AnthropicRequestBuilder.imageValidationError(data: data) {
+                return "\(attachment.fileName): \(validationError)"
+            }
+        }
+        return nil
+    }
+
+    private func usesAnthropicModel(_ models: [String]) -> Bool {
+        models.contains { model in
+            let normalizedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedModel.isEmpty else { return false }
+            return (modelProviders[normalizedModel] ?? provider) == .anthropic
+        }
+    }
+
+    private func anthropicImageAttachments(
+        in attachments: [Message.FileAttachment]
+    ) -> [Message.FileAttachment] {
+        let supportedTypes = Set(AnthropicRequestBuilder.supportedImageTypes)
+        return attachments.filter { supportedTypes.contains($0.mimeType.lowercased()) }
     }
 
     fileprivate func cancelTextRequest(_ flightID: RequestFlightID) {

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -897,6 +897,24 @@ class AIService: ObservableObject {
         return .chat
     }
 
+    /// Returns a user-facing reason when a selected model cannot consume attachments.
+    func attachmentSupportError(for models: [String]) -> String? {
+        for model in models {
+            let normalizedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedModel.isEmpty else { continue }
+
+            if getModelCapability(normalizedModel) == .imageGeneration {
+                return "Image generation models do not accept attachments. Remove the attachment or choose a chat model."
+            }
+
+            let modelProvider = modelProviders[normalizedModel] ?? provider
+            if modelProvider == .appleIntelligence {
+                return "Apple Intelligence does not support attachments. Choose a vision-capable cloud model."
+            }
+        }
+        return nil
+    }
+
     fileprivate func cancelTextRequest(_ flightID: RequestFlightID) {
         let dataTask = currentTask.take(ifOwnedBy: flightID)
         let backgroundDataTask = backgroundDataTasks.removeValue(forKey: flightID)
@@ -1402,6 +1420,22 @@ class AIService: ObservableObject {
                 "isAzure": "\(usesAzureEndpoint)"
             ]
         )
+
+        if effectiveProvider == .appleIntelligence,
+           messages.contains(where: { $0.attachments?.isEmpty == false })
+        {
+            let error = AIError.apiError(
+                "Apple Intelligence does not support attachments. Choose a vision-capable cloud model."
+            )
+            DiagnosticsLogger.log(
+                .aiService,
+                level: .error,
+                message: "Apple Intelligence request rejected because it contains attachments",
+                metadata: ["model": requestModel]
+            )
+            onError(error)
+            return requestHandle
+        }
 
         // Handle Apple Intelligence separately
         #if !os(watchOS)

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -917,19 +917,10 @@ class AIService: ObservableObject {
         return nil
     }
 
-    /// Returns a user-facing reason when Apple Intelligence cannot consume attachment history.
+    /// Returns a user-facing reason when a selected model cannot consume attachment history.
     func attachmentHistorySupportError(for models: [String], messages: [Message]) -> String? {
         guard messages.contains(where: { $0.attachments?.isEmpty == false }) else { return nil }
-
-        for model in models {
-            let normalizedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !normalizedModel.isEmpty else { continue }
-            let modelProvider = modelProviders[normalizedModel] ?? provider
-            if modelProvider == .appleIntelligence {
-                return "Apple Intelligence does not support attachments. Choose a vision-capable cloud model."
-            }
-        }
-        return nil
+        return attachmentSupportError(for: models)
     }
 
     /// Returns a user-facing reason when an Anthropic request would exceed its image limit.

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -10,7 +10,9 @@
 
 import Combine
 import Foundation
+import ImageIO
 import os
+import UniformTypeIdentifiers
 
 // swiftlint:disable type_body_length
 // This service intentionally aggregates every provider workflow until we extract dedicated modules.
@@ -948,18 +950,12 @@ class AIService: ObservableObject {
     func attachmentImageValidationError(
         for models: [String],
         inMemoryAttachments attachments: [Message.FileAttachment]
-    ) -> String? {
-        guard usesAnthropicModel(models) else { return nil }
-
-        for attachment in anthropicImageAttachments(in: attachments) {
-            guard let data = attachment.data else {
-                return "Unable to load image attachment \"\(attachment.fileName)\". Remove it and try again."
-            }
-            if let validationError = AnthropicRequestBuilder.imageValidationError(data: data) {
-                return "\(attachment.fileName): \(validationError)"
-            }
-        }
-        return nil
+    ) async -> String? {
+        await attachmentImageValidationError(
+            for: models,
+            loading: attachments,
+            loadAttachmentData: { _ in nil }
+        )
     }
 
     func attachmentImageValidationError(
@@ -967,9 +963,9 @@ class AIService: ObservableObject {
         loading attachments: [Message.FileAttachment],
         loadAttachmentData: @Sendable (String) async -> Data?
     ) async -> String? {
-        guard usesAnthropicModel(models) else { return nil }
+        let appliesAnthropicPolicy = usesAnthropicModel(models)
 
-        for attachment in anthropicImageAttachments(in: attachments) {
+        for attachment in imageAttachments(in: attachments) {
             guard !Task.isCancelled else { return nil }
             let data: Data? = if let inlineData = attachment.data {
                 inlineData
@@ -981,7 +977,25 @@ class AIService: ObservableObject {
             guard let data else {
                 return "Unable to load image attachment \"\(attachment.fileName)\". Remove it and try again."
             }
-            if let validationError = AnthropicRequestBuilder.imageValidationError(data: data) {
+            if appliesAnthropicPolicy,
+               let validationError = AnthropicRequestBuilder.imageValidationError(data: data)
+            {
+                return "\(attachment.fileName): \(validationError)"
+            }
+
+            let validationTask = Task.detached(priority: .utility) {
+                Self.providerImageValidationError(
+                    data: data,
+                    declaredMimeType: attachment.mimeType
+                )
+            }
+            let validationError = await withTaskCancellationHandler {
+                await validationTask.value
+            } onCancel: {
+                validationTask.cancel()
+            }
+            guard !Task.isCancelled else { return nil }
+            if let validationError {
                 return "\(attachment.fileName): \(validationError)"
             }
         }
@@ -993,8 +1007,6 @@ class AIService: ObservableObject {
         in messages: [Message],
         loadAttachmentData: @Sendable (String) async -> Data?
     ) async -> String? {
-        guard usesAnthropicModel(models) else { return nil }
-
         let attachments = messages.reduce(into: [Message.FileAttachment]()) { result, message in
             guard message.role == .user else { return }
             result.append(contentsOf: message.attachments ?? [])
@@ -1014,10 +1026,65 @@ class AIService: ObservableObject {
         }
     }
 
-    private func anthropicImageAttachments(
+    private func imageAttachments(
         in attachments: [Message.FileAttachment]
     ) -> [Message.FileAttachment] {
         attachments.filter { $0.mimeType.lowercased().hasPrefix("image/") }
+    }
+
+    private nonisolated static func providerImageValidationError(
+        data: Data,
+        declaredMimeType: String
+    ) -> String? {
+        guard !Task.isCancelled,
+              !data.isEmpty,
+              let source = CGImageSourceCreateWithData(data as CFData, nil),
+              CGImageSourceGetCount(source) > 0
+        else {
+            return "Image data is invalid or corrupted."
+        }
+
+        let decodedContentType = CGImageSourceGetType(source)
+            .flatMap { UTType($0 as String) }
+        guard let decodedContentType,
+              let decodedFormat = providerImageFormat(for: decodedContentType),
+              let declaredContentType = UTType(mimeType: declaredMimeType),
+              let declaredFormat = providerImageFormat(for: declaredContentType)
+        else {
+            return "Unsupported image format. Supported: JPEG, PNG, GIF, WebP"
+        }
+        guard decodedFormat == declaredFormat else {
+            return "Image data does not match the declared \(declaredMimeType) format."
+        }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: 64,
+            kCGImageSourceShouldCacheImmediately: true,
+        ]
+        guard !Task.isCancelled,
+              CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) != nil
+        else {
+            return Task.isCancelled ? nil : "Image data is invalid or corrupted."
+        }
+        return nil
+    }
+
+    private nonisolated static func providerImageFormat(for contentType: UTType) -> String? {
+        if contentType.conforms(to: .jpeg) {
+            return "jpeg"
+        }
+        if contentType.conforms(to: .png) {
+            return "png"
+        }
+        if contentType.conforms(to: .gif) {
+            return "gif"
+        }
+        if contentType.conforms(to: .webP) {
+            return "webp"
+        }
+        return nil
     }
 
     fileprivate func cancelTextRequest(_ flightID: RequestFlightID) {

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -915,6 +915,21 @@ class AIService: ObservableObject {
         return nil
     }
 
+    /// Returns a user-facing reason when Apple Intelligence cannot consume attachment history.
+    func attachmentHistorySupportError(for models: [String], messages: [Message]) -> String? {
+        guard messages.contains(where: { $0.attachments?.isEmpty == false }) else { return nil }
+
+        for model in models {
+            let normalizedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedModel.isEmpty else { continue }
+            let modelProvider = modelProviders[normalizedModel] ?? provider
+            if modelProvider == .appleIntelligence {
+                return "Apple Intelligence does not support attachments. Choose a vision-capable cloud model."
+            }
+        }
+        return nil
+    }
+
     /// Returns a user-facing reason when an Anthropic request would exceed its image limit.
     func attachmentImageLimitError(for models: [String], messages: [Message]) -> String? {
         guard usesAnthropicModel(models) else { return nil }
@@ -950,13 +965,21 @@ class AIService: ObservableObject {
 
     func attachmentImageValidationError(
         for models: [String],
-        loading attachments: [Message.FileAttachment]
+        loading attachments: [Message.FileAttachment],
+        loadAttachmentData: @Sendable (String) async -> Data?
     ) async -> String? {
         guard usesAnthropicModel(models) else { return nil }
 
         for attachment in anthropicImageAttachments(in: attachments) {
             guard !Task.isCancelled else { return nil }
-            guard let data = await attachment.loadContent() else {
+            let data: Data? = if let inlineData = attachment.data {
+                inlineData
+            } else if let localPath = attachment.localPath {
+                await loadAttachmentData(localPath)
+            } else {
+                nil
+            }
+            guard let data else {
                 return "Unable to load image attachment \"\(attachment.fileName)\". Remove it and try again."
             }
             if let validationError = AnthropicRequestBuilder.imageValidationError(data: data) {

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -934,11 +934,10 @@ class AIService: ObservableObject {
     func attachmentImageLimitError(for models: [String], messages: [Message]) -> String? {
         guard usesAnthropicModel(models) else { return nil }
 
-        let supportedTypes = Set(AnthropicRequestBuilder.supportedImageTypes)
         let imageCount = messages.reduce(into: 0) { count, message in
             guard message.role == .user else { return }
             count += message.attachments?.count(where: {
-                supportedTypes.contains($0.mimeType.lowercased())
+                $0.mimeType.lowercased().hasPrefix("image/")
             }) ?? 0
         }
         guard imageCount > AnthropicRequestBuilder.maxImagesPerRequest else { return nil }
@@ -989,6 +988,24 @@ class AIService: ObservableObject {
         return nil
     }
 
+    func attachmentImageValidationError(
+        for models: [String],
+        in messages: [Message],
+        loadAttachmentData: @Sendable (String) async -> Data?
+    ) async -> String? {
+        guard usesAnthropicModel(models) else { return nil }
+
+        let attachments = messages.reduce(into: [Message.FileAttachment]()) { result, message in
+            guard message.role == .user else { return }
+            result.append(contentsOf: message.attachments ?? [])
+        }
+        return await attachmentImageValidationError(
+            for: models,
+            loading: attachments,
+            loadAttachmentData: loadAttachmentData
+        )
+    }
+
     private func usesAnthropicModel(_ models: [String]) -> Bool {
         models.contains { model in
             let normalizedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1000,8 +1017,7 @@ class AIService: ObservableObject {
     private func anthropicImageAttachments(
         in attachments: [Message.FileAttachment]
     ) -> [Message.FileAttachment] {
-        let supportedTypes = Set(AnthropicRequestBuilder.supportedImageTypes)
-        return attachments.filter { supportedTypes.contains($0.mimeType.lowercased()) }
+        attachments.filter { $0.mimeType.lowercased().hasPrefix("image/") }
     }
 
     fileprivate func cancelTextRequest(_ flightID: RequestFlightID) {

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -915,6 +915,27 @@ class AIService: ObservableObject {
         return nil
     }
 
+    /// Returns a user-facing reason when an Anthropic request would exceed its image limit.
+    func attachmentImageLimitError(for models: [String], messages: [Message]) -> String? {
+        let usesAnthropic = models.contains { model in
+            let normalizedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedModel.isEmpty else { return false }
+            return (modelProviders[normalizedModel] ?? provider) == .anthropic
+        }
+        guard usesAnthropic else { return nil }
+
+        let supportedTypes = Set(AnthropicRequestBuilder.supportedImageTypes)
+        let imageCount = messages.reduce(into: 0) { count, message in
+            guard message.role == .user else { return }
+            count += message.attachments?.count(where: {
+                supportedTypes.contains($0.mimeType.lowercased())
+            }) ?? 0
+        }
+        guard imageCount > AnthropicRequestBuilder.maxImagesPerRequest else { return nil }
+
+        return "Anthropic supports at most \(AnthropicRequestBuilder.maxImagesPerRequest) images per request. Remove some images or start a new conversation."
+    }
+
     fileprivate func cancelTextRequest(_ flightID: RequestFlightID) {
         let dataTask = currentTask.take(ifOwnedBy: flightID)
         let backgroundDataTask = backgroundDataTasks.removeValue(forKey: flightID)

--- a/Sources/Ayna/Services/AnthropicRequestBuilder.swift
+++ b/Sources/Ayna/Services/AnthropicRequestBuilder.swift
@@ -444,15 +444,10 @@ enum AnthropicRequestBuilder {
     /// - Throws: `AynaError` if validation fails
     static func validateAndBuildImageBlock(data: Data, fileName _: String?) throws -> [String: Any] {
         try Task.checkCancellation()
-        // Check size
-        if data.count > maxImageSizeBytes {
-            let sizeMB = Double(data.count) / 1_048_576.0
-            throw AynaError.apiError(message: "Image too large: \(String(format: "%.1f", sizeMB)) MB (max 3.75 MB)")
+        if let validationError = imageValidationError(data: data) {
+            throw AynaError.apiError(message: validationError)
         }
-
-        // Detect media type from magic bytes
-        let mediaType = detectImageMediaType(data: data)
-        guard let type = mediaType else {
+        guard let type = detectImageMediaType(data: data) else {
             throw AynaError.apiError(message: "Unsupported image format. Supported: JPEG, PNG, GIF, WebP")
         }
 
@@ -469,6 +464,17 @@ enum AnthropicRequestBuilder {
                 "data": encodedData
             ]
         ]
+    }
+
+    static func imageValidationError(data: Data) -> String? {
+        if data.count > maxImageSizeBytes {
+            let sizeMB = Double(data.count) / 1_048_576.0
+            return "Image too large: \(String(format: "%.1f", sizeMB)) MB (max 3.75 MB)"
+        }
+        guard detectImageMediaType(data: data) != nil else {
+            return "Unsupported image format. Supported: JPEG, PNG, GIF, WebP"
+        }
+        return nil
     }
 
     /// Detect image media type from magic bytes.

--- a/Sources/Ayna/Services/AnthropicRequestBuilder.swift
+++ b/Sources/Ayna/Services/AnthropicRequestBuilder.swift
@@ -50,7 +50,7 @@ enum AnthropicRequestBuilder {
     // MARK: - Constants
 
     /// Maximum number of images per request
-    static let maxImagesPerRequest = 20
+    static let maxImagesPerRequest = ChatDraftContent.maximumImageCount
 
     /// Maximum image size in bytes (3.75 MB)
     static let maxImageSizeBytes = 3_932_160

--- a/Sources/Ayna/Services/AttachmentStorage.swift
+++ b/Sources/Ayna/Services/AttachmentStorage.swift
@@ -174,6 +174,28 @@ final class AttachmentStorage: @unchecked Sendable {
         }
     }
 
+    /// Saves data off the caller's actor while preserving cleanup-generation fencing.
+    func saveData(
+        data: Data,
+        extension: String = "dat",
+        generation expectedGeneration: AttachmentStorageGeneration? = nil
+    ) async throws -> String {
+        try Task.checkCancellation()
+        let saveTask = Task.detached(priority: .utility) { [self] in
+            try Task.checkCancellation()
+            return try save(
+                data: data,
+                extension: `extension`,
+                generation: expectedGeneration
+            )
+        }
+        return try await withTaskCancellationHandler {
+            try await saveTask.value
+        } onCancel: {
+            saveTask.cancel()
+        }
+    }
+
     nonisolated static func sanitizedExtension(_ fileExtension: String) -> String {
         let components = fileExtension
             .lowercased()

--- a/Sources/Ayna/ViewModels/ConversationManager.swift
+++ b/Sources/Ayna/ViewModels/ConversationManager.swift
@@ -2746,32 +2746,19 @@ final class ConversationManager: ObservableObject {
         }
     }
 
-    /// Adds multiple messages and a response group atomically.
-    /// This ensures the UI updates once with all data ready, preventing visual glitches
-    /// where multi-model responses appear as separate messages briefly.
-    func addMultiModelResponse(
+    /// Starts or retries a multi-model response as one conversation mutation.
+    func beginMultiModelResponse(
         to conversation: Conversation,
         messages: [Message],
         responseGroup: ResponseGroup
-    ) {
-        if let index = conversations.firstIndex(where: { $0.id == conversation.id }) {
-            // Add all messages
-            for message in messages {
-                conversations[index].messages.append(message)
-            }
-            // Add the response group
-            conversations[index].addResponseGroup(responseGroup)
-            conversations[index].updatedAt = Date()
-            save(conversations[index])
-        }
-    }
+    ) -> Conversation? {
+        guard let index = getConversationIndex(for: conversation.id) else { return nil }
 
-    /// Adds a response group to track parallel responses
-    func addResponseGroup(to conversation: Conversation, group: ResponseGroup) {
-        if let index = getConversationIndex(for: conversation.id) {
-            conversations[index].addResponseGroup(group)
-            save(conversations[index])
-        }
+        conversations[index].removeFailedResponseGroups(for: responseGroup.userMessageId)
+        conversations[index].messages.append(contentsOf: messages)
+        conversations[index].addResponseGroup(responseGroup)
+        save(conversations[index])
+        return conversations[index]
     }
 
     /// Updates a response group (e.g., when streaming completes)

--- a/Sources/Ayna/ViewModels/ConversationManager.swift
+++ b/Sources/Ayna/ViewModels/ConversationManager.swift
@@ -2917,17 +2917,26 @@ final class ConversationManager: ObservableObject {
             return
         }
 
+        let content = firstMessage.content
+        if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let imageCount = firstMessage.attachments?.count(where: {
+                $0.mimeType.starts(with: "image/")
+            }) ?? 0
+            guard imageCount > 0 else { return }
+            let fallbackTitle = imageCount == 1 ? "Image" : "\(imageCount) Images"
+            renameConversation(conversation, newTitle: fallbackTitle)
+            return
+        }
+
         // Skip AI title generation for image generation models - use fallback instead
         let modelCapability = AIService.shared.getModelCapability(conversation.model)
         if modelCapability == .imageGeneration {
             // Use simple fallback title for image generation conversations
-            let content = firstMessage.content
             let fallbackTitle = String(content.prefix(50))
             renameConversation(conversation, newTitle: fallbackTitle + (content.count > 50 ? "..." : ""))
             return
         }
 
-        let content = firstMessage.content
         let titleRequestGeneration = beginTitleRequest(for: conversation.id)
         let firstMessageId = firstMessage.id
 

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -774,9 +774,6 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         consuming preparation: SendPreparation?,
         attachmentErrors: [String] = []
     ) {
-        guard validateAttachmentHistorySupport(for: payload) else { return }
-        guard validateAttachmentImageLimit(for: payload) else { return }
-
         // Check for multi-model mode
         if payload.selectedModels.count >= 2 {
             sendToMultipleModels(
@@ -1749,15 +1746,11 @@ extension IOSChatViewModel {
         consuming preparation: SendPreparation?,
         attachmentErrors: [String] = []
     ) {
-        guard validateAttachmentHistorySupport(for: payload) else { return }
-        guard validateAttachmentImageLimit(for: payload) else { return }
+        guard validateAttachmentRules(for: payload) else { return }
 
-        let hasHistoricalImages = proposedMessages(for: payload).contains { message in
-            guard message.role == .user else { return false }
-            return message.attachments?.contains(where: {
-                $0.mimeType.lowercased().hasPrefix("image/")
-            }) == true
-        }
+        let hasHistoricalImages = ConversationSendPreflight.hasImageAttachments(
+            in: proposedMessages(for: payload)
+        )
         guard !payload.attachments.isEmpty || hasHistoricalImages else {
             sendPreparedPayload(
                 payload,
@@ -1797,9 +1790,10 @@ extension IOSChatViewModel {
                 return
             }
 
-            let validationError = await aiService.attachmentImageValidationError(
-                for: requestModels(for: preparedPayload),
-                in: proposedMessages(for: preparedPayload),
+            let validationFailure = await ConversationSendPreflight.attachmentDataFailure(
+                models: requestModels(for: preparedPayload),
+                messages: proposedMessages(for: preparedPayload),
+                aiService: aiService,
                 loadAttachmentData: { [attachmentStorage] path in
                     await attachmentStorage.loadData(path: path)
                 }
@@ -1808,13 +1802,13 @@ extension IOSChatViewModel {
                 await discardStoredAttachments(at: newlyStoredPaths)
                 return
             }
-            if let validationError {
+            if let validationFailure {
                 await discardStoredAttachments(at: newlyStoredPaths)
                 sendPreparationTask = nil
                 sendPreparationID = nil
                 isGenerating = false
-                errorMessage = validationError
-                errorRecoverySuggestion = "Remove the image or choose a different model."
+                errorMessage = validationFailure.message
+                errorRecoverySuggestion = validationFailure.recoverySuggestion
                 restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
                 return
             }
@@ -1881,31 +1875,17 @@ extension IOSChatViewModel {
         }.value
     }
 
-    private func validateAttachmentImageLimit(for payload: PreparedSend) -> Bool {
-        let proposedMessages = proposedMessages(for: payload)
-        guard let limitError = aiService.attachmentImageLimitError(
-            for: requestModels(for: payload),
-            messages: proposedMessages
+    private func validateAttachmentRules(for payload: PreparedSend) -> Bool {
+        guard let failure = ConversationSendPreflight.attachmentRuleFailure(
+            models: requestModels(for: payload),
+            messages: proposedMessages(for: payload),
+            aiService: aiService
         ) else {
             return true
         }
 
-        errorMessage = limitError
-        errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
-        restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
-        return false
-    }
-
-    private func validateAttachmentHistorySupport(for payload: PreparedSend) -> Bool {
-        guard let supportError = aiService.attachmentHistorySupportError(
-            for: requestModels(for: payload),
-            messages: proposedMessages(for: payload)
-        ) else {
-            return true
-        }
-
-        errorMessage = supportError
-        errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+        errorMessage = failure.message
+        errorRecoverySuggestion = failure.recoverySuggestion
         restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
         return false
     }
@@ -1949,11 +1929,6 @@ extension IOSChatViewModel {
                 model: resendModel,
                 conversationID: conversationID
             )
-        }
-
-        guard aiService.getModelCapability(resendModel) != .imageGeneration else {
-            performEdit()
-            return
         }
         preflightHistoryMutation(
             models: [resendModel],
@@ -2050,10 +2025,6 @@ extension IOSChatViewModel {
                 conversationID: conversationID
             )
         }
-        guard aiService.getModelCapability(model) != .imageGeneration else {
-            performRetry()
-            return
-        }
 
         var retryConversation = conversation
         retryConversation.messages = Array(conversation.messages.prefix(messageIndex))
@@ -2069,30 +2040,17 @@ extension IOSChatViewModel {
         messages: [Message],
         onSuccess: @escaping @MainActor @Sendable () -> Void
     ) {
-        if let supportError = aiService.attachmentHistorySupportError(
-            for: models,
-            messages: messages
+        if let failure = ConversationSendPreflight.attachmentRuleFailure(
+            models: models,
+            messages: messages,
+            aiService: aiService
         ) {
-            errorMessage = supportError
-            errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
-            return
-        }
-        if let limitError = aiService.attachmentImageLimitError(
-            for: models,
-            messages: messages
-        ) {
-            errorMessage = limitError
-            errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
+            errorMessage = failure.message
+            errorRecoverySuggestion = failure.recoverySuggestion
             return
         }
 
-        let hasImages = messages.contains { message in
-            guard message.role == .user else { return false }
-            return message.attachments?.contains(where: {
-                $0.mimeType.lowercased().hasPrefix("image/")
-            }) == true
-        }
-        guard hasImages else {
+        guard ConversationSendPreflight.hasImageAttachments(in: messages) else {
             onSuccess()
             return
         }
@@ -2103,9 +2061,10 @@ extension IOSChatViewModel {
         let task = Task { @MainActor [weak self] in
             defer { self?.sendPreparationDidFinish?() }
             guard let self else { return }
-            let validationError = await self.aiService.attachmentImageValidationError(
-                for: models,
-                in: messages,
+            let failure = await ConversationSendPreflight.attachmentDataFailure(
+                models: models,
+                messages: messages,
+                aiService: self.aiService,
                 loadAttachmentData: { [attachmentStorage = self.attachmentStorage] path in
                     await attachmentStorage.loadData(path: path)
                 }
@@ -2115,9 +2074,9 @@ extension IOSChatViewModel {
             self.sendPreparationTask = nil
             self.sendPreparationID = nil
             self.isGenerating = false
-            if let validationError {
-                self.errorMessage = validationError
-                self.errorRecoverySuggestion = "Remove the image or choose a different model."
+            if let failure {
+                self.errorMessage = failure.message
+                self.errorRecoverySuggestion = failure.recoverySuggestion
                 return
             }
             onSuccess()
@@ -2290,13 +2249,11 @@ extension IOSChatViewModel {
         )
         let responseGroupId = responsePlan.responseGroupId
         let messageIdsByModel = responsePlan.messageIDsByModel
-        conversationManager.addMultiModelResponse(
+        guard let updatedConversation = conversationManager.beginMultiModelResponse(
             to: targetConversation,
             messages: responsePlan.placeholderMessages,
             responseGroup: responsePlan.responseGroup
-        )
-
-        guard let updatedConversation = conversation else {
+        ) else {
             isGenerating = false
             errorMessage = "Unable to prepare this conversation for sending."
             capturePendingSendFailure()
@@ -2858,11 +2815,17 @@ extension IOSChatViewModel {
         let responseGroupId = responsePlan.responseGroupId
         let messageIds = responsePlan.messageIDsByModel
 
-        for placeholderMessage in responsePlan.placeholderMessages {
-            conversationManager.addMessage(to: conversation, message: placeholderMessage)
+        guard conversationManager.beginMultiModelResponse(
+            to: conversation,
+            messages: responsePlan.placeholderMessages,
+            responseGroup: responsePlan.responseGroup
+        ) != nil else {
+            _ = coordinator.finishOperation(operationID)
+            isGenerating = false
+            errorMessage = "Unable to prepare this conversation for sending."
+            capturePendingSendFailure()
+            return
         }
-
-        conversationManager.addResponseGroup(to: conversation, group: responsePlan.responseGroup)
 
         let conversationManager = conversationManager
         let cancelledMessageIDs = Array(messageIds.values)

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -39,6 +39,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     @Published var errorMessage: String?
     @Published var attachedFiles: [URL] = []
     @Published var attachedImages: [UIImage] = []
+    @Published var pastedImages: [PastedImage] = []
+    @Published var pasteImportSessionID = UUID()
     @Published private(set) var messageContentRevision = 0
 
     /// The name of the tool currently being executed (for UI indicator)
@@ -115,6 +117,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         let text: String
         let attachedFiles: [URL]
         let attachedImages: [UIImage]
+        let pastedImages: [PastedImage]
         let selectedModel: String
         let selectedModels: Set<String>
         let requestModel: String
@@ -259,6 +262,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         failedMessage = nil
         cleanupAttachedFiles()
         attachedImages.removeAll()
+        pastedImages.removeAll()
+        pasteImportSessionID = UUID()
         selectedModel = aiService.selectedModel
         selectedModels = [aiService.selectedModel]
 
@@ -529,6 +534,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             text: messageText.trimmingCharacters(in: .whitespacesAndNewlines),
             attachedFiles: attachedFiles,
             attachedImages: attachedImages,
+            pastedImages: pastedImages,
             selectedModel: selectedModel,
             selectedModels: selectedModels,
             requestModel: currentConversation?.model ?? selectedModel
@@ -549,6 +555,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         guard !preparation.text.isEmpty
             || !preparation.attachedFiles.isEmpty
             || !preparation.attachedImages.isEmpty
+            || !preparation.pastedImages.isEmpty
         else {
             DiagnosticsLogger.log(
                 .chatView,
@@ -556,6 +563,20 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                 message: "⚠️ Empty message, ignoring"
             )
             return
+        }
+
+        if !preparation.attachedFiles.isEmpty
+            || !preparation.attachedImages.isEmpty
+            || !preparation.pastedImages.isEmpty
+        {
+            let attachmentModels = preparation.selectedModels.count >= 2
+                ? Array(preparation.selectedModels)
+                : [preparation.requestModel]
+            if let supportError = aiService.attachmentSupportError(for: attachmentModels) {
+                errorMessage = supportError
+                errorRecoverySuggestion = nil
+                return
+            }
         }
 
         // Prevent sending while already generating
@@ -567,6 +588,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             )
             return
         }
+
+        pasteImportSessionID = UUID()
 
             // A manual send during the short deep-link delay takes over the same durable claim.
             // Keep ownership until the user message is committed so failed hydration can restore it.
@@ -640,7 +663,6 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         return wasPending
     }
 
-    // swiftlint:disable:next function_body_length
     private func sendPreparedMessage(_ preparation: SendPreparation) {
         // Check for multi-model mode
         if preparation.selectedModels.count >= 2 {
@@ -691,31 +713,12 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                 "textLength": "\(preparation.text.count)",
                 "attachmentCount": "\(preparation.attachedFiles.count)",
                 "imageCount": "\(preparation.attachedImages.count)",
+                "pastedImageCount": "\(preparation.pastedImages.count)",
             ]
         )
 
-        var userMessage = Message(role: .user, content: preparation.text)
-
-        // Process file attachments with proper resource cleanup
-        if !preparation.attachedFiles.isEmpty {
-            let result = IOSFileAttachmentUtils.processAttachments(from: preparation.attachedFiles)
-            userMessage.attachments = result.attachments
-            if !result.errors.isEmpty {
-                errorMessage = result.errors.joined(separator: "\n")
-            }
-            cleanupAttachedFiles(preparation.attachedFiles)
-        }
-
-        // Process image attachments from photo library
-        if !preparation.attachedImages.isEmpty {
-            let imageAttachments = IOSFileAttachmentUtils.processImageAttachments(from: preparation.attachedImages)
-            if userMessage.attachments == nil {
-                userMessage.attachments = imageAttachments
-            } else {
-                userMessage.attachments?.append(contentsOf: imageAttachments)
-            }
-            removeAttachedImages(preparation.attachedImages)
-        }
+        let messageBuild = makeUserMessage(from: preparation)
+        let userMessage = messageBuild.message
 
         conversationManager.addMessage(to: targetConversation, message: userMessage)
         consumePendingAutoSendClaim(afterCommittingTo: targetConversationId)
@@ -736,7 +739,9 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             messageText = ""
         }
         isGenerating = true
-        errorMessage = nil
+        errorMessage = messageBuild.errors.isEmpty
+            ? nil
+            : messageBuild.errors.joined(separator: "\n")
         errorRecoverySuggestion = nil
         failedMessage = nil
 
@@ -1572,6 +1577,52 @@ private extension IOSChatViewModel {
             }
         }
     }
+
+    func removePastedImages(_ images: [PastedImage]) {
+        let imageIDs = Set(images.map(\.id))
+        pastedImages.removeAll { imageIDs.contains($0.id) }
+    }
+
+    private func makeUserMessage(
+        from preparation: SendPreparation
+    ) -> (message: Message, errors: [String]) {
+        var attachments: [Message.FileAttachment] = []
+        var errors: [String] = []
+
+        if !preparation.attachedFiles.isEmpty {
+            let result = IOSFileAttachmentUtils.processAttachments(from: preparation.attachedFiles)
+            attachments.append(contentsOf: result.attachments)
+            errors.append(contentsOf: result.errors)
+            cleanupAttachedFiles(preparation.attachedFiles)
+        }
+
+        if !preparation.attachedImages.isEmpty {
+            attachments.append(contentsOf: IOSFileAttachmentUtils.processImageAttachments(
+                from: preparation.attachedImages
+            ))
+            removeAttachedImages(preparation.attachedImages)
+        }
+
+        if !preparation.pastedImages.isEmpty {
+            attachments.append(contentsOf: preparation.pastedImages.map { pastedImage in
+                Message.FileAttachment(
+                    fileName: pastedImage.fileName,
+                    mimeType: pastedImage.mimeType,
+                    data: pastedImage.data
+                )
+            })
+            removePastedImages(preparation.pastedImages)
+        }
+
+        return (
+            Message(
+                role: .user,
+                content: preparation.text,
+                attachments: attachments.isEmpty ? nil : attachments
+            ),
+            errors
+        )
+    }
 }
 
 // MARK: - Message Retry and Editing
@@ -1801,10 +1852,6 @@ extension IOSChatViewModel {
     private func sendToMultipleModels(_ preparation: SendPreparation) {
         guard !isGenerating else { return }
         let text = preparation.text
-        guard !text.isEmpty else {
-            restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
-            return
-        }
 
         guard let targetConversation = getOrCreateConversationForMultiModel(
             selectedModels: preparation.selectedModels
@@ -1831,7 +1878,8 @@ extension IOSChatViewModel {
         DiagnosticsLogger.log(.chatView, level: .info, message: "🔀 Starting iOS multi-model request",
                               metadata: ["models": models.joined(separator: ", ")])
 
-        let userMessage = Message(role: .user, content: text)
+        let messageBuild = makeUserMessage(from: preparation)
+        let userMessage = messageBuild.message
         conversationManager.addMessage(to: targetConversation, message: userMessage)
         consumePendingAutoSendClaim(afterCommittingTo: conversationId)
 
@@ -1844,7 +1892,9 @@ extension IOSChatViewModel {
             messageText = ""
         }
         isGenerating = true
-        errorMessage = nil
+        errorMessage = messageBuild.errors.isEmpty
+            ? nil
+            : messageBuild.errors.joined(separator: "\n")
 
         let responsePlan = createResponsePlanForMultiModel(
             models: models,

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -127,6 +127,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     }
 
     private struct PreparedSend {
+        let userMessageID: UUID
         let text: String
         let attachments: [Message.FileAttachment]
         let selectedModel: String
@@ -135,6 +136,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
 
         func makeUserMessage() -> Message {
             Message(
+                id: userMessageID,
                 role: .user,
                 content: text,
                 attachments: attachments.isEmpty ? nil : attachments
@@ -702,6 +704,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     private func sendPreparedMessage(_ preparation: SendPreparation) {
         let messageBuild = makeUserMessage(from: preparation)
         let payload = PreparedSend(
+            userMessageID: messageBuild.message.id,
             text: preparation.text,
             attachments: messageBuild.message.attachments ?? [],
             selectedModel: preparation.selectedModel,
@@ -728,18 +731,33 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         )
     }
 
-    private func validateAttachmentImageLimit(
-        for payload: PreparedSend,
-        consuming preparation: SendPreparation?
-    ) -> Bool {
-        guard preparation != nil else { return true }
-
-        let requestModels = payload.selectedModels.count >= 2
+    private func requestModels(for payload: PreparedSend) -> [String] {
+        payload.selectedModels.count >= 2
             ? Array(payload.selectedModels)
             : [payload.requestModel.isEmpty ? payload.selectedModel : payload.requestModel]
-        let proposedMessages = (conversation?.messages ?? []) + [payload.makeUserMessage()]
+    }
+
+    private func validateAttachmentImageData(for payload: PreparedSend) -> Bool {
+        guard let validationError = aiService.attachmentImageValidationError(
+            for: requestModels(for: payload),
+            inMemoryAttachments: payload.attachments
+        ) else {
+            return true
+        }
+
+        errorMessage = validationError
+        errorRecoverySuggestion = "Remove the image or choose a different model."
+        restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+        return false
+    }
+
+    private func validateAttachmentImageLimit(for payload: PreparedSend) -> Bool {
+        let proposedMessages = ChatDraftContent.messagesByIncludingUserMessageIfNeeded(
+            payload.makeUserMessage(),
+            in: conversation?.messages ?? []
+        )
         guard let limitError = aiService.attachmentImageLimitError(
-            for: requestModels,
+            for: requestModels(for: payload),
             messages: proposedMessages
         ) else {
             return true
@@ -751,12 +769,40 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         return false
     }
 
+    @discardableResult
+    private func commitUserMessageIfNeeded(
+        _ userMessage: Message,
+        to conversation: Conversation,
+        consuming preparation: SendPreparation?
+    ) -> Bool {
+        guard !conversation.messages.contains(where: { $0.id == userMessage.id }) else {
+            return false
+        }
+
+        conversationManager.addMessage(to: conversation, message: userMessage)
+        consumePendingAutoSendClaim(afterCommittingTo: conversation.id)
+        if let preparation {
+            consumeComposer(preparation)
+        }
+
+        if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: userMessage.content) {
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .info,
+                message: "💾 Memory command processed",
+                metadata: ["response": memoryResponse]
+            )
+        }
+        return true
+    }
+
     private func sendPreparedPayload(
         _ payload: PreparedSend,
         consuming preparation: SendPreparation?,
         attachmentErrors: [String] = []
     ) {
-        guard validateAttachmentImageLimit(for: payload, consuming: preparation) else { return }
+        guard validateAttachmentImageData(for: payload) else { return }
+        guard validateAttachmentImageLimit(for: payload) else { return }
 
         // Check for multi-model mode
         if payload.selectedModels.count >= 2 {
@@ -814,21 +860,14 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         )
 
         let userMessage = payload.makeUserMessage()
-
-        conversationManager.addMessage(to: targetConversation, message: userMessage)
-        consumePendingAutoSendClaim(afterCommittingTo: targetConversationId)
-        if let preparation {
-            consumeComposer(preparation)
-        }
-
-        // Process memory commands (e.g., "remember that I prefer dark mode")
-        if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: payload.text) {
-            DiagnosticsLogger.log(
-                .chatView,
-                level: .info,
-                message: "💾 Memory command processed",
-                metadata: ["response": memoryResponse]
-            )
+        let committedUserMessage = commitUserMessageIfNeeded(
+            userMessage,
+            to: targetConversation,
+            consuming: preparation
+        )
+        let reusesCommittedUserMessage = !committedUserMessage
+        if committedUserMessage {
+            SoundEngine.messageSent()
         }
 
         pendingSendPayload = payload
@@ -840,13 +879,12 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         errorRecoverySuggestion = nil
         failedMessage = nil
 
-        // Play message sent sound
-        SoundEngine.messageSent()
-
         DiagnosticsLogger.log(
             .chatView,
             level: .info,
-            message: "📝 User message added, isGenerating=true",
+            message: reusesCommittedUserMessage
+                ? "🔄 Reusing committed user message, isGenerating=true"
+                : "📝 User message added, isGenerating=true",
             metadata: ["userMessageId": userMessage.id.uuidString]
         )
 
@@ -1974,11 +2012,13 @@ extension IOSChatViewModel {
         pendingSendPayload = payload
         failedSendPayload = nil
         failedMessage = nil
+        let userMessage = payload.makeUserMessage()
         generateImagesWithMultipleModels(
             prompt: payload.text,
             models: models,
             conversation: conversation,
-            draftText: preparation?.draftText
+            draftText: preparation?.draftText,
+            userMessage: userMessage
         )
         return true
     }
@@ -1990,7 +2030,6 @@ extension IOSChatViewModel {
         attachmentErrors: [String]
     ) {
         guard !isGenerating else { return }
-        let text = payload.text
 
         guard let targetConversation = getOrCreateConversationForMultiModel(
             selectedModels: payload.selectedModels
@@ -2014,16 +2053,11 @@ extension IOSChatViewModel {
                               metadata: ["models": models.joined(separator: ", ")])
 
         let userMessage = payload.makeUserMessage()
-        conversationManager.addMessage(to: targetConversation, message: userMessage)
-        consumePendingAutoSendClaim(afterCommittingTo: conversationId)
-        if let preparation {
-            consumeComposer(preparation)
-        }
-
-        if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: text) {
-            DiagnosticsLogger.log(.chatView, level: .info, message: "💾 Memory command processed",
-                                  metadata: ["response": memoryResponse])
-        }
+        commitUserMessageIfNeeded(
+            userMessage,
+            to: targetConversation,
+            consuming: preparation
+        )
 
         pendingSendPayload = payload
         failedSendPayload = nil
@@ -2561,7 +2595,8 @@ extension IOSChatViewModel {
         prompt: String,
         models: [String],
         conversation: Conversation,
-        draftText: String?
+        draftText: String?,
+        userMessage: Message
     ) {
         let coordinator = imageGenerationCoordinator
         let operationID = coordinator.beginOperation()
@@ -2574,9 +2609,10 @@ extension IOSChatViewModel {
         let conversationId = conversation.id
         let previousImageSource = previousImageSource(in: conversation)
 
-        let userMessage = Message(role: .user, content: prompt)
-        conversationManager.addMessage(to: conversation, message: userMessage)
-        consumePendingAutoSendClaim(afterCommittingTo: conversationId)
+        if !conversation.messages.contains(where: { $0.id == userMessage.id }) {
+            conversationManager.addMessage(to: conversation, message: userMessage)
+            consumePendingAutoSendClaim(afterCommittingTo: conversationId)
+        }
 
         if let draftText, messageText == draftText {
             messageText = ""

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -1923,96 +1923,15 @@ extension IOSChatViewModel {
 extension IOSChatViewModel {
     /// Retry from a specific assistant message.
     func retryMessage(beforeMessage: Message) {
-        guard !isGenerating else { return }
         guard let conversation else { return }
-        let targetConversationId = conversation.id
-        let retryModel = beforeMessage.model ?? conversation.model
-        let isImageRetry = aiService.getModelCapability(retryModel) == .imageGeneration
-
-        DiagnosticsLogger.log(
-            .chatView,
-            level: .info,
-            message: "🔄 Retrying message",
-            metadata: ["conversationId": targetConversationId.uuidString]
-        )
-
-        // Find the index of the message to retry
-        guard let messageIndex = conversation.messages.firstIndex(where: { $0.id == beforeMessage.id }) else {
-            return
-        }
-
-        // Remove the assistant message and any subsequent messages
-        let updatedMessages = Array(conversation.messages.prefix(messageIndex))
-
-        if !isImageRetry {
-            var retryConversation = conversation
-            retryConversation.messages = updatedMessages
-            if let supportError = aiService.attachmentHistorySupportError(
-                for: [retryModel],
-                messages: retryConversation.getEffectiveHistory()
-            ) {
-                errorMessage = supportError
-                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
-                return
-            }
-        }
-
-        // Update the conversation
-        if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == targetConversationId }) {
-            conversationManager.conversations[convIndex].messages = updatedMessages
-        }
-
-        // Create a new assistant message placeholder
-        var assistantMessage = Message(role: .assistant, content: "", model: retryModel)
-        if isImageRetry {
-            assistantMessage.mediaType = .image
-        }
-        conversationManager.addMessage(to: conversation, message: assistantMessage)
-
-        isGenerating = true
-        errorMessage = nil
-
-        // Re-fetch conversation with updated messages
-        guard let updatedConversation = self.conversation else {
-            isGenerating = false
-            return
-        }
-        if isImageRetry {
-            guard let prompt = updatedMessages.last(where: { $0.role == .user })?.content else {
-                isGenerating = false
-                return
-            }
-            generateImage(
-                text: prompt,
-                assistantMessage: assistantMessage,
-                conversationId: targetConversationId,
-                model: retryModel
-            )
-            return
-        }
-            var messagesToSend = updatedConversation.getEffectiveHistory()
-
-        // Prepend system prompt if configured
-        if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
-        }
-
-        // Get available tools and use helper method
-        let tools = aiService.getAllAvailableTools()
-        toolCallDepth = 0
-
-        sendMessageWithToolSupport(
-            messages: messagesToSend,
-            model: retryModel,
-            conversationId: targetConversationId,
-            assistantMessageId: assistantMessage.id,
-            tools: tools
+        scheduleRetry(
+            beforeMessageID: beforeMessage.id,
+            model: beforeMessage.model ?? conversation.model
         )
     }
 
     func editMessageAndResend(_ message: Message, newContent: String) {
-        guard !isGenerating, let conversation else { return }
+        guard !isGenerating, sendPreparationTask == nil, let conversation else { return }
         guard let proposedHistory = ChatDraftContent.effectiveHistory(
             byEditingUserMessage: message.id,
             newContent: newContent,
@@ -2022,33 +1941,25 @@ extension IOSChatViewModel {
         }
 
         let resendModel = conversation.model
-        if aiService.getModelCapability(resendModel) != .imageGeneration {
-            if let supportError = aiService.attachmentHistorySupportError(
-                for: [resendModel],
-                messages: proposedHistory
-            ) {
-                errorMessage = supportError
-                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
-                return
-            }
-            if let limitError = aiService.attachmentImageLimitError(
-                for: [resendModel],
-                messages: proposedHistory
-            ) {
-                errorMessage = limitError
-                errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
-                return
-            }
+        let conversationID = conversation.id
+        let performEdit: @MainActor @Sendable () -> Void = { [weak self] in
+            self?.performEditMessageAndResend(
+                messageID: message.id,
+                newContent: newContent,
+                model: resendModel,
+                conversationID: conversationID
+            )
         }
 
-        guard conversationManager.editMessage(
-            in: conversation,
-            messageId: message.id,
-            newContent: newContent
-        ) else {
+        guard aiService.getModelCapability(resendModel) != .imageGeneration else {
+            performEdit()
             return
         }
-        resendAfterEdit()
+        preflightHistoryMutation(
+            models: [resendModel],
+            messages: proposedHistory,
+            onSuccess: performEdit
+        )
     }
 
     /// Re-send the last user message to get a new AI response after editing.
@@ -2112,49 +2023,131 @@ extension IOSChatViewModel {
     /// Switch to a different model and retry the message.
     /// This retries with the specified model without changing the conversation's default model.
     func switchModelAndRetry(beforeMessage: Message, newModel: String) {
-        guard !isGenerating else { return }
-        guard let conversation else { return }
-        let targetConversationId = conversation.id
-        let isImageRetry = aiService.getModelCapability(newModel) == .imageGeneration
+        scheduleRetry(beforeMessageID: beforeMessage.id, model: newModel)
+    }
 
-        DiagnosticsLogger.log(
-            .chatView,
-            level: .info,
-            message: "🔄 Switching model and retrying",
-            metadata: [
-                "conversationId": targetConversationId.uuidString,
-                "newModel": newModel,
-            ]
-        )
-
-        // Find the index of the message to retry
-        guard let messageIndex = conversation.messages.firstIndex(where: { $0.id == beforeMessage.id }) else {
+    private func scheduleRetry(beforeMessageID: UUID, model: String) {
+        guard !isGenerating, sendPreparationTask == nil, let conversation else { return }
+        guard let messageIndex = conversation.messages.firstIndex(where: { $0.id == beforeMessageID }) else {
             return
         }
 
-        // Remove the assistant message and any subsequent messages
-        let updatedMessages = Array(conversation.messages.prefix(messageIndex))
+        let conversationID = conversation.id
+        DiagnosticsLogger.log(
+            .chatView,
+            level: .info,
+            message: "🔄 Retrying message",
+            metadata: [
+                "conversationId": conversationID.uuidString,
+                "model": model,
+            ]
+        )
 
-        if !isImageRetry {
-            var retryConversation = conversation
-            retryConversation.messages = updatedMessages
-            if let supportError = aiService.attachmentHistorySupportError(
-                for: [newModel],
-                messages: retryConversation.getEffectiveHistory()
-            ) {
-                errorMessage = supportError
-                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+        let performRetry: @MainActor @Sendable () -> Void = { [weak self] in
+            self?.performRetry(
+                beforeMessageID: beforeMessageID,
+                model: model,
+                conversationID: conversationID
+            )
+        }
+        guard aiService.getModelCapability(model) != .imageGeneration else {
+            performRetry()
+            return
+        }
+
+        var retryConversation = conversation
+        retryConversation.messages = Array(conversation.messages.prefix(messageIndex))
+        preflightHistoryMutation(
+            models: [model],
+            messages: retryConversation.getEffectiveHistory(),
+            onSuccess: performRetry
+        )
+    }
+
+    private func preflightHistoryMutation(
+        models: [String],
+        messages: [Message],
+        onSuccess: @escaping @MainActor @Sendable () -> Void
+    ) {
+        if let supportError = aiService.attachmentHistorySupportError(
+            for: models,
+            messages: messages
+        ) {
+            errorMessage = supportError
+            errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+            return
+        }
+        if let limitError = aiService.attachmentImageLimitError(
+            for: models,
+            messages: messages
+        ) {
+            errorMessage = limitError
+            errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
+            return
+        }
+
+        let hasImages = messages.contains { message in
+            guard message.role == .user else { return false }
+            return message.attachments?.contains(where: {
+                $0.mimeType.lowercased().hasPrefix("image/")
+            }) == true
+        }
+        guard hasImages else {
+            onSuccess()
+            return
+        }
+
+        let preparationID = UUID()
+        sendPreparationID = preparationID
+        isGenerating = true
+        let task = Task { @MainActor [weak self] in
+            defer { self?.sendPreparationDidFinish?() }
+            guard let self else { return }
+            let validationError = await self.aiService.attachmentImageValidationError(
+                for: models,
+                in: messages,
+                loadAttachmentData: { [attachmentStorage = self.attachmentStorage] path in
+                    await attachmentStorage.loadData(path: path)
+                }
+            )
+            guard !Task.isCancelled, self.sendPreparationID == preparationID else { return }
+
+            self.sendPreparationTask = nil
+            self.sendPreparationID = nil
+            self.isGenerating = false
+            if let validationError {
+                self.errorMessage = validationError
+                self.errorRecoverySuggestion = "Remove the image or choose a different model."
                 return
             }
+            onSuccess()
+        }
+        sendPreparationTask = task
+    }
+
+    private func performRetry(
+        beforeMessageID: UUID,
+        model: String,
+        conversationID: UUID
+    ) {
+        guard !isGenerating, sendPreparationTask == nil,
+              self.conversationId == conversationID,
+              let conversation = conversationManager.conversation(byId: conversationID),
+              let messageIndex = conversation.messages.firstIndex(where: { $0.id == beforeMessageID })
+        else {
+            return
         }
 
-        // Update the conversation
-        if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == targetConversationId }) {
-            conversationManager.conversations[convIndex].messages = updatedMessages
+        let updatedMessages = Array(conversation.messages.prefix(messageIndex))
+        guard let conversationIndex = conversationManager.conversations.firstIndex(where: {
+            $0.id == conversationID
+        }) else {
+            return
         }
+        conversationManager.conversations[conversationIndex].messages = updatedMessages
 
-        // Create a new assistant message placeholder with the new model
-        var assistantMessage = Message(role: .assistant, content: "", model: newModel)
+        let isImageRetry = aiService.getModelCapability(model) == .imageGeneration
+        var assistantMessage = Message(role: .assistant, content: "", model: model)
         if isImageRetry {
             assistantMessage.mediaType = .image
         }
@@ -2162,9 +2155,7 @@ extension IOSChatViewModel {
 
         isGenerating = true
         errorMessage = nil
-
-        // Re-fetch conversation with updated messages
-        guard let updatedConversation = self.conversation else {
+        guard let updatedConversation = conversationManager.conversation(byId: conversationID) else {
             isGenerating = false
             return
         }
@@ -2176,31 +2167,46 @@ extension IOSChatViewModel {
             generateImage(
                 text: prompt,
                 assistantMessage: assistantMessage,
-                conversationId: targetConversationId,
-                model: newModel
+                conversationId: conversationID,
+                model: model
             )
             return
         }
-            var messagesToSend = updatedConversation.getEffectiveHistory()
 
-        // Prepend system prompt if configured
+        var messagesToSend = updatedConversation.getEffectiveHistory()
         if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
+            messagesToSend.insert(Message(role: .system, content: systemPrompt), at: 0)
         }
 
-        // Get available tools and use helper method
-        let tools = aiService.getAllAvailableTools()
         toolCallDepth = 0
-
-        // Use the new model for this request
         sendMessageWithToolSupport(
             messages: messagesToSend,
-            model: newModel,
-            conversationId: targetConversationId,
+            model: model,
+            conversationId: conversationID,
             assistantMessageId: assistantMessage.id,
-            tools: tools
+            tools: aiService.getAllAvailableTools()
         )
+    }
+
+    private func performEditMessageAndResend(
+        messageID: UUID,
+        newContent: String,
+        model: String,
+        conversationID: UUID
+    ) {
+        guard !isGenerating, sendPreparationTask == nil,
+              self.conversationId == conversationID,
+              let conversation = conversationManager.conversation(byId: conversationID),
+              conversation.model == model,
+              conversationManager.editMessage(
+                  in: conversation,
+                  messageId: messageID,
+                  newContent: newContent
+              )
+        else {
+            return
+        }
+        resendAfterEdit()
     }
 }
 

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -58,6 +58,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     var conversationManager: ConversationManager
     let aiService: AIService
     private let executeBuiltInTool: IOSBuiltInToolExecutor
+    private let attachmentStorage: AttachmentStorage
     private let imageGenerationCoordinator = ImageGenerationCoordinator()
         private let toolChainCoordinator = ToolChainCoordinator()
         private let toolCallRequestRoundCoordinator = ToolCallRequestRoundCoordinator<ToolExecutionResult>()
@@ -183,13 +184,15 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         conversationId: UUID,
         conversationManager: ConversationManager,
         aiService: AIService? = nil,
-        executeBuiltInTool: IOSBuiltInToolExecutor? = nil
+        executeBuiltInTool: IOSBuiltInToolExecutor? = nil,
+        attachmentStorage: AttachmentStorage = .shared
     ) {
         let resolvedAIService = aiService ?? .shared
         self.conversationId = conversationId
         isNewChatMode = false
         self.conversationManager = conversationManager
         self.aiService = resolvedAIService
+        self.attachmentStorage = attachmentStorage
         self.executeBuiltInTool = executeBuiltInTool ?? { name, arguments in
             await resolvedAIService.executeBuiltInToolWithCitations(
                 name: name,
@@ -204,13 +207,15 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     init(
         conversationManager: ConversationManager,
         aiService: AIService? = nil,
-        executeBuiltInTool: IOSBuiltInToolExecutor? = nil
+        executeBuiltInTool: IOSBuiltInToolExecutor? = nil,
+        attachmentStorage: AttachmentStorage = .shared
     ) {
         let resolvedAIService = aiService ?? .shared
         conversationId = nil
         isNewChatMode = true
         self.conversationManager = conversationManager
         self.aiService = resolvedAIService
+        self.attachmentStorage = attachmentStorage
         self.executeBuiltInTool = executeBuiltInTool ?? { name, arguments in
             await resolvedAIService.executeBuiltInToolWithCitations(
                 name: name,
@@ -432,7 +437,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         failedMessage = nil
         errorMessage = nil
         errorRecoverySuggestion = nil
-        sendPreparedPayload(payload, consuming: nil)
+        prepareOrSendPayload(payload, consuming: nil)
     }
 
     /// Dismiss the current error without retrying
@@ -724,7 +729,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             return
         }
 
-        sendPreparedPayload(
+        prepareOrSendPayload(
             payload,
             consuming: preparation,
             attachmentErrors: messageBuild.errors
@@ -735,38 +740,6 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         payload.selectedModels.count >= 2
             ? Array(payload.selectedModels)
             : [payload.requestModel.isEmpty ? payload.selectedModel : payload.requestModel]
-    }
-
-    private func validateAttachmentImageData(for payload: PreparedSend) -> Bool {
-        guard let validationError = aiService.attachmentImageValidationError(
-            for: requestModels(for: payload),
-            inMemoryAttachments: payload.attachments
-        ) else {
-            return true
-        }
-
-        errorMessage = validationError
-        errorRecoverySuggestion = "Remove the image or choose a different model."
-        restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
-        return false
-    }
-
-    private func validateAttachmentImageLimit(for payload: PreparedSend) -> Bool {
-        let proposedMessages = ChatDraftContent.messagesByIncludingUserMessageIfNeeded(
-            payload.makeUserMessage(),
-            in: conversation?.messages ?? []
-        )
-        guard let limitError = aiService.attachmentImageLimitError(
-            for: requestModels(for: payload),
-            messages: proposedMessages
-        ) else {
-            return true
-        }
-
-        errorMessage = limitError
-        errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
-        restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
-        return false
     }
 
     @discardableResult
@@ -801,7 +774,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         consuming preparation: SendPreparation?,
         attachmentErrors: [String] = []
     ) {
-        guard validateAttachmentImageData(for: payload) else { return }
+        guard validateAttachmentHistorySupport(for: payload) else { return }
         guard validateAttachmentImageLimit(for: payload) else { return }
 
         // Check for multi-model mode
@@ -1770,6 +1743,175 @@ private extension IOSChatViewModel {
                 attachments: attachments.isEmpty ? nil : attachments
             ),
             errors
+        )
+    }
+}
+
+extension IOSChatViewModel {
+    private func prepareOrSendPayload(
+        _ payload: PreparedSend,
+        consuming preparation: SendPreparation?,
+        attachmentErrors: [String] = []
+    ) {
+        guard validateAttachmentHistorySupport(for: payload) else { return }
+        guard validateAttachmentImageLimit(for: payload) else { return }
+
+        guard !payload.attachments.isEmpty else {
+            sendPreparedPayload(
+                payload,
+                consuming: preparation,
+                attachmentErrors: attachmentErrors
+            )
+            return
+        }
+
+        prepareStoredPayloadAndSend(
+            payload,
+            consuming: preparation,
+            attachmentErrors: attachmentErrors
+        )
+    }
+
+    private func prepareStoredPayloadAndSend(
+        _ payload: PreparedSend,
+        consuming preparation: SendPreparation?,
+        attachmentErrors: [String]
+    ) {
+        let preparationID = UUID()
+        sendPreparationID = preparationID
+        isGenerating = true
+
+        let task = Task { @MainActor in
+            defer { sendPreparationDidFinish?() }
+
+            let preparedPayload = preparation == nil
+                ? payload
+                : await persistAttachmentData(in: payload)
+            let newlyStoredPaths = Set(preparedPayload.attachments.compactMap(\.localPath))
+                .subtracting(payload.attachments.compactMap(\.localPath))
+
+            guard !Task.isCancelled, sendPreparationID == preparationID else {
+                await discardStoredAttachments(at: newlyStoredPaths)
+                return
+            }
+
+            let validationError = await aiService.attachmentImageValidationError(
+                for: requestModels(for: preparedPayload),
+                loading: preparedPayload.attachments,
+                loadAttachmentData: { [attachmentStorage] path in
+                    await attachmentStorage.loadData(path: path)
+                }
+            )
+            guard !Task.isCancelled, sendPreparationID == preparationID else {
+                await discardStoredAttachments(at: newlyStoredPaths)
+                return
+            }
+            if let validationError {
+                await discardStoredAttachments(at: newlyStoredPaths)
+                sendPreparationTask = nil
+                sendPreparationID = nil
+                isGenerating = false
+                errorMessage = validationError
+                errorRecoverySuggestion = "Remove the image or choose a different model."
+                restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+                return
+            }
+
+            // Release preparation ownership before the synchronous handoff. This keeps the
+            // existing multi-model guard and stop-button semantics unchanged.
+            sendPreparationTask = nil
+            sendPreparationID = nil
+            isGenerating = false
+            sendPreparedPayload(
+                preparedPayload,
+                consuming: preparation,
+                attachmentErrors: attachmentErrors
+            )
+
+            let wasCommitted = conversationManager.conversations.contains { conversation in
+                conversation.messages.contains(where: { $0.id == preparedPayload.userMessageID })
+            }
+            if !wasCommitted {
+                await discardStoredAttachments(at: newlyStoredPaths)
+            }
+        }
+        sendPreparationTask = task
+    }
+
+    private func persistAttachmentData(in payload: PreparedSend) async -> PreparedSend {
+        let generation = attachmentStorage.currentGeneration()
+        var attachments = payload.attachments
+
+        for index in attachments.indices {
+            guard attachments[index].localPath == nil,
+                  let data = attachments[index].data
+            else {
+                continue
+            }
+            let fileExtension = (attachments[index].fileName as NSString).pathExtension
+            if let localPath = try? await attachmentStorage.saveData(
+                data: data,
+                extension: fileExtension,
+                generation: generation
+            ) {
+                attachments[index].data = nil
+                attachments[index].localPath = localPath
+            }
+        }
+
+        return PreparedSend(
+            userMessageID: payload.userMessageID,
+            text: payload.text,
+            attachments: attachments,
+            selectedModel: payload.selectedModel,
+            selectedModels: payload.selectedModels,
+            requestModel: payload.requestModel
+        )
+    }
+
+    private func discardStoredAttachments(at paths: Set<String>) async {
+        guard !paths.isEmpty else { return }
+        let storage = attachmentStorage
+        await Task.detached(priority: .utility) {
+            for path in paths {
+                storage.delete(path: path)
+            }
+        }.value
+    }
+
+    private func validateAttachmentImageLimit(for payload: PreparedSend) -> Bool {
+        let proposedMessages = proposedMessages(for: payload)
+        guard let limitError = aiService.attachmentImageLimitError(
+            for: requestModels(for: payload),
+            messages: proposedMessages
+        ) else {
+            return true
+        }
+
+        errorMessage = limitError
+        errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
+        restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+        return false
+    }
+
+    private func validateAttachmentHistorySupport(for payload: PreparedSend) -> Bool {
+        guard let supportError = aiService.attachmentHistorySupportError(
+            for: requestModels(for: payload),
+            messages: proposedMessages(for: payload)
+        ) else {
+            return true
+        }
+
+        errorMessage = supportError
+        errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+        restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+        return false
+    }
+
+    private func proposedMessages(for payload: PreparedSend) -> [Message] {
+        ChatDraftContent.messagesByIncludingUserMessageIfNeeded(
+            payload.makeUserMessage(),
+            in: conversation?.messages ?? []
         )
     }
 }

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -728,11 +728,36 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         )
     }
 
+    private func validateAttachmentImageLimit(
+        for payload: PreparedSend,
+        consuming preparation: SendPreparation?
+    ) -> Bool {
+        guard preparation != nil else { return true }
+
+        let requestModels = payload.selectedModels.count >= 2
+            ? Array(payload.selectedModels)
+            : [payload.requestModel.isEmpty ? payload.selectedModel : payload.requestModel]
+        let proposedMessages = (conversation?.messages ?? []) + [payload.makeUserMessage()]
+        guard let limitError = aiService.attachmentImageLimitError(
+            for: requestModels,
+            messages: proposedMessages
+        ) else {
+            return true
+        }
+
+        errorMessage = limitError
+        errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
+        restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+        return false
+    }
+
     private func sendPreparedPayload(
         _ payload: PreparedSend,
         consuming preparation: SendPreparation?,
         attachmentErrors: [String] = []
     ) {
+        guard validateAttachmentImageLimit(for: payload, consuming: preparation) else { return }
+
         // Check for multi-model mode
         if payload.selectedModels.count >= 2 {
             sendToMultipleModels(

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -41,6 +41,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     @Published var attachedImages: [UIImage] = []
     @Published var pastedImages: [PastedImage] = []
     @Published var pasteImportSessionID = UUID()
+    @Published var isImportingPastedImages = false
     @Published private(set) var messageContentRevision = 0
 
     /// The name of the tool currently being executed (for UI indicator)
@@ -83,8 +84,10 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     /// This prevents runaway tool chains while still allowing reasonable agentic workflows.
     private let maxToolCallDepth = 10
 
-    /// Stores the pending user message text for retry on failure
-    private var pendingUserMessage: String?
+    /// Captures the accepted send independently from the live composer so retry never
+    /// overwrites or combines with a draft created while the request was running.
+    private var pendingSendPayload: PreparedSend?
+    private var failedSendPayload: PreparedSend?
 
     private struct StreamingChunkKey: Hashable, Sendable {
         let conversationId: UUID
@@ -121,6 +124,22 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         let selectedModel: String
         let selectedModels: Set<String>
         let requestModel: String
+    }
+
+    private struct PreparedSend {
+        let text: String
+        let attachments: [Message.FileAttachment]
+        let selectedModel: String
+        let selectedModels: Set<String>
+        let requestModel: String
+
+        func makeUserMessage() -> Message {
+            Message(
+                role: .user,
+                content: text,
+                attachments: attachments.isEmpty ? nil : attachments
+            )
+        }
     }
 
     private var toolExecutionStates: [
@@ -264,6 +283,9 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         attachedImages.removeAll()
         pastedImages.removeAll()
         pasteImportSessionID = UUID()
+        isImportingPastedImages = false
+        pendingSendPayload = nil
+        failedSendPayload = nil
         selectedModel = aiService.selectedModel
         selectedModels = [aiService.selectedModel]
 
@@ -395,30 +417,34 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     /// Retry the last failed message
     func retryFailedMessage() {
         guard !isGenerating else { return }
-        guard let message = failedMessage else { return }
+        guard let payload = failedSendPayload else { return }
 
         DiagnosticsLogger.log(
             .chatView,
             level: .info,
             message: "🔄 Retrying failed message",
-            metadata: ["messageLength": "\(message.count)"]
+            metadata: ["messageLength": "\(payload.text.count)"]
         )
 
-        // Clear error state
+        failedSendPayload = nil
         failedMessage = nil
         errorMessage = nil
         errorRecoverySuggestion = nil
-
-        // Set message text and send
-        messageText = message
-        sendMessage()
+        sendPreparedPayload(payload, consuming: nil)
     }
 
     /// Dismiss the current error without retrying
     func dismissError() {
         failedMessage = nil
+        failedSendPayload = nil
         errorMessage = nil
         errorRecoverySuggestion = nil
+    }
+
+    private func capturePendingSendFailure() {
+        failedSendPayload = pendingSendPayload
+        failedMessage = pendingSendPayload?.text
+        pendingSendPayload = nil
     }
 
     /// Handle file import results from the file importer.
@@ -523,11 +549,20 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         toolCallDepth = 0
             activeAssistantMessageId = nil
             activeMultiModelResponseGroupId = nil
-        pendingUserMessage = nil
+        pendingSendPayload = nil
     }
 
     /// Send a message in the current conversation.
     func sendMessage() {
+        guard !isImportingPastedImages else {
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .info,
+                message: "Waiting for pasted image import before sending"
+            )
+            return
+        }
+
         let currentConversation = conversation
         let preparation = SendPreparation(
             draftText: messageText,
@@ -552,10 +587,11 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             ]
         )
 
-        guard !preparation.text.isEmpty
-            || !preparation.attachedFiles.isEmpty
-            || !preparation.attachedImages.isEmpty
-            || !preparation.pastedImages.isEmpty
+        guard ChatDraftContent.isSendable(
+            text: preparation.text,
+            fileURLs: preparation.attachedFiles,
+            inMemoryImageCount: preparation.attachedImages.count + preparation.pastedImages.count
+        )
         else {
             DiagnosticsLogger.log(
                 .chatView,
@@ -664,9 +700,46 @@ typealias IOSBuiltInToolExecutor = @MainActor (
     }
 
     private func sendPreparedMessage(_ preparation: SendPreparation) {
+        let messageBuild = makeUserMessage(from: preparation)
+        let payload = PreparedSend(
+            text: preparation.text,
+            attachments: messageBuild.message.attachments ?? [],
+            selectedModel: preparation.selectedModel,
+            selectedModels: preparation.selectedModels,
+            requestModel: preparation.requestModel
+        )
+
+        guard ChatDraftContent.isSendable(
+            text: payload.text,
+            attachments: payload.attachments
+        ) else {
+            errorMessage = messageBuild.errors.isEmpty
+                ? "Unable to load the selected attachment."
+                : messageBuild.errors.joined(separator: "\n")
+            errorRecoverySuggestion = nil
+            restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+            return
+        }
+
+        sendPreparedPayload(
+            payload,
+            consuming: preparation,
+            attachmentErrors: messageBuild.errors
+        )
+    }
+
+    private func sendPreparedPayload(
+        _ payload: PreparedSend,
+        consuming preparation: SendPreparation?,
+        attachmentErrors: [String] = []
+    ) {
         // Check for multi-model mode
-        if preparation.selectedModels.count >= 2 {
-            sendToMultipleModels(preparation)
+        if payload.selectedModels.count >= 2 {
+            sendToMultipleModels(
+                payload,
+                consuming: preparation,
+                attachmentErrors: attachmentErrors
+            )
             return
         }
 
@@ -681,8 +754,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             conversationId = newConv.id
 
             // Update model if different from default
-            if newConv.model != preparation.selectedModel {
-                conversationManager.updateModel(for: newConv, model: preparation.selectedModel)
+            if newConv.model != payload.selectedModel {
+                conversationManager.updateModel(for: newConv, model: payload.selectedModel)
             }
 
             DiagnosticsLogger.log(
@@ -710,21 +783,21 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             message: "📤 Sending message",
             metadata: [
                 "conversationId": targetConversationId.uuidString,
-                "textLength": "\(preparation.text.count)",
-                "attachmentCount": "\(preparation.attachedFiles.count)",
-                "imageCount": "\(preparation.attachedImages.count)",
-                "pastedImageCount": "\(preparation.pastedImages.count)",
+                "textLength": "\(payload.text.count)",
+                "attachmentCount": "\(payload.attachments.count)",
             ]
         )
 
-        let messageBuild = makeUserMessage(from: preparation)
-        let userMessage = messageBuild.message
+        let userMessage = payload.makeUserMessage()
 
         conversationManager.addMessage(to: targetConversation, message: userMessage)
         consumePendingAutoSendClaim(afterCommittingTo: targetConversationId)
+        if let preparation {
+            consumeComposer(preparation)
+        }
 
         // Process memory commands (e.g., "remember that I prefer dark mode")
-        if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: preparation.text) {
+        if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: payload.text) {
             DiagnosticsLogger.log(
                 .chatView,
                 level: .info,
@@ -733,15 +806,12 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             )
         }
 
-        // Store the message text for retry in case of failure
-        pendingUserMessage = preparation.text
-        if messageText == preparation.draftText {
-            messageText = ""
-        }
+        pendingSendPayload = payload
+        failedSendPayload = nil
         isGenerating = true
-        errorMessage = messageBuild.errors.isEmpty
+        errorMessage = attachmentErrors.isEmpty
             ? nil
-            : messageBuild.errors.joined(separator: "\n")
+            : attachmentErrors.joined(separator: "\n")
         errorRecoverySuggestion = nil
         failedMessage = nil
 
@@ -756,9 +826,9 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         )
 
         // Create a capability-aware placeholder so cancellation/rollback can identify image work.
-        let requestModel = preparation.requestModel.isEmpty
+        let requestModel = payload.requestModel.isEmpty
             ? targetConversation.model
-            : preparation.requestModel
+            : payload.requestModel
         let isImageRequest = aiService.getModelCapability(requestModel) == .imageGeneration
         var assistantMessage = Message(role: .assistant, content: "", model: requestModel)
         if isImageRequest {
@@ -786,7 +856,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
 
         if isImageRequest {
             generateImage(
-                text: preparation.text,
+                text: payload.text,
                 assistantMessage: assistantMessage,
                 conversationId: targetConversationId,
                 model: requestModel
@@ -1242,7 +1312,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             isGenerating = false
             currentToolName = nil
             toolCallDepth = 0
-            pendingUserMessage = nil
+            pendingSendPayload = nil
             SoundEngine.messageReceived()
 
             if let finalConversation = conversationManager.conversation(byId: conversationId) {
@@ -1287,7 +1357,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                 isGenerating = false
                 currentToolName = nil
                 toolCallDepth = 0
-                pendingUserMessage = nil
+                pendingSendPayload = nil
                 if let updatedConversation = conversationManager.conversation(byId: conversationId) {
                     conversationManager.saveImmediately(updatedConversation)
                 }
@@ -1310,8 +1380,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             toolCallDepth = 0
             errorMessage = ErrorPresenter.userMessage(for: error)
             errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
-            failedMessage = pendingUserMessage
-            pendingUserMessage = nil
+            capturePendingSendFailure()
             let assistantHasToolCalls = conversationManager
                 .conversation(byId: conversationId)?
                 .messages.first(where: { $0.id == assistantMessageId })?
@@ -1557,6 +1626,11 @@ private extension IOSChatViewModel {
     }
 
     func cleanupAttachedFiles(_ files: [URL]) {
+        deleteTemporaryAttachedFiles(files)
+        removeAttachedFiles(files)
+    }
+
+    func deleteTemporaryAttachedFiles(_ files: [URL]) {
         let tempDirPath = FileManager.default.temporaryDirectory.path
         for url in files {
             if FileManager.default.fileExists(atPath: url.path),
@@ -1564,6 +1638,11 @@ private extension IOSChatViewModel {
             {
                 try? FileManager.default.removeItem(at: url)
             }
+        }
+    }
+
+    func removeAttachedFiles(_ files: [URL]) {
+        for url in files {
             if let index = attachedFiles.firstIndex(of: url) {
                 attachedFiles.remove(at: index)
             }
@@ -1583,6 +1662,16 @@ private extension IOSChatViewModel {
         pastedImages.removeAll { imageIDs.contains($0.id) }
     }
 
+    private func consumeComposer(_ preparation: SendPreparation) {
+        if messageText == preparation.draftText {
+            messageText = ""
+        }
+        deleteTemporaryAttachedFiles(preparation.attachedFiles)
+        removeAttachedFiles(preparation.attachedFiles)
+        removeAttachedImages(preparation.attachedImages)
+        removePastedImages(preparation.pastedImages)
+    }
+
     private func makeUserMessage(
         from preparation: SendPreparation
     ) -> (message: Message, errors: [String]) {
@@ -1593,14 +1682,12 @@ private extension IOSChatViewModel {
             let result = IOSFileAttachmentUtils.processAttachments(from: preparation.attachedFiles)
             attachments.append(contentsOf: result.attachments)
             errors.append(contentsOf: result.errors)
-            cleanupAttachedFiles(preparation.attachedFiles)
         }
 
         if !preparation.attachedImages.isEmpty {
             attachments.append(contentsOf: IOSFileAttachmentUtils.processImageAttachments(
                 from: preparation.attachedImages
             ))
-            removeAttachedImages(preparation.attachedImages)
         }
 
         if !preparation.pastedImages.isEmpty {
@@ -1611,7 +1698,6 @@ private extension IOSChatViewModel {
                     data: pastedImage.data
                 )
             })
-            removePastedImages(preparation.pastedImages)
         }
 
         return (
@@ -1848,53 +1934,80 @@ extension IOSChatViewModel {
 // MARK: - Multi-Model Message Sending
 
 extension IOSChatViewModel {
+    private func sendMultiModelImageIfNeeded(
+        _ payload: PreparedSend,
+        consuming preparation: SendPreparation?,
+        conversation: Conversation,
+        models: [String]
+    ) -> Bool {
+        guard let firstModel = payload.selectedModels.sorted().first,
+              aiService.getModelCapability(firstModel) == .imageGeneration
+        else {
+            return false
+        }
+
+        pendingSendPayload = payload
+        failedSendPayload = nil
+        failedMessage = nil
+        generateImagesWithMultipleModels(
+            prompt: payload.text,
+            models: models,
+            conversation: conversation,
+            draftText: preparation?.draftText
+        )
+        return true
+    }
+
     /// Sends a message to multiple models in parallel for comparison
-    private func sendToMultipleModels(_ preparation: SendPreparation) {
+    private func sendToMultipleModels(
+        _ payload: PreparedSend,
+        consuming preparation: SendPreparation?,
+        attachmentErrors: [String]
+    ) {
         guard !isGenerating else { return }
-        let text = preparation.text
+        let text = payload.text
 
         guard let targetConversation = getOrCreateConversationForMultiModel(
-            selectedModels: preparation.selectedModels
+            selectedModels: payload.selectedModels
         ) else {
             restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
             return
         }
         let conversationId = targetConversation.id
-        let models = Array(preparation.selectedModels)
+        let models = Array(payload.selectedModels)
 
-        // Check for image generation and route accordingly
-        if let firstModel = preparation.selectedModels.sorted().first,
-           aiService.getModelCapability(firstModel) == .imageGeneration
-        {
-            generateImagesWithMultipleModels(
-                prompt: text,
-                models: models,
-                conversation: targetConversation,
-                draftText: preparation.draftText
-            )
+        if sendMultiModelImageIfNeeded(
+            payload,
+            consuming: preparation,
+            conversation: targetConversation,
+            models: models
+        ) {
             return
         }
 
         DiagnosticsLogger.log(.chatView, level: .info, message: "🔀 Starting iOS multi-model request",
                               metadata: ["models": models.joined(separator: ", ")])
 
-        let messageBuild = makeUserMessage(from: preparation)
-        let userMessage = messageBuild.message
+        let userMessage = payload.makeUserMessage()
         conversationManager.addMessage(to: targetConversation, message: userMessage)
         consumePendingAutoSendClaim(afterCommittingTo: conversationId)
+        if let preparation {
+            consumeComposer(preparation)
+        }
 
         if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: text) {
             DiagnosticsLogger.log(.chatView, level: .info, message: "💾 Memory command processed",
                                   metadata: ["response": memoryResponse])
         }
 
-        if messageText == preparation.draftText {
-            messageText = ""
-        }
+        pendingSendPayload = payload
+        failedSendPayload = nil
+        failedMessage = nil
         isGenerating = true
-        errorMessage = messageBuild.errors.isEmpty
+        errorMessage = attachmentErrors.isEmpty
             ? nil
-            : messageBuild.errors.joined(separator: "\n")
+            : attachmentErrors.joined(separator: "\n")
+        errorRecoverySuggestion = nil
 
         let responsePlan = createResponsePlanForMultiModel(
             models: models,
@@ -1910,6 +2023,8 @@ extension IOSChatViewModel {
 
         guard let updatedConversation = conversation else {
             isGenerating = false
+            errorMessage = "Unable to prepare this conversation for sending."
+            capturePendingSendFailure()
             return
         }
         var messagesToSend = updatedConversation.getEffectiveHistory().filter { $0.responseGroupId != responseGroupId }
@@ -2017,6 +2132,7 @@ extension IOSChatViewModel {
         }
         activeMultiModelResponseGroupId = nil
         guard coordinator.finishOperation(operationID) else { return }
+        pendingSendPayload = nil
 
         if isNewChatMode {
             onConversationCreated?(conversationId)
@@ -2199,6 +2315,7 @@ extension IOSChatViewModel {
            group.responses.allSatisfy({ $0.status == .failed })
         {
             errorMessage = "All models failed"
+            capturePendingSendFailure()
         }
     }
 }
@@ -2228,7 +2345,7 @@ extension IOSChatViewModel {
             toolCallDepth = 0
             activeAssistantMessageId = nil
             activeMultiModelResponseGroupId = nil
-            pendingUserMessage = nil
+            pendingSendPayload = nil
         }
 
         private func finalizePersistedTextGeneration() {
@@ -2353,6 +2470,7 @@ extension IOSChatViewModel {
 
                     guard coordinator.finishOperation(operationID) else { return }
                     self.isGenerating = false
+                    self.pendingSendPayload = nil
                     if self.isNewChatMode {
                         self.onConversationCreated?(conversationId)
                     }
@@ -2371,6 +2489,7 @@ extension IOSChatViewModel {
                     self.isGenerating = false
                     self.errorMessage = ErrorPresenter.userMessage(for: error)
                     self.errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
+                    self.capturePendingSendFailure()
                     self.conversationManager.removeMessage(
                         conversationId: conversationId,
                         messageId: assistantMessageId
@@ -2417,7 +2536,7 @@ extension IOSChatViewModel {
         prompt: String,
         models: [String],
         conversation: Conversation,
-        draftText: String
+        draftText: String?
     ) {
         let coordinator = imageGenerationCoordinator
         let operationID = coordinator.beginOperation()
@@ -2434,7 +2553,7 @@ extension IOSChatViewModel {
         conversationManager.addMessage(to: conversation, message: userMessage)
         consumePendingAutoSendClaim(afterCommittingTo: conversationId)
 
-        if messageText == draftText {
+        if let draftText, messageText == draftText {
             messageText = ""
         }
         isGenerating = true
@@ -2579,7 +2698,11 @@ extension IOSChatViewModel {
             await deleteImageData(at: imagePath)
             counter.increment()
             if counter.isComplete {
-                finalizeImageGenerationBatch(conversationId: conversationId, operationID: operationID)
+                finalizeImageGenerationBatch(
+                    conversationId: conversationId,
+                    responseGroupId: responseGroupId,
+                    operationID: operationID
+                )
             }
             return
         }
@@ -2606,14 +2729,22 @@ extension IOSChatViewModel {
             )
             counter.increment()
             if counter.isComplete {
-                finalizeImageGenerationBatch(conversationId: conversationId, operationID: operationID)
+                finalizeImageGenerationBatch(
+                    conversationId: conversationId,
+                    responseGroupId: responseGroupId,
+                    operationID: operationID
+                )
             }
             return
         }
 
         counter.increment()
         if counter.isComplete {
-            finalizeImageGenerationBatch(conversationId: conversationId, operationID: operationID)
+            finalizeImageGenerationBatch(
+                conversationId: conversationId,
+                responseGroupId: responseGroupId,
+                operationID: operationID
+            )
         }
     }
 
@@ -2651,7 +2782,11 @@ extension IOSChatViewModel {
 
         counter.increment()
         if counter.isComplete {
-            finalizeImageGenerationBatch(conversationId: conversationId, operationID: operationID)
+            finalizeImageGenerationBatch(
+                conversationId: conversationId,
+                responseGroupId: responseGroupId,
+                operationID: operationID
+            )
         }
     }
 
@@ -2676,12 +2811,21 @@ extension IOSChatViewModel {
     /// Finalizes a batch of image generation requests
     private func finalizeImageGenerationBatch(
         conversationId: UUID,
+        responseGroupId: UUID,
         operationID: ImageGenerationCoordinator.OperationID
     ) {
         guard imageGenerationCoordinator.finishOperation(operationID) else { return }
         isGenerating = false
         if let conversation = conversationManager.conversation(byId: conversationId) {
             conversationManager.save(conversation)
+            if let group = conversation.getResponseGroup(responseGroupId),
+               group.responses.allSatisfy({ $0.status == .failed })
+            {
+                errorMessage = "All models failed"
+                capturePendingSendFailure()
+            } else {
+                pendingSendPayload = nil
+            }
         }
         if isNewChatMode {
             onConversationCreated?(conversationId)

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -1431,10 +1431,6 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                 conversationManager.save(updatedConversation)
                         }
 
-            if isNewChatMode {
-                onConversationCreated?(conversationId)
-                    }
-
             DiagnosticsLogger.log(
                 .chatView,
                 level: .error,
@@ -2015,6 +2011,46 @@ extension IOSChatViewModel {
         )
     }
 
+    func editMessageAndResend(_ message: Message, newContent: String) {
+        guard !isGenerating, let conversation else { return }
+        guard let proposedHistory = ChatDraftContent.effectiveHistory(
+            byEditingUserMessage: message.id,
+            newContent: newContent,
+            in: conversation
+        ) else {
+            return
+        }
+
+        let resendModel = conversation.model
+        if aiService.getModelCapability(resendModel) != .imageGeneration {
+            if let supportError = aiService.attachmentHistorySupportError(
+                for: [resendModel],
+                messages: proposedHistory
+            ) {
+                errorMessage = supportError
+                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+                return
+            }
+            if let limitError = aiService.attachmentImageLimitError(
+                for: [resendModel],
+                messages: proposedHistory
+            ) {
+                errorMessage = limitError
+                errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
+                return
+            }
+        }
+
+        guard conversationManager.editMessage(
+            in: conversation,
+            messageId: message.id,
+            newContent: newContent
+        ) else {
+            return
+        }
+        resendAfterEdit()
+    }
+
     /// Re-send the last user message to get a new AI response after editing.
     func resendAfterEdit() {
         guard !isGenerating else { return }
@@ -2357,6 +2393,10 @@ extension IOSChatViewModel {
     ) {
         guard coordinator.owns(operationID, conversationID: conversationId) else { return }
 
+        let didAllResponsesFail = allResponsesFailed(
+            conversationId: conversationId,
+            responseGroupId: activeMultiModelResponseGroupId
+        )
         multiModelReasoningBuffer.finishAll()
         flushAllStreamingChunks(conversationId: conversationId)
         isGenerating = false
@@ -2367,9 +2407,23 @@ extension IOSChatViewModel {
         guard coordinator.finishOperation(operationID) else { return }
         pendingSendPayload = nil
 
-        if isNewChatMode {
+        if isNewChatMode, !didAllResponsesFail {
             onConversationCreated?(conversationId)
         }
+    }
+
+    private func allResponsesFailed(
+        conversationId: UUID,
+        responseGroupId: UUID?
+    ) -> Bool {
+        guard let responseGroupId,
+              let group = conversationManager.conversation(byId: conversationId)?
+              .getResponseGroup(responseGroupId),
+              !group.responses.isEmpty
+        else {
+            return false
+        }
+        return group.responses.allSatisfy { $0.status == .failed }
     }
 
     private func finishAndPersistMultiModelReasoning(conversationId: UUID) {
@@ -2731,10 +2785,6 @@ extension IOSChatViewModel {
                         self.conversationManager.save(conversation)
                     }
 
-                    if self.isNewChatMode {
-                        self.onConversationCreated?(conversationId)
-                    }
-
                     DiagnosticsLogger.log(
                         .chatView,
                         level: .error,
@@ -3051,18 +3101,20 @@ extension IOSChatViewModel {
     ) {
         guard imageGenerationCoordinator.finishOperation(operationID) else { return }
         isGenerating = false
+        let didAllResponsesFail = allResponsesFailed(
+            conversationId: conversationId,
+            responseGroupId: responseGroupId
+        )
         if let conversation = conversationManager.conversation(byId: conversationId) {
             conversationManager.save(conversation)
-            if let group = conversation.getResponseGroup(responseGroupId),
-               group.responses.allSatisfy({ $0.status == .failed })
-            {
+            if didAllResponsesFail {
                 errorMessage = "All models failed"
                 capturePendingSendFailure()
             } else {
                 pendingSendPayload = nil
             }
         }
-        if isNewChatMode {
+        if isNewChatMode, !didAllResponsesFail {
             onConversationCreated?(conversationId)
         }
     }

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -1756,7 +1756,13 @@ extension IOSChatViewModel {
         guard validateAttachmentHistorySupport(for: payload) else { return }
         guard validateAttachmentImageLimit(for: payload) else { return }
 
-        guard !payload.attachments.isEmpty else {
+        let hasHistoricalImages = proposedMessages(for: payload).contains { message in
+            guard message.role == .user else { return false }
+            return message.attachments?.contains(where: {
+                $0.mimeType.lowercased().hasPrefix("image/")
+            }) == true
+        }
+        guard !payload.attachments.isEmpty || hasHistoricalImages else {
             sendPreparedPayload(
                 payload,
                 consuming: preparation,
@@ -1797,7 +1803,7 @@ extension IOSChatViewModel {
 
             let validationError = await aiService.attachmentImageValidationError(
                 for: requestModels(for: preparedPayload),
-                loading: preparedPayload.attachments,
+                in: proposedMessages(for: preparedPayload),
                 loadAttachmentData: { [attachmentStorage] path in
                     await attachmentStorage.loadData(path: path)
                 }
@@ -1942,6 +1948,19 @@ extension IOSChatViewModel {
         // Remove the assistant message and any subsequent messages
         let updatedMessages = Array(conversation.messages.prefix(messageIndex))
 
+        if !isImageRetry {
+            var retryConversation = conversation
+            retryConversation.messages = updatedMessages
+            if let supportError = aiService.attachmentHistorySupportError(
+                for: [retryModel],
+                messages: retryConversation.getEffectiveHistory()
+            ) {
+                errorMessage = supportError
+                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+                return
+            }
+        }
+
         // Update the conversation
         if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == targetConversationId }) {
             conversationManager.conversations[convIndex].messages = updatedMessages
@@ -2079,6 +2098,19 @@ extension IOSChatViewModel {
 
         // Remove the assistant message and any subsequent messages
         let updatedMessages = Array(conversation.messages.prefix(messageIndex))
+
+        if !isImageRetry {
+            var retryConversation = conversation
+            retryConversation.messages = updatedMessages
+            if let supportError = aiService.attachmentHistorySupportError(
+                for: [newModel],
+                messages: retryConversation.getEffectiveHistory()
+            ) {
+                errorMessage = supportError
+                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+                return
+            }
+        }
 
         // Update the conversation
         if let convIndex = conversationManager.conversations.firstIndex(where: { $0.id == targetConversationId }) {

--- a/Sources/Ayna/Views/iOS/IOSChatView.swift
+++ b/Sources/Ayna/Views/iOS/IOSChatView.swift
@@ -197,6 +197,7 @@ struct IOSChatView: View {
                 attachedImages: $viewModel.attachedImages,
                 pastedImages: $viewModel.pastedImages,
                 pasteImportSessionID: $viewModel.pasteImportSessionID,
+                isImportingPastedImages: $viewModel.isImportingPastedImages,
                 errorRecoverySuggestion: viewModel.errorRecoverySuggestion,
                 onRetry: viewModel.failedMessage != nil ? { viewModel.retryFailedMessage() } : nil,
                 showAttachmentButton: true,

--- a/Sources/Ayna/Views/iOS/IOSChatView.swift
+++ b/Sources/Ayna/Views/iOS/IOSChatView.swift
@@ -195,6 +195,8 @@ struct IOSChatView: View {
                 errorMessage: $viewModel.errorMessage,
                 attachedFiles: $viewModel.attachedFiles,
                 attachedImages: $viewModel.attachedImages,
+                pastedImages: $viewModel.pastedImages,
+                pasteImportSessionID: $viewModel.pasteImportSessionID,
                 errorRecoverySuggestion: viewModel.errorRecoverySuggestion,
                 onRetry: viewModel.failedMessage != nil ? { viewModel.retryFailedMessage() } : nil,
                 showAttachmentButton: true,

--- a/Sources/Ayna/Views/iOS/IOSChatView.swift
+++ b/Sources/Ayna/Views/iOS/IOSChatView.swift
@@ -71,14 +71,10 @@ struct IOSChatView: View {
                                                 viewModel.switchModelAndRetry(beforeMessage: message, newModel: newModel)
                                             } : nil,
                                             onEdit: message.role == .user && !viewModel.isGenerating ? { newContent in
-                                                let edited = conversationManager.editMessage(
-                                                    in: conversation,
-                                                    messageId: message.id,
+                                                viewModel.editMessageAndResend(
+                                                    message,
                                                     newContent: newContent
                                                 )
-                                                if edited {
-                                                    viewModel.resendAfterEdit()
-                                                }
                                             } : nil,
                                             availableModels: aiService.usableModels
                                         )

--- a/Sources/Ayna/Views/iOS/IOSContentView.swift
+++ b/Sources/Ayna/Views/iOS/IOSContentView.swift
@@ -208,14 +208,10 @@ struct IOSNewChatView: View {
                                             viewModel.switchModelAndRetry(beforeMessage: message, newModel: newModel)
                                         } : nil,
                                         onEdit: message.role == .user ? { newContent in
-                                            let edited = conversationManager.editMessage(
-                                                in: conversation,
-                                                messageId: message.id,
+                                            viewModel.editMessageAndResend(
+                                                message,
                                                 newContent: newContent
                                             )
-                                            if edited {
-                                                viewModel.resendAfterEdit()
-                                            }
                                         } : nil,
                                         availableModels: aiService.usableModels
                                     )

--- a/Sources/Ayna/Views/iOS/IOSContentView.swift
+++ b/Sources/Ayna/Views/iOS/IOSContentView.swift
@@ -288,6 +288,7 @@ struct IOSNewChatView: View {
                 attachedImages: $viewModel.attachedImages,
                 pastedImages: $viewModel.pastedImages,
                 pasteImportSessionID: $viewModel.pasteImportSessionID,
+                isImportingPastedImages: $viewModel.isImportingPastedImages,
                 errorRecoverySuggestion: viewModel.errorRecoverySuggestion,
                 onRetry: viewModel.failedMessage != nil ? { viewModel.retryFailedMessage() } : nil,
                 showAttachmentButton: true,

--- a/Sources/Ayna/Views/iOS/IOSContentView.swift
+++ b/Sources/Ayna/Views/iOS/IOSContentView.swift
@@ -286,6 +286,8 @@ struct IOSNewChatView: View {
                 errorMessage: $viewModel.errorMessage,
                 attachedFiles: $viewModel.attachedFiles,
                 attachedImages: $viewModel.attachedImages,
+                pastedImages: $viewModel.pastedImages,
+                pasteImportSessionID: $viewModel.pasteImportSessionID,
                 errorRecoverySuggestion: viewModel.errorRecoverySuggestion,
                 onRetry: viewModel.failedMessage != nil ? { viewModel.retryFailedMessage() } : nil,
                 showAttachmentButton: true,

--- a/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
@@ -9,6 +9,7 @@
 import os.log
 import PhotosUI
 import SwiftUI
+import UIKit
 import UniformTypeIdentifiers
 
 /// A reusable message composer component for iOS chat views.
@@ -20,6 +21,8 @@ struct IOSMessageComposer: View {
     @Binding var errorMessage: String?
     @Binding var attachedFiles: [URL]
     @Binding var attachedImages: [UIImage]
+    @Binding var pastedImages: [PastedImage]
+    @Binding var pasteImportSessionID: UUID
 
     /// Optional recovery suggestion for the current error
     var errorRecoverySuggestion: String?
@@ -97,6 +100,8 @@ struct IOSMessageComposer: View {
         errorMessage: Binding<String?>,
         attachedFiles: Binding<[URL]> = .constant([]),
         attachedImages: Binding<[UIImage]> = .constant([]),
+        pastedImages: Binding<[PastedImage]> = .constant([]),
+        pasteImportSessionID: Binding<UUID>,
         errorRecoverySuggestion: String? = nil,
         onRetry: (() -> Void)? = nil,
         showAttachmentButton: Bool = true,
@@ -112,6 +117,8 @@ struct IOSMessageComposer: View {
         _errorMessage = errorMessage
         _attachedFiles = attachedFiles
         _attachedImages = attachedImages
+        _pastedImages = pastedImages
+        _pasteImportSessionID = pasteImportSessionID
         self.errorRecoverySuggestion = errorRecoverySuggestion
         self.onRetry = onRetry
         self.showAttachmentButton = showAttachmentButton
@@ -141,7 +148,7 @@ struct IOSMessageComposer: View {
             }
 
             // Attached files display
-            if !attachedFiles.isEmpty || !attachedImages.isEmpty {
+            if !attachedFiles.isEmpty || !attachedImages.isEmpty || !pastedImages.isEmpty {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: Spacing.sm) {
                         ForEach(attachedFiles, id: \.self) { url in
@@ -149,6 +156,9 @@ struct IOSMessageComposer: View {
                         }
                         ForEach(attachedImages.indices, id: \.self) { index in
                             imageAttachmentChip(for: attachedImages[index], at: index)
+                        }
+                        ForEach(pastedImages) { pastedImage in
+                            pastedImageAttachmentChip(for: pastedImage)
                         }
                     }
                     .padding(.horizontal, Spacing.md)
@@ -191,22 +201,28 @@ struct IOSMessageComposer: View {
 
                 // Text field container - iMessage style pill with inline send button
                 HStack(alignment: .center, spacing: 0) {
-                    TextField("Ask anything", text: $messageText, axis: .vertical)
-                        .lineLimit(1 ... 5)
-                        .font(.body)
-                        .padding(.leading, 16)
-                        .padding(.trailing, 8)
-                        .padding(.vertical, 8)
-                        .accessibilityIdentifier("\(identifierPrefix).textEditor")
-                        .onSubmit {
-                            if !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, !isGenerating {
+                    IOSPasteAwareTextEditor(
+                        text: $messageText,
+                        pasteImportSessionID: $pasteImportSessionID,
+                        placeholder: "Ask anything",
+                        accessibilityIdentifier: "\(identifierPrefix).textEditor",
+                        onSubmit: {
+                            if hasSendableContent, !isGenerating {
                                 handleSendOrCancel()
                             }
+                        },
+                        onPasteImages: { images in
+                            pastedImages.append(contentsOf: images)
+                        },
+                        onPasteFailure: { message in
+                            errorMessage = message
                         }
-                        .submitLabel(.send)
+                    )
+                        .frame(maxWidth: .infinity)
+                        .accessibilityIdentifier("\(identifierPrefix).textEditor")
 
                     // Send/Stop button inside the text field - iMessage style
-                    if !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isGenerating {
+                    if hasSendableContent || isGenerating {
                         Button(action: handleSendOrCancel) {
                             Image(systemName: isGenerating ? "stop.circle.fill" : "arrow.up.circle.fill")
                                 .font(.system(size: 26))
@@ -224,7 +240,7 @@ struct IOSMessageComposer: View {
                 .clipShape(Capsule())
                 // Smooth spring animation when height changes from multiline text
                 .animation(Motion.springSnappy, value: messageText.contains("\n") || messageText.count > 40)
-                .animation(Motion.springSnappy, value: !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isGenerating)
+                .animation(Motion.springSnappy, value: hasSendableContent || isGenerating)
             }
             .padding(.horizontal, Spacing.md)
         }
@@ -279,6 +295,44 @@ struct IOSMessageComposer: View {
         .accessibilityIdentifier("\(identifierPrefix).attachment.image\(index)")
     }
 
+    private func pastedImageAttachmentChip(for pastedImage: PastedImage) -> some View {
+        HStack(spacing: Spacing.xxs) {
+            if let image = UIImage(data: pastedImage.data) {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 24, height: 24)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+            } else {
+                Image(systemName: "photo")
+                    .frame(width: 24, height: 24)
+            }
+            Text("Pasted image")
+                .font(Typography.caption)
+                .lineLimit(1)
+            Button {
+                pastedImages.removeAll { $0.id == pastedImage.id }
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(Typography.caption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .accessibilityIdentifier("\(identifierPrefix).attachment.remove.\(pastedImage.id.uuidString)")
+            .accessibilityLabel("Remove pasted image")
+        }
+        .padding(Spacing.xs)
+        .background(Theme.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: Spacing.CornerRadius.md))
+        .accessibilityIdentifier("\(identifierPrefix).attachment.\(pastedImage.id.uuidString)")
+    }
+
+    private var hasSendableContent: Bool {
+        !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !attachedFiles.isEmpty
+            || !attachedImages.isEmpty
+            || !pastedImages.isEmpty
+    }
+
     private func handleSendOrCancel() {
         if isGenerating {
             // Use centralized haptic engine
@@ -301,6 +355,221 @@ struct IOSMessageComposer: View {
                 metadata: ["textLength": "\(messageText.count)"]
             )
             onSend()
+        }
+    }
+}
+
+private struct IOSPasteAwareTextEditor: UIViewRepresentable {
+    @Binding var text: String
+    @Binding var pasteImportSessionID: UUID
+
+    let placeholder: String
+    let accessibilityIdentifier: String
+    let onSubmit: () -> Void
+    let onPasteImages: ([PastedImage]) -> Void
+    let onPasteFailure: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> PasteAwareTextView {
+        let textView = PasteAwareTextView()
+        textView.delegate = context.coordinator
+        textView.backgroundColor = .clear
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.adjustsFontForContentSizeCategory = true
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.isScrollEnabled = false
+        textView.returnKeyType = .send
+        textView.textContainerInset = UIEdgeInsets(top: 7, left: 16, bottom: 7, right: 8)
+        textView.textContainer.lineFragmentPadding = 0
+        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textView.accessibilityIdentifier = accessibilityIdentifier
+        textView.placeholder = placeholder
+        configurePasteHandling(for: textView)
+        textView.onPasteFailure = onPasteFailure
+        textView.text = text
+        textView.updatePlaceholderVisibility()
+        return textView
+    }
+
+    func updateUIView(_ textView: PasteAwareTextView, context: Context) {
+        context.coordinator.parent = self
+        configurePasteHandling(for: textView)
+        textView.onPasteFailure = onPasteFailure
+        textView.placeholder = placeholder
+        if textView.text != text {
+            textView.text = text
+        }
+        textView.updatePlaceholderVisibility()
+        textView.invalidateIntrinsicContentSize()
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        uiView: PasteAwareTextView,
+        context _: Context
+    ) -> CGSize? {
+        let width = proposal.width ?? 280
+        let fittingSize = uiView.sizeThatFits(CGSize(
+            width: width,
+            height: CGFloat.greatestFiniteMagnitude
+        ))
+        let lineHeight = uiView.font?.lineHeight ?? 20
+        let insets = uiView.textContainerInset.top + uiView.textContainerInset.bottom
+        let maximumHeight = ceil((lineHeight * 5) + insets)
+        let height = min(max(fittingSize.height, 34), maximumHeight)
+        uiView.isScrollEnabled = fittingSize.height > maximumHeight
+        return CGSize(width: width, height: height)
+    }
+
+    private func configurePasteHandling(for textView: PasteAwareTextView) {
+        let expectedSessionID = pasteImportSessionID
+        textView.updatePasteImportSession(expectedSessionID)
+        textView.onPasteImages = { images in
+            guard pasteImportSessionID == expectedSessionID else { return }
+            onPasteImages(images)
+        }
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var parent: IOSPasteAwareTextEditor
+
+        init(parent: IOSPasteAwareTextEditor) {
+            self.parent = parent
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            parent.text = textView.text
+            (textView as? PasteAwareTextView)?.updatePlaceholderVisibility()
+            textView.invalidateIntrinsicContentSize()
+        }
+
+        func textView(
+            _: UITextView,
+            shouldChangeTextIn _: NSRange,
+            replacementText text: String
+        ) -> Bool {
+            guard text == "\n" else { return true }
+            parent.onSubmit()
+            return false
+        }
+    }
+}
+
+@MainActor
+private final class PasteAwareTextView: UITextView {
+    private let placeholderLabel = UILabel()
+    private var pasteImportTask: Task<Void, Never>?
+    private var pasteImportSessionID: UUID?
+
+    var onPasteImages: (([PastedImage]) -> Void)?
+    var onPasteFailure: ((String) -> Void)?
+    var placeholder = "" {
+        didSet { placeholderLabel.text = placeholder }
+    }
+
+    override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+        configurePlaceholder()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func paste(_ sender: Any?) {
+        let providers = UIPasteboard.general.itemProviders.filter { provider in
+            provider.registeredContentTypes.contains { $0.conforms(to: .image) }
+        }
+        guard !providers.isEmpty else {
+            super.paste(sender)
+            return
+        }
+
+        let previousTask = pasteImportTask
+        let expectedSessionID = pasteImportSessionID
+        pasteImportTask = Task { @MainActor [weak self] in
+            await previousTask?.value
+            guard let self,
+                  !Task.isCancelled,
+                  pasteImportSessionID == expectedSessionID
+            else {
+                return
+            }
+
+            var images: [PastedImage] = []
+            for provider in providers {
+                if let image = await Self.loadImage(from: provider) {
+                    images.append(image)
+                }
+                guard !Task.isCancelled,
+                      pasteImportSessionID == expectedSessionID
+                else {
+                    return
+                }
+            }
+
+            guard !images.isEmpty else {
+                UINotificationFeedbackGenerator().notificationOccurred(.error)
+                DiagnosticsLogger.log(
+                    .chatView,
+                    level: .error,
+                    message: "Failed to import pasted clipboard image"
+                )
+                onPasteFailure?("The pasted image could not be attached.")
+                return
+            }
+            onPasteImages?(images)
+        }
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window == nil {
+            invalidatePasteImports()
+        }
+    }
+
+    func updatePasteImportSession(_ sessionID: UUID) {
+        guard pasteImportSessionID != sessionID else { return }
+        invalidatePasteImports()
+        pasteImportSessionID = sessionID
+    }
+
+    func updatePlaceholderVisibility() {
+        placeholderLabel.isHidden = !text.isEmpty
+    }
+
+    private func configurePlaceholder() {
+        placeholderLabel.font = .preferredFont(forTextStyle: .body)
+        placeholderLabel.adjustsFontForContentSizeCategory = true
+        placeholderLabel.textColor = .placeholderText
+        placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
+        placeholderLabel.isUserInteractionEnabled = false
+        addSubview(placeholderLabel)
+        NSLayoutConstraint.activate([
+            placeholderLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            placeholderLabel.topAnchor.constraint(equalTo: topAnchor, constant: 7),
+            placeholderLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -8),
+        ])
+    }
+
+    private func invalidatePasteImports() {
+        pasteImportTask?.cancel()
+        pasteImportTask = nil
+        pasteImportSessionID = nil
+    }
+
+    private static func loadImage(from provider: NSItemProvider) async -> PastedImage? {
+        await withCheckedContinuation { continuation in
+            _ = provider.loadTransferable(type: PastedImage.self) { result in
+                continuation.resume(returning: try? result.get())
+            }
         }
     }
 }

--- a/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
@@ -529,9 +529,9 @@ private struct IOSPasteAwareTextEditor: UIViewRepresentable {
 @MainActor
 private final class PasteAwareTextView: UITextView {
     private let placeholderLabel = UILabel()
-    private var pasteImportTask: Task<Void, Never>?
+    private var pasteImportTail: Task<Void, Never>?
+    private var pasteImportTasks: [UUID: Task<Void, Never>] = [:]
     private var pasteImportSessionID: UUID?
-    private var activePasteImportID: UUID?
     private var reservedImageCount = 0
 
     var onPasteImages: (([PastedImage]) -> Void)?
@@ -602,12 +602,11 @@ private final class PasteAwareTextView: UITextView {
 
         let reservationCount = providers.count
         reservedImageCount += reservationCount
-        let previousTask = pasteImportTask
+        let previousTask = pasteImportTail
         let expectedSessionID = pasteImportSessionID
         let importID = UUID()
-        activePasteImportID = importID
         onPasteImportStateChange?(true)
-        pasteImportTask = Task { @MainActor [weak self] in
+        let importTask = Task { @MainActor [weak self] in
             await previousTask?.value
             guard let self else { return }
             defer {
@@ -615,7 +614,7 @@ private final class PasteAwareTextView: UITextView {
                     reservationCount,
                     sessionID: expectedSessionID
                 )
-                self.finishPasteImport(importID)
+                self.finishPasteImport(importID, sessionID: expectedSessionID)
             }
             guard !Task.isCancelled,
                   pasteImportSessionID == expectedSessionID
@@ -662,6 +661,8 @@ private final class PasteAwareTextView: UITextView {
                 reportImageLimit()
             }
         }
+        pasteImportTasks[importID] = importTask
+        pasteImportTail = importTask
     }
 
     private static func imageProviders(from pasteboard: UIPasteboard) -> [NSItemProvider] {
@@ -702,21 +703,26 @@ private final class PasteAwareTextView: UITextView {
     }
 
     private func invalidatePasteImports() {
-        pasteImportTask?.cancel()
-        pasteImportTask = nil
+        let hadActiveImports = !pasteImportTasks.isEmpty
+        for task in pasteImportTasks.values {
+            task.cancel()
+        }
+        pasteImportTasks.removeAll()
+        pasteImportTail = nil
         reservedImageCount = 0
-        if activePasteImportID != nil {
-            activePasteImportID = nil
+        if hadActiveImports {
             onPasteImportStateChange?(false)
         }
         pasteImportSessionID = nil
     }
 
-    private func finishPasteImport(_ importID: UUID) {
-        guard activePasteImportID == importID else { return }
-        activePasteImportID = nil
-        pasteImportTask = nil
-        onPasteImportStateChange?(false)
+    private func finishPasteImport(_ importID: UUID, sessionID: UUID?) {
+        guard pasteImportSessionID == sessionID else { return }
+        pasteImportTasks[importID] = nil
+        if pasteImportTasks.isEmpty {
+            pasteImportTail = nil
+            onPasteImportStateChange?(false)
+        }
     }
 
     private func releaseImageReservation(_ count: Int, sessionID: UUID?) {

--- a/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
@@ -738,11 +738,74 @@ private final class PasteAwareTextView: UITextView {
     }
 
     private static func loadImage(from provider: NSItemProvider) async -> PastedImage? {
-        await withCheckedContinuation { continuation in
-            _ = provider.loadTransferable(type: PastedImage.self) { result in
-                continuation.resume(returning: try? result.get())
+        let load = ItemProviderImageLoad()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                load.start(provider: provider, continuation: continuation)
             }
+        } onCancel: {
+            load.cancel()
         }
+    }
+}
+
+private final class ItemProviderImageLoad: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<PastedImage?, Never>?
+    private var progress: Progress?
+    private var isFinished = false
+
+    func start(
+        provider: NSItemProvider,
+        continuation: CheckedContinuation<PastedImage?, Never>
+    ) {
+        let shouldStart = lock.withLock {
+            guard !isFinished else { return false }
+            self.continuation = continuation
+            return true
+        }
+        guard shouldStart else {
+            continuation.resume(returning: nil)
+            return
+        }
+
+        let progress = provider.loadTransferable(type: PastedImage.self) { [self] result in
+            finish(with: try? result.get())
+        }
+        let shouldCancel = lock.withLock {
+            guard !isFinished else { return true }
+            self.progress = progress
+            return false
+        }
+        if shouldCancel {
+            progress.cancel()
+        }
+    }
+
+    func cancel() {
+        let completion = lock.withLock {
+            () -> (Progress?, CheckedContinuation<PastedImage?, Never>?)? in
+            guard !isFinished else { return nil }
+            isFinished = true
+            let completion = (progress, continuation)
+            progress = nil
+            continuation = nil
+            return completion
+        }
+        guard let completion else { return }
+        completion.0?.cancel()
+        completion.1?.resume(returning: nil)
+    }
+
+    private func finish(with image: PastedImage?) {
+        let continuation = lock.withLock { () -> CheckedContinuation<PastedImage?, Never>? in
+            guard !isFinished else { return nil }
+            isFinished = true
+            progress = nil
+            defer { self.continuation = nil }
+            return self.continuation
+        }
+        continuation?.resume(returning: image)
     }
 }
 

--- a/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
@@ -6,6 +6,7 @@
 //  Created on 11/24/25.
 //
 
+import ImageIO
 import os.log
 import PhotosUI
 import SwiftUI
@@ -23,6 +24,7 @@ struct IOSMessageComposer: View {
     @Binding var attachedImages: [UIImage]
     @Binding var pastedImages: [PastedImage]
     @Binding var pasteImportSessionID: UUID
+    @Binding var isImportingPastedImages: Bool
 
     /// Optional recovery suggestion for the current error
     var errorRecoverySuggestion: String?
@@ -102,6 +104,7 @@ struct IOSMessageComposer: View {
         attachedImages: Binding<[UIImage]> = .constant([]),
         pastedImages: Binding<[PastedImage]> = .constant([]),
         pasteImportSessionID: Binding<UUID>,
+        isImportingPastedImages: Binding<Bool>,
         errorRecoverySuggestion: String? = nil,
         onRetry: (() -> Void)? = nil,
         showAttachmentButton: Bool = true,
@@ -119,6 +122,7 @@ struct IOSMessageComposer: View {
         _attachedImages = attachedImages
         _pastedImages = pastedImages
         _pasteImportSessionID = pasteImportSessionID
+        _isImportingPastedImages = isImportingPastedImages
         self.errorRecoverySuggestion = errorRecoverySuggestion
         self.onRetry = onRetry
         self.showAttachmentButton = showAttachmentButton
@@ -204,10 +208,11 @@ struct IOSMessageComposer: View {
                     IOSPasteAwareTextEditor(
                         text: $messageText,
                         pasteImportSessionID: $pasteImportSessionID,
+                        isImportingPastedImages: $isImportingPastedImages,
                         placeholder: "Ask anything",
                         accessibilityIdentifier: "\(identifierPrefix).textEditor",
                         onSubmit: {
-                            if hasSendableContent, !isGenerating {
+                            if canSend, !isGenerating {
                                 handleSendOrCancel()
                             }
                         },
@@ -230,6 +235,7 @@ struct IOSMessageComposer: View {
                                 .symbolEffect(.pulse, options: .repeating, value: isGenerating)
                         }
                         .padding(.trailing, 5)
+                        .disabled(!isGenerating && !canSend)
                         .accessibilityLabel(isGenerating ? "Stop generating" : "Send message")
                         .accessibilityIdentifier("\(identifierPrefix).sendButton")
                         .transition(.scale.combined(with: .opacity))
@@ -297,16 +303,7 @@ struct IOSMessageComposer: View {
 
     private func pastedImageAttachmentChip(for pastedImage: PastedImage) -> some View {
         HStack(spacing: Spacing.xxs) {
-            if let image = UIImage(data: pastedImage.data) {
-                Image(uiImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 24, height: 24)
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
-            } else {
-                Image(systemName: "photo")
-                    .frame(width: 24, height: 24)
-            }
+            IOSPastedImageThumbnail(pastedImage: pastedImage)
             Text("Pasted image")
                 .font(Typography.caption)
                 .lineLimit(1)
@@ -327,10 +324,15 @@ struct IOSMessageComposer: View {
     }
 
     private var hasSendableContent: Bool {
-        !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            || !attachedFiles.isEmpty
-            || !attachedImages.isEmpty
-            || !pastedImages.isEmpty
+        ChatDraftContent.isSendable(
+            text: messageText,
+            fileURLs: attachedFiles,
+            inMemoryImageCount: attachedImages.count + pastedImages.count
+        )
+    }
+
+    private var canSend: Bool {
+        hasSendableContent && !isImportingPastedImages
     }
 
     private func handleSendOrCancel() {
@@ -345,6 +347,7 @@ struct IOSMessageComposer: View {
             )
             onCancel()
         } else {
+            guard canSend else { return }
             // Use centralized haptic engine
             HapticEngine.sendButtonTap()
 
@@ -359,9 +362,53 @@ struct IOSMessageComposer: View {
     }
 }
 
+private struct IOSPastedImageThumbnail: View {
+    let pastedImage: PastedImage
+
+    @State private var image: UIImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+            } else {
+                Image(systemName: "photo")
+            }
+        }
+        .frame(width: 24, height: 24)
+        .accessibilityHidden(true)
+        .task(id: pastedImage.id) {
+            let data = pastedImage.data
+            image = await Task.detached(priority: .utility) {
+                guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+                    return nil
+                }
+                let options: [CFString: Any] = [
+                    kCGImageSourceCreateThumbnailFromImageAlways: true,
+                    kCGImageSourceCreateThumbnailWithTransform: true,
+                    kCGImageSourceThumbnailMaxPixelSize: 96,
+                    kCGImageSourceShouldCacheImmediately: true,
+                ]
+                guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(
+                    source,
+                    0,
+                    options as CFDictionary
+                ) else {
+                    return nil
+                }
+                return UIImage(cgImage: thumbnail)
+            }.value
+        }
+    }
+}
+
 private struct IOSPasteAwareTextEditor: UIViewRepresentable {
     @Binding var text: String
     @Binding var pasteImportSessionID: UUID
+    @Binding var isImportingPastedImages: Bool
 
     let placeholder: String
     let accessibilityIdentifier: String
@@ -387,6 +434,7 @@ private struct IOSPasteAwareTextEditor: UIViewRepresentable {
         textView.textContainer.lineFragmentPadding = 0
         textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         textView.accessibilityIdentifier = accessibilityIdentifier
+        textView.accessibilityLabel = placeholder
         textView.placeholder = placeholder
         configurePasteHandling(for: textView)
         textView.onPasteFailure = onPasteFailure
@@ -400,6 +448,7 @@ private struct IOSPasteAwareTextEditor: UIViewRepresentable {
         configurePasteHandling(for: textView)
         textView.onPasteFailure = onPasteFailure
         textView.placeholder = placeholder
+        textView.accessibilityLabel = placeholder
         if textView.text != text {
             textView.text = text
         }
@@ -432,6 +481,9 @@ private struct IOSPasteAwareTextEditor: UIViewRepresentable {
             guard pasteImportSessionID == expectedSessionID else { return }
             onPasteImages(images)
         }
+        textView.onPasteImportStateChange = { isImporting in
+            isImportingPastedImages = isImporting
+        }
     }
 
     @MainActor
@@ -449,11 +501,16 @@ private struct IOSPasteAwareTextEditor: UIViewRepresentable {
         }
 
         func textView(
-            _: UITextView,
+            _ textView: UITextView,
             shouldChangeTextIn _: NSRange,
             replacementText text: String
         ) -> Bool {
             guard text == "\n" else { return true }
+            if let pasteAwareTextView = textView as? PasteAwareTextView,
+               pasteAwareTextView.isInsertingModifiedNewline
+            {
+                return true
+            }
             parent.onSubmit()
             return false
         }
@@ -465,9 +522,12 @@ private final class PasteAwareTextView: UITextView {
     private let placeholderLabel = UILabel()
     private var pasteImportTask: Task<Void, Never>?
     private var pasteImportSessionID: UUID?
+    private var activePasteImportID: UUID?
 
     var onPasteImages: (([PastedImage]) -> Void)?
     var onPasteFailure: ((String) -> Void)?
+    var onPasteImportStateChange: ((Bool) -> Void)?
+    private(set) var isInsertingModifiedNewline = false
     var placeholder = "" {
         didSet { placeholderLabel.text = placeholder }
     }
@@ -489,6 +549,22 @@ private final class PasteAwareTextView: UITextView {
         return super.canPerformAction(action, withSender: sender)
     }
 
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        let containsShiftReturn = presses.contains { press in
+            guard let key = press.key else { return false }
+            return key.keyCode == .keyboardReturnOrEnter
+                && key.modifierFlags.contains(.shift)
+        }
+        guard containsShiftReturn else {
+            super.pressesBegan(presses, with: event)
+            return
+        }
+
+        isInsertingModifiedNewline = true
+        insertText("\n")
+        isInsertingModifiedNewline = false
+    }
+
     override func paste(_ sender: Any?) {
         let providers = Self.imageProviders(from: .general)
         guard !providers.isEmpty else {
@@ -498,10 +574,14 @@ private final class PasteAwareTextView: UITextView {
 
         let previousTask = pasteImportTask
         let expectedSessionID = pasteImportSessionID
+        let importID = UUID()
+        activePasteImportID = importID
+        onPasteImportStateChange?(true)
         pasteImportTask = Task { @MainActor [weak self] in
             await previousTask?.value
-            guard let self,
-                  !Task.isCancelled,
+            guard let self else { return }
+            defer { self.finishPasteImport(importID) }
+            guard !Task.isCancelled,
                   pasteImportSessionID == expectedSessionID
             else {
                 return
@@ -573,7 +653,18 @@ private final class PasteAwareTextView: UITextView {
     private func invalidatePasteImports() {
         pasteImportTask?.cancel()
         pasteImportTask = nil
+        if activePasteImportID != nil {
+            activePasteImportID = nil
+            onPasteImportStateChange?(false)
+        }
         pasteImportSessionID = nil
+    }
+
+    private func finishPasteImport(_ importID: UUID) {
+        guard activePasteImportID == importID else { return }
+        activePasteImportID = nil
+        pasteImportTask = nil
+        onPasteImportStateChange?(false)
     }
 
     private static func loadImage(from provider: NSItemProvider) async -> PastedImage? {

--- a/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
@@ -482,10 +482,15 @@ private final class PasteAwareTextView: UITextView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func paste(_ sender: Any?) {
-        let providers = UIPasteboard.general.itemProviders.filter { provider in
-            provider.registeredContentTypes.contains { $0.conforms(to: .image) }
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(paste(_:)), UIPasteboard.general.hasImages {
+            return true
         }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    override func paste(_ sender: Any?) {
+        let providers = Self.imageProviders(from: .general)
         guard !providers.isEmpty else {
             super.paste(sender)
             return
@@ -525,6 +530,12 @@ private final class PasteAwareTextView: UITextView {
                 return
             }
             onPasteImages?(images)
+        }
+    }
+
+    private static func imageProviders(from pasteboard: UIPasteboard) -> [NSItemProvider] {
+        pasteboard.itemProviders.filter { provider in
+            provider.registeredContentTypes.contains { $0.conforms(to: .image) }
         }
     }
 

--- a/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
@@ -382,7 +382,7 @@ private struct IOSPastedImageThumbnail: View {
         .accessibilityHidden(true)
         .task(id: pastedImage.id) {
             let data = pastedImage.data
-            image = await Task.detached(priority: .utility) {
+            let thumbnail = await Task.detached(priority: .utility) { () -> CGImage? in
                 guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
                     return nil
                 }
@@ -392,15 +392,14 @@ private struct IOSPastedImageThumbnail: View {
                     kCGImageSourceThumbnailMaxPixelSize: 96,
                     kCGImageSourceShouldCacheImmediately: true,
                 ]
-                guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(
+                return CGImageSourceCreateThumbnailAtIndex(
                     source,
                     0,
                     options as CFDictionary
-                ) else {
-                    return nil
-                }
-                return UIImage(cgImage: thumbnail)
+                )
             }.value
+            guard !Task.isCancelled, let thumbnail else { return }
+            image = UIImage(cgImage: thumbnail)
         }
     }
 }

--- a/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
@@ -566,10 +566,17 @@ private final class PasteAwareTextView: UITextView {
     }
 
     override func paste(_ sender: Any?) {
-        let providers = Self.imageProviders(from: .general)
-        guard !providers.isEmpty else {
+        let pasteboard = UIPasteboard.general
+        let imageProviders = Self.imageProviders(from: pasteboard)
+        guard !imageProviders.isEmpty else {
             super.paste(sender)
             return
+        }
+        let providers = Array(imageProviders.prefix(ChatDraftContent.maximumImageCount))
+        let skippedImageCount = imageProviders.count - providers.count
+
+        if pasteboard.hasStrings {
+            super.paste(sender)
         }
 
         let previousTask = pasteImportTask
@@ -610,6 +617,11 @@ private final class PasteAwareTextView: UITextView {
                 return
             }
             onPasteImages?(images)
+            if skippedImageCount > 0 {
+                onPasteFailure?(
+                    "Only the first \(ChatDraftContent.maximumImageCount) clipboard images were attached."
+                )
+            }
         }
     }
 

--- a/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
@@ -209,6 +209,7 @@ struct IOSMessageComposer: View {
                         text: $messageText,
                         pasteImportSessionID: $pasteImportSessionID,
                         isImportingPastedImages: $isImportingPastedImages,
+                        remainingImageCapacity: { remainingImageCapacity },
                         placeholder: "Ask anything",
                         accessibilityIdentifier: "\(identifierPrefix).textEditor",
                         onSubmit: {
@@ -335,6 +336,13 @@ struct IOSMessageComposer: View {
         hasSendableContent && !isImportingPastedImages
     }
 
+    private var remainingImageCapacity: Int {
+        ChatDraftContent.remainingImageCapacity(
+            fileURLs: attachedFiles,
+            inMemoryImageCount: attachedImages.count + pastedImages.count
+        )
+    }
+
     private func handleSendOrCancel() {
         if isGenerating {
             // Use centralized haptic engine
@@ -409,6 +417,7 @@ private struct IOSPasteAwareTextEditor: UIViewRepresentable {
     @Binding var pasteImportSessionID: UUID
     @Binding var isImportingPastedImages: Bool
 
+    let remainingImageCapacity: () -> Int
     let placeholder: String
     let accessibilityIdentifier: String
     let onSubmit: () -> Void
@@ -476,6 +485,7 @@ private struct IOSPasteAwareTextEditor: UIViewRepresentable {
     private func configurePasteHandling(for textView: PasteAwareTextView) {
         let expectedSessionID = pasteImportSessionID
         textView.updatePasteImportSession(expectedSessionID)
+        textView.remainingImageCapacity = remainingImageCapacity
         textView.onPasteImages = { images in
             guard pasteImportSessionID == expectedSessionID else { return }
             onPasteImages(images)
@@ -522,10 +532,12 @@ private final class PasteAwareTextView: UITextView {
     private var pasteImportTask: Task<Void, Never>?
     private var pasteImportSessionID: UUID?
     private var activePasteImportID: UUID?
+    private var reservedImageCount = 0
 
     var onPasteImages: (([PastedImage]) -> Void)?
     var onPasteFailure: ((String) -> Void)?
     var onPasteImportStateChange: ((Bool) -> Void)?
+    var remainingImageCapacity: (() -> Int)?
     private(set) var isInsertingModifiedNewline = false
     var placeholder = "" {
         didSet { placeholderLabel.text = placeholder }
@@ -571,13 +583,25 @@ private final class PasteAwareTextView: UITextView {
             super.paste(sender)
             return
         }
-        let providers = Array(imageProviders.prefix(ChatDraftContent.maximumImageCount))
-        let skippedImageCount = imageProviders.count - providers.count
 
         if pasteboard.hasStrings {
             super.paste(sender)
         }
 
+        let capacity = max(
+            0,
+            (remainingImageCapacity?() ?? ChatDraftContent.maximumImageCount)
+                - reservedImageCount
+        )
+        let providers = Array(imageProviders.prefix(capacity))
+        let initiallySkippedImageCount = max(0, imageProviders.count - providers.count)
+        guard !providers.isEmpty else {
+            reportImageLimit()
+            return
+        }
+
+        let reservationCount = providers.count
+        reservedImageCount += reservationCount
         let previousTask = pasteImportTask
         let expectedSessionID = pasteImportSessionID
         let importID = UUID()
@@ -586,7 +610,13 @@ private final class PasteAwareTextView: UITextView {
         pasteImportTask = Task { @MainActor [weak self] in
             await previousTask?.value
             guard let self else { return }
-            defer { self.finishPasteImport(importID) }
+            defer {
+                self.releaseImageReservation(
+                    reservationCount,
+                    sessionID: expectedSessionID
+                )
+                self.finishPasteImport(importID)
+            }
             guard !Task.isCancelled,
                   pasteImportSessionID == expectedSessionID
             else {
@@ -605,7 +635,16 @@ private final class PasteAwareTextView: UITextView {
                 }
             }
 
-            guard !images.isEmpty else {
+            let finalCapacity = max(
+                0,
+                remainingImageCapacity?() ?? ChatDraftContent.maximumImageCount
+            )
+            let acceptedImages = Array(images.prefix(finalCapacity))
+            guard !acceptedImages.isEmpty else {
+                if finalCapacity == 0 {
+                    reportImageLimit()
+                    return
+                }
                 UINotificationFeedbackGenerator().notificationOccurred(.error)
                 DiagnosticsLogger.log(
                     .chatView,
@@ -615,11 +654,12 @@ private final class PasteAwareTextView: UITextView {
                 onPasteFailure?("The pasted image could not be attached.")
                 return
             }
-            onPasteImages?(images)
+            onPasteImages?(acceptedImages)
+
+            let skippedImageCount = initiallySkippedImageCount
+                + max(0, images.count - acceptedImages.count)
             if skippedImageCount > 0 {
-                onPasteFailure?(
-                    "Only the first \(ChatDraftContent.maximumImageCount) clipboard images were attached."
-                )
+                reportImageLimit()
             }
         }
     }
@@ -664,6 +704,7 @@ private final class PasteAwareTextView: UITextView {
     private func invalidatePasteImports() {
         pasteImportTask?.cancel()
         pasteImportTask = nil
+        reservedImageCount = 0
         if activePasteImportID != nil {
             activePasteImportID = nil
             onPasteImportStateChange?(false)
@@ -676,6 +717,18 @@ private final class PasteAwareTextView: UITextView {
         activePasteImportID = nil
         pasteImportTask = nil
         onPasteImportStateChange?(false)
+    }
+
+    private func releaseImageReservation(_ count: Int, sessionID: UUID?) {
+        guard pasteImportSessionID == sessionID else { return }
+        reservedImageCount = max(0, reservedImageCount - count)
+    }
+
+    private func reportImageLimit() {
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        onPasteFailure?(
+            "A draft can contain at most \(ChatDraftContent.maximumImageCount) images. Extra clipboard images were not attached."
+        )
     }
 
     private static func loadImage(from provider: NSItemProvider) async -> PastedImage? {

--- a/Sources/Ayna/Views/iOS/IOSMessageView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageView.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+import ImageIO
 import os.log
 import Photos
 import SwiftUI
@@ -814,9 +815,26 @@ private struct IOSMessageAttachmentView: View {
         guard !didFinishLoading else { return }
         let data = await attachment.loadContent()
         guard !Task.isCancelled else { return }
-        decodedImage = await Task.detached(priority: .userInitiated) {
-            data.flatMap(UIImage.init(data:))
+        let thumbnail = await Task.detached(priority: .userInitiated) { () -> CGImage? in
+            guard let data,
+                  let source = CGImageSourceCreateWithData(data as CFData, nil)
+            else {
+                return nil
+            }
+            let options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceThumbnailMaxPixelSize: PastedImage.maximumDimension,
+                kCGImageSourceShouldCacheImmediately: true,
+            ]
+            return CGImageSourceCreateThumbnailAtIndex(
+                source,
+                0,
+                options as CFDictionary
+            )
         }.value
+        guard !Task.isCancelled else { return }
+        decodedImage = thumbnail.map { UIImage(cgImage: $0) }
         didFinishLoading = true
     }
 }

--- a/Sources/Ayna/Views/iOS/IOSMessageView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageView.swift
@@ -237,17 +237,8 @@ struct IOSMessageView: View {
 
             VStack(alignment: .leading, spacing: Spacing.sm) {
                 if let attachments = message.attachments, !attachments.isEmpty {
-                    ForEach(attachments, id: \.fileName) { attachment in
-                        HStack {
-                            Image(systemName: "doc.fill")
-                                .foregroundStyle(Theme.textSecondary)
-                            Text(attachment.fileName)
-                                .font(Typography.caption)
-                                .lineLimit(1)
-                        }
-                        .padding(Spacing.xs)
-                        .background(Color.black.opacity(0.1))
-                        .clipShape(.rect(cornerRadius: Spacing.CornerRadius.sm))
+                    ForEach(Array(attachments.enumerated()), id: \.offset) { _, attachment in
+                        IOSMessageAttachmentView(attachment: attachment)
                     }
                 }
 
@@ -762,6 +753,69 @@ private struct MessageBubbleShape: Shape {
                 path.closeSubpath()
             }
         }
+    }
+}
+
+private struct IOSMessageAttachmentView: View {
+    let attachment: Message.FileAttachment
+
+    @State private var decodedImage: UIImage?
+    @State private var didFinishLoading = false
+
+    var body: some View {
+        if attachment.mimeType.starts(with: "image/") {
+            imageAttachment
+        } else {
+            fileAttachment
+        }
+    }
+
+    @ViewBuilder
+    private var imageAttachment: some View {
+        if let decodedImage {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Image(uiImage: decodedImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: Spacing.Component.bubbleMaxWidth - 20, maxHeight: 320)
+                    .clipShape(.rect(cornerRadius: Spacing.CornerRadius.md))
+                    .accessibilityLabel("Image attachment \(attachment.fileName)")
+
+                Text(verbatim: attachment.fileName)
+                    .font(Typography.caption)
+                    .lineLimit(1)
+            }
+        } else if didFinishLoading {
+            fileAttachment
+        } else {
+            ProgressView()
+                .frame(width: 100, height: 100)
+                .task {
+                    await loadImage()
+                }
+        }
+    }
+
+    private var fileAttachment: some View {
+        HStack {
+            Image(systemName: "doc.fill")
+                .foregroundStyle(Theme.textSecondary)
+            Text(verbatim: attachment.fileName)
+                .font(Typography.caption)
+                .lineLimit(1)
+        }
+        .padding(Spacing.xs)
+        .background(Color.black.opacity(0.1))
+        .clipShape(.rect(cornerRadius: Spacing.CornerRadius.sm))
+    }
+
+    @MainActor
+    private func loadImage() async {
+        guard !didFinishLoading else { return }
+        let data = await attachment.loadContent()
+        guard !Task.isCancelled else { return }
+        decodedImage = data.flatMap(UIImage.init(data:))
+        didFinishLoading = true
     }
 }
 

--- a/Sources/Ayna/Views/iOS/IOSMessageView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageView.swift
@@ -237,7 +237,7 @@ struct IOSMessageView: View {
 
             VStack(alignment: .leading, spacing: Spacing.sm) {
                 if let attachments = message.attachments, !attachments.isEmpty {
-                    ForEach(Array(attachments.enumerated()), id: \.offset) { _, attachment in
+                    ForEach(attachments) { attachment in
                         IOSMessageAttachmentView(attachment: attachment)
                     }
                 }

--- a/Sources/Ayna/Views/iOS/IOSMessageView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageView.swift
@@ -815,8 +815,9 @@ private struct IOSMessageAttachmentView: View {
         guard !didFinishLoading else { return }
         let data = await attachment.loadContent()
         guard !Task.isCancelled else { return }
-        let thumbnail = await Task.detached(priority: .userInitiated) { () -> CGImage? in
-            guard let data,
+        let decodeTask = Task.detached(priority: .userInitiated) { () -> CGImage? in
+            guard !Task.isCancelled,
+                  let data,
                   let source = CGImageSourceCreateWithData(data as CFData, nil)
             else {
                 return nil
@@ -827,12 +828,18 @@ private struct IOSMessageAttachmentView: View {
                 kCGImageSourceThumbnailMaxPixelSize: PastedImage.maximumDimension,
                 kCGImageSourceShouldCacheImmediately: true,
             ]
-            return CGImageSourceCreateThumbnailAtIndex(
+            let thumbnail = CGImageSourceCreateThumbnailAtIndex(
                 source,
                 0,
                 options as CFDictionary
             )
-        }.value
+            return Task.isCancelled ? nil : thumbnail
+        }
+        let thumbnail = await withTaskCancellationHandler {
+            await decodeTask.value
+        } onCancel: {
+            decodeTask.cancel()
+        }
         guard !Task.isCancelled else { return }
         decodedImage = thumbnail.map { UIImage(cgImage: $0) }
         didFinishLoading = true

--- a/Sources/Ayna/Views/iOS/IOSMessageView.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageView.swift
@@ -814,7 +814,9 @@ private struct IOSMessageAttachmentView: View {
         guard !didFinishLoading else { return }
         let data = await attachment.loadContent()
         guard !Task.isCancelled else { return }
-        decodedImage = data.flatMap(UIImage.init(data:))
+        decodedImage = await Task.detached(priority: .userInitiated) {
+            data.flatMap(UIImage.init(data:))
+        }.value
         didFinishLoading = true
     }
 }

--- a/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
+++ b/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
@@ -15,6 +15,8 @@ struct ChatInputArea: View {
     @Binding var messageText: String
     @Binding var isComposerFocused: Bool
     @Binding var attachedFiles: [URL]
+    @Binding var pastedImages: [PastedImage]
+    @Binding var pasteImportSessionID: UUID
     @Binding var attachedAppContent: AppContent?
     @Binding var selectedModels: Set<String>
     @Binding var selectedModel: String
@@ -42,7 +44,7 @@ struct ChatInputArea: View {
             MCPToolSummaryView(isExpanded: $isToolSectionExpanded)
 
             // Attached files preview
-            if !attachedFiles.isEmpty {
+            if !attachedFiles.isEmpty || !pastedImages.isEmpty {
                 attachedFilesView
             }
 
@@ -79,6 +81,11 @@ struct ChatInputArea: View {
                 ForEach(attachedFiles, id: \.self) { fileURL in
                     AttachedFileRow(fileURL: fileURL) {
                         onRemoveFile(fileURL)
+                    }
+                }
+                ForEach(pastedImages) { pastedImage in
+                    PastedImageRow(pastedImage: pastedImage) {
+                        pastedImages.removeAll { $0.id == pastedImage.id }
                     }
                 }
             }
@@ -154,7 +161,11 @@ struct ChatInputArea: View {
             DynamicTextEditor(
                 text: $messageText,
                 isFirstResponder: $isComposerFocused,
+                pasteImportSessionID: $pasteImportSessionID,
                 onSubmit: onSendMessage,
+                onPasteImages: { images in
+                    pastedImages.append(contentsOf: images)
+                },
                 accessibilityIdentifier: textEditorIdentifier
             )
             .frame(height: textHeight)
@@ -252,12 +263,12 @@ struct ChatInputArea: View {
                 } else {
                     Image(systemName: "arrow.up.circle.fill")
                         .font(.system(size: Typography.IconSize.xl))
-                        .foregroundStyle(messageText.isEmpty ? Theme.textSecondary.opacity(0.5) : Theme.accent)
+                        .foregroundStyle(hasSendableContent ? Theme.accent : Theme.textSecondary.opacity(0.5))
                 }
             }
         }
         .buttonStyle(.plain)
-        .allowsHitTesting(isGenerating || !messageText.isEmpty)
+        .allowsHitTesting(isGenerating || hasSendableContent)
         .accessibilityIdentifier(sendButtonIdentifier)
         .padding(.horizontal, Spacing.md)
         .frame(height: textHeight + Spacing.xxl)
@@ -285,6 +296,12 @@ struct ChatInputArea: View {
 
         let calculatedHeight = ceil(boundingRect.height) + 4
         return min(max(calculatedHeight, baseHeight), maxHeight)
+    }
+
+    private var hasSendableContent: Bool {
+        !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !attachedFiles.isEmpty
+            || !pastedImages.isEmpty
     }
 }
 
@@ -387,6 +404,41 @@ struct AttachedFileRow: View {
 
         AttachmentThumbnailCache.insert(image, for: fileURL)
         thumbnail = image
+    }
+}
+
+private struct PastedImageRow: View {
+    let pastedImage: PastedImage
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: Spacing.sm) {
+            if let image = NSImage(data: pastedImage.data) {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 48, height: 48)
+                    .clipShape(RoundedRectangle(cornerRadius: Spacing.CornerRadius.sm))
+            } else {
+                Image(systemName: "photo")
+                    .font(.system(size: Typography.IconSize.lg))
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(width: 48, height: 48)
+            }
+
+            Text("Pasted image")
+                .font(Typography.caption)
+
+            Button(action: onRemove) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: Typography.IconSize.md))
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove pasted image")
+        }
+        .padding(Spacing.sm)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Spacing.CornerRadius.md))
     }
 }
 

--- a/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
+++ b/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
@@ -8,7 +8,6 @@
 
 import AppKit
 import SwiftUI
-import UniformTypeIdentifiers
 
 /// The chat input/composer area including text editor, attachments, and model selector
 struct ChatInputArea: View {
@@ -17,6 +16,7 @@ struct ChatInputArea: View {
     @Binding var attachedFiles: [URL]
     @Binding var pastedImages: [PastedImage]
     @Binding var pasteImportSessionID: UUID
+    @Binding var isImportingPastedImages: Bool
     @Binding var attachedAppContent: AppContent?
     @Binding var selectedModels: Set<String>
     @Binding var selectedModel: String
@@ -162,7 +162,11 @@ struct ChatInputArea: View {
                 text: $messageText,
                 isFirstResponder: $isComposerFocused,
                 pasteImportSessionID: $pasteImportSessionID,
-                onSubmit: onSendMessage,
+                isImportingPastedImages: $isImportingPastedImages,
+                onSubmit: {
+                    guard canSend else { return }
+                    onSendMessage()
+                },
                 onPasteImages: { images in
                     pastedImages.append(contentsOf: images)
                 },
@@ -263,12 +267,12 @@ struct ChatInputArea: View {
                 } else {
                     Image(systemName: "arrow.up.circle.fill")
                         .font(.system(size: Typography.IconSize.xl))
-                        .foregroundStyle(hasSendableContent ? Theme.accent : Theme.textSecondary.opacity(0.5))
+                        .foregroundStyle(canSend ? Theme.accent : Theme.textSecondary.opacity(0.5))
                 }
             }
         }
         .buttonStyle(.plain)
-        .allowsHitTesting(isGenerating || hasSendableContent)
+        .allowsHitTesting(isGenerating || canSend)
         .accessibilityIdentifier(sendButtonIdentifier)
         .padding(.horizontal, Spacing.md)
         .frame(height: textHeight + Spacing.xxl)
@@ -299,9 +303,15 @@ struct ChatInputArea: View {
     }
 
     private var hasSendableContent: Bool {
-        !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            || !attachedFiles.isEmpty
-            || !pastedImages.isEmpty
+        ChatDraftContent.isSendable(
+            text: messageText,
+            fileURLs: attachedFiles,
+            inMemoryImageCount: pastedImages.count
+        )
+    }
+
+    private var canSend: Bool {
+        hasSendableContent && !isImportingPastedImages
     }
 }
 
@@ -334,7 +344,7 @@ struct AttachedFileRow: View {
     }
 
     private var isImageFile: Bool {
-        fileURL.isImageFile
+        ChatDraftContent.isImageFile(fileURL)
     }
 
     var body: some View {
@@ -410,11 +420,12 @@ struct AttachedFileRow: View {
 private struct PastedImageRow: View {
     let pastedImage: PastedImage
     let onRemove: () -> Void
+    @State private var thumbnail: NSImage?
 
     var body: some View {
         HStack(spacing: Spacing.sm) {
-            if let image = NSImage(data: pastedImage.data) {
-                Image(nsImage: image)
+            if let thumbnail {
+                Image(nsImage: thumbnail)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 48, height: 48)
@@ -439,18 +450,12 @@ private struct PastedImageRow: View {
         }
         .padding(Spacing.sm)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Spacing.CornerRadius.md))
-    }
-}
-
-private extension URL {
-    var isImageFile: Bool {
-        guard !pathExtension.isEmpty,
-              let contentType = UTType(filenameExtension: pathExtension.lowercased())
-        else {
-            return false
+        .task(id: pastedImage.id) {
+            guard thumbnail == nil else { return }
+            thumbnail = NSImage(data: pastedImage.data)?.scaledThumbnail(
+                maxSize: NSSize(width: 48, height: 48)
+            )
         }
-
-        return contentType.conforms(to: .image)
     }
 }
 

--- a/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
+++ b/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
@@ -164,6 +164,7 @@ struct ChatInputArea: View {
                 isFirstResponder: $isComposerFocused,
                 pasteImportSessionID: $pasteImportSessionID,
                 isImportingPastedImages: $isImportingPastedImages,
+                remainingImageCapacity: { remainingImageCapacity },
                 onSubmit: {
                     guard canSend else { return }
                     onSendMessage()
@@ -313,6 +314,13 @@ struct ChatInputArea: View {
 
     private var canSend: Bool {
         hasSendableContent && !isImportingPastedImages
+    }
+
+    private var remainingImageCapacity: Int {
+        ChatDraftContent.remainingImageCapacity(
+            fileURLs: attachedFiles,
+            inMemoryImageCount: pastedImages.count
+        )
     }
 }
 

--- a/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
+++ b/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
@@ -7,6 +7,7 @@
 //
 
 import AppKit
+import ImageIO
 import SwiftUI
 
 /// The chat input/composer area including text editor, attachments, and model selector
@@ -452,8 +453,23 @@ private struct PastedImageRow: View {
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Spacing.CornerRadius.md))
         .task(id: pastedImage.id) {
             guard thumbnail == nil else { return }
-            thumbnail = NSImage(data: pastedImage.data)?.scaledThumbnail(
-                maxSize: NSSize(width: 48, height: 48)
+            let data = pastedImage.data
+            let image = await Task.detached(priority: .utility) { () -> CGImage? in
+                guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+                    return nil
+                }
+                let options: [CFString: Any] = [
+                    kCGImageSourceCreateThumbnailFromImageAlways: true,
+                    kCGImageSourceCreateThumbnailWithTransform: true,
+                    kCGImageSourceThumbnailMaxPixelSize: 96,
+                    kCGImageSourceShouldCacheImmediately: true,
+                ]
+                return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+            }.value
+            guard !Task.isCancelled, let image else { return }
+            thumbnail = NSImage(
+                cgImage: image,
+                size: NSSize(width: image.width, height: image.height)
             )
         }
     }

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
@@ -188,13 +188,14 @@ extension MacChatView {
         let responseGroupId = responsePlan.responseGroupId
         let messageIds = responsePlan.messageIDsByModel
 
-        for placeholderMessage in responsePlan.placeholderMessages {
-            conversationManager.addMessage(to: conversation, message: placeholderMessage)
-        }
-
-        // Add response group to conversation
-        if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }) {
-            conversationManager.conversations[index].responseGroups.append(responsePlan.responseGroup)
+        guard conversationManager.beginMultiModelResponse(
+            to: conversation,
+            messages: responsePlan.placeholderMessages,
+            responseGroup: responsePlan.responseGroup
+        ) != nil else {
+            _ = coordinator.finishOperation(operationID)
+            isGenerating = false
+            return
         }
 
         registerImageBatchCancellation(
@@ -457,22 +458,16 @@ extension MacChatView {
             metadata: ["models": models.joined(separator: ", ")]
         )
 
-        // Get updated conversation
-        guard let updatedConversation = conversationManager.conversations.first(where: {
-            $0.id == conversation.id
-        }) else {
+        let responsePlan = MultiModelResponsePlan(models: models, userMessageId: userMessageId)
+        let responseGroupId = responsePlan.responseGroupId
+        guard let updatedConversation = conversationManager.beginMultiModelResponse(
+            to: conversation,
+            messages: responsePlan.placeholderMessages,
+            responseGroup: responsePlan.responseGroup
+        ) else {
             isGenerating = false
             return
         }
-
-        let responsePlan = MultiModelResponsePlan(models: models, userMessageId: userMessageId)
-        let responseGroupId = responsePlan.responseGroupId
-        for placeholderMessage in responsePlan.placeholderMessages {
-            conversationManager.addMessage(to: conversation, message: placeholderMessage)
-        }
-
-        // Add response group to conversation
-        conversationManager.addResponseGroup(to: conversation, group: responsePlan.responseGroup)
 
         let messageIdsByModel = responsePlan.messageIDsByModel
 

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
@@ -134,11 +134,16 @@ extension MacChatView {
             await deleteImageData(at: imagePath)
             _ = imageGenerationCoordinator.finishOperation(operationID)
             isGenerating = false
+            retainFailedSendState(
+                errorMessage: "Unable to save the generated image.",
+                recoverySuggestion: "Try again or choose a different model."
+            )
             return
         }
 
         guard imageGenerationCoordinator.finishOperation(operationID) else { return }
         isGenerating = false
+        clearFailedSendState()
     }
 
     private func handleImageGenerationError(
@@ -149,8 +154,10 @@ extension MacChatView {
         guard imageGenerationCoordinator.finishOperation(operationID) else { return }
 
         isGenerating = false
-        errorMessage = ErrorPresenter.userMessage(for: error)
-        errorRecoverySuggestion = ErrorPresenter.recoverySuggestion(for: error)
+        retainFailedSendState(
+            errorMessage: ErrorPresenter.userMessage(for: error),
+            recoverySuggestion: ErrorPresenter.recoverySuggestion(for: error)
+        )
 
         // Remove the empty assistant placeholder message since we show error in banner
         conversationManager.removeMessage(conversationId: conversation.id, messageId: messageId)
@@ -251,7 +258,8 @@ extension MacChatView {
                         finishImageBatchIfComplete(
                             counter: counter,
                             coordinator: coordinator,
-                            operationID: operationID
+                            operationID: operationID,
+                            responseGroupID: responseGroupId
                         )
                     }
                 }
@@ -277,7 +285,8 @@ extension MacChatView {
                         finishImageBatchIfComplete(
                             counter: counter,
                             coordinator: coordinator,
-                            operationID: operationID
+                            operationID: operationID,
+                            responseGroupID: responseGroupId
                         )
                     }
                 }
@@ -322,16 +331,31 @@ extension MacChatView {
         finishImageBatchIfComplete(
             counter: counter,
             coordinator: coordinator,
-            operationID: operationID
+            operationID: operationID,
+            responseGroupID: responseGroupID
         )
     }
 
     private func finishImageBatchIfComplete(
         counter: MainActorCompletionCounter,
         coordinator: ImageGenerationCoordinator,
-        operationID: ImageGenerationCoordinator.OperationID
+        operationID: ImageGenerationCoordinator.OperationID,
+        responseGroupID: UUID
     ) {
         guard counter.isComplete, coordinator.finishOperation(operationID) else { return }
+        let hasSuccessfulResponse = conversationManager.conversation(byId: conversation.id)?
+            .getResponseGroup(responseGroupID)?
+            .responses
+            .contains { $0.status == .completed || $0.status == .selected } == true
+
+        if hasSuccessfulResponse {
+            clearFailedSendState()
+        } else {
+            retainFailedSendState(
+                errorMessage: "Image generation failed for all selected models.",
+                recoverySuggestion: "Try again or choose different models."
+            )
+        }
         if let conversation = conversationManager.conversation(byId: conversation.id) {
             conversationManager.save(conversation)
         }
@@ -512,19 +536,12 @@ extension MacChatView {
             },
             onAllComplete: {
                 coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
-                    guard coordinator.owns(operationID, conversationID: conversationId) else { return }
-                    multiModelReasoningBuffer.finishAll()
-                    isGenerating = false
-                    logChat("🏁 All models completed", level: .info)
-
-                    // Save the conversation immediately on completion
-                    if let convIndex = conversationManager.conversations.firstIndex(where: {
-                        $0.id == conversationId
-                    }) {
-                        conversationManager.saveImmediately(conversationManager.conversations[convIndex])
-                    }
-                    activeMultiModelResponseGroupID = nil
-                    _ = coordinator.finishOperation(operationID)
+                    finishMultiModelMessage(
+                        coordinator: coordinator,
+                        operationID: operationID,
+                        conversationID: conversationId,
+                        responseGroupID: responseGroupId
+                    )
                 }
             },
             onError: { model, error in
@@ -592,6 +609,38 @@ extension MacChatView {
             finishAndPersistMultiModelReasoning(conversationId: conversationId)
             request.cancel()
         }
+    }
+
+    private func finishMultiModelMessage(
+        coordinator: ToolChainCoordinator,
+        operationID: ToolChainCoordinator.OperationID,
+        conversationID: UUID,
+        responseGroupID: UUID
+    ) {
+        guard coordinator.owns(operationID, conversationID: conversationID) else { return }
+        multiModelReasoningBuffer.finishAll()
+        isGenerating = false
+        logChat("🏁 All models completed", level: .info)
+
+        if let conversationIndex = conversationManager.conversations.firstIndex(where: {
+            $0.id == conversationID
+        }) {
+            conversationManager.saveImmediately(conversationManager.conversations[conversationIndex])
+        }
+        let hasSuccessfulResponse = conversationManager.conversation(byId: conversationID)?
+            .getResponseGroup(responseGroupID)?
+            .responses
+            .contains { $0.status == .completed || $0.status == .selected } == true
+        if hasSuccessfulResponse {
+            clearFailedSendState()
+        } else {
+            retainFailedSendState(
+                errorMessage: "All selected models failed to respond.",
+                recoverySuggestion: "Try again or choose different models."
+            )
+        }
+        activeMultiModelResponseGroupID = nil
+        _ = coordinator.finishOperation(operationID)
     }
 
     private func bufferMultiModelReasoning(

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
@@ -31,11 +31,6 @@ extension MacChatView {
                 conversationID: conversationID
             )
         }
-
-        guard aiService.getModelCapability(resendModel) != .imageGeneration else {
-            performEdit()
-            return
-        }
         preflightHistoryMutation(
             models: [resendModel],
             messages: proposedHistory,
@@ -92,10 +87,6 @@ extension MacChatView {
                 usesConversationModel: usesConversationModel
             )
         }
-        guard aiService.getModelCapability(model) != .imageGeneration else {
-            retryAction()
-            return
-        }
 
         var retryConversation = targetConversation
         retryConversation.messages = Array(targetConversation.messages.prefix(assistantIndex))
@@ -111,30 +102,17 @@ extension MacChatView {
         messages: [Message],
         onSuccess: @escaping @MainActor @Sendable () -> Void
     ) {
-        if let supportError = aiService.attachmentHistorySupportError(
-            for: models,
-            messages: messages
+        if let failure = ConversationSendPreflight.attachmentRuleFailure(
+            models: models,
+            messages: messages,
+            aiService: aiService
         ) {
-            errorMessage = supportError
-            errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
-            return
-        }
-        if let limitError = aiService.attachmentImageLimitError(
-            for: models,
-            messages: messages
-        ) {
-            errorMessage = limitError
-            errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
+            errorMessage = failure.message
+            errorRecoverySuggestion = failure.recoverySuggestion
             return
         }
 
-        let hasImages = messages.contains { message in
-            guard message.role == .user else { return false }
-            return message.attachments?.contains(where: {
-                $0.mimeType.lowercased().hasPrefix("image/")
-            }) == true
-        }
-        guard hasImages else {
+        guard ConversationSendPreflight.hasImageAttachments(in: messages) else {
             onSuccess()
             return
         }
@@ -143,9 +121,10 @@ extension MacChatView {
         sendPreparationID = preparationID
         isGenerating = true
         let task = Task { @MainActor in
-            let validationError = await aiService.attachmentImageValidationError(
-                for: models,
-                in: messages,
+            let failure = await ConversationSendPreflight.attachmentDataFailure(
+                models: models,
+                messages: messages,
+                aiService: aiService,
                 loadAttachmentData: { path in
                     await AttachmentStorage.shared.loadData(path: path)
                 }
@@ -155,9 +134,9 @@ extension MacChatView {
             sendPreparationTask = nil
             sendPreparationID = nil
             isGenerating = false
-            if let validationError {
-                errorMessage = validationError
-                errorRecoverySuggestion = "Remove the image or choose a different model."
+            if let failure {
+                errorMessage = failure.message
+                errorRecoverySuggestion = failure.recoverySuggestion
                 return
             }
             onSuccess()

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
@@ -37,6 +37,19 @@ extension MacChatView {
         guard let userIndex = userMessageIndex else { return }
         let userMessage = currentConversation.messages[userIndex]
 
+        if aiService.getModelCapability(currentConversation.model) != .imageGeneration {
+            var retryConversation = currentConversation
+            retryConversation.messages = Array(currentConversation.messages.prefix(assistantIndex))
+            if let supportError = aiService.attachmentHistorySupportError(
+                for: [currentConversation.model],
+                messages: retryConversation.getEffectiveHistory()
+            ) {
+                errorMessage = supportError
+                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+                return
+            }
+        }
+
         // Remove all messages from the assistant message onwards
         if let convIndex = conversationManager.conversations.firstIndex(where: {
             $0.id == conversation.id
@@ -81,6 +94,19 @@ extension MacChatView {
 
         guard let userIndex = userMessageIndex else { return }
         let userMessage = currentConversation.messages[userIndex]
+
+        if aiService.getModelCapability(model) != .imageGeneration {
+            var retryConversation = currentConversation
+            retryConversation.messages = Array(currentConversation.messages.prefix(assistantIndex))
+            if let supportError = aiService.attachmentHistorySupportError(
+                for: [model],
+                messages: retryConversation.getEffectiveHistory()
+            ) {
+                errorMessage = supportError
+                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+                return
+            }
+        }
 
         // Remove all messages from the assistant message onwards
         if let convIndex = conversationManager.conversations.firstIndex(where: {

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
@@ -11,6 +11,48 @@ import SwiftUI
 // MARK: - Retry & Resend Methods
 
 extension MacChatView {
+    func editMessageAndResend(_ message: Message, newContent: String) {
+        guard let proposedHistory = ChatDraftContent.effectiveHistory(
+            byEditingUserMessage: message.id,
+            newContent: newContent,
+            in: currentConversation
+        ) else {
+            return
+        }
+
+        let resendModel = currentConversation.model
+        if aiService.getModelCapability(resendModel) != .imageGeneration {
+            if let supportError = aiService.attachmentHistorySupportError(
+                for: [resendModel],
+                messages: proposedHistory
+            ) {
+                errorMessage = supportError
+                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+                return
+            }
+            if let limitError = aiService.attachmentImageLimitError(
+                for: [resendModel],
+                messages: proposedHistory
+            ) {
+                errorMessage = limitError
+                errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
+                return
+            }
+        }
+
+        guard conversationManager.editMessage(
+            in: currentConversation,
+            messageId: message.id,
+            newContent: newContent
+        ) else {
+            return
+        }
+
+        var editedMessage = message
+        editedMessage.content = newContent
+        resendMessage(editedMessage)
+    }
+
     /// Retry the message that came before the specified assistant message
     func retryLastMessage(beforeMessage: Message) {
         guard !isGenerating else { return }

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 extension MacChatView {
     func editMessageAndResend(_ message: Message, newContent: String) {
+        guard !isGenerating, sendPreparationTask == nil else { return }
         guard let proposedHistory = ChatDraftContent.effectiveHistory(
             byEditingUserMessage: message.id,
             newContent: newContent,
@@ -21,87 +22,34 @@ extension MacChatView {
         }
 
         let resendModel = currentConversation.model
-        if aiService.getModelCapability(resendModel) != .imageGeneration {
-            if let supportError = aiService.attachmentHistorySupportError(
-                for: [resendModel],
-                messages: proposedHistory
-            ) {
-                errorMessage = supportError
-                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
-                return
-            }
-            if let limitError = aiService.attachmentImageLimitError(
-                for: [resendModel],
-                messages: proposedHistory
-            ) {
-                errorMessage = limitError
-                errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
-                return
-            }
+        let conversationID = currentConversation.id
+        let performEdit: @MainActor @Sendable () -> Void = {
+            performEditMessageAndResend(
+                messageID: message.id,
+                newContent: newContent,
+                model: resendModel,
+                conversationID: conversationID
+            )
         }
 
-        guard conversationManager.editMessage(
-            in: currentConversation,
-            messageId: message.id,
-            newContent: newContent
-        ) else {
+        guard aiService.getModelCapability(resendModel) != .imageGeneration else {
+            performEdit()
             return
         }
-
-        var editedMessage = message
-        editedMessage.content = newContent
-        resendMessage(editedMessage)
+        preflightHistoryMutation(
+            models: [resendModel],
+            messages: proposedHistory,
+            onSuccess: performEdit
+        )
     }
 
     /// Retry the message that came before the specified assistant message
     func retryLastMessage(beforeMessage: Message) {
-        guard !isGenerating else { return }
-
-        // Find the user message that came before this assistant message
-        guard
-            let assistantIndex = currentConversation.messages.firstIndex(where: {
-                $0.id == beforeMessage.id
-            }),
-            assistantIndex > 0
-        else {
-            return
-        }
-
-        // Find the last user message before this assistant message
-        var userMessageIndex: Int?
-        for index in (0 ..< assistantIndex).reversed()
-            where currentConversation.messages[index].role == .user
-        {
-            userMessageIndex = index
-            break
-        }
-
-        guard let userIndex = userMessageIndex else { return }
-        let userMessage = currentConversation.messages[userIndex]
-
-        if aiService.getModelCapability(currentConversation.model) != .imageGeneration {
-            var retryConversation = currentConversation
-            retryConversation.messages = Array(currentConversation.messages.prefix(assistantIndex))
-            if let supportError = aiService.attachmentHistorySupportError(
-                for: [currentConversation.model],
-                messages: retryConversation.getEffectiveHistory()
-            ) {
-                errorMessage = supportError
-                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
-                return
-            }
-        }
-
-        // Remove all messages from the assistant message onwards
-        if let convIndex = conversationManager.conversations.firstIndex(where: {
-            $0.id == conversation.id
-        }) {
-            conversationManager.conversations[convIndex].messages.removeSubrange(assistantIndex...)
-            conversationManager.save(conversationManager.conversations[convIndex])
-        }
-
-        // Resend the user message
-        resendMessage(userMessage)
+        scheduleRetry(
+            beforeMessageID: beforeMessage.id,
+            model: currentConversation.model,
+            usesConversationModel: true
+        )
     }
 
     /// Switch model and retry
@@ -113,53 +61,160 @@ extension MacChatView {
 
     /// Retry with a specific model (without changing conversation's default model)
     func retryWithModel(beforeMessage: Message, model: String) {
-        guard !isGenerating else { return }
+        scheduleRetry(
+            beforeMessageID: beforeMessage.id,
+            model: model,
+            usesConversationModel: false
+        )
+    }
 
-        // Find the user message that came before this assistant message
-        guard
-            let assistantIndex = currentConversation.messages.firstIndex(where: {
-                $0.id == beforeMessage.id
-            }),
-            assistantIndex > 0
+    private func scheduleRetry(
+        beforeMessageID: UUID,
+        model: String,
+        usesConversationModel: Bool
+    ) {
+        guard !isGenerating, sendPreparationTask == nil else { return }
+        let targetConversation = currentConversation
+        guard let assistantIndex = targetConversation.messages.firstIndex(where: {
+            $0.id == beforeMessageID
+        }), assistantIndex > 0,
+            targetConversation.messages[..<assistantIndex].last(where: { $0.role == .user }) != nil
         else {
             return
         }
 
-        // Find the last user message before this assistant message
-        var userMessageIndex: Int?
-        for index in (0 ..< assistantIndex).reversed()
-            where currentConversation.messages[index].role == .user
-        {
-            userMessageIndex = index
-            break
+        let conversationID = targetConversation.id
+        let performRetry: @MainActor @Sendable () -> Void = {
+            performRetry(
+                beforeMessageID: beforeMessageID,
+                model: model,
+                conversationID: conversationID,
+                usesConversationModel: usesConversationModel
+            )
+        }
+        guard aiService.getModelCapability(model) != .imageGeneration else {
+            performRetry()
+            return
         }
 
-        guard let userIndex = userMessageIndex else { return }
-        let userMessage = currentConversation.messages[userIndex]
+        var retryConversation = targetConversation
+        retryConversation.messages = Array(targetConversation.messages.prefix(assistantIndex))
+        preflightHistoryMutation(
+            models: [model],
+            messages: retryConversation.getEffectiveHistory(),
+            onSuccess: performRetry
+        )
+    }
 
-        if aiService.getModelCapability(model) != .imageGeneration {
-            var retryConversation = currentConversation
-            retryConversation.messages = Array(currentConversation.messages.prefix(assistantIndex))
-            if let supportError = aiService.attachmentHistorySupportError(
-                for: [model],
-                messages: retryConversation.getEffectiveHistory()
-            ) {
-                errorMessage = supportError
-                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+    private func preflightHistoryMutation(
+        models: [String],
+        messages: [Message],
+        onSuccess: @escaping @MainActor @Sendable () -> Void
+    ) {
+        if let supportError = aiService.attachmentHistorySupportError(
+            for: models,
+            messages: messages
+        ) {
+            errorMessage = supportError
+            errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+            return
+        }
+        if let limitError = aiService.attachmentImageLimitError(
+            for: models,
+            messages: messages
+        ) {
+            errorMessage = limitError
+            errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
+            return
+        }
+
+        let hasImages = messages.contains { message in
+            guard message.role == .user else { return false }
+            return message.attachments?.contains(where: {
+                $0.mimeType.lowercased().hasPrefix("image/")
+            }) == true
+        }
+        guard hasImages else {
+            onSuccess()
+            return
+        }
+
+        let preparationID = UUID()
+        sendPreparationID = preparationID
+        isGenerating = true
+        let task = Task { @MainActor in
+            let validationError = await aiService.attachmentImageValidationError(
+                for: models,
+                in: messages,
+                loadAttachmentData: { path in
+                    await AttachmentStorage.shared.loadData(path: path)
+                }
+            )
+            guard !Task.isCancelled, sendPreparationID == preparationID else { return }
+
+            sendPreparationTask = nil
+            sendPreparationID = nil
+            isGenerating = false
+            if let validationError {
+                errorMessage = validationError
+                errorRecoverySuggestion = "Remove the image or choose a different model."
                 return
             }
+            onSuccess()
+        }
+        sendPreparationTask = task
+    }
+
+    private func performRetry(
+        beforeMessageID: UUID,
+        model: String,
+        conversationID: UUID,
+        usesConversationModel: Bool
+    ) {
+        guard !isGenerating, sendPreparationTask == nil,
+              let targetConversation = conversationManager.conversation(byId: conversationID),
+              !usesConversationModel || targetConversation.model == model,
+              let assistantIndex = targetConversation.messages.firstIndex(where: {
+                  $0.id == beforeMessageID
+              }), assistantIndex > 0,
+              let userMessage = targetConversation.messages[..<assistantIndex]
+              .last(where: { $0.role == .user }),
+              let conversationIndex = conversationManager.conversations.firstIndex(where: {
+                  $0.id == conversationID
+              })
+        else {
+            return
         }
 
-        // Remove all messages from the assistant message onwards
-        if let convIndex = conversationManager.conversations.firstIndex(where: {
-            $0.id == conversation.id
-        }) {
-            conversationManager.conversations[convIndex].messages.removeSubrange(assistantIndex...)
-            conversationManager.save(conversationManager.conversations[convIndex])
+        conversationManager.conversations[conversationIndex].messages.removeSubrange(assistantIndex...)
+        conversationManager.save(conversationManager.conversations[conversationIndex])
+        if usesConversationModel {
+            resendMessage(userMessage)
+        } else {
+            resendMessageWithModel(userMessage, model: model)
         }
+    }
 
-        // Resend the user message with the specified model
-        resendMessageWithModel(userMessage, model: model)
+    private func performEditMessageAndResend(
+        messageID: UUID,
+        newContent: String,
+        model: String,
+        conversationID: UUID
+    ) {
+        guard !isGenerating, sendPreparationTask == nil,
+              let targetConversation = conversationManager.conversation(byId: conversationID),
+              targetConversation.model == model,
+              conversationManager.editMessage(
+                  in: targetConversation,
+                  messageId: messageID,
+                  newContent: newContent
+              ),
+              let editedMessage = conversationManager.conversation(byId: conversationID)?
+              .messages.first(where: { $0.id == messageID })
+        else {
+            return
+        }
+        resendMessage(editedMessage)
     }
 
     /// Resend a message

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
@@ -84,7 +84,7 @@ extension MacChatView {
         }
 
         let conversationID = targetConversation.id
-        let performRetry: @MainActor @Sendable () -> Void = {
+        let retryAction: @MainActor @Sendable () -> Void = {
             performRetry(
                 beforeMessageID: beforeMessageID,
                 model: model,
@@ -93,7 +93,7 @@ extension MacChatView {
             )
         }
         guard aiService.getModelCapability(model) != .imageGeneration else {
-            performRetry()
+            retryAction()
             return
         }
 
@@ -102,7 +102,7 @@ extension MacChatView {
         preflightHistoryMutation(
             models: [model],
             messages: retryConversation.getEffectiveHistory(),
-            onSuccess: performRetry
+            onSuccess: retryAction
         )
     }
 

--- a/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
+++ b/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
@@ -15,6 +15,7 @@ struct DynamicTextEditor: NSViewRepresentable {
     @Binding var text: String
     @Binding var isFirstResponder: Bool
     @Binding var pasteImportSessionID: UUID
+    @Binding var isImportingPastedImages: Bool
     let onSubmit: () -> Void
     let onPasteImages: ([PastedImage]) -> Void
     let accessibilityIdentifier: String?
@@ -107,6 +108,9 @@ struct DynamicTextEditor: NSViewRepresentable {
             guard pasteImportSessionID == expectedSessionID else { return }
             onPasteImages(images)
         }
+        textView.onPasteImportStateChange = { isImporting in
+            isImportingPastedImages = isImporting
+        }
     }
 
     private func syncFirstResponderState(for textView: NSTextView, retryCount: Int = 8) {
@@ -185,8 +189,10 @@ private final class PasteAwareTextView: NSTextView {
     ]
 
     var onPasteImages: (([PastedImage]) -> Void)?
+    var onPasteImportStateChange: ((Bool) -> Void)?
     private var pasteImportTask: Task<Void, Never>?
     private var pasteImportSessionID: UUID?
+    private var activePasteImportID: UUID?
 
     override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
         if item.action == #selector(paste(_:)), Self.hasImageCandidates(in: .general) {
@@ -204,10 +210,14 @@ private final class PasteAwareTextView: NSTextView {
 
         let previousTask = pasteImportTask
         let expectedSessionID = pasteImportSessionID
+        let importID = UUID()
+        activePasteImportID = importID
+        onPasteImportStateChange?(true)
         pasteImportTask = Task { @MainActor [weak self] in
             await previousTask?.value
-            guard let self,
-                  !Task.isCancelled,
+            guard let self else { return }
+            defer { self.finishPasteImport(importID) }
+            guard !Task.isCancelled,
                   pasteImportSessionID == expectedSessionID
             else {
                 return
@@ -297,7 +307,18 @@ private final class PasteAwareTextView: NSTextView {
     private func invalidatePasteImports() {
         pasteImportTask?.cancel()
         pasteImportTask = nil
+        if activePasteImportID != nil {
+            activePasteImportID = nil
+            onPasteImportStateChange?(false)
+        }
         pasteImportSessionID = nil
+    }
+
+    private func finishPasteImport(_ importID: UUID) {
+        guard activePasteImportID == importID else { return }
+        activePasteImportID = nil
+        pasteImportTask = nil
+        onPasteImportStateChange?(false)
     }
 }
 #endif

--- a/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
+++ b/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
@@ -203,13 +203,14 @@ private final class PasteAwareTextView: NSTextView {
 
     override func paste(_ sender: Any?) {
         let pasteboard = NSPasteboard.general
-        let imageCandidates = Self.imageCandidates(from: pasteboard)
-        guard !imageCandidates.isEmpty else {
+        let selection = Self.imageCandidates(
+            from: pasteboard,
+            limit: ChatDraftContent.maximumImageCount
+        )
+        guard !selection.candidates.isEmpty else {
             super.paste(sender)
             return
         }
-        let candidates = Array(imageCandidates.prefix(ChatDraftContent.maximumImageCount))
-        let skippedImageCount = imageCandidates.count - candidates.count
 
         if pasteboard.string(forType: .string) != nil {
             super.paste(sender)
@@ -231,7 +232,7 @@ private final class PasteAwareTextView: NSTextView {
             }
 
             let images: [PastedImage] = await Task.detached(priority: .userInitiated) {
-                candidates.compactMap { candidate -> PastedImage? in
+                selection.candidates.compactMap { candidate -> PastedImage? in
                     guard let contentType = UTType(candidate.contentTypeIdentifier) else {
                         return nil
                     }
@@ -257,13 +258,13 @@ private final class PasteAwareTextView: NSTextView {
                 return
             }
             onPasteImages?(images)
-            if skippedImageCount > 0 {
+            if selection.skippedImageCount > 0 {
                 NSSound.beep()
                 DiagnosticsLogger.log(
                     .chatView,
                     level: .default,
                     message: "Skipped clipboard images above the request limit",
-                    metadata: ["skippedImageCount": "\(skippedImageCount)"]
+                    metadata: ["skippedImageCount": "\(selection.skippedImageCount)"]
                 )
             }
         }
@@ -282,9 +283,22 @@ private final class PasteAwareTextView: NSTextView {
         pasteImportSessionID = sessionID
     }
 
-    private static func imageCandidates(from pasteboard: NSPasteboard) -> [Candidate] {
+    private static func imageCandidates(
+        from pasteboard: NSPasteboard,
+        limit: Int
+    ) -> (candidates: [Candidate], skippedImageCount: Int) {
         if let pasteboardItems = pasteboard.pasteboardItems, !pasteboardItems.isEmpty {
-            return pasteboardItems.compactMap { item in
+            let supportedTypes = Set(supportedImageTypes.map(\.pasteboardType))
+            var selectedItems: [NSPasteboardItem] = []
+            var imageItemCount = 0
+            for item in pasteboardItems where !supportedTypes.isDisjoint(with: item.types) {
+                imageItemCount += 1
+                if selectedItems.count < limit {
+                    selectedItems.append(item)
+                }
+            }
+
+            let candidates = selectedItems.compactMap { item in
                 for supportedType in supportedImageTypes {
                     if let data = item.data(forType: supportedType.pasteboardType) {
                         return Candidate(
@@ -295,17 +309,24 @@ private final class PasteAwareTextView: NSTextView {
                 }
                 return nil
             }
+            return (
+                candidates,
+                skippedImageCount: max(0, imageItemCount - selectedItems.count)
+            )
         }
 
         for supportedType in supportedImageTypes {
             if let data = pasteboard.data(forType: supportedType.pasteboardType) {
-                return [Candidate(
-                    data: data,
-                    contentTypeIdentifier: supportedType.contentType.identifier
-                )]
+                return (
+                    [Candidate(
+                        data: data,
+                        contentTypeIdentifier: supportedType.contentType.identifier
+                    )],
+                    skippedImageCount: 0
+                )
             }
         }
-        return []
+        return ([], skippedImageCount: 0)
     }
 
     private static func hasImageCandidates(in pasteboard: NSPasteboard) -> Bool {

--- a/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
+++ b/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
@@ -202,10 +202,17 @@ private final class PasteAwareTextView: NSTextView {
     }
 
     override func paste(_ sender: Any?) {
-        let candidates = Self.imageCandidates(from: .general)
-        guard !candidates.isEmpty else {
+        let pasteboard = NSPasteboard.general
+        let imageCandidates = Self.imageCandidates(from: pasteboard)
+        guard !imageCandidates.isEmpty else {
             super.paste(sender)
             return
+        }
+        let candidates = Array(imageCandidates.prefix(ChatDraftContent.maximumImageCount))
+        let skippedImageCount = imageCandidates.count - candidates.count
+
+        if pasteboard.string(forType: .string) != nil {
+            super.paste(sender)
         }
 
         let previousTask = pasteImportTask
@@ -250,6 +257,15 @@ private final class PasteAwareTextView: NSTextView {
                 return
             }
             onPasteImages?(images)
+            if skippedImageCount > 0 {
+                NSSound.beep()
+                DiagnosticsLogger.log(
+                    .chatView,
+                    level: .default,
+                    message: "Skipped clipboard images above the request limit",
+                    metadata: ["skippedImageCount": "\(skippedImageCount)"]
+                )
+            }
         }
     }
 

--- a/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
+++ b/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
@@ -16,6 +16,7 @@ struct DynamicTextEditor: NSViewRepresentable {
     @Binding var isFirstResponder: Bool
     @Binding var pasteImportSessionID: UUID
     @Binding var isImportingPastedImages: Bool
+    let remainingImageCapacity: () -> Int
     let onSubmit: () -> Void
     let onPasteImages: ([PastedImage]) -> Void
     let accessibilityIdentifier: String?
@@ -104,6 +105,7 @@ struct DynamicTextEditor: NSViewRepresentable {
     private func configurePasteHandling(for textView: PasteAwareTextView) {
         let expectedSessionID = pasteImportSessionID
         textView.updatePasteImportSession(expectedSessionID)
+        textView.remainingImageCapacity = remainingImageCapacity
         textView.onPasteImages = { images in
             guard pasteImportSessionID == expectedSessionID else { return }
             onPasteImages(images)
@@ -176,6 +178,17 @@ private final class PasteAwareTextView: NSTextView {
         let contentTypeIdentifier: String
     }
 
+    private enum CandidateSource {
+        case item(NSPasteboardItem)
+        case preloaded(Candidate)
+    }
+
+    private struct CandidateSelection {
+        let sources: [CandidateSource]
+        let skippedImageCount: Int
+        let hasImageCandidates: Bool
+    }
+
     private static let supportedImageTypes: [(
         pasteboardType: NSPasteboard.PasteboardType,
         contentType: UTType
@@ -190,9 +203,11 @@ private final class PasteAwareTextView: NSTextView {
 
     var onPasteImages: (([PastedImage]) -> Void)?
     var onPasteImportStateChange: ((Bool) -> Void)?
+    var remainingImageCapacity: (() -> Int)?
     private var pasteImportTask: Task<Void, Never>?
     private var pasteImportSessionID: UUID?
     private var activePasteImportID: UUID?
+    private var reservedImageCount = 0
 
     override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
         if item.action == #selector(paste(_:)), Self.hasImageCandidates(in: .general) {
@@ -203,17 +218,43 @@ private final class PasteAwareTextView: NSTextView {
 
     override func paste(_ sender: Any?) {
         let pasteboard = NSPasteboard.general
-        let selection = Self.imageCandidates(
-            from: pasteboard,
-            limit: ChatDraftContent.maximumImageCount
+        let capacity = max(
+            0,
+            (remainingImageCapacity?() ?? ChatDraftContent.maximumImageCount)
+                - reservedImageCount
         )
-        guard !selection.candidates.isEmpty else {
+        let selection = Self.imageCandidateSelection(
+            from: pasteboard,
+            limit: capacity
+        )
+        guard selection.hasImageCandidates else {
             super.paste(sender)
             return
         }
 
         if pasteboard.string(forType: .string) != nil {
             super.paste(sender)
+        }
+
+        guard !selection.sources.isEmpty else {
+            reportImageLimit(skippedImageCount: selection.skippedImageCount)
+            return
+        }
+
+        let selectedSourceCount = selection.sources.count
+        reservedImageCount += selectedSourceCount
+        let candidates = selection.sources.compactMap(Self.loadCandidate)
+        let failedCandidateCount = selectedSourceCount - candidates.count
+        reservedImageCount -= failedCandidateCount
+        let reservationCount = candidates.count
+        guard reservationCount > 0 else {
+            NSSound.beep()
+            DiagnosticsLogger.log(
+                .chatView,
+                level: .error,
+                message: "Failed to load pasted clipboard image data"
+            )
+            return
         }
 
         let previousTask = pasteImportTask
@@ -224,7 +265,13 @@ private final class PasteAwareTextView: NSTextView {
         pasteImportTask = Task { @MainActor [weak self] in
             await previousTask?.value
             guard let self else { return }
-            defer { self.finishPasteImport(importID) }
+            defer {
+                self.releaseImageReservation(
+                    reservationCount,
+                    sessionID: expectedSessionID
+                )
+                self.finishPasteImport(importID)
+            }
             guard !Task.isCancelled,
                   pasteImportSessionID == expectedSessionID
             else {
@@ -232,7 +279,7 @@ private final class PasteAwareTextView: NSTextView {
             }
 
             let images: [PastedImage] = await Task.detached(priority: .userInitiated) {
-                selection.candidates.compactMap { candidate -> PastedImage? in
+                candidates.compactMap { candidate -> PastedImage? in
                     guard let contentType = UTType(candidate.contentTypeIdentifier) else {
                         return nil
                     }
@@ -248,7 +295,19 @@ private final class PasteAwareTextView: NSTextView {
             else {
                 return
             }
-            guard !images.isEmpty else {
+
+            let finalCapacity = max(
+                0,
+                remainingImageCapacity?() ?? ChatDraftContent.maximumImageCount
+            )
+            let acceptedImages = Array(images.prefix(finalCapacity))
+            guard !acceptedImages.isEmpty else {
+                if finalCapacity == 0 {
+                    reportImageLimit(
+                        skippedImageCount: selection.skippedImageCount + images.count
+                    )
+                    return
+                }
                 NSSound.beep()
                 DiagnosticsLogger.log(
                     .chatView,
@@ -257,15 +316,12 @@ private final class PasteAwareTextView: NSTextView {
                 )
                 return
             }
-            onPasteImages?(images)
-            if selection.skippedImageCount > 0 {
-                NSSound.beep()
-                DiagnosticsLogger.log(
-                    .chatView,
-                    level: .default,
-                    message: "Skipped clipboard images above the request limit",
-                    metadata: ["skippedImageCount": "\(selection.skippedImageCount)"]
-                )
+            onPasteImages?(acceptedImages)
+
+            let skippedImageCount = selection.skippedImageCount
+                + max(0, images.count - acceptedImages.count)
+            if skippedImageCount > 0 {
+                reportImageLimit(skippedImageCount: skippedImageCount)
             }
         }
     }
@@ -283,50 +339,72 @@ private final class PasteAwareTextView: NSTextView {
         pasteImportSessionID = sessionID
     }
 
-    private static func imageCandidates(
+    private static func imageCandidateSelection(
         from pasteboard: NSPasteboard,
         limit: Int
-    ) -> (candidates: [Candidate], skippedImageCount: Int) {
+    ) -> CandidateSelection {
         if let pasteboardItems = pasteboard.pasteboardItems, !pasteboardItems.isEmpty {
             let supportedTypes = Set(supportedImageTypes.map(\.pasteboardType))
-            var selectedItems: [NSPasteboardItem] = []
+            var selectedItems: [CandidateSource] = []
             var imageItemCount = 0
             for item in pasteboardItems where !supportedTypes.isDisjoint(with: item.types) {
                 imageItemCount += 1
                 if selectedItems.count < limit {
-                    selectedItems.append(item)
+                    selectedItems.append(.item(item))
                 }
             }
-
-            let candidates = selectedItems.compactMap { item in
-                for supportedType in supportedImageTypes {
-                    if let data = item.data(forType: supportedType.pasteboardType) {
-                        return Candidate(
-                            data: data,
-                            contentTypeIdentifier: supportedType.contentType.identifier
-                        )
-                    }
-                }
-                return nil
-            }
-            return (
-                candidates,
-                skippedImageCount: max(0, imageItemCount - selectedItems.count)
+            return CandidateSelection(
+                sources: selectedItems,
+                skippedImageCount: max(0, imageItemCount - selectedItems.count),
+                hasImageCandidates: imageItemCount > 0
             )
         }
 
         for supportedType in supportedImageTypes {
+            if limit == 0,
+               pasteboard.availableType(from: [supportedType.pasteboardType]) != nil
+            {
+                return CandidateSelection(
+                    sources: [],
+                    skippedImageCount: 1,
+                    hasImageCandidates: true
+                )
+            }
             if let data = pasteboard.data(forType: supportedType.pasteboardType) {
-                return (
-                    [Candidate(
-                        data: data,
-                        contentTypeIdentifier: supportedType.contentType.identifier
-                    )],
-                    skippedImageCount: 0
+                return CandidateSelection(
+                    sources: [
+                        .preloaded(Candidate(
+                            data: data,
+                            contentTypeIdentifier: supportedType.contentType.identifier
+                        )),
+                    ],
+                    skippedImageCount: 0,
+                    hasImageCandidates: true
                 )
             }
         }
-        return ([], skippedImageCount: 0)
+        return CandidateSelection(
+            sources: [],
+            skippedImageCount: 0,
+            hasImageCandidates: false
+        )
+    }
+
+    private static func loadCandidate(_ source: CandidateSource) -> Candidate? {
+        switch source {
+        case let .item(item):
+            for supportedType in supportedImageTypes {
+                if let data = item.data(forType: supportedType.pasteboardType) {
+                    return Candidate(
+                        data: data,
+                        contentTypeIdentifier: supportedType.contentType.identifier
+                    )
+                }
+            }
+            return nil
+        case let .preloaded(candidate):
+            return candidate
+        }
     }
 
     private static func hasImageCandidates(in pasteboard: NSPasteboard) -> Bool {
@@ -344,6 +422,7 @@ private final class PasteAwareTextView: NSTextView {
     private func invalidatePasteImports() {
         pasteImportTask?.cancel()
         pasteImportTask = nil
+        reservedImageCount = 0
         if activePasteImportID != nil {
             activePasteImportID = nil
             onPasteImportStateChange?(false)
@@ -356,6 +435,21 @@ private final class PasteAwareTextView: NSTextView {
         activePasteImportID = nil
         pasteImportTask = nil
         onPasteImportStateChange?(false)
+    }
+
+    private func releaseImageReservation(_ count: Int, sessionID: UUID?) {
+        guard pasteImportSessionID == sessionID else { return }
+        reservedImageCount = max(0, reservedImageCount - count)
+    }
+
+    private func reportImageLimit(skippedImageCount: Int) {
+        NSSound.beep()
+        DiagnosticsLogger.log(
+            .chatView,
+            level: .default,
+            message: "Skipped clipboard images above the draft limit",
+            metadata: ["skippedImageCount": "\(skippedImageCount)"]
+        )
     }
 }
 #endif

--- a/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
+++ b/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
@@ -204,9 +204,9 @@ private final class PasteAwareTextView: NSTextView {
     var onPasteImages: (([PastedImage]) -> Void)?
     var onPasteImportStateChange: ((Bool) -> Void)?
     var remainingImageCapacity: (() -> Int)?
-    private var pasteImportTask: Task<Void, Never>?
+    private var pasteImportTail: Task<Void, Never>?
+    private var pasteImportTasks: [UUID: Task<Void, Never>] = [:]
     private var pasteImportSessionID: UUID?
-    private var activePasteImportID: UUID?
     private var reservedImageCount = 0
 
     override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
@@ -257,12 +257,11 @@ private final class PasteAwareTextView: NSTextView {
             return
         }
 
-        let previousTask = pasteImportTask
+        let previousTask = pasteImportTail
         let expectedSessionID = pasteImportSessionID
         let importID = UUID()
-        activePasteImportID = importID
         onPasteImportStateChange?(true)
-        pasteImportTask = Task { @MainActor [weak self] in
+        let importTask = Task { @MainActor [weak self] in
             await previousTask?.value
             guard let self else { return }
             defer {
@@ -270,7 +269,7 @@ private final class PasteAwareTextView: NSTextView {
                     reservationCount,
                     sessionID: expectedSessionID
                 )
-                self.finishPasteImport(importID)
+                self.finishPasteImport(importID, sessionID: expectedSessionID)
             }
             guard !Task.isCancelled,
                   pasteImportSessionID == expectedSessionID
@@ -278,17 +277,27 @@ private final class PasteAwareTextView: NSTextView {
                 return
             }
 
-            let images: [PastedImage] = await Task.detached(priority: .userInitiated) {
-                candidates.compactMap { candidate -> PastedImage? in
+            let conversionTask = Task.detached(priority: .userInitiated) {
+                var images: [PastedImage] = []
+                for candidate in candidates {
+                    guard !Task.isCancelled else { break }
                     guard let contentType = UTType(candidate.contentTypeIdentifier) else {
-                        return nil
+                        continue
                     }
-                    return try? PastedImage.importing(
+                    if let image = try? PastedImage.importing(
                         data: candidate.data,
                         contentType: contentType
-                    )
+                    ) {
+                        images.append(image)
+                    }
                 }
-            }.value
+                return images
+            }
+            let images = await withTaskCancellationHandler {
+                await conversionTask.value
+            } onCancel: {
+                conversionTask.cancel()
+            }
 
             guard !Task.isCancelled,
                   pasteImportSessionID == expectedSessionID
@@ -324,6 +333,8 @@ private final class PasteAwareTextView: NSTextView {
                 reportImageLimit(skippedImageCount: skippedImageCount)
             }
         }
+        pasteImportTasks[importID] = importTask
+        pasteImportTail = importTask
     }
 
     override func viewWillMove(toWindow newWindow: NSWindow?) {
@@ -420,21 +431,26 @@ private final class PasteAwareTextView: NSTextView {
     }
 
     private func invalidatePasteImports() {
-        pasteImportTask?.cancel()
-        pasteImportTask = nil
+        let hadActiveImports = !pasteImportTasks.isEmpty
+        for task in pasteImportTasks.values {
+            task.cancel()
+        }
+        pasteImportTasks.removeAll()
+        pasteImportTail = nil
         reservedImageCount = 0
-        if activePasteImportID != nil {
-            activePasteImportID = nil
+        if hadActiveImports {
             onPasteImportStateChange?(false)
         }
         pasteImportSessionID = nil
     }
 
-    private func finishPasteImport(_ importID: UUID) {
-        guard activePasteImportID == importID else { return }
-        activePasteImportID = nil
-        pasteImportTask = nil
-        onPasteImportStateChange?(false)
+    private func finishPasteImport(_ importID: UUID, sessionID: UUID?) {
+        guard pasteImportSessionID == sessionID else { return }
+        pasteImportTasks[importID] = nil
+        if pasteImportTasks.isEmpty {
+            pasteImportTail = nil
+            onPasteImportStateChange?(false)
+        }
     }
 
     private func releaseImageReservation(_ count: Int, sessionID: UUID?) {

--- a/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
+++ b/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
@@ -8,24 +8,46 @@
 
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Dynamic Text Editor with auto-sizing and keyboard shortcuts
 struct DynamicTextEditor: NSViewRepresentable {
     @Binding var text: String
     @Binding var isFirstResponder: Bool
+    @Binding var pasteImportSessionID: UUID
     let onSubmit: () -> Void
+    let onPasteImages: ([PastedImage]) -> Void
     let accessibilityIdentifier: String?
 
     typealias Coordinator = DynamicTextEditorCoordinator
 
     func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSTextView.scrollableTextView()
-        guard let textView = scrollView.documentView as? NSTextView else {
-            return scrollView
-        }
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
 
+        let contentSize = scrollView.contentSize
+        let textView = PasteAwareTextView(frame: NSRect(origin: .zero, size: contentSize))
+        scrollView.documentView = textView
+
+        context.coordinator.onSubmit = onSubmit
         textView.delegate = context.coordinator
+        configurePasteHandling(for: textView)
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.allowsUndo = true
         textView.isRichText = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.minSize = NSSize(width: 0, height: contentSize.height)
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
         textView.font = .systemFont(ofSize: 15)
         textView.textColor = .labelColor
         textView.backgroundColor = .clear
@@ -37,20 +59,17 @@ struct DynamicTextEditor: NSViewRepresentable {
         // Remove default scroll view padding
         textView.textContainerInset = NSSize(width: 0, height: 2)
         textView.textContainer?.lineFragmentPadding = 0
-
-        // Configure scroll view
-        scrollView.hasVerticalScroller = true
-        scrollView.autohidesScrollers = true
-        scrollView.hasHorizontalScroller = false
-        scrollView.drawsBackground = false
-        scrollView.borderType = .noBorder
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(
+            width: contentSize.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
 
         if let identifier = accessibilityIdentifier {
             textView.setAccessibilityIdentifier(identifier)
             scrollView.setAccessibilityIdentifier("\(identifier).scrollView")
         }
 
-        context.coordinator.onSubmit = onSubmit
         syncFirstResponderState(for: textView)
 
         return scrollView
@@ -66,6 +85,9 @@ struct DynamicTextEditor: NSViewRepresentable {
         }
 
         context.coordinator.onSubmit = onSubmit
+        if let pasteAwareTextView = textView as? PasteAwareTextView {
+            configurePasteHandling(for: pasteAwareTextView)
+        }
         if let identifier = accessibilityIdentifier {
             textView.setAccessibilityIdentifier(identifier)
             scrollView.setAccessibilityIdentifier("\(identifier).scrollView")
@@ -76,6 +98,15 @@ struct DynamicTextEditor: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator {
         DynamicTextEditorCoordinator(self)
+    }
+
+    private func configurePasteHandling(for textView: PasteAwareTextView) {
+        let expectedSessionID = pasteImportSessionID
+        textView.updatePasteImportSession(expectedSessionID)
+        textView.onPasteImages = { images in
+            guard pasteImportSessionID == expectedSessionID else { return }
+            onPasteImages(images)
+        }
     }
 
     private func syncFirstResponderState(for textView: NSTextView, retryCount: Int = 8) {
@@ -131,6 +162,120 @@ final class DynamicTextEditorCoordinator: NSObject, NSTextViewDelegate {
             }
         }
         return false
+    }
+}
+
+@MainActor
+private final class PasteAwareTextView: NSTextView {
+    private struct Candidate: Sendable {
+        let data: Data
+        let contentTypeIdentifier: String
+    }
+
+    var onPasteImages: (([PastedImage]) -> Void)?
+    private var pasteImportTask: Task<Void, Never>?
+    private var pasteImportSessionID: UUID?
+
+    override func paste(_ sender: Any?) {
+        let candidates = Self.imageCandidates(from: .general)
+        guard !candidates.isEmpty else {
+            super.paste(sender)
+            return
+        }
+
+        let previousTask = pasteImportTask
+        let expectedSessionID = pasteImportSessionID
+        pasteImportTask = Task { @MainActor [weak self] in
+            await previousTask?.value
+            guard let self,
+                  !Task.isCancelled,
+                  pasteImportSessionID == expectedSessionID
+            else {
+                return
+            }
+
+            let images: [PastedImage] = await Task.detached(priority: .userInitiated) {
+                candidates.compactMap { candidate -> PastedImage? in
+                    guard let contentType = UTType(candidate.contentTypeIdentifier) else {
+                        return nil
+                    }
+                    return try? PastedImage.importing(
+                        data: candidate.data,
+                        contentType: contentType
+                    )
+                }
+            }.value
+
+            guard !Task.isCancelled,
+                  pasteImportSessionID == expectedSessionID
+            else {
+                return
+            }
+            guard !images.isEmpty else {
+                NSSound.beep()
+                DiagnosticsLogger.log(
+                    .chatView,
+                    level: .error,
+                    message: "Failed to import pasted clipboard image"
+                )
+                return
+            }
+            onPasteImages?(images)
+        }
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        if newWindow == nil {
+            invalidatePasteImports()
+        }
+    }
+
+    func updatePasteImportSession(_ sessionID: UUID) {
+        guard pasteImportSessionID != sessionID else { return }
+        invalidatePasteImports()
+        pasteImportSessionID = sessionID
+    }
+
+    private static func imageCandidates(from pasteboard: NSPasteboard) -> [Candidate] {
+        let supportedTypes: [(pasteboardType: NSPasteboard.PasteboardType, contentType: UTType)] = [
+            (.init(UTType.png.identifier), .png),
+            (.init(UTType.jpeg.identifier), .jpeg),
+            (.init(UTType.gif.identifier), .gif),
+            (.init(UTType.webP.identifier), .webP),
+            (.init(UTType.tiff.identifier), .tiff),
+            (.init(UTType.heic.identifier), .heic),
+        ]
+
+        if let pasteboardItems = pasteboard.pasteboardItems, !pasteboardItems.isEmpty {
+            return pasteboardItems.compactMap { item in
+                for supportedType in supportedTypes {
+                    if let data = item.data(forType: supportedType.pasteboardType) {
+                        return Candidate(
+                            data: data,
+                            contentTypeIdentifier: supportedType.contentType.identifier
+                        )
+                    }
+                }
+                return nil
+            }
+        }
+
+        for supportedType in supportedTypes {
+            if let data = pasteboard.data(forType: supportedType.pasteboardType) {
+                return [Candidate(
+                    data: data,
+                    contentTypeIdentifier: supportedType.contentType.identifier
+                )]
+            }
+        }
+        return []
+    }
+
+    private func invalidatePasteImports() {
+        pasteImportTask?.cancel()
+        pasteImportTask = nil
+        pasteImportSessionID = nil
     }
 }
 #endif

--- a/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
+++ b/Sources/Ayna/Views/macOS/DynamicTextEditor.swift
@@ -172,9 +172,28 @@ private final class PasteAwareTextView: NSTextView {
         let contentTypeIdentifier: String
     }
 
+    private static let supportedImageTypes: [(
+        pasteboardType: NSPasteboard.PasteboardType,
+        contentType: UTType
+    )] = [
+        (.init(UTType.png.identifier), .png),
+        (.init(UTType.jpeg.identifier), .jpeg),
+        (.init(UTType.gif.identifier), .gif),
+        (.init(UTType.webP.identifier), .webP),
+        (.init(UTType.tiff.identifier), .tiff),
+        (.init(UTType.heic.identifier), .heic),
+    ]
+
     var onPasteImages: (([PastedImage]) -> Void)?
     private var pasteImportTask: Task<Void, Never>?
     private var pasteImportSessionID: UUID?
+
+    override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
+        if item.action == #selector(paste(_:)), Self.hasImageCandidates(in: .general) {
+            return true
+        }
+        return super.validateUserInterfaceItem(item)
+    }
 
     override func paste(_ sender: Any?) {
         let candidates = Self.imageCandidates(from: .general)
@@ -238,18 +257,9 @@ private final class PasteAwareTextView: NSTextView {
     }
 
     private static func imageCandidates(from pasteboard: NSPasteboard) -> [Candidate] {
-        let supportedTypes: [(pasteboardType: NSPasteboard.PasteboardType, contentType: UTType)] = [
-            (.init(UTType.png.identifier), .png),
-            (.init(UTType.jpeg.identifier), .jpeg),
-            (.init(UTType.gif.identifier), .gif),
-            (.init(UTType.webP.identifier), .webP),
-            (.init(UTType.tiff.identifier), .tiff),
-            (.init(UTType.heic.identifier), .heic),
-        ]
-
         if let pasteboardItems = pasteboard.pasteboardItems, !pasteboardItems.isEmpty {
             return pasteboardItems.compactMap { item in
-                for supportedType in supportedTypes {
+                for supportedType in supportedImageTypes {
                     if let data = item.data(forType: supportedType.pasteboardType) {
                         return Candidate(
                             data: data,
@@ -261,7 +271,7 @@ private final class PasteAwareTextView: NSTextView {
             }
         }
 
-        for supportedType in supportedTypes {
+        for supportedType in supportedImageTypes {
             if let data = pasteboard.data(forType: supportedType.pasteboardType) {
                 return [Candidate(
                     data: data,
@@ -270,6 +280,18 @@ private final class PasteAwareTextView: NSTextView {
             }
         }
         return []
+    }
+
+    private static func hasImageCandidates(in pasteboard: NSPasteboard) -> Bool {
+        let supportedTypes = Set(supportedImageTypes.map(\.pasteboardType))
+
+        if let pasteboardItems = pasteboard.pasteboardItems, !pasteboardItems.isEmpty {
+            return pasteboardItems.contains { item in
+                !supportedTypes.isDisjoint(with: item.types)
+            }
+        }
+
+        return pasteboard.availableType(from: Array(supportedTypes)) != nil
     }
 
     private func invalidatePasteImports() {

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -314,14 +314,7 @@ struct MacChatView: View {
                         )
                     },
                     onEditMessage: { message, newContent in
-                        let edited = conversationManager.editMessage(
-                            in: currentConversation,
-                            messageId: message.id,
-                            newContent: newContent
-                        )
-                        if edited {
-                            resendMessage(message)
-                        }
+                        editMessageAndResend(message, newContent: newContent)
                     },
                     onAppearAction: {
                         updateTranscriptPlan()

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -1034,8 +1034,8 @@ struct MacChatView: View {
 
         // This method coordinates attachment handling, MCP tool availability, streaming setup, and state
         // resets. Breaking it apart right now would require plumbing a large amount of shared state, so
-        // we defer that refactor and explicitly allow the longer body.
-        // swiftlint:disable:next function_body_length
+        // we defer that refactor and explicitly allow the longer, branching body.
+        // swiftlint:disable:next function_body_length cyclomatic_complexity
         private func sendMessage(
             preparationID: UUID,
             preparation: SendPreparation
@@ -1131,10 +1131,10 @@ struct MacChatView: View {
                 return
             }
 
-            guard await ConversationSendPreflight.loadConversationHistory(
+            guard let loadedConversation = await ConversationSendPreflight.loadConversationHistory(
                 conversationId: conversation.id,
                 manager: conversationManager
-            ) != nil else {
+            ) else {
                 discardStoredAttachments(
                     in: userMessage,
                     ifOwnedByPreparation: ownsStoredAttachments
@@ -1155,6 +1155,25 @@ struct MacChatView: View {
                     ifOwnedByPreparation: ownsStoredAttachments
                 )
                 return
+            }
+
+            if preparation.consumesComposer {
+                let requestModels = selectedModelsToSend.isEmpty
+                    ? [activeModel]
+                    : Array(selectedModelsToSend)
+                if let limitError = aiService.attachmentImageLimitError(
+                    for: requestModels,
+                    messages: loadedConversation.messages + [userMessage]
+                ) {
+                    discardStoredAttachments(
+                        in: userMessage,
+                        ifOwnedByPreparation: ownsStoredAttachments
+                    )
+                    errorMessage = limitError
+                    errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
+                    restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+                    return
+                }
             }
 
             if appContentToSend != nil {

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -188,8 +188,8 @@ struct MacChatView: View {
     @State private var currentToolName: String?
     @State private var isComposerFocused = true
     @State private var toolChainTimeoutTask: Task<Void, Never>?
-        @State private var sendPreparationTask: Task<Void, Never>?
-        @State private var sendPreparationID: UUID?
+        @State var sendPreparationTask: Task<Void, Never>?
+        @State var sendPreparationID: UUID?
         @State private var pendingAutoSendClaim: MacPendingAutoSendClaim?
         @State var activeAssistantMessageID: UUID?
         @State var activeMultiModelResponseGroupID: UUID?

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -1153,9 +1153,13 @@ struct MacChatView: View {
             let requestModels = selectedModelsToSend.isEmpty
                 ? [activeModel]
                 : Array(selectedModelsToSend)
+            let requestMessages = ChatDraftContent.messagesByIncludingUserMessageIfNeeded(
+                userMessage,
+                in: loadedConversation.messages
+            )
             let validationError = await aiService.attachmentImageValidationError(
                 for: requestModels,
-                loading: userMessage.attachments ?? [],
+                in: requestMessages,
                 loadAttachmentData: { path in
                     await AttachmentStorage.shared.loadData(path: path)
                 }
@@ -1177,10 +1181,6 @@ struct MacChatView: View {
                 restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
                 return
             }
-            let requestMessages = ChatDraftContent.messagesByIncludingUserMessageIfNeeded(
-                userMessage,
-                in: loadedConversation.messages
-            )
             if let supportError = aiService.attachmentHistorySupportError(
                 for: requestModels,
                 messages: requestMessages

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -1155,7 +1155,10 @@ struct MacChatView: View {
                 : Array(selectedModelsToSend)
             let validationError = await aiService.attachmentImageValidationError(
                 for: requestModels,
-                loading: userMessage.attachments ?? []
+                loading: userMessage.attachments ?? [],
+                loadAttachmentData: { path in
+                    await AttachmentStorage.shared.loadData(path: path)
+                }
             )
             guard sendPreparationID == preparationID, !Task.isCancelled else {
                 discardStoredAttachments(
@@ -1178,6 +1181,19 @@ struct MacChatView: View {
                 userMessage,
                 in: loadedConversation.messages
             )
+            if let supportError = aiService.attachmentHistorySupportError(
+                for: requestModels,
+                messages: requestMessages
+            ) {
+                discardStoredAttachments(
+                    in: userMessage,
+                    ifOwnedByPreparation: ownsStoredAttachments
+                )
+                errorMessage = supportError
+                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+                restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+                return
+            }
             if let limitError = aiService.attachmentImageLimitError(
                 for: requestModels,
                 messages: requestMessages

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -945,14 +945,7 @@ struct MacChatView: View {
             for preparation: SendPreparation
         ) async -> (message: Message, ownsStoredAttachments: Bool) {
             if let prebuiltUserMessage = preparation.prebuiltUserMessage {
-                return (
-                    Message(
-                        role: .user,
-                        content: prebuiltUserMessage.content,
-                        attachments: prebuiltUserMessage.attachments
-                    ),
-                    false
-                )
+                return (prebuiltUserMessage, false)
             }
 
             let message = await ChatMessageBuilder.createUserMessage(
@@ -1157,23 +1150,50 @@ struct MacChatView: View {
                 return
             }
 
-            if preparation.consumesComposer {
-                let requestModels = selectedModelsToSend.isEmpty
-                    ? [activeModel]
-                    : Array(selectedModelsToSend)
-                if let limitError = aiService.attachmentImageLimitError(
-                    for: requestModels,
-                    messages: loadedConversation.messages + [userMessage]
-                ) {
-                    discardStoredAttachments(
-                        in: userMessage,
-                        ifOwnedByPreparation: ownsStoredAttachments
-                    )
-                    errorMessage = limitError
-                    errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
-                    restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
-                    return
-                }
+            let requestModels = selectedModelsToSend.isEmpty
+                ? [activeModel]
+                : Array(selectedModelsToSend)
+            let validationError = await aiService.attachmentImageValidationError(
+                for: requestModels,
+                loading: userMessage.attachments ?? []
+            )
+            guard sendPreparationID == preparationID, !Task.isCancelled else {
+                discardStoredAttachments(
+                    in: userMessage,
+                    ifOwnedByPreparation: ownsStoredAttachments
+                )
+                return
+            }
+            if let validationError {
+                discardStoredAttachments(
+                    in: userMessage,
+                    ifOwnedByPreparation: ownsStoredAttachments
+                )
+                errorMessage = validationError
+                errorRecoverySuggestion = "Remove the image or choose a different model."
+                restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+                return
+            }
+            let requestMessages = ChatDraftContent.messagesByIncludingUserMessageIfNeeded(
+                userMessage,
+                in: loadedConversation.messages
+            )
+            if let limitError = aiService.attachmentImageLimitError(
+                for: requestModels,
+                messages: requestMessages
+            ) {
+                discardStoredAttachments(
+                    in: userMessage,
+                    ifOwnedByPreparation: ownsStoredAttachments
+                )
+                errorMessage = limitError
+                errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
+                restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+                return
+            }
+
+            let reusesCommittedUserMessage = loadedConversation.messages.contains {
+                $0.id == userMessage.id
             }
 
             if appContentToSend != nil {
@@ -1189,22 +1209,26 @@ struct MacChatView: View {
         }
 
             logChat(
-                "📨 Creating message with \(userMessage.attachments?.count ?? 0) attachments",
+                reusesCommittedUserMessage
+                    ? "🔄 Reusing committed user message"
+                    : "📨 Creating message with \(userMessage.attachments?.count ?? 0) attachments",
             level: .info,
             metadata: ["attachmentCount": "\(userMessage.attachments?.count ?? 0)"]
             )
-            conversationManager.addMessage(to: conversation, message: userMessage)
-            consumePendingAutoSendClaim(
-                afterCommitting: promptText,
-                to: conversation.id
-            )
+            if !reusesCommittedUserMessage {
+                conversationManager.addMessage(to: conversation, message: userMessage)
+                consumePendingAutoSendClaim(
+                    afterCommitting: promptText,
+                    to: conversation.id
+                )
 
-        // Process memory commands (e.g., "remember that I prefer dark mode")
-        if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: userMessage.content) {
-            logChat("💾 Memory command processed: \(memoryResponse)", level: .info)
-        }
+                // Process memory commands (e.g., "remember that I prefer dark mode")
+                if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: userMessage.content) {
+                    logChat("💾 Memory command processed: \(memoryResponse)", level: .info)
+                }
 
-            consumeComposer(for: preparation)
+                consumeComposer(for: preparation)
+            }
         isComposerFocused = true
         errorMessage = nil
         errorRecoverySuggestion = nil

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -1133,9 +1133,10 @@ struct MacChatView: View {
                 userMessage,
                 in: loadedConversation.messages
             )
-            let validationError = await aiService.attachmentImageValidationError(
-                for: requestModels,
-                in: requestMessages,
+            let validationFailure = await ConversationSendPreflight.attachmentFailure(
+                models: requestModels,
+                messages: requestMessages,
+                aiService: aiService,
                 loadAttachmentData: { path in
                     await AttachmentStorage.shared.loadData(path: path)
                 }
@@ -1147,39 +1148,13 @@ struct MacChatView: View {
                 )
                 return
             }
-            if let validationError {
+            if let validationFailure {
                 discardStoredAttachments(
                     in: userMessage,
                     ifOwnedByPreparation: ownsStoredAttachments
                 )
-                errorMessage = validationError
-                errorRecoverySuggestion = "Remove the image or choose a different model."
-                restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
-                return
-            }
-            if let supportError = aiService.attachmentHistorySupportError(
-                for: requestModels,
-                messages: requestMessages
-            ) {
-                discardStoredAttachments(
-                    in: userMessage,
-                    ifOwnedByPreparation: ownsStoredAttachments
-                )
-                errorMessage = supportError
-                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
-                restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
-                return
-            }
-            if let limitError = aiService.attachmentImageLimitError(
-                for: requestModels,
-                messages: requestMessages
-            ) {
-                discardStoredAttachments(
-                    in: userMessage,
-                    ifOwnedByPreparation: ownsStoredAttachments
-                )
-                errorMessage = limitError
-                errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
+                errorMessage = validationFailure.message
+                errorRecoverySuggestion = validationFailure.recoverySuggestion
                 restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
                 return
             }

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -117,6 +117,7 @@ struct MacChatView: View {
     private struct SendPreparation {
         let promptText: String
         let files: [URL]
+        let pastedImages: [PastedImage]
         let appContent: AppContent?
         let selectedModel: String
         let selectedModels: Set<String>
@@ -147,6 +148,8 @@ struct MacChatView: View {
     @State private var failedMessage: String?
     @State private var selectedModel: String
     @State private var attachedFiles: [URL] = []
+    @State private var pastedImages: [PastedImage] = []
+    @State private var pasteImportSessionID = UUID()
     @State var toolCallDepth = 0
     @State private var currentToolName: String?
     @State private var isComposerFocused = true
@@ -334,6 +337,8 @@ struct MacChatView: View {
                     messageText: $messageText,
                     isComposerFocused: $isComposerFocused,
                     attachedFiles: $attachedFiles,
+                    pastedImages: $pastedImages,
+                    pasteImportSessionID: $pasteImportSessionID,
                     attachedAppContent: $attachedAppContent,
                     selectedModels: $selectedModels,
                     selectedModel: $selectedModel,
@@ -813,7 +818,10 @@ struct MacChatView: View {
             return
         }
 
-        guard !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !attachedFiles.isEmpty
+            || !pastedImages.isEmpty
+        else {
             isComposerFocused = true
             return
         }
@@ -821,11 +829,13 @@ struct MacChatView: View {
             let preparation = SendPreparation(
                 promptText: messageText,
                 files: attachedFiles,
+                pastedImages: pastedImages,
                 appContent: attachedAppContent,
                 selectedModel: selectedModel,
                 selectedModels: selectedModels,
                 activeModel: resolveModelForSending(selection: selectedModel)
             )
+            pasteImportSessionID = UUID()
             let preparationID = UUID()
             sendPreparationID = preparationID
             isGenerating = true
@@ -888,6 +898,17 @@ struct MacChatView: View {
             }
         }
 
+        private func attachmentSupportError(
+            files: [URL],
+            pastedImages: [PastedImage],
+            selectedModels: Set<String>,
+            activeModel: String
+        ) -> String? {
+            guard !files.isEmpty || !pastedImages.isEmpty else { return nil }
+            let models = selectedModels.isEmpty ? [activeModel] : Array(selectedModels)
+            return aiService.attachmentSupportError(for: models)
+        }
+
         // This method coordinates attachment handling, MCP tool availability, streaming setup, and state
         // resets. Breaking it apart right now would require plumbing a large amount of shared state, so
         // we defer that refactor and explicitly allow the longer body.
@@ -935,14 +956,26 @@ struct MacChatView: View {
             return
         }
 
+            let promptText = preparation.promptText
+            let filesToSend = preparation.files
+            let pastedImagesToSend = preparation.pastedImages
+            let appContentToSend = preparation.appContent
+            let selectedModelsToSend = preparation.selectedModels
+
+            if let supportError = attachmentSupportError(
+                files: filesToSend,
+                pastedImages: pastedImagesToSend,
+                selectedModels: selectedModelsToSend,
+                activeModel: activeModel
+            ) {
+                errorMessage = supportError
+                restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
+                return
+            }
         ensureConversationModelMatchesSelection(
             activeModel,
             expectedSelection: preparation.selectedModel
         )
-            let promptText = preparation.promptText
-            let filesToSend = preparation.files
-            let appContentToSend = preparation.appContent
-            let selectedModelsToSend = preparation.selectedModels
         logChat(
             "🎯 Sending message with model \(activeModel)",
             level: .info,
@@ -954,7 +987,8 @@ struct MacChatView: View {
                 text: promptText,
                 appContent: appContentToSend,
                 fileURLs: filesToSend,
-            saveToStorage: true
+                pastedImages: pastedImagesToSend,
+                saveToStorage: true
         )
             guard sendPreparationID == preparationID, !Task.isCancelled else {
                 discardStoredAttachments(in: userMessage)
@@ -1014,6 +1048,8 @@ struct MacChatView: View {
             }
         isComposerFocused = true
             attachedFiles.removeAll { filesToSend.contains($0) }
+            let pastedImageIDs = Set(pastedImagesToSend.map(\.id))
+            pastedImages.removeAll { pastedImageIDs.contains($0.id) }
             if isSameAppContent(attachedAppContent, appContentToSend) {
                 attachedAppContent = nil
             }

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -967,7 +967,7 @@ struct MacChatView: View {
             attachedFiles.removeAll { preparation.files.contains($0) }
             let pastedImageIDs = Set(preparation.pastedImages.map(\.id))
             pastedImages.removeAll { pastedImageIDs.contains($0.id) }
-            if isSameAppContent(attachedAppContent, preparation.appContent) {
+            if AppContent.hasSamePayload(attachedAppContent, preparation.appContent) {
                 attachedAppContent = nil
             }
         }
@@ -994,23 +994,6 @@ struct MacChatView: View {
                 in: conversationManager
             )
             pendingAutoSendClaim = nil
-        }
-
-        private func isSameAppContent(_ lhs: AppContent?, _ rhs: AppContent?) -> Bool {
-            switch (lhs, rhs) {
-            case (nil, nil):
-                true
-            case let (lhs?, rhs?):
-                lhs.appName == rhs.appName &&
-                    lhs.bundleIdentifier == rhs.bundleIdentifier &&
-                    lhs.windowTitle == rhs.windowTitle &&
-                    lhs.content == rhs.content &&
-                    lhs.contentType == rhs.contentType &&
-                    lhs.isTruncated == rhs.isTruncated &&
-                    lhs.originalLength == rhs.originalLength
-            default:
-                false
-            }
         }
 
         private func attachmentSupportError(

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -122,6 +122,38 @@ struct MacChatView: View {
         let selectedModel: String
         let selectedModels: Set<String>
         let activeModel: String?
+        let prebuiltUserMessage: Message?
+        let consumesComposer: Bool
+
+        init(
+            promptText: String,
+            files: [URL],
+            pastedImages: [PastedImage],
+            appContent: AppContent?,
+            selectedModel: String,
+            selectedModels: Set<String>,
+            activeModel: String?,
+            prebuiltUserMessage: Message? = nil,
+            consumesComposer: Bool = true
+        ) {
+            self.promptText = promptText
+            self.files = files
+            self.pastedImages = pastedImages
+            self.appContent = appContent
+            self.selectedModel = selectedModel
+            self.selectedModels = selectedModels
+            self.activeModel = activeModel
+            self.prebuiltUserMessage = prebuiltUserMessage
+            self.consumesComposer = consumesComposer
+        }
+    }
+
+    private struct FailedSendPayload {
+        let promptText: String
+        let userMessage: Message
+        let selectedModel: String
+        let selectedModels: Set<String>
+        let activeModel: String
     }
 
     let conversation: Conversation
@@ -150,6 +182,8 @@ struct MacChatView: View {
     @State private var attachedFiles: [URL] = []
     @State private var pastedImages: [PastedImage] = []
     @State private var pasteImportSessionID = UUID()
+    @State private var isImportingPastedImages = false
+    @State private var failedSendPayload: FailedSendPayload?
     @State var toolCallDepth = 0
     @State private var currentToolName: String?
     @State private var isComposerFocused = true
@@ -339,6 +373,7 @@ struct MacChatView: View {
                     attachedFiles: $attachedFiles,
                     pastedImages: $pastedImages,
                     pasteImportSessionID: $pasteImportSessionID,
+                    isImportingPastedImages: $isImportingPastedImages,
                     attachedAppContent: $attachedAppContent,
                     selectedModels: $selectedModels,
                     selectedModel: $selectedModel,
@@ -693,25 +728,56 @@ struct MacChatView: View {
 
     /// Retry the last failed message
     private func retryFailedMessage() {
-        guard let message = failedMessage else { return }
+        guard !isGenerating, sendPreparationTask == nil,
+              let payload = failedSendPayload
+        else {
+            return
+        }
 
-        logChat("🔄 Retrying failed message", level: .info, metadata: ["messageLength": "\(message.count)"])
+        logChat(
+            "🔄 Retrying failed message",
+            level: .info,
+            metadata: ["messageLength": "\(payload.promptText.count)"]
+        )
 
-        // Clear error state
-        failedMessage = nil
         errorMessage = nil
         errorRecoverySuggestion = nil
 
-        // Set message text and send
-        messageText = message
-            beginSendMessage()
+        scheduleSend(
+            SendPreparation(
+                promptText: payload.promptText,
+                files: [],
+                pastedImages: [],
+                appContent: nil,
+                selectedModel: payload.selectedModel,
+                selectedModels: payload.selectedModels,
+                activeModel: payload.activeModel,
+                prebuiltUserMessage: payload.userMessage,
+                consumesComposer: false
+            )
+        )
     }
 
     /// Dismiss the current error without retrying
     private func dismissError() {
         failedMessage = nil
+        failedSendPayload = nil
         errorMessage = nil
         errorRecoverySuggestion = nil
+    }
+
+    func clearFailedSendState() {
+        failedMessage = nil
+        failedSendPayload = nil
+    }
+
+    func retainFailedSendState(
+        errorMessage: String,
+        recoverySuggestion: String? = nil
+    ) {
+        failedMessage = failedSendPayload?.promptText
+        self.errorMessage = errorMessage
+        errorRecoverySuggestion = recoverySuggestion
     }
 
         private func cancelOwnedGenerationForLifecycle() {
@@ -818,9 +884,12 @@ struct MacChatView: View {
             return
         }
 
-        guard !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            || !attachedFiles.isEmpty
-            || !pastedImages.isEmpty
+        guard !isImportingPastedImages,
+              ChatDraftContent.isSendable(
+                  text: messageText,
+                  fileURLs: attachedFiles,
+                  inMemoryImageCount: pastedImages.count
+              )
         else {
             isComposerFocused = true
             return
@@ -836,6 +905,13 @@ struct MacChatView: View {
                 activeModel: resolveModelForSending(selection: selectedModel)
             )
             pasteImportSessionID = UUID()
+            scheduleSend(preparation, delay: delay)
+        }
+
+        private func scheduleSend(
+            _ preparation: SendPreparation,
+            delay: Duration? = nil
+        ) {
             let preparationID = UUID()
             sendPreparationID = preparationID
             isGenerating = true
@@ -854,6 +930,52 @@ struct MacChatView: View {
                 if let localPath = attachment.localPath {
                     AttachmentStorage.shared.delete(path: localPath)
                 }
+            }
+        }
+
+        private func discardStoredAttachments(
+            in message: Message,
+            ifOwnedByPreparation ownsStoredAttachments: Bool
+        ) {
+            guard ownsStoredAttachments else { return }
+            discardStoredAttachments(in: message)
+        }
+
+        private func makeUserMessage(
+            for preparation: SendPreparation
+        ) async -> (message: Message, ownsStoredAttachments: Bool) {
+            if let prebuiltUserMessage = preparation.prebuiltUserMessage {
+                return (
+                    Message(
+                        role: .user,
+                        content: prebuiltUserMessage.content,
+                        attachments: prebuiltUserMessage.attachments
+                    ),
+                    false
+                )
+            }
+
+            let message = await ChatMessageBuilder.createUserMessage(
+                text: preparation.promptText,
+                appContent: preparation.appContent,
+                fileURLs: preparation.files,
+                pastedImages: preparation.pastedImages,
+                saveToStorage: true
+            )
+            return (message, true)
+        }
+
+        private func consumeComposer(for preparation: SendPreparation) {
+            guard preparation.consumesComposer else { return }
+
+            if messageText == preparation.promptText {
+                messageText = ""
+            }
+            attachedFiles.removeAll { preparation.files.contains($0) }
+            let pastedImageIDs = Set(preparation.pastedImages.map(\.id))
+            pastedImages.removeAll { pastedImageIDs.contains($0.id) }
+            if isSameAppContent(attachedAppContent, preparation.appContent) {
+                attachedAppContent = nil
             }
         }
 
@@ -901,10 +1023,11 @@ struct MacChatView: View {
         private func attachmentSupportError(
             files: [URL],
             pastedImages: [PastedImage],
+            hasPrebuiltAttachments: Bool,
             selectedModels: Set<String>,
             activeModel: String
         ) -> String? {
-            guard !files.isEmpty || !pastedImages.isEmpty else { return nil }
+            guard !files.isEmpty || !pastedImages.isEmpty || hasPrebuiltAttachments else { return nil }
             let models = selectedModels.isEmpty ? [activeModel] : Array(selectedModels)
             return aiService.attachmentSupportError(for: models)
         }
@@ -965,6 +1088,7 @@ struct MacChatView: View {
             if let supportError = attachmentSupportError(
                 files: filesToSend,
                 pastedImages: pastedImagesToSend,
+                hasPrebuiltAttachments: preparation.prebuiltUserMessage?.attachments?.isEmpty == false,
                 selectedModels: selectedModelsToSend,
                 activeModel: activeModel
             ) {
@@ -982,16 +1106,28 @@ struct MacChatView: View {
             metadata: ["model": activeModel]
         )
 
-        // Build user message using ChatMessageBuilder
-        let userMessage = await ChatMessageBuilder.createUserMessage(
-                text: promptText,
-                appContent: appContentToSend,
-                fileURLs: filesToSend,
-                pastedImages: pastedImagesToSend,
-                saveToStorage: true
-        )
+            let userMessageBuild = await makeUserMessage(for: preparation)
+            let userMessage = userMessageBuild.message
+            let ownsStoredAttachments = userMessageBuild.ownsStoredAttachments
             guard sendPreparationID == preparationID, !Task.isCancelled else {
-                discardStoredAttachments(in: userMessage)
+                discardStoredAttachments(
+                    in: userMessage,
+                    ifOwnedByPreparation: ownsStoredAttachments
+                )
+                return
+            }
+
+            guard ChatDraftContent.isSendable(
+                text: userMessage.content,
+                attachments: userMessage.attachments ?? []
+            ) else {
+                discardStoredAttachments(
+                    in: userMessage,
+                    ifOwnedByPreparation: ownsStoredAttachments
+                )
+                errorMessage = "Unable to load a supported image attachment."
+                errorRecoverySuggestion = "Choose a JPEG, PNG, GIF, or WebP image and try again."
+                restorePendingAutoSendClaimIfNeeded(clearVisibleDraft: false)
                 return
             }
 
@@ -999,7 +1135,10 @@ struct MacChatView: View {
                 conversationId: conversation.id,
                 manager: conversationManager
             ) != nil else {
-                discardStoredAttachments(in: userMessage)
+                discardStoredAttachments(
+                    in: userMessage,
+                    ifOwnedByPreparation: ownsStoredAttachments
+                )
                 guard sendPreparationID == preparationID, !Task.isCancelled else { return }
                 logChat(
                     "❌ Conversation changed while preparing attachments",
@@ -1011,7 +1150,10 @@ struct MacChatView: View {
                 return
             }
             guard sendPreparationID == preparationID, !Task.isCancelled else {
-                discardStoredAttachments(in: userMessage)
+                discardStoredAttachments(
+                    in: userMessage,
+                    ifOwnedByPreparation: ownsStoredAttachments
+                )
                 return
             }
 
@@ -1043,19 +1185,18 @@ struct MacChatView: View {
             logChat("💾 Memory command processed: \(memoryResponse)", level: .info)
         }
 
-            if messageText == promptText {
-        messageText = ""
-            }
+            consumeComposer(for: preparation)
         isComposerFocused = true
-            attachedFiles.removeAll { filesToSend.contains($0) }
-            let pastedImageIDs = Set(pastedImagesToSend.map(\.id))
-            pastedImages.removeAll { pastedImageIDs.contains($0.id) }
-            if isSameAppContent(attachedAppContent, appContentToSend) {
-                attachedAppContent = nil
-            }
         errorMessage = nil
         errorRecoverySuggestion = nil
         failedMessage = promptText // Store for retry in case of failure
+            failedSendPayload = FailedSendPayload(
+                promptText: promptText,
+                userMessage: userMessage,
+                selectedModel: preparation.selectedModel,
+                selectedModels: selectedModelsToSend,
+                activeModel: activeModel
+            )
         logChat("🔄 isGenerating set to TRUE", level: .info)
 
         // Get updated messages after adding user message
@@ -1480,6 +1621,7 @@ struct MacChatView: View {
                 toolCallDepth = 0
                 isGenerating = false
                 failedMessage = nil
+                failedSendPayload = nil
             case let .launchContinuation(continuation):
                 toolChainTimeoutTask?.cancel()
                 toolChainTimeoutTask = nil

--- a/Sources/Ayna/Views/macOS/MacMessageView.swift
+++ b/Sources/Ayna/Views/macOS/MacMessageView.swift
@@ -9,6 +9,7 @@
 // swiftlint:disable file_length
 
 import Combine
+import ImageIO
 import SwiftUI
 
 // MARK: - Design System Integration
@@ -723,15 +724,38 @@ struct MacMessageView: View {
         }
     }
 
-    /// Loads and caches an attachment image to prevent memory leaks from repeated decoding
-    /// Note: NSImage is non-Sendable so we create it on @MainActor directly
+    /// Loads and caches an attachment image to prevent memory leaks from repeated decoding.
+    /// ImageIO performs the decode off actor; NSImage remains main-actor confined.
     private func loadAttachmentImage(at index: Int, attachment: Message.FileAttachment) {
         guard cachedAttachmentImages[index] == nil else { return }
         Task { @MainActor in
             guard let data = await attachment.loadContent() else { return }
-            if let image = NSImage(data: data) {
-                cachedAttachmentImages[index] = image
+            let decodeTask = Task.detached(priority: .userInitiated) { () -> CGImage? in
+                guard !Task.isCancelled,
+                      let source = CGImageSourceCreateWithData(data as CFData, nil)
+                else {
+                    return nil
+                }
+                let options: [CFString: Any] = [
+                    kCGImageSourceCreateThumbnailFromImageAlways: true,
+                    kCGImageSourceCreateThumbnailWithTransform: true,
+                    kCGImageSourceThumbnailMaxPixelSize: 1024,
+                    kCGImageSourceShouldCacheImmediately: true,
+                ]
+                let thumbnail = CGImageSourceCreateThumbnailAtIndex(
+                    source,
+                    0,
+                    options as CFDictionary
+                )
+                return Task.isCancelled ? nil : thumbnail
             }
+            let thumbnail = await withTaskCancellationHandler {
+                await decodeTask.value
+            } onCancel: {
+                decodeTask.cancel()
+            }
+            guard !Task.isCancelled, let thumbnail else { return }
+            cachedAttachmentImages[index] = NSImage(cgImage: thumbnail, size: .zero)
         }
     }
 

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -608,31 +608,16 @@ struct MacNewChatView: View {
                 userMessage,
                 in: existingMessages
             )
-            if let supportError = aiService.attachmentHistorySupportError(
-                for: models,
-                messages: proposedMessages
-            ) {
-                errorMessage = supportError
-                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
-                return false
-            }
-            if let limitError = aiService.attachmentImageLimitError(
-                for: models,
-                messages: proposedMessages
-            ) {
-                errorMessage = limitError
-                errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
-                return false
-            }
-            if let validationError = await aiService.attachmentImageValidationError(
-                for: models,
-                in: proposedMessages,
+            if let failure = await ConversationSendPreflight.attachmentFailure(
+                models: models,
+                messages: proposedMessages,
+                aiService: aiService,
                 loadAttachmentData: { path in
                     await AttachmentStorage.shared.loadData(path: path)
                 }
             ) {
-                errorMessage = validationError
-                errorRecoverySuggestion = "Remove the image or choose a different model."
+                errorMessage = failure.message
+                errorRecoverySuggestion = failure.recoverySuggestion
                 return false
             }
             return true
@@ -842,11 +827,6 @@ struct MacNewChatView: View {
                 conversationID: conversationID
             )
         }
-
-        guard aiService.getModelCapability(resendModel) != .imageGeneration else {
-            performEdit()
-            return
-        }
         preflightHistoryMutation(
             models: [resendModel],
             messages: proposedHistory,
@@ -859,30 +839,17 @@ struct MacNewChatView: View {
         messages: [Message],
         onSuccess: @escaping @MainActor @Sendable () -> Void
     ) {
-        if let supportError = aiService.attachmentHistorySupportError(
-            for: models,
-            messages: messages
+        if let failure = ConversationSendPreflight.attachmentRuleFailure(
+            models: models,
+            messages: messages,
+            aiService: aiService
         ) {
-            errorMessage = supportError
-            errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
-            return
-        }
-        if let limitError = aiService.attachmentImageLimitError(
-            for: models,
-            messages: messages
-        ) {
-            errorMessage = limitError
-            errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
+            errorMessage = failure.message
+            errorRecoverySuggestion = failure.recoverySuggestion
             return
         }
 
-        let hasImages = messages.contains { message in
-            guard message.role == .user else { return false }
-            return message.attachments?.contains(where: {
-                $0.mimeType.lowercased().hasPrefix("image/")
-            }) == true
-        }
-        guard hasImages else {
+        guard ConversationSendPreflight.hasImageAttachments(in: messages) else {
             onSuccess()
             return
         }
@@ -891,9 +858,10 @@ struct MacNewChatView: View {
         sendPreparationID = preparationID
         isGenerating = true
         let task = Task { @MainActor in
-            let validationError = await aiService.attachmentImageValidationError(
-                for: models,
-                in: messages,
+            let failure = await ConversationSendPreflight.attachmentDataFailure(
+                models: models,
+                messages: messages,
+                aiService: aiService,
                 loadAttachmentData: { path in
                     await AttachmentStorage.shared.loadData(path: path)
                 }
@@ -903,9 +871,9 @@ struct MacNewChatView: View {
             sendPreparationTask = nil
             sendPreparationID = nil
             isGenerating = false
-            if let validationError {
-                errorMessage = validationError
-                errorRecoverySuggestion = "Remove the image or choose a different model."
+            if let failure {
+                errorMessage = failure.message
+                errorRecoverySuggestion = failure.recoverySuggestion
                 return
             }
             onSuccess()
@@ -1034,12 +1002,14 @@ struct MacNewChatView: View {
         let responseGroupId = responsePlan.responseGroupId
         let messageIds = responsePlan.messageIDsByModel
 
-        for placeholderMessage in responsePlan.placeholderMessages {
-            conversationManager.addMessage(to: conversation, message: placeholderMessage)
-        }
-
-        if let index = conversationManager.conversations.firstIndex(where: { $0.id == conversation.id }) {
-            conversationManager.conversations[index].responseGroups.append(responsePlan.responseGroup)
+        guard conversationManager.beginMultiModelResponse(
+            to: conversation,
+            messages: responsePlan.placeholderMessages,
+            responseGroup: responsePlan.responseGroup
+        ) != nil else {
+            _ = coordinator.finishOperation(operationID)
+            isGenerating = false
+            return
         }
 
         registerNewChatImageBatchCancellation(
@@ -1208,11 +1178,8 @@ struct MacNewChatView: View {
             metadata: ["models": models.joined(separator: ", ")]
         )
 
-        // Get updated conversation
         guard let conversationId = currentConversationId,
-              let updatedConversation = conversationManager.conversations.first(where: {
-                  $0.id == conversationId
-              })
+              let conversation = conversationManager.conversation(byId: conversationId)
         else {
             isGenerating = false
             return
@@ -1220,12 +1187,14 @@ struct MacNewChatView: View {
 
         let responsePlan = MultiModelResponsePlan(models: models, userMessageId: userMessageId)
         let responseGroupId = responsePlan.responseGroupId
-        for placeholderMessage in responsePlan.placeholderMessages {
-            conversationManager.addMessage(to: updatedConversation, message: placeholderMessage)
+        guard let updatedConversation = conversationManager.beginMultiModelResponse(
+            to: conversation,
+            messages: responsePlan.placeholderMessages,
+            responseGroup: responsePlan.responseGroup
+        ) else {
+            isGenerating = false
+            return
         }
-
-        // Add response group to conversation
-        conversationManager.addResponseGroup(to: updatedConversation, group: responsePlan.responseGroup)
 
         let messageIdsByModel = responsePlan.messageIDsByModel
 

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -586,7 +586,7 @@ struct MacNewChatView: View {
             return conversation
         }
 
-        private func validateAttachmentImageLimit(
+        private func validateAttachments(
             for userMessage: Message,
             conversationId: UUID?,
             models: [String]
@@ -623,6 +623,17 @@ struct MacNewChatView: View {
             ) {
                 errorMessage = limitError
                 errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
+                return false
+            }
+            if let validationError = await aiService.attachmentImageValidationError(
+                for: models,
+                in: proposedMessages,
+                loadAttachmentData: { path in
+                    await AttachmentStorage.shared.loadData(path: path)
+                }
+            ) {
+                errorMessage = validationError
+                errorRecoverySuggestion = "Remove the image or choose a different model."
                 return false
             }
             return true
@@ -699,20 +710,7 @@ struct MacNewChatView: View {
             let requestModels = selectedModelsToSend.isEmpty
                 ? [activeModel]
                 : Array(selectedModelsToSend)
-            let validationError = await aiService.attachmentImageValidationError(
-                for: requestModels,
-                loading: userMessage.attachments ?? [],
-                loadAttachmentData: { path in
-                    await AttachmentStorage.shared.loadData(path: path)
-                }
-            )
-            guard sendPreparationID == preparationID, !Task.isCancelled else { return }
-            if let validationError {
-                errorMessage = validationError
-                errorRecoverySuggestion = "Remove the image or choose a different model."
-                return
-            }
-            guard await validateAttachmentImageLimit(
+            guard await validateAttachments(
                 for: userMessage,
                 conversationId: currentConversationId,
                 models: requestModels

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -547,7 +547,9 @@ struct MacNewChatView: View {
                 attachedFiles.removeAll { preparation.files.contains($0) }
                 let pastedImageIDs = Set(preparation.pastedImages.map(\.id))
                 pastedImages.removeAll { pastedImageIDs.contains($0.id) }
-                attachedAppContent = nil
+                if AppContent.hasSamePayload(attachedAppContent, preparation.appContent) {
+                    attachedAppContent = nil
+                }
             }
             isComposerFocused = true
             return true

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -454,6 +454,36 @@ struct MacNewChatView: View {
             sendPreparationID = nil
         }
 
+        private func validateAttachmentImageLimit(
+            for userMessage: Message,
+            conversationId: UUID?,
+            models: [String]
+        ) async -> Bool {
+            let existingMessages: [Message]
+            if let conversationId {
+                guard let loadedConversation = await ConversationSendPreflight.loadConversationHistory(
+                    conversationId: conversationId,
+                    manager: conversationManager
+                ) else {
+                    errorMessage = "Unable to load this conversation's history. Try again."
+                    return false
+                }
+                existingMessages = loadedConversation.messages
+            } else {
+                existingMessages = []
+            }
+
+            guard let limitError = aiService.attachmentImageLimitError(
+                for: models,
+                messages: existingMessages + [userMessage]
+            ) else {
+                return true
+            }
+            errorMessage = limitError
+            errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
+            return false
+        }
+
         private func sendMessage(preparationID: UUID, preparation: SendPreparation) async {
             var handedOff = false
             defer {
@@ -509,6 +539,15 @@ struct MacNewChatView: View {
                 errorRecoverySuggestion = "Choose a JPEG, PNG, GIF, or WebP image and try again."
                 return
             }
+
+            let requestModels = selectedModelsToSend.isEmpty
+                ? [activeModel]
+                : Array(selectedModelsToSend)
+            guard await validateAttachmentImageLimit(
+                for: userMessage,
+                conversationId: currentConversationId,
+                models: requestModels
+            ) else { return }
 
         // Get or create the conversation
         let conversation: Conversation

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -823,6 +823,7 @@ struct MacNewChatView: View {
         newContent: String,
         in conversation: Conversation
     ) {
+        guard !isGenerating, sendPreparationTask == nil else { return }
         guard let proposedHistory = ChatDraftContent.effectiveHistory(
             byEditingUserMessage: message.id,
             newContent: newContent,
@@ -832,30 +833,101 @@ struct MacNewChatView: View {
         }
 
         let resendModel = conversation.model
-        if aiService.getModelCapability(resendModel) != .imageGeneration {
-            if let supportError = aiService.attachmentHistorySupportError(
-                for: [resendModel],
-                messages: proposedHistory
-            ) {
-                errorMessage = supportError
-                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
-                return
-            }
-            if let limitError = aiService.attachmentImageLimitError(
-                for: [resendModel],
-                messages: proposedHistory
-            ) {
-                errorMessage = limitError
-                errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
-                return
-            }
+        let conversationID = conversation.id
+        let performEdit: @MainActor @Sendable () -> Void = {
+            performEditMessageAndResend(
+                messageID: message.id,
+                newContent: newContent,
+                model: resendModel,
+                conversationID: conversationID
+            )
         }
 
-        guard conversationManager.editMessage(
-            in: conversation,
-            messageId: message.id,
-            newContent: newContent
-        ), let updatedConversation = conversationManager.conversation(byId: conversation.id)
+        guard aiService.getModelCapability(resendModel) != .imageGeneration else {
+            performEdit()
+            return
+        }
+        preflightHistoryMutation(
+            models: [resendModel],
+            messages: proposedHistory,
+            onSuccess: performEdit
+        )
+    }
+
+    private func preflightHistoryMutation(
+        models: [String],
+        messages: [Message],
+        onSuccess: @escaping @MainActor @Sendable () -> Void
+    ) {
+        if let supportError = aiService.attachmentHistorySupportError(
+            for: models,
+            messages: messages
+        ) {
+            errorMessage = supportError
+            errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+            return
+        }
+        if let limitError = aiService.attachmentImageLimitError(
+            for: models,
+            messages: messages
+        ) {
+            errorMessage = limitError
+            errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
+            return
+        }
+
+        let hasImages = messages.contains { message in
+            guard message.role == .user else { return false }
+            return message.attachments?.contains(where: {
+                $0.mimeType.lowercased().hasPrefix("image/")
+            }) == true
+        }
+        guard hasImages else {
+            onSuccess()
+            return
+        }
+
+        let preparationID = UUID()
+        sendPreparationID = preparationID
+        isGenerating = true
+        let task = Task { @MainActor in
+            let validationError = await aiService.attachmentImageValidationError(
+                for: models,
+                in: messages,
+                loadAttachmentData: { path in
+                    await AttachmentStorage.shared.loadData(path: path)
+                }
+            )
+            guard !Task.isCancelled, sendPreparationID == preparationID else { return }
+
+            sendPreparationTask = nil
+            sendPreparationID = nil
+            isGenerating = false
+            if let validationError {
+                errorMessage = validationError
+                errorRecoverySuggestion = "Remove the image or choose a different model."
+                return
+            }
+            onSuccess()
+        }
+        sendPreparationTask = task
+    }
+
+    private func performEditMessageAndResend(
+        messageID: UUID,
+        newContent: String,
+        model: String,
+        conversationID: UUID
+    ) {
+        guard !isGenerating, sendPreparationTask == nil,
+              let conversation = conversationManager.conversation(byId: conversationID),
+              conversation.model == model,
+              conversationManager.editMessage(
+                  in: conversation,
+                  messageId: messageID,
+                  newContent: newContent
+              ),
+              let updatedConversation = conversationManager.conversation(byId: conversationID)
         else {
             return
         }

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -11,12 +11,22 @@ import SwiftUI
 
 // swiftlint:disable:next type_body_length
 struct MacNewChatView: View {
+    private struct SendPreparation {
+        let text: String
+        let files: [URL]
+        let pastedImages: [PastedImage]
+        let appContent: AppContent?
+        let selectedModels: Set<String>
+        let activeModel: String?
+    }
     @EnvironmentObject var conversationManager: ConversationManager
     @ObservedObject var aiService = AIService.shared
     @Binding var selectedConversationId: UUID?
     @State private var messageText = ""
     @State private var isComposerFocused = true
     @State private var attachedFiles: [URL] = []
+    @State private var pastedImages: [PastedImage] = []
+    @State private var pasteImportSessionID = UUID()
     @State var isGenerating = false
     @State var currentConversationId: UUID?
     @State private var selectedModel = AIService.shared.selectedModel
@@ -248,6 +258,8 @@ struct MacNewChatView: View {
             messageText: $messageText,
             isComposerFocused: $isComposerFocused,
             attachedFiles: $attachedFiles,
+            pastedImages: $pastedImages,
+            pasteImportSessionID: $pasteImportSessionID,
             attachedAppContent: $attachedAppContent,
             selectedModels: $selectedModels,
             selectedModel: $selectedModel,
@@ -411,17 +423,26 @@ struct MacNewChatView: View {
             return
         }
 
-        guard !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+            !attachedFiles.isEmpty || !pastedImages.isEmpty else {
             isComposerFocused = true
             return
         }
-
+            let preparation = SendPreparation(
+                text: messageText,
+                files: attachedFiles,
+                pastedImages: pastedImages,
+                appContent: attachedAppContent,
+                selectedModels: selectedModels,
+                activeModel: resolveModelForSending()
+            )
+            pasteImportSessionID = UUID()
             let preparationID = UUID()
             sendPreparationID = preparationID
             isGenerating = true
             let task = Task { @MainActor in
                 guard !Task.isCancelled, sendPreparationID == preparationID else { return }
-                await sendMessage(preparationID: preparationID)
+                await sendMessage(preparationID: preparationID, preparation: preparation)
             }
             sendPreparationTask = task
         }
@@ -432,7 +453,7 @@ struct MacNewChatView: View {
             sendPreparationID = nil
         }
 
-        private func sendMessage(preparationID: UUID) async {
+        private func sendMessage(preparationID: UUID, preparation: SendPreparation) async {
             var handedOff = false
             defer {
                 if sendPreparationID == preparationID {
@@ -447,20 +468,27 @@ struct MacNewChatView: View {
             dismissError()
             guard sendPreparationID == preparationID, !Task.isCancelled else { return }
 
-        guard let activeModel = resolveModelForSending() else {
+        guard let activeModel = preparation.activeModel else {
             logNewChat("⚠️ Cannot send message: no model selected", level: .error)
             errorMessage = "Select a model in Settings → Models"
             errorRecoverySuggestion = "Add or select a model before sending your first message"
             shouldOfferOpenSettings = true
             return
         }
-
+        let textToSend = preparation.text
+        let filesToSend = preparation.files
+            let pastedImagesToSend = preparation.pastedImages
+            let appContentToSend = preparation.appContent
+            let selectedModelsToSend = preparation.selectedModels
+            if !filesToSend.isEmpty || !pastedImagesToSend.isEmpty {
+                let attachmentModels = selectedModelsToSend.isEmpty ? [activeModel] : Array(selectedModelsToSend)
+                if let supportError = aiService.attachmentSupportError(for: attachmentModels) {
+                    errorMessage = supportError
+                    return
+                }
+            }
         aiService.selectedModel = activeModel
         ensureConversationModelMatchesSelection(activeModel)
-
-        let textToSend = messageText
-        let filesToSend = attachedFiles
-            let appContentToSend = attachedAppContent
 
             // Attachment construction is the only suspension in send preparation. Do it before
             // mutating conversation state, then recheck lifecycle ownership before committing.
@@ -468,6 +496,7 @@ struct MacNewChatView: View {
                 text: textToSend,
                 appContent: appContentToSend,
                 fileURLs: filesToSend,
+                pastedImages: pastedImagesToSend,
                 saveToStorage: false
             )
             guard sendPreparationID == preparationID, !Task.isCancelled else { return }
@@ -504,8 +533,8 @@ struct MacNewChatView: View {
 
         // Update conversation with multi-model settings
         var updatedConversation = conversation
-        updatedConversation.activeModels = Array(selectedModels)
-        updatedConversation.multiModelEnabled = selectedModels.count > 1
+        updatedConversation.activeModels = Array(selectedModelsToSend)
+        updatedConversation.multiModelEnabled = selectedModelsToSend.count > 1
         conversationManager.updateConversation(updatedConversation)
 
             if appContentToSend != nil {
@@ -528,9 +557,13 @@ struct MacNewChatView: View {
         }
 
         // Clear input first
-        messageText = ""
+        if messageText == textToSend {
+            messageText = ""
+        }
         isComposerFocused = true
-        attachedFiles.removeAll()
+        attachedFiles.removeAll { filesToSend.contains($0) }
+        let pastedImageIDs = Set(pastedImagesToSend.map(\.id))
+        pastedImages.removeAll { pastedImageIDs.contains($0.id) }
         attachedAppContent = nil // Clear app content after sending
 
         // DON'T switch views yet - stay in NewChatView so the stop button remains visible
@@ -541,8 +574,8 @@ struct MacNewChatView: View {
         if modelCapability == .imageGeneration {
                 handedOff = true
             // Image generation flow - handle multi-model image gen
-            if selectedModels.count > 1 {
-                generateMultiModelImages(prompt: textToSend, models: Array(selectedModels), conversation: conversation)
+            if selectedModelsToSend.count > 1 {
+                generateMultiModelImages(prompt: textToSend, models: Array(selectedModelsToSend), conversation: conversation)
             } else {
                 generateImage(prompt: textToSend, model: activeModel, conversation: conversation)
             }
@@ -550,11 +583,11 @@ struct MacNewChatView: View {
         }
 
         // Send the message immediately (no delay needed)
-        if selectedModels.count > 1 {
+        if selectedModelsToSend.count > 1 {
                 handedOff = true
             sendMultiModelMessage(
                 userMessageId: userMessage.id,
-                models: Array(selectedModels),
+                models: Array(selectedModelsToSend),
                 temperature: conversation.temperature
             )
         } else {

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -1201,8 +1201,7 @@ struct MacNewChatView: View {
         // Prepare messages for API
         var messagesToSend = updatedConversation.getEffectiveHistory()
         if let systemPrompt = conversationManager.effectiveSystemPrompt(for: updatedConversation) {
-            let systemMessage = Message(role: .system, content: systemPrompt)
-            messagesToSend.insert(systemMessage, at: 0)
+            messagesToSend.insert(Message(role: .system, content: systemPrompt), at: 0)
         }
 
             // Send to all models in parallel under this view's owner-specific operation.

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -178,14 +178,11 @@ struct MacNewChatView: View {
                                             onEdit: message.role == .user && currentConversation != nil
                                                 ? { newContent in
                                                     if let conversation = currentConversation {
-                                                        let edited = conversationManager.editMessage(
-                                                            in: conversation,
-                                                            messageId: message.id,
-                                                            newContent: newContent
-                                                    )
-                                                        if edited {
-                                                            sendMessageForConversation(conversation, model: conversation.model)
-                                                        }
+                                                        editMessageAndResend(
+                                                            message,
+                                                            newContent: newContent,
+                                                            in: conversation
+                                                        )
                                                     }
                                                 } : nil
                                         )
@@ -819,6 +816,50 @@ struct MacNewChatView: View {
                 tools: tools,
                 assistantMessageID: assistantMessage.id
         )
+    }
+
+    private func editMessageAndResend(
+        _ message: Message,
+        newContent: String,
+        in conversation: Conversation
+    ) {
+        guard let proposedHistory = ChatDraftContent.effectiveHistory(
+            byEditingUserMessage: message.id,
+            newContent: newContent,
+            in: conversation
+        ) else {
+            return
+        }
+
+        let resendModel = conversation.model
+        if aiService.getModelCapability(resendModel) != .imageGeneration {
+            if let supportError = aiService.attachmentHistorySupportError(
+                for: [resendModel],
+                messages: proposedHistory
+            ) {
+                errorMessage = supportError
+                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+                return
+            }
+            if let limitError = aiService.attachmentImageLimitError(
+                for: [resendModel],
+                messages: proposedHistory
+            ) {
+                errorMessage = limitError
+                errorRecoverySuggestion = "Remove images from the conversation or start a new conversation."
+                return
+            }
+        }
+
+        guard conversationManager.editMessage(
+            in: conversation,
+            messageId: message.id,
+            newContent: newContent
+        ), let updatedConversation = conversationManager.conversation(byId: conversation.id)
+        else {
+            return
+        }
+        sendMessageForConversation(updatedConversation, model: updatedConversation.model)
     }
 
     // MARK: - Image Generation

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -543,6 +543,14 @@ struct MacNewChatView: View {
             let requestModels = selectedModelsToSend.isEmpty
                 ? [activeModel]
                 : Array(selectedModelsToSend)
+            if let validationError = aiService.attachmentImageValidationError(
+                for: requestModels,
+                inMemoryAttachments: userMessage.attachments ?? []
+            ) {
+                errorMessage = validationError
+                errorRecoverySuggestion = "Remove the image or choose a different model."
+                return
+            }
             guard await validateAttachmentImageLimit(
                 for: userMessage,
                 conversationId: currentConversationId,

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 #if os(macOS)
 //
 //  MacNewChatView.swift
@@ -27,6 +28,7 @@ struct MacNewChatView: View {
     @State private var attachedFiles: [URL] = []
     @State private var pastedImages: [PastedImage] = []
     @State private var pasteImportSessionID = UUID()
+    @State private var isImportingPastedImages = false
     @State var isGenerating = false
     @State var currentConversationId: UUID?
     @State private var selectedModel = AIService.shared.selectedModel
@@ -260,6 +262,7 @@ struct MacNewChatView: View {
             attachedFiles: $attachedFiles,
             pastedImages: $pastedImages,
             pasteImportSessionID: $pasteImportSessionID,
+            isImportingPastedImages: $isImportingPastedImages,
             attachedAppContent: $attachedAppContent,
             selectedModels: $selectedModels,
             selectedModel: $selectedModel,
@@ -422,9 +425,7 @@ struct MacNewChatView: View {
             isComposerFocused = true
             return
         }
-
-        guard !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
-            !attachedFiles.isEmpty || !pastedImages.isEmpty else {
+        guard !isImportingPastedImages, ChatDraftContent.isSendable(text: messageText, fileURLs: attachedFiles, inMemoryImageCount: pastedImages.count) else {
             isComposerFocused = true
             return
         }
@@ -500,6 +501,14 @@ struct MacNewChatView: View {
                 saveToStorage: false
             )
             guard sendPreparationID == preparationID, !Task.isCancelled else { return }
+            guard ChatDraftContent.isSendable(
+                text: userMessage.content,
+                attachments: userMessage.attachments ?? []
+            ) else {
+                errorMessage = "Unable to load a supported image attachment."
+                errorRecoverySuggestion = "Choose a JPEG, PNG, GIF, or WebP image and try again."
+                return
+            }
 
         // Get or create the conversation
         let conversation: Conversation

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -19,7 +19,37 @@ struct MacNewChatView: View {
         let appContent: AppContent?
         let selectedModels: Set<String>
         let activeModel: String?
+        let prebuiltUserMessage: Message?
+        let consumesComposer: Bool
+
+        init(
+            text: String,
+            files: [URL],
+            pastedImages: [PastedImage],
+            appContent: AppContent?,
+            selectedModels: Set<String>,
+            activeModel: String?,
+            prebuiltUserMessage: Message? = nil,
+            consumesComposer: Bool = true
+        ) {
+            self.text = text
+            self.files = files
+            self.pastedImages = pastedImages
+            self.appContent = appContent
+            self.selectedModels = selectedModels
+            self.activeModel = activeModel
+            self.prebuiltUserMessage = prebuiltUserMessage
+            self.consumesComposer = consumesComposer
+        }
     }
+
+    private struct FailedSendPayload {
+        let text: String
+        let userMessage: Message
+        let selectedModels: Set<String>
+        let activeModel: String
+    }
+
     @EnvironmentObject var conversationManager: ConversationManager
     @ObservedObject var aiService = AIService.shared
     @Binding var selectedConversationId: UUID?
@@ -49,6 +79,7 @@ struct MacNewChatView: View {
     @State var errorMessage: String?
     @State var errorRecoverySuggestion: String?
     @State var shouldOfferOpenSettings = false
+    @State private var failedSendPayload: FailedSendPayload?
 
     // App content attachment (Attach from App)
     @State private var showAppContentPicker = false
@@ -213,6 +244,7 @@ struct MacNewChatView: View {
                         ErrorBannerView(
                             message: errorMessage,
                             recoverySuggestion: errorRecoverySuggestion,
+                            onRetry: failedSendPayload == nil ? nil : { retryFailedMessage() },
                             openSettingsTab: shouldOfferOpenSettings ? SettingsTab.models : nil,
                             onDismiss: { dismissError() },
                             identifierPrefix: "newchat.error"
@@ -438,6 +470,10 @@ struct MacNewChatView: View {
                 activeModel: resolveModelForSending()
             )
             pasteImportSessionID = UUID()
+            scheduleSend(preparation)
+        }
+
+        private func scheduleSend(_ preparation: SendPreparation) {
             let preparationID = UUID()
             sendPreparationID = preparationID
             isGenerating = true
@@ -448,10 +484,106 @@ struct MacNewChatView: View {
             sendPreparationTask = task
         }
 
+        private func retryFailedMessage() {
+            guard !isGenerating, sendPreparationTask == nil,
+                  let payload = failedSendPayload
+            else {
+                return
+            }
+
+            errorMessage = nil
+            errorRecoverySuggestion = nil
+            shouldOfferOpenSettings = false
+            scheduleSend(SendPreparation(
+                text: payload.text,
+                files: [],
+                pastedImages: [],
+                appContent: nil,
+                selectedModels: payload.selectedModels,
+                activeModel: payload.activeModel,
+                prebuiltUserMessage: payload.userMessage,
+                consumesComposer: false
+            ))
+        }
+
         func cancelSendPreparation() {
             sendPreparationTask?.cancel()
             sendPreparationTask = nil
             sendPreparationID = nil
+        }
+
+        private func discardStoredAttachments(in message: Message) {
+            for attachment in message.attachments ?? [] {
+                if let localPath = attachment.localPath {
+                    AttachmentStorage.shared.delete(path: localPath)
+                }
+            }
+        }
+
+        private func commitUserMessageIfNeeded(
+            _ userMessage: Message,
+            to conversation: Conversation,
+            consuming preparation: SendPreparation
+        ) -> Bool {
+            let reusesCommittedUserMessage = conversation.messages.contains { $0.id == userMessage.id }
+            if !reusesCommittedUserMessage {
+                conversationManager.addMessage(to: conversation, message: userMessage)
+                guard conversationManager.conversation(byId: conversation.id)?.messages.contains(where: {
+                    $0.id == userMessage.id
+                }) == true else {
+                    errorMessage = "Unable to save this message. Try again."
+                    return false
+                }
+
+                if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: userMessage.content) {
+                    logNewChat("💾 Memory command processed: \(memoryResponse)", level: .info)
+                }
+            }
+
+            if preparation.consumesComposer {
+                if messageText == preparation.text {
+                    messageText = ""
+                }
+                attachedFiles.removeAll { preparation.files.contains($0) }
+                let pastedImageIDs = Set(preparation.pastedImages.map(\.id))
+                pastedImages.removeAll { pastedImageIDs.contains($0.id) }
+                attachedAppContent = nil
+            }
+            isComposerFocused = true
+            return true
+        }
+
+        private func resolveConversation(
+            activeModel: String,
+            selectedModels: Set<String>
+        ) -> Conversation? {
+            let conversation: Conversation
+            if let existingId = currentConversationId,
+               let existingConversation = conversationManager.conversation(byId: existingId)
+            {
+                conversation = existingConversation
+                logNewChat(
+                    "📝 Continuing with existing conversation: \(existingId)",
+                    metadata: ["conversationId": existingId.uuidString]
+                )
+            } else {
+                conversationManager.createNewConversation()
+                guard let newConversation = conversationManager.conversations.first else { return nil }
+                conversation = newConversation
+                currentConversationId = newConversation.id
+                logNewChat(
+                    "🆕 Created new conversation: \(newConversation.id)",
+                    level: .info,
+                    metadata: ["conversationId": newConversation.id.uuidString]
+                )
+            }
+
+            conversationManager.updateModel(for: conversation, model: activeModel)
+            var updatedConversation = conversation
+            updatedConversation.activeModels = Array(selectedModels)
+            updatedConversation.multiModelEnabled = selectedModels.count > 1
+            conversationManager.updateConversation(updatedConversation)
+            return conversation
         }
 
         private func validateAttachmentImageLimit(
@@ -473,20 +605,36 @@ struct MacNewChatView: View {
                 existingMessages = []
             }
 
-            guard let limitError = aiService.attachmentImageLimitError(
+            let proposedMessages = ChatDraftContent.messagesByIncludingUserMessageIfNeeded(
+                userMessage,
+                in: existingMessages
+            )
+            if let supportError = aiService.attachmentHistorySupportError(
                 for: models,
-                messages: existingMessages + [userMessage]
-            ) else {
-                return true
+                messages: proposedMessages
+            ) {
+                errorMessage = supportError
+                errorRecoverySuggestion = "Choose a vision-capable cloud model or start a new conversation."
+                return false
             }
-            errorMessage = limitError
-            errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
-            return false
+            if let limitError = aiService.attachmentImageLimitError(
+                for: models,
+                messages: proposedMessages
+            ) {
+                errorMessage = limitError
+                errorRecoverySuggestion = "Remove images from the draft or start a new conversation."
+                return false
+            }
+            return true
         }
 
         private func sendMessage(preparationID: UUID, preparation: SendPreparation) async {
             var handedOff = false
+            var uncommittedUserMessage: Message?
             defer {
+                if let uncommittedUserMessage {
+                    discardStoredAttachments(in: uncommittedUserMessage)
+                }
                 if sendPreparationID == preparationID {
                     sendPreparationTask = nil
                     sendPreparationID = nil
@@ -511,7 +659,9 @@ struct MacNewChatView: View {
             let pastedImagesToSend = preparation.pastedImages
             let appContentToSend = preparation.appContent
             let selectedModelsToSend = preparation.selectedModels
-            if !filesToSend.isEmpty || !pastedImagesToSend.isEmpty {
+            if !filesToSend.isEmpty || !pastedImagesToSend.isEmpty
+                || preparation.prebuiltUserMessage?.attachments?.isEmpty == false
+            {
                 let attachmentModels = selectedModelsToSend.isEmpty ? [activeModel] : Array(selectedModelsToSend)
                 if let supportError = aiService.attachmentSupportError(for: attachmentModels) {
                     errorMessage = supportError
@@ -523,13 +673,19 @@ struct MacNewChatView: View {
 
             // Attachment construction is the only suspension in send preparation. Do it before
             // mutating conversation state, then recheck lifecycle ownership before committing.
-            let userMessage = await ChatMessageBuilder.createUserMessage(
-                text: textToSend,
-                appContent: appContentToSend,
-                fileURLs: filesToSend,
-                pastedImages: pastedImagesToSend,
-                saveToStorage: false
-            )
+            let userMessage: Message
+            if let prebuiltUserMessage = preparation.prebuiltUserMessage {
+                userMessage = prebuiltUserMessage
+            } else {
+                userMessage = await ChatMessageBuilder.createUserMessage(
+                    text: textToSend,
+                    appContent: appContentToSend,
+                    fileURLs: filesToSend,
+                    pastedImages: pastedImagesToSend,
+                    saveToStorage: true
+                )
+                uncommittedUserMessage = userMessage
+            }
             guard sendPreparationID == preparationID, !Task.isCancelled else { return }
             guard ChatDraftContent.isSendable(
                 text: userMessage.content,
@@ -543,10 +699,15 @@ struct MacNewChatView: View {
             let requestModels = selectedModelsToSend.isEmpty
                 ? [activeModel]
                 : Array(selectedModelsToSend)
-            if let validationError = aiService.attachmentImageValidationError(
+            let validationError = await aiService.attachmentImageValidationError(
                 for: requestModels,
-                inMemoryAttachments: userMessage.attachments ?? []
-            ) {
+                loading: userMessage.attachments ?? [],
+                loadAttachmentData: { path in
+                    await AttachmentStorage.shared.loadData(path: path)
+                }
+            )
+            guard sendPreparationID == preparationID, !Task.isCancelled else { return }
+            if let validationError {
                 errorMessage = validationError
                 errorRecoverySuggestion = "Remove the image or choose a different model."
                 return
@@ -556,42 +717,12 @@ struct MacNewChatView: View {
                 conversationId: currentConversationId,
                 models: requestModels
             ) else { return }
+            guard sendPreparationID == preparationID, !Task.isCancelled else { return }
 
-        // Get or create the conversation
-        let conversation: Conversation
-        if let existingId = currentConversationId,
-           let existingConversation = conversationManager.conversations.first(where: {
-               $0.id == existingId
-           })
-        {
-            // Continue with existing conversation
-            conversation = existingConversation
-            logNewChat(
-                "📝 Continuing with existing conversation: \(existingId)",
-                metadata: ["conversationId": existingId.uuidString]
-            )
-        } else {
-            // Create a new conversation
-            conversationManager.createNewConversation()
-            guard let newConversation = conversationManager.conversations.first else {
-                return
-            }
-            conversation = newConversation
-            currentConversationId = newConversation.id
-            logNewChat(
-                "🆕 Created new conversation: \(newConversation.id)",
-                level: .info,
-                metadata: ["conversationId": newConversation.id.uuidString]
-            )
-        }
-
-        conversationManager.updateModel(for: conversation, model: activeModel)
-
-        // Update conversation with multi-model settings
-        var updatedConversation = conversation
-        updatedConversation.activeModels = Array(selectedModelsToSend)
-        updatedConversation.multiModelEnabled = selectedModelsToSend.count > 1
-        conversationManager.updateConversation(updatedConversation)
+            guard let conversation = resolveConversation(
+                activeModel: activeModel,
+                selectedModels: selectedModelsToSend
+            ) else { return }
 
             if appContentToSend != nil {
             logNewChat(
@@ -605,22 +736,18 @@ struct MacNewChatView: View {
             )
         }
 
-        conversationManager.addMessage(to: conversation, message: userMessage)
-
-        // Process memory commands (e.g., "remember that I prefer dark mode")
-        if let memoryResponse = MemoryContextProvider.shared.processMemoryCommand(in: userMessage.content) {
-            logNewChat("💾 Memory command processed: \(memoryResponse)", level: .info)
-        }
-
-        // Clear input first
-        if messageText == textToSend {
-            messageText = ""
-        }
-        isComposerFocused = true
-        attachedFiles.removeAll { filesToSend.contains($0) }
-        let pastedImageIDs = Set(pastedImagesToSend.map(\.id))
-        pastedImages.removeAll { pastedImageIDs.contains($0.id) }
-        attachedAppContent = nil // Clear app content after sending
+            guard commitUserMessageIfNeeded(
+                userMessage,
+                to: conversation,
+                consuming: preparation
+            ) else { return }
+            uncommittedUserMessage = nil
+            failedSendPayload = FailedSendPayload(
+                text: textToSend,
+                userMessage: userMessage,
+                selectedModels: selectedModelsToSend,
+                activeModel: activeModel
+            )
 
         // DON'T switch views yet - stay in NewChatView so the stop button remains visible
         // The view switch will happen in the completion handler after generation finishes
@@ -745,6 +872,7 @@ struct MacNewChatView: View {
 
                 guard coordinator.finishOperation(operationID) else { return }
                 isGenerating = false
+                failedSendPayload = nil
                 selectedConversationId = conversation.id
             }
         }
@@ -943,8 +1071,16 @@ struct MacNewChatView: View {
         guard counter.isComplete, coordinator.finishOperation(operationID) else { return }
         if let conversation = conversationManager.conversation(byId: conversationID) {
             conversationManager.save(conversation)
+            if let group = conversation.responseGroups.last,
+               group.responses.allSatisfy({ $0.status == .failed })
+            {
+                isGenerating = false
+                errorMessage = errorMessage ?? "All models failed"
+                return
+            }
         }
         isGenerating = false
+        failedSendPayload = nil
         selectedConversationId = conversationID
     }
 
@@ -1042,6 +1178,15 @@ struct MacNewChatView: View {
                     }
                         activeMultiModelResponseGroupID = nil
                         guard coordinator.finishOperation(operationID) else { return }
+
+                        if let conversation = conversationManager.conversation(byId: conversationId),
+                           let group = conversation.getResponseGroup(responseGroupId),
+                           group.responses.allSatisfy({ $0.status == .failed })
+                        {
+                            errorMessage = errorMessage ?? "All models failed"
+                            return
+                        }
+                        failedSendPayload = nil
 
                     // Switch to chat view
                     selectedConversationId = conversationId
@@ -1369,6 +1514,7 @@ struct MacNewChatView: View {
                     currentToolName = nil
                 toolCallDepth = 0
                     isGenerating = false
+                failedSendPayload = nil
                     logNewChat(
                     "✅ Initial message finished streaming, switching to ChatView",
                         level: .info,
@@ -1448,6 +1594,7 @@ struct MacNewChatView: View {
     }
 
     private func dismissError() {
+        failedSendPayload = nil
         errorMessage = nil
         errorRecoverySuggestion = nil
         shouldOfferOpenSettings = false

--- a/Tests/AynaIOSUITests/IOSSmokeUITests.swift
+++ b/Tests/AynaIOSUITests/IOSSmokeUITests.swift
@@ -1,3 +1,4 @@
+import UIKit
 import XCTest
 
 /// Smoke tests for iOS app - covers critical user flows
@@ -42,6 +43,44 @@ final class IOSSmokeUITests: IOSUITestCase {
     }
 
     // MARK: - Conversation Tests
+
+    func testComposerPastesImagesAndPlainText() throws {
+        try skipIfNavigationBroken()
+
+        let pasteboard = UIPasteboard.general
+        pasteboard.items = []
+        defer { pasteboard.items = [] }
+
+        let composer = try XCTUnwrap(
+            app.waitForTextInput(
+                identifier: "newchat.composer.textEditor",
+                timeout: UITestTimeout.normal
+            )
+        )
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 8, height: 8)).image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 8, height: 8))
+        }
+        pasteboard.image = image
+
+        pasteFromEditMenu(into: composer)
+
+        let attachments = app.descendants(matching: .any)["newchat.composer.attachmentsList"]
+        XCTAssertTrue(
+            attachments.waitForExistence(timeout: UITestTimeout.async),
+            "Image paste should create a composer attachment"
+        )
+        XCTAssertTrue(
+            app.buttons["newchat.composer.sendButton"].waitForExistence(timeout: UITestTimeout.normal),
+            "Image-only paste should enable sending"
+        )
+
+        let pastedText = "Plain clipboard text"
+        pasteboard.string = pastedText
+        pasteFromEditMenu(into: composer)
+
+        XCTAssertEqual(composer.value as? String, pastedText)
+    }
 
     /// Combined test: verifies conversation creation, response, and sidebar listing
     func testNewConversationCreationAndSidebarListing() throws {
@@ -174,6 +213,24 @@ final class IOSSmokeUITests: IOSUITestCase {
         let welcomeText = app.staticTexts["How can I help you?"]
         let hasEmptyState = emptyState.waitForExistence(timeout: UITestTimeout.normal) || welcomeText.waitForExistence(timeout: UITestTimeout.normal)
         XCTAssertTrue(hasEmptyState, "Empty state or welcome view should be visible after navigating to new chat")
+    }
+
+    private func pasteFromEditMenu(into element: XCUIElement) {
+        element.tap()
+        element.press(forDuration: 1)
+
+        let pasteMenuItem = app.menuItems["Paste"]
+        if pasteMenuItem.waitForExistence(timeout: UITestTimeout.immediate) {
+            pasteMenuItem.tap()
+            return
+        }
+
+        let pasteButton = app.buttons["Paste"]
+        XCTAssertTrue(
+            pasteButton.waitForExistence(timeout: UITestTimeout.immediate),
+            "Paste should be available in the edit menu"
+        )
+        pasteButton.tap()
     }
 }
 

--- a/Tests/AynaIOSUITests/IOSSmokeUITests.swift
+++ b/Tests/AynaIOSUITests/IOSSmokeUITests.swift
@@ -1,4 +1,5 @@
 import UIKit
+import UniformTypeIdentifiers
 import XCTest
 
 /// Smoke tests for iOS app - covers critical user flows
@@ -44,7 +45,7 @@ final class IOSSmokeUITests: IOSUITestCase {
 
     // MARK: - Conversation Tests
 
-    func testComposerPastesImagesAndPlainText() throws {
+    func testComposerPastesImagesPlainTextAndMixedContent() throws {
         try skipIfNavigationBroken()
 
         let pasteboard = UIPasteboard.general
@@ -80,6 +81,31 @@ final class IOSSmokeUITests: IOSUITestCase {
         pasteFromEditMenu(into: composer)
 
         XCTAssertEqual(composer.value as? String, pastedText)
+
+        let attachmentPredicate = NSPredicate(
+            format: "identifier BEGINSWITH %@ AND NOT identifier CONTAINS %@",
+            "newchat.composer.attachment.",
+            ".remove."
+        )
+        let attachmentElements = app.descendants(matching: .any).matching(attachmentPredicate)
+        let nextAttachment = attachmentElements.element(boundBy: attachmentElements.count)
+        let mixedText = " plus mixed clipboard text"
+        let mixedImageData = try XCTUnwrap(image.pngData())
+        pasteboard.items = [[
+            UTType.png.identifier: mixedImageData,
+            UTType.plainText.identifier: mixedText,
+        ]]
+
+        pasteFromEditMenu(into: composer)
+
+        XCTAssertTrue(
+            nextAttachment.waitForExistence(timeout: UITestTimeout.async),
+            "Mixed paste should import its image representation"
+        )
+        XCTAssertTrue(
+            (composer.value as? String)?.contains(mixedText) == true,
+            "Mixed paste should preserve its text representation"
+        )
     }
 
     /// Combined test: verifies conversation creation, response, and sidebar listing

--- a/Tests/AynaTests/AIServiceAppleIntelligenceTests.swift
+++ b/Tests/AynaTests/AIServiceAppleIntelligenceTests.swift
@@ -229,6 +229,43 @@ import Testing
             second.complete()
         }
 
+        @Test("Apple requests reject attachments anywhere in message history")
+        func appleRequestsRejectAttachmentsAnywhereInMessageHistory() async {
+            let appleService = FlightTestAppleIntelligenceService()
+            let service = AIService(appleIntelligenceService: appleService)
+            let model = "apple-attachments"
+            configureAppleModels([model], on: service)
+            var attachedHistoryMessage = Message(role: .user, content: "Earlier image")
+            attachedHistoryMessage.attachments = [
+                Message.FileAttachment(
+                    fileName: "pasted-image.png",
+                    mimeType: "image/png",
+                    data: Data([0x89]),
+                    localPath: nil
+                ),
+            ]
+
+            await confirmation("Error callback invoked") { errorReceived in
+                _ = service.sendMessage(
+                    messages: [
+                        attachedHistoryMessage,
+                        Message(role: .assistant, content: "Earlier response"),
+                        Message(role: .user, content: "Latest question"),
+                    ],
+                    model: model,
+                    onChunk: { chunk in Issue.record("Unexpected chunk: \(chunk)") },
+                    onComplete: { Issue.record("Unexpected completion") },
+                    onError: { error in
+                        #expect(error.localizedDescription ==
+                            "Apple Intelligence does not support attachments. Choose a vision-capable cloud model.")
+                        errorReceived()
+                    }
+                )
+            }
+
+            #expect(appleService.requests.isEmpty)
+        }
+
         @Test("Apple tool continuation preserves matched calls and drops orphaned calls", .timeLimit(.minutes(1)))
         func appleToolContinuationPreservesMatchedCallsAndDropsOrphans() async throws {
             let appleService = FlightTestAppleIntelligenceService()

--- a/Tests/AynaTests/AIServiceTests.swift
+++ b/Tests/AynaTests/AIServiceTests.swift
@@ -71,6 +71,18 @@ extension AIServiceGlobalStateTests {
                 retried,
                 in: [retried]
             )
+            let unsupportedLabeledImages = Message(
+                role: .user,
+                content: "",
+                attachments: Array(
+                    repeating: Message.FileAttachment(
+                        fileName: "image.heic",
+                        mimeType: "image/heic",
+                        data: Data(repeating: 0, count: 12)
+                    ),
+                    count: AnthropicRequestBuilder.maxImagesPerRequest + 1
+                )
+            )
 
             #expect(service.attachmentImageLimitError(
                 for: [anthropicModel],
@@ -89,6 +101,10 @@ extension AIServiceGlobalStateTests {
                 for: [anthropicModel],
                 messages: retryHistory
             ) == nil)
+            #expect(service.attachmentImageLimitError(
+                for: [anthropicModel],
+                messages: [unsupportedLabeledImages]
+            ) == "Anthropic supports at most 20 images per request. Remove some images or start a new conversation.")
         }
 
         @Test
@@ -146,13 +162,33 @@ extension AIServiceGlobalStateTests {
                 mimeType: "image/jpeg",
                 localPath: "stored.jpg"
             )
+            let unsupportedAttachment = Message.FileAttachment(
+                fileName: "photo.heic",
+                mimeType: "image/heic",
+                data: Data(repeating: 0, count: 12)
+            )
             #expect(service.attachmentImageValidationError(
                 for: [anthropicModel],
                 inMemoryAttachments: [inlineAttachment]
             )?.contains("Image too large") == true)
+            #expect(service.attachmentImageValidationError(
+                for: [anthropicModel],
+                inMemoryAttachments: [unsupportedAttachment]
+            )?.contains("Unsupported image format") == true)
             #expect(await service.attachmentImageValidationError(
                 for: [anthropicModel],
                 loading: [storedAttachment],
+                loadAttachmentData: { path in
+                    path == "stored.jpg" ? oversizedImageData : nil
+                }
+            )?.contains("Image too large") == true)
+            #expect(await service.attachmentImageValidationError(
+                for: [anthropicModel],
+                in: [Message(
+                    role: .user,
+                    content: "Earlier image",
+                    attachments: [storedAttachment]
+                )],
                 loadAttachmentData: { path in
                     path == "stored.jpg" ? oversizedImageData : nil
                 }

--- a/Tests/AynaTests/AIServiceTests.swift
+++ b/Tests/AynaTests/AIServiceTests.swift
@@ -92,6 +92,37 @@ extension AIServiceGlobalStateTests {
         }
 
         @Test
+        func `Apple Intelligence attachment history is rejected before dispatch`() {
+            let service = makeService()
+            let appleModel = "apple-test"
+            let openAIModel = "openai-test"
+            service.modelProviders[appleModel] = .appleIntelligence
+            service.modelProviders[openAIModel] = .openai
+            let imageMessage = Message(
+                role: .user,
+                content: "",
+                attachments: [Message.FileAttachment(
+                    fileName: "image.png",
+                    mimeType: "image/png",
+                    data: Data([0x89, 0x50, 0x4E, 0x47])
+                )]
+            )
+
+            #expect(service.attachmentHistorySupportError(
+                for: [appleModel],
+                messages: [imageMessage, Message(role: .user, content: "Continue")]
+            ) == "Apple Intelligence does not support attachments. Choose a vision-capable cloud model.")
+            #expect(service.attachmentHistorySupportError(
+                for: [openAIModel],
+                messages: [imageMessage]
+            ) == nil)
+            #expect(service.attachmentHistorySupportError(
+                for: [appleModel],
+                messages: [Message(role: .user, content: "Text only")]
+            ) == nil)
+        }
+
+        @Test
         func `Anthropic image bytes are validated before request dispatch`() async {
             let service = makeService()
             let anthropicModel = "claude-test"
@@ -115,19 +146,16 @@ extension AIServiceGlobalStateTests {
                 mimeType: "image/jpeg",
                 localPath: "stored.jpg"
             )
-            let originalLoader = Message.attachmentAsyncLoader
-            Message.attachmentAsyncLoader = { path in
-                path == "stored.jpg" ? oversizedImageData : nil
-            }
-            defer { Message.attachmentAsyncLoader = originalLoader }
-
             #expect(service.attachmentImageValidationError(
                 for: [anthropicModel],
                 inMemoryAttachments: [inlineAttachment]
             )?.contains("Image too large") == true)
             #expect(await service.attachmentImageValidationError(
                 for: [anthropicModel],
-                loading: [storedAttachment]
+                loading: [storedAttachment],
+                loadAttachmentData: { path in
+                    path == "stored.jpg" ? oversizedImageData : nil
+                }
             )?.contains("Image too large") == true)
             #expect(service.attachmentImageValidationError(
                 for: [openAIModel],

--- a/Tests/AynaTests/AIServiceTests.swift
+++ b/Tests/AynaTests/AIServiceTests.swift
@@ -139,12 +139,14 @@ extension AIServiceGlobalStateTests {
         }
 
         @Test
-        func `Anthropic image bytes are validated before request dispatch`() async {
+        func `provider image bytes are validated before request dispatch`() async throws {
             let service = makeService()
             let anthropicModel = "claude-test"
             let openAIModel = "openai-test"
             service.modelProviders[anthropicModel] = .anthropic
             service.modelProviders[openAIModel] = .openai
+            let validPNGData = try #require(Data(base64Encoded:
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="))
 
             var oversizedJPEG = Data([0xFF, 0xD8, 0xFF, 0xE0, 0, 0, 0, 0, 0, 0, 0, 0])
             oversizedJPEG.append(Data(
@@ -167,11 +169,21 @@ extension AIServiceGlobalStateTests {
                 mimeType: "image/heic",
                 data: Data(repeating: 0, count: 12)
             )
-            #expect(service.attachmentImageValidationError(
+            let validAttachment = Message.FileAttachment(
+                fileName: "valid.png",
+                mimeType: "image/png",
+                data: validPNGData
+            )
+            let mismatchedAttachment = Message.FileAttachment(
+                fileName: "renamed.jpg",
+                mimeType: "image/jpeg",
+                data: validPNGData
+            )
+            #expect(await service.attachmentImageValidationError(
                 for: [anthropicModel],
                 inMemoryAttachments: [inlineAttachment]
             )?.contains("Image too large") == true)
-            #expect(service.attachmentImageValidationError(
+            #expect(await service.attachmentImageValidationError(
                 for: [anthropicModel],
                 inMemoryAttachments: [unsupportedAttachment]
             )?.contains("Unsupported image format") == true)
@@ -193,10 +205,18 @@ extension AIServiceGlobalStateTests {
                     path == "stored.jpg" ? oversizedImageData : nil
                 }
             )?.contains("Image too large") == true)
-            #expect(service.attachmentImageValidationError(
+            #expect(await service.attachmentImageValidationError(
                 for: [openAIModel],
                 inMemoryAttachments: [inlineAttachment]
+            )?.contains("invalid or corrupted") == true)
+            #expect(await service.attachmentImageValidationError(
+                for: [openAIModel],
+                inMemoryAttachments: [validAttachment]
             ) == nil)
+            #expect(await service.attachmentImageValidationError(
+                for: [openAIModel],
+                inMemoryAttachments: [mismatchedAttachment]
+            )?.contains("does not match") == true)
         }
 
         @Test

--- a/Tests/AynaTests/AIServiceTests.swift
+++ b/Tests/AynaTests/AIServiceTests.swift
@@ -62,6 +62,15 @@ extension AIServiceGlobalStateTests {
                     count: AnthropicRequestBuilder.maxImagesPerRequest + 1
                 )
             )
+            let retried = Message(
+                role: .user,
+                content: "Retry",
+                attachments: Array(repeating: attachment, count: 11)
+            )
+            let retryHistory = ChatDraftContent.messagesByIncludingUserMessageIfNeeded(
+                retried,
+                in: [retried]
+            )
 
             #expect(service.attachmentImageLimitError(
                 for: [anthropicModel],
@@ -74,6 +83,55 @@ extension AIServiceGlobalStateTests {
             #expect(service.attachmentImageLimitError(
                 for: [openAIModel],
                 messages: [exceeding]
+            ) == nil)
+            #expect(retryHistory.first?.attachments?.count == 11)
+            #expect(service.attachmentImageLimitError(
+                for: [anthropicModel],
+                messages: retryHistory
+            ) == nil)
+        }
+
+        @Test
+        func `Anthropic image bytes are validated before request dispatch`() async {
+            let service = makeService()
+            let anthropicModel = "claude-test"
+            let openAIModel = "openai-test"
+            service.modelProviders[anthropicModel] = .anthropic
+            service.modelProviders[openAIModel] = .openai
+
+            var oversizedJPEG = Data([0xFF, 0xD8, 0xFF, 0xE0, 0, 0, 0, 0, 0, 0, 0, 0])
+            oversizedJPEG.append(Data(
+                repeating: 0,
+                count: AnthropicRequestBuilder.maxImageSizeBytes
+            ))
+            let oversizedImageData = oversizedJPEG
+            let inlineAttachment = Message.FileAttachment(
+                fileName: "large.jpg",
+                mimeType: "image/jpeg",
+                data: oversizedImageData
+            )
+            let storedAttachment = Message.FileAttachment(
+                fileName: "stored.jpg",
+                mimeType: "image/jpeg",
+                localPath: "stored.jpg"
+            )
+            let originalLoader = Message.attachmentAsyncLoader
+            Message.attachmentAsyncLoader = { path in
+                path == "stored.jpg" ? oversizedImageData : nil
+            }
+            defer { Message.attachmentAsyncLoader = originalLoader }
+
+            #expect(service.attachmentImageValidationError(
+                for: [anthropicModel],
+                inMemoryAttachments: [inlineAttachment]
+            )?.contains("Image too large") == true)
+            #expect(await service.attachmentImageValidationError(
+                for: [anthropicModel],
+                loading: [storedAttachment]
+            )?.contains("Image too large") == true)
+            #expect(service.attachmentImageValidationError(
+                for: [openAIModel],
+                inMemoryAttachments: [inlineAttachment]
             ) == nil)
         }
 

--- a/Tests/AynaTests/AIServiceTests.swift
+++ b/Tests/AynaTests/AIServiceTests.swift
@@ -35,6 +35,49 @@ extension AIServiceGlobalStateTests {
         }
 
         @Test
+        func `Anthropic image limit is validated across request history`() {
+            let service = makeService()
+            let anthropicModel = "claude-test"
+            let openAIModel = "openai-test"
+            service.modelProviders[anthropicModel] = .anthropic
+            service.modelProviders[openAIModel] = .openai
+            let attachment = Message.FileAttachment(
+                fileName: "image.png",
+                mimeType: "image/png",
+                data: Data([0x89, 0x50, 0x4E, 0x47])
+            )
+            let allowed = Message(
+                role: .user,
+                content: "",
+                attachments: Array(
+                    repeating: attachment,
+                    count: AnthropicRequestBuilder.maxImagesPerRequest
+                )
+            )
+            let exceeding = Message(
+                role: .user,
+                content: "",
+                attachments: Array(
+                    repeating: attachment,
+                    count: AnthropicRequestBuilder.maxImagesPerRequest + 1
+                )
+            )
+
+            #expect(service.attachmentImageLimitError(
+                for: [anthropicModel],
+                messages: [allowed]
+            ) == nil)
+            #expect(service.attachmentImageLimitError(
+                for: [anthropicModel],
+                messages: [exceeding]
+            ) == "Anthropic supports at most 20 images per request. Remove some images or start a new conversation.")
+            #expect(service.attachmentImageLimitError(
+                for: [openAIModel],
+                messages: [exceeding]
+            ) == nil)
+        }
+
+        @Test
         func `An unrecognized default provider cannot route inherited models`() throws {
             let inheritedModel = "future-inherited"
             let explicitModel = "valid-explicit"

--- a/Tests/AynaTests/AppContentTests.swift
+++ b/Tests/AynaTests/AppContentTests.swift
@@ -32,6 +32,44 @@
             #expect(!truncated.isTruncated)
         }
 
+        @Test("Attachment payload comparison ignores display icon identity")
+        func attachmentPayloadComparison() {
+            let first = AppContent(
+                appName: "Test",
+                appIcon: nil,
+                bundleIdentifier: "com.test",
+                windowTitle: "Window",
+                content: "Captured content",
+                contentType: .selectedText,
+                isTruncated: false,
+                originalLength: 16
+            )
+            let samePayload = AppContent(
+                appName: first.appName,
+                appIcon: nil,
+                bundleIdentifier: first.bundleIdentifier,
+                windowTitle: first.windowTitle,
+                content: first.content,
+                contentType: first.contentType,
+                isTruncated: first.isTruncated,
+                originalLength: first.originalLength
+            )
+            let replacement = AppContent(
+                appName: first.appName,
+                appIcon: nil,
+                bundleIdentifier: first.bundleIdentifier,
+                windowTitle: first.windowTitle,
+                content: "Newer captured content",
+                contentType: first.contentType,
+                isTruncated: false,
+                originalLength: 22
+            )
+
+            #expect(AppContent.hasSamePayload(nil, nil))
+            #expect(AppContent.hasSamePayload(first, samePayload))
+            #expect(!AppContent.hasSamePayload(first, replacement))
+        }
+
         @Test("Truncation of long content")
         func truncationLongContent() {
             let longContent = String(repeating: "a", count: 5000)

--- a/Tests/AynaTests/AttachmentStorageTests.swift
+++ b/Tests/AynaTests/AttachmentStorageTests.swift
@@ -20,6 +20,33 @@ struct AttachmentStorageTests {
     }
 
     @Test
+    func `cancelled async attachment save exits before disk I O`() async throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let storage = AttachmentStorage(
+            directoryURL: directory,
+            dataCache: AttachmentDataCache()
+        )
+
+        let wasCancelled = await Task.detached { () -> Bool in
+            withUnsafeCurrentTask { $0?.cancel() }
+            do {
+                _ = try await storage.saveData(
+                    data: Data(repeating: 0xA5, count: 2 * 1_048_576),
+                    extension: "bin"
+                )
+                return false
+            } catch is CancellationError {
+                return true
+            } catch {
+                return false
+            }
+        }.value
+
+        #expect(wasCancelled)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+    }
+
+    @Test
     func `async message and attachment helpers load stored data`() async throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
         let storage = AttachmentStorage(

--- a/Tests/AynaTests/ChatDraftContentTests.swift
+++ b/Tests/AynaTests/ChatDraftContentTests.swift
@@ -46,6 +46,24 @@ struct ChatDraftContentTests {
     }
 
     @Test
+    func `remaining image capacity counts draft images across sources`() {
+        let fileURLs = [
+            URL(fileURLWithPath: "/tmp/photo.png"),
+            URL(fileURLWithPath: "/tmp/notes.txt"),
+            URL(fileURLWithPath: "/tmp/second.webp"),
+        ]
+
+        #expect(ChatDraftContent.remainingImageCapacity(
+            fileURLs: fileURLs,
+            inMemoryImageCount: 3
+        ) == ChatDraftContent.maximumImageCount - 5)
+        #expect(ChatDraftContent.remainingImageCapacity(
+            fileURLs: fileURLs,
+            inMemoryImageCount: ChatDraftContent.maximumImageCount
+        ) == 0)
+    }
+
+    @Test
     func `built non-image attachments alone are not sendable`() {
         let attachments = [
             Message.FileAttachment(

--- a/Tests/AynaTests/ChatDraftContentTests.swift
+++ b/Tests/AynaTests/ChatDraftContentTests.swift
@@ -70,4 +70,22 @@ struct ChatDraftContentTests {
 
         #expect(ChatDraftContent.isSendable(text: "", attachments: attachments))
     }
+
+    @Test
+    func `request history includes a user message only once by identity`() {
+        let userMessage = Message(role: .user, content: "Retry me")
+        let assistantMessage = Message(role: .assistant, content: "")
+
+        let appended = ChatDraftContent.messagesByIncludingUserMessageIfNeeded(
+            userMessage,
+            in: [assistantMessage]
+        )
+        let reused = ChatDraftContent.messagesByIncludingUserMessageIfNeeded(
+            userMessage,
+            in: [userMessage, assistantMessage]
+        )
+
+        #expect(appended.map(\.id) == [assistantMessage.id, userMessage.id])
+        #expect(reused.map(\.id) == [userMessage.id, assistantMessage.id])
+    }
 }

--- a/Tests/AynaTests/ChatDraftContentTests.swift
+++ b/Tests/AynaTests/ChatDraftContentTests.swift
@@ -1,0 +1,73 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("Chat Draft Content Tests", .tags(.fast))
+struct ChatDraftContentTests {
+    @Test
+    func `non-image attachments alone are not sendable`() {
+        let fileURLs = [
+            URL(fileURLWithPath: "/tmp/notes.txt"),
+            URL(fileURLWithPath: "/tmp/document.pdf"),
+        ]
+
+        #expect(!ChatDraftContent.isSendable(
+            text: " \n ",
+            fileURLs: fileURLs,
+            inMemoryImageCount: 0
+        ))
+    }
+
+    @Test
+    func `image attachment alone is sendable`() {
+        #expect(ChatDraftContent.isSendable(
+            text: "",
+            fileURLs: [URL(fileURLWithPath: "/tmp/photo.PNG")],
+            inMemoryImageCount: 0
+        ))
+    }
+
+    @Test
+    func `text alone is sendable`() {
+        #expect(ChatDraftContent.isSendable(
+            text: " Describe this ",
+            fileURLs: [],
+            inMemoryImageCount: 0
+        ))
+    }
+
+    @Test
+    func `in-memory image alone is sendable`() {
+        #expect(ChatDraftContent.isSendable(
+            text: "",
+            fileURLs: [],
+            inMemoryImageCount: 1
+        ))
+    }
+
+    @Test
+    func `built non-image attachments alone are not sendable`() {
+        let attachments = [
+            Message.FileAttachment(
+                fileName: "document.pdf",
+                mimeType: "application/pdf",
+                data: Data("document".utf8)
+            ),
+        ]
+
+        #expect(!ChatDraftContent.isSendable(text: "", attachments: attachments))
+    }
+
+    @Test
+    func `built provider image attachment alone is sendable`() {
+        let attachments = [
+            Message.FileAttachment(
+                fileName: "photo.png",
+                mimeType: "image/png",
+                data: Data([0x89, 0x50, 0x4E, 0x47])
+            ),
+        ]
+
+        #expect(ChatDraftContent.isSendable(text: "", attachments: attachments))
+    }
+}

--- a/Tests/AynaTests/ChatDraftContentTests.swift
+++ b/Tests/AynaTests/ChatDraftContentTests.swift
@@ -106,4 +106,28 @@ struct ChatDraftContentTests {
         #expect(appended.map(\.id) == [assistantMessage.id, userMessage.id])
         #expect(reused.map(\.id) == [userMessage.id, assistantMessage.id])
     }
+
+    @Test
+    func `edited history changes the target and excludes later messages without mutation`() throws {
+        let userMessage = Message(role: .user, content: "Original")
+        let assistantMessage = Message(role: .assistant, content: "Old response")
+        var conversation = Conversation(model: "test-model", systemPromptMode: .disabled)
+        conversation.messages = [userMessage, assistantMessage]
+
+        let history = try #require(ChatDraftContent.effectiveHistory(
+            byEditingUserMessage: userMessage.id,
+            newContent: "Replacement",
+            in: conversation
+        ))
+
+        #expect(history.count == 1)
+        #expect(history.first?.id == userMessage.id)
+        #expect(history.first?.content == "Replacement")
+        #expect(conversation.messages == [userMessage, assistantMessage])
+        #expect(ChatDraftContent.effectiveHistory(
+            byEditingUserMessage: assistantMessage.id,
+            newContent: "Invalid",
+            in: conversation
+        ) == nil)
+    }
 }

--- a/Tests/AynaTests/ChatMessageBuilderTests.swift
+++ b/Tests/AynaTests/ChatMessageBuilderTests.swift
@@ -7,6 +7,69 @@ import Testing
     @MainActor
     struct ChatMessageBuilderTests {
         @Test
+        func `user message keeps pasted image bytes inline`() async throws {
+            let firstImageData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A])
+            let secondImageData = Data([0x89, 0x50, 0x4E, 0x47, 0x01, 0x02])
+            let firstPastedImage = PastedImage(
+                data: firstImageData,
+                mimeType: "image/png",
+                fileExtension: "png"
+            )
+            let secondPastedImage = PastedImage(
+                data: secondImageData,
+                mimeType: "image/png",
+                fileExtension: "png"
+            )
+
+            let message = await ChatMessageBuilder.createUserMessage(
+                text: "",
+                appContent: nil,
+                fileURLs: [],
+                pastedImages: [firstPastedImage, secondPastedImage]
+            )
+            let attachments = try #require(message.attachments)
+
+            #expect(message.content.isEmpty)
+            #expect(attachments.count == 2)
+            #expect(Set(attachments.map(\.fileName)).count == 2)
+            #expect(attachments.allSatisfy { $0.fileName.hasSuffix(".png") })
+            #expect(attachments.allSatisfy { $0.mimeType == "image/png" })
+            #expect(attachments.map(\.data) == [firstImageData, secondImageData])
+            #expect(attachments.allSatisfy { $0.localPath == nil })
+        }
+
+        @Test
+        func `pasted image is saved to attachment storage when requested`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let storage = AttachmentStorage(
+                directoryURL: directory,
+                dataCache: AttachmentDataCache()
+            )
+            let imageData = Data([0xFF, 0xD8, 0xFF, 0xE0])
+            let pastedImage = PastedImage(
+                data: imageData,
+                mimeType: "image/jpeg",
+                fileExtension: "jpg"
+            )
+
+            let attachments = await ChatMessageBuilder.buildAttachments(
+                from: [],
+                pastedImages: [pastedImage],
+                saveToStorage: true,
+                attachmentStorage: storage
+            )
+            let attachment = try #require(attachments.first)
+            let localPath = try #require(attachment.localPath)
+
+            #expect(attachments.count == 1)
+            #expect(attachment.fileName.hasSuffix(".jpg"))
+            #expect(attachment.mimeType == "image/jpeg")
+            #expect(attachment.data == nil)
+            #expect(localPath.hasSuffix(".jpg"))
+            #expect(storage.load(path: localPath) == imageData)
+        }
+
+        @Test
         func `fenced attachment storage falls back to inline bytes`() async throws {
             let directory = try TestHelpers.makeTemporaryDirectory()
             let storage = AttachmentStorage(

--- a/Tests/AynaTests/ChatTranscriptPlanTests.swift
+++ b/Tests/AynaTests/ChatTranscriptPlanTests.swift
@@ -20,6 +20,29 @@ struct ChatTranscriptPlanTests {
     }
 
     @Test
+    func `plan shows attachment-only user messages`() {
+        let message = Message(
+            role: .user,
+            content: "",
+            attachments: [
+                Message.FileAttachment(
+                    fileName: "pasted-image.png",
+                    mimeType: "image/png",
+                    data: Data([0x89, 0x50, 0x4E, 0x47]),
+                    localPath: nil
+                )
+            ]
+        )
+        let conversation = Conversation(messages: [message])
+
+        let plan = ChatTranscriptPlan(conversation: conversation, isGenerating: false)
+
+        let expected = ChatTranscriptMessage(message: message, displayKind: .text)
+        #expect(plan.visibleMessages == [expected])
+        #expect(plan.items == [.message(expected)])
+    }
+
+    @Test
     func `plan hides empty assistant tool-call placeholders`() {
         #if !os(watchOS)
             var placeholder = Message(role: .assistant, content: "")

--- a/Tests/AynaTests/ConversationEffectiveHistoryTests.swift
+++ b/Tests/AynaTests/ConversationEffectiveHistoryTests.swift
@@ -122,7 +122,7 @@ struct ConversationEffectiveHistoryTests {
     }
 
     @Test
-    func `replacement response group removes failed partials for the same user turn`() {
+    func `explicit replacement removes failed partials for the same user turn`() {
         let user = Message(role: .user, content: "Question")
         let failedGroupID = UUID()
         let failedPartial = Message(
@@ -169,6 +169,7 @@ struct ConversationEffectiveHistoryTests {
             responseGroups: [failedGroup, unrelatedGroup]
         )
 
+        conversation.removeFailedResponseGroups(for: user.id)
         conversation.addResponseGroup(replacementGroup)
 
         #expect(conversation.responseGroups.map(\.id) == [unrelatedGroupID, replacementGroupID])
@@ -183,6 +184,24 @@ struct ConversationEffectiveHistoryTests {
             unrelatedUser.id,
             unrelatedResponse.id,
         ])
+    }
+
+    @Test
+    func `adding a response group does not remove prior attempts`() {
+        let user = Message(role: .user, content: "Question")
+        let failedGroup = ResponseGroup(
+            userMessageId: user.id,
+            responses: [.init(id: UUID(), modelName: "model-a", status: .failed)]
+        )
+        let replacementGroup = ResponseGroup(
+            userMessageId: user.id,
+            responses: [.init(id: UUID(), modelName: "model-a", status: .streaming)]
+        )
+        var conversation = Conversation(responseGroups: [failedGroup])
+
+        conversation.addResponseGroup(replacementGroup)
+
+        #expect(conversation.responseGroups.map(\.id) == [failedGroup.id, replacementGroup.id])
     }
 
     @Test

--- a/Tests/AynaTests/ConversationEffectiveHistoryTests.swift
+++ b/Tests/AynaTests/ConversationEffectiveHistoryTests.swift
@@ -122,6 +122,70 @@ struct ConversationEffectiveHistoryTests {
     }
 
     @Test
+    func `replacement response group removes failed partials for the same user turn`() {
+        let user = Message(role: .user, content: "Question")
+        let failedGroupID = UUID()
+        let failedPartial = Message(
+            role: .assistant,
+            content: "Failed partial",
+            responseGroupId: failedGroupID
+        )
+        let failedGroup = ResponseGroup(
+            id: failedGroupID,
+            userMessageId: user.id,
+            responses: [
+                .init(id: failedPartial.id, modelName: "model-a", status: .failed),
+            ]
+        )
+        let unrelatedUser = Message(role: .user, content: "Other question")
+        let unrelatedGroupID = UUID()
+        let unrelatedResponse = Message(
+            role: .assistant,
+            content: "Other answer",
+            responseGroupId: unrelatedGroupID
+        )
+        let unrelatedGroup = ResponseGroup(
+            id: unrelatedGroupID,
+            userMessageId: unrelatedUser.id,
+            responses: [
+                .init(id: unrelatedResponse.id, modelName: "model-b", status: .completed),
+            ]
+        )
+        let replacementGroupID = UUID()
+        let replacementPlaceholder = Message(
+            role: .assistant,
+            content: "",
+            responseGroupId: replacementGroupID
+        )
+        let replacementGroup = ResponseGroup(
+            id: replacementGroupID,
+            userMessageId: user.id,
+            responses: [
+                .init(id: replacementPlaceholder.id, modelName: "model-a", status: .streaming),
+            ]
+        )
+        var conversation = Conversation(
+            messages: [user, failedPartial, unrelatedUser, unrelatedResponse, replacementPlaceholder],
+            responseGroups: [failedGroup, unrelatedGroup]
+        )
+
+        conversation.addResponseGroup(replacementGroup)
+
+        #expect(conversation.responseGroups.map(\.id) == [unrelatedGroupID, replacementGroupID])
+        #expect(conversation.messages.map(\.id) == [
+            user.id,
+            unrelatedUser.id,
+            unrelatedResponse.id,
+            replacementPlaceholder.id,
+        ])
+        #expect(conversation.getEffectiveHistory().map(\.id) == [
+            user.id,
+            unrelatedUser.id,
+            unrelatedResponse.id,
+        ])
+    }
+
+    @Test
     func `failed fallback prefers the conversation model`() {
         let groupID = UUID()
         let user = Message(role: .user, content: "Question")

--- a/Tests/AynaTests/ConversationManagerTests.swift
+++ b/Tests/AynaTests/ConversationManagerTests.swift
@@ -112,6 +112,42 @@ struct ConversationManagerTests {
 
     @Test
     @MainActor
+    func `begin multi-model response returns the updated retry history`() throws {
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let manager = makeManager(directory: directory)
+        let user = Message(role: .user, content: "Question")
+        let failedGroupID = UUID()
+        let failedPartial = Message(
+            role: .assistant,
+            content: "Failed partial",
+            responseGroupId: failedGroupID
+        )
+        let failedGroup = ResponseGroup(
+            id: failedGroupID,
+            userMessageId: user.id,
+            responses: [.init(id: failedPartial.id, modelName: "model-a", status: .failed)]
+        )
+        let conversation = Conversation(
+            messages: [user, failedPartial],
+            responseGroups: [failedGroup]
+        )
+        manager.conversations = [conversation]
+
+        let responsePlan = MultiModelResponsePlan(models: ["model-a"], userMessageId: user.id)
+        let updated = try #require(manager.beginMultiModelResponse(
+            to: conversation,
+            messages: responsePlan.placeholderMessages,
+            responseGroup: responsePlan.responseGroup
+        ))
+
+        #expect(updated == manager.conversation(byId: conversation.id))
+        #expect(updated.responseGroups.map(\.id) == [responsePlan.responseGroup.id])
+        #expect(!updated.messages.contains { $0.id == failedPartial.id })
+        #expect(updated.messages.contains { $0.responseGroupId == responsePlan.responseGroup.id })
+    }
+
+    @Test
+    @MainActor
     func `attachment-only first message uses stable image title without AI generation`() async throws {
         let previousAutoGenerateTitle = defaults.object(forKey: "autoGenerateTitle")
         defaults.set(true, forKey: "autoGenerateTitle")

--- a/Tests/AynaTests/ConversationManagerTests.swift
+++ b/Tests/AynaTests/ConversationManagerTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import Testing
 
 // swiftlint:disable identifier_name
-@Suite("ConversationManager Tests", .tags(.viewModel, .persistence))
+@Suite("ConversationManager Tests", .tags(.viewModel, .persistence), .serialized)
 // swiftlint:disable:next type_body_length
 struct ConversationManagerTests {
     private var defaults: UserDefaults
@@ -113,11 +113,16 @@ struct ConversationManagerTests {
     @Test
     @MainActor
     func `attachment-only first message uses stable image title without AI generation`() async throws {
+        let previousAutoGenerateTitle = defaults.object(forKey: "autoGenerateTitle")
         defaults.set(true, forKey: "autoGenerateTitle")
         let previousSelectedModel = AIService.shared.selectedModel
         AIService.shared.selectedModel = ""
         defer {
-            defaults.set(false, forKey: "autoGenerateTitle")
+            if let previousAutoGenerateTitle {
+                defaults.set(previousAutoGenerateTitle, forKey: "autoGenerateTitle")
+            } else {
+                defaults.removeObject(forKey: "autoGenerateTitle")
+            }
             AIService.shared.selectedModel = previousSelectedModel
         }
 

--- a/Tests/AynaTests/ConversationManagerTests.swift
+++ b/Tests/AynaTests/ConversationManagerTests.swift
@@ -112,6 +112,43 @@ struct ConversationManagerTests {
 
     @Test
     @MainActor
+    func `attachment-only first message uses stable image title without AI generation`() async throws {
+        defaults.set(true, forKey: "autoGenerateTitle")
+        let previousSelectedModel = AIService.shared.selectedModel
+        AIService.shared.selectedModel = ""
+        defer {
+            defaults.set(false, forKey: "autoGenerateTitle")
+            AIService.shared.selectedModel = previousSelectedModel
+        }
+
+        let directory = try TestHelpers.makeTemporaryDirectory()
+        let manager = makeManager(directory: directory)
+        manager.createNewConversation()
+        let conversation = try #require(manager.conversations.first)
+        var message = Message(role: .user, content: "")
+        message.attachments = [
+            Message.FileAttachment(
+                fileName: "pasted-image.png",
+                mimeType: "image/png",
+                data: Data([0x89]),
+                localPath: nil
+            ),
+        ]
+
+        manager.addMessage(to: conversation, message: message)
+
+        let fallbackTitle = try #require(manager.conversation(byId: conversation.id)?.title)
+        #expect(fallbackTitle == "Image")
+        #expect(!fallbackTitle.isEmpty)
+
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        #expect(manager.conversation(byId: conversation.id)?.title == fallbackTitle)
+    }
+
+    @Test
+    @MainActor
     func `search finds matches in title and messages`() throws {
         let directory = try TestHelpers.makeTemporaryDirectory()
 

--- a/Tests/AynaTests/ConversationSendPreflightTests.swift
+++ b/Tests/AynaTests/ConversationSendPreflightTests.swift
@@ -5,6 +5,40 @@ import Testing
 @Suite("Conversation Send Preflight Tests", .tags(.viewModel, .async))
 @MainActor
 struct ConversationSendPreflightTests {
+    @Test
+    func `attachment preflight combines policy and data validation`() async {
+        let service = AIService(urlSession: URLSession(configuration: .ephemeral))
+        let imageModel = "image-test"
+        let openAIModel = "openai-test"
+        service.modelEndpointTypes[imageModel] = .imageGeneration
+        service.modelProviders[openAIModel] = .openai
+        let storedImage = Message(
+            role: .user,
+            content: "Image",
+            attachments: [Message.FileAttachment(
+                fileName: "stored.png",
+                mimeType: "image/png",
+                localPath: "stored.png"
+            )]
+        )
+
+        let policyFailure = await ConversationSendPreflight.attachmentFailure(
+            models: [imageModel],
+            messages: [storedImage],
+            aiService: service,
+            loadAttachmentData: { _ in Data() }
+        )
+        let dataFailure = await ConversationSendPreflight.attachmentFailure(
+            models: [openAIModel],
+            messages: [storedImage],
+            aiService: service,
+            loadAttachmentData: { _ in Data([0x89, 0x50, 0x4E, 0x47]) }
+        )
+
+        #expect(policyFailure?.message.contains("do not accept attachments") == true)
+        #expect(dataFailure?.message.contains("invalid or corrupted") == true)
+    }
+
     @Test(.timeLimit(.minutes(1)))
     // swiftlint:disable:next identifier_name
     func `Send preflight waits for full history before request preparation`() async throws {

--- a/Tests/AynaTests/DynamicTextEditorPasteTests.swift
+++ b/Tests/AynaTests/DynamicTextEditorPasteTests.swift
@@ -86,6 +86,71 @@
         }
 
         @Test(.timeLimit(.minutes(1)))
+        func `repeated paste loads only the remaining draft capacity`() async throws {
+            let pasteboard = NSPasteboard.general
+            let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
+            defer { snapshot.restore(to: pasteboard) }
+
+            let imageData = try #require(Self.imageData)
+            let state = EditorState()
+            let hostedEditor = try Self.hostEditor(state: state)
+
+            let firstProviders = (0 ..< 18).map { _ in
+                PasteboardImageDataProvider(data: imageData)
+            }
+            pasteboard.clearContents()
+            #expect(pasteboard.writeObjects(firstProviders.map { Self.pasteboardItem(for: $0) }))
+            hostedEditor.textView.paste(nil)
+            #expect(await Self.waitUntil {
+                !state.isImportingPastedImages && state.pastedImages.count == 18
+            })
+
+            let secondProviders = (0 ..< 5).map { _ in
+                PasteboardImageDataProvider(data: imageData)
+            }
+            pasteboard.clearContents()
+            #expect(pasteboard.writeObjects(secondProviders.map { Self.pasteboardItem(for: $0) }))
+            hostedEditor.textView.paste(nil)
+            #expect(await Self.waitUntil {
+                !state.isImportingPastedImages
+                    && state.pastedImages.count == ChatDraftContent.maximumImageCount
+            })
+
+            #expect(firstProviders.reduce(0) { $0 + $1.requestCount } == 18)
+            #expect(secondProviders.reduce(0) { $0 + $1.requestCount } == 2)
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `rapid repeated paste reserves capacity before loading image data`() async throws {
+            let pasteboard = NSPasteboard.general
+            let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
+            defer { snapshot.restore(to: pasteboard) }
+
+            let imageData = try #require(Self.imageData)
+            let existingImage = try PastedImage.importing(data: imageData, contentType: .png)
+            let state = EditorState()
+            state.pastedImages = Array(
+                repeating: existingImage,
+                count: ChatDraftContent.maximumImageCount - 2
+            )
+            let hostedEditor = try Self.hostEditor(state: state)
+            let providers = (0 ..< 2).map { _ in
+                PasteboardImageDataProvider(data: imageData)
+            }
+            pasteboard.clearContents()
+            #expect(pasteboard.writeObjects(providers.map { Self.pasteboardItem(for: $0) }))
+
+            hostedEditor.textView.paste(nil)
+            hostedEditor.textView.paste(nil)
+
+            #expect(await Self.waitUntil {
+                !state.isImportingPastedImages
+                    && state.pastedImages.count == ChatDraftContent.maximumImageCount
+            })
+            #expect(providers.reduce(0) { $0 + $1.requestCount } == 2)
+        }
+
+        @Test(.timeLimit(.minutes(1)))
         func `rotating the paste session discards an in-flight image import`() async throws {
             let pasteboard = NSPasteboard.general
             let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
@@ -134,6 +199,9 @@
                     get: { state.isImportingPastedImages },
                     set: { state.isImportingPastedImages = $0 }
                 ),
+                remainingImageCapacity: {
+                    max(0, ChatDraftContent.maximumImageCount - state.pastedImages.count)
+                },
                 onSubmit: {},
                 onPasteImages: { state.pastedImages.append(contentsOf: $0) },
                 accessibilityIdentifier: "test.dynamicTextEditor"
@@ -182,6 +250,14 @@
                 }
             }
             return nil
+        }
+
+        private static func pasteboardItem(
+            for provider: PasteboardImageDataProvider
+        ) -> NSPasteboardItem {
+            let item = NSPasteboardItem()
+            item.setDataProvider(provider, forTypes: [.init("public.png")])
+            return item
         }
 
         private struct HostedEditor {

--- a/Tests/AynaTests/DynamicTextEditorPasteTests.swift
+++ b/Tests/AynaTests/DynamicTextEditorPasteTests.swift
@@ -57,6 +57,35 @@
         }
 
         @Test(.timeLimit(.minutes(1)))
+        func `paste caps image data loading before import`() async throws {
+            let pasteboard = NSPasteboard.general
+            let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
+            defer { snapshot.restore(to: pasteboard) }
+
+            let imageData = try #require(Self.imageData)
+            let providers = (0 ... ChatDraftContent.maximumImageCount).map { _ in
+                PasteboardImageDataProvider(data: imageData)
+            }
+            let items = providers.map { provider in
+                let item = NSPasteboardItem()
+                item.setDataProvider(provider, forTypes: [.init("public.png")])
+                return item
+            }
+            pasteboard.clearContents()
+            #expect(pasteboard.writeObjects(items))
+
+            let state = EditorState()
+            let hostedEditor = try Self.hostEditor(state: state)
+            hostedEditor.textView.paste(nil)
+
+            #expect(await Self.waitUntil {
+                !state.isImportingPastedImages
+                    && state.pastedImages.count == ChatDraftContent.maximumImageCount
+            })
+            #expect(providers.reduce(0) { $0 + $1.requestCount } == ChatDraftContent.maximumImageCount)
+        }
+
+        @Test(.timeLimit(.minutes(1)))
         func `rotating the paste session discards an in-flight image import`() async throws {
             let pasteboard = NSPasteboard.general
             let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
@@ -169,6 +198,24 @@
         var pasteImportSessionID = UUID()
         var isImportingPastedImages = false
         var pastedImages: [PastedImage] = []
+    }
+
+    private final class PasteboardImageDataProvider: NSObject, NSPasteboardItemDataProvider {
+        private let data: Data
+        private(set) var requestCount = 0
+
+        init(data: Data) {
+            self.data = data
+        }
+
+        func pasteboard(
+            _: NSPasteboard?,
+            item: NSPasteboardItem,
+            provideDataForType type: NSPasteboard.PasteboardType
+        ) {
+            requestCount += 1
+            item.setData(data, forType: type)
+        }
     }
 
     private struct PasteboardSnapshot {

--- a/Tests/AynaTests/DynamicTextEditorPasteTests.swift
+++ b/Tests/AynaTests/DynamicTextEditorPasteTests.swift
@@ -14,14 +14,81 @@
             let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
             defer { snapshot.restore(to: pasteboard) }
 
-            let imageData = try #require(Data(base64Encoded:
-                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="))
+            let imageData = try #require(Self.imageData)
             let image = try #require(NSImage(data: imageData))
             pasteboard.clearContents()
             #expect(pasteboard.writeObjects([image]))
 
             let state = EditorState()
-            let editor = DynamicTextEditor(
+            let hostedEditor = try Self.hostEditor(state: state)
+            let textView = hostedEditor.textView
+            #expect(String(describing: type(of: textView)).contains("PasteAwareTextView"))
+
+            let pasteMenuItem = NSMenuItem(
+                title: "Paste",
+                action: #selector(NSText.paste(_:)),
+                keyEquivalent: "v"
+            )
+            #expect(textView.validateUserInterfaceItem(pasteMenuItem))
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `mixed clipboard preserves text and imports its image`() async throws {
+            let pasteboard = NSPasteboard.general
+            let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
+            defer { snapshot.restore(to: pasteboard) }
+
+            let imageData = try #require(Self.imageData)
+            let item = NSPasteboardItem()
+            item.setString("Clipboard text", forType: .string)
+            item.setData(imageData, forType: .init("public.png"))
+            pasteboard.clearContents()
+            #expect(pasteboard.writeObjects([item]))
+
+            let state = EditorState()
+            let hostedEditor = try Self.hostEditor(state: state)
+            hostedEditor.textView.paste(nil)
+
+            #expect(state.text == "Clipboard text")
+            #expect(await Self.waitUntil {
+                !state.isImportingPastedImages && state.pastedImages.count == 1
+            })
+            #expect(state.pastedImages.first?.mimeType == "image/png")
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `rotating the paste session discards an in-flight image import`() async throws {
+            let pasteboard = NSPasteboard.general
+            let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
+            defer { snapshot.restore(to: pasteboard) }
+
+            let imageData = try #require(Self.imageData)
+            let item = NSPasteboardItem()
+            item.setData(imageData, forType: .init("public.png"))
+            pasteboard.clearContents()
+            #expect(pasteboard.writeObjects([item]))
+
+            let state = EditorState()
+            let hostedEditor = try Self.hostEditor(state: state)
+            hostedEditor.textView.paste(nil)
+            #expect(state.isImportingPastedImages)
+
+            state.pasteImportSessionID = UUID()
+            hostedEditor.host.rootView = Self.editor(state: state)
+            hostedEditor.host.layoutSubtreeIfNeeded()
+
+            #expect(await Self.waitUntil { !state.isImportingPastedImages })
+            try await Task.sleep(for: .milliseconds(50))
+            #expect(state.pastedImages.isEmpty)
+        }
+
+        private static var imageData: Data? {
+            Data(base64Encoded:
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
+        }
+
+        private static func editor(state: EditorState) -> DynamicTextEditor {
+            DynamicTextEditor(
                 text: Binding(
                     get: { state.text },
                     set: { state.text = $0 }
@@ -39,10 +106,15 @@
                     set: { state.isImportingPastedImages = $0 }
                 ),
                 onSubmit: {},
-                onPasteImages: { _ in },
+                onPasteImages: { state.pastedImages.append(contentsOf: $0) },
                 accessibilityIdentifier: "test.dynamicTextEditor"
             )
-            let host = NSHostingView(rootView: editor)
+        }
+
+        private static func hostEditor(
+            state: EditorState
+        ) throws -> HostedEditor {
+            let host = NSHostingView(rootView: editor(state: state))
             host.frame = NSRect(x: 0, y: 0, width: 480, height: 120)
             let window = NSWindow(
                 contentRect: host.frame,
@@ -52,16 +124,21 @@
             )
             window.contentView = host
             host.layoutSubtreeIfNeeded()
+            let textView = try #require(findTextView(in: host))
+            return HostedEditor(host: host, window: window, textView: textView)
+        }
 
-            let textView = try #require(Self.findTextView(in: host))
-            #expect(String(describing: type(of: textView)).contains("PasteAwareTextView"))
-
-            let pasteMenuItem = NSMenuItem(
-                title: "Paste",
-                action: #selector(NSText.paste(_:)),
-                keyEquivalent: "v"
-            )
-            #expect(textView.validateUserInterfaceItem(pasteMenuItem))
+        private static func waitUntil(
+            timeout: Duration = .seconds(2),
+            condition: @escaping @MainActor () -> Bool
+        ) async -> Bool {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while !condition(), clock.now < deadline {
+                await Task.yield()
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+            return condition()
         }
 
         private static func findTextView(in view: NSView) -> NSTextView? {
@@ -77,6 +154,12 @@
             }
             return nil
         }
+
+        private struct HostedEditor {
+            let host: NSHostingView<DynamicTextEditor>
+            let window: NSWindow
+            let textView: NSTextView
+        }
     }
 
     @MainActor
@@ -85,6 +168,7 @@
         var isFirstResponder = false
         var pasteImportSessionID = UUID()
         var isImportingPastedImages = false
+        var pastedImages: [PastedImage] = []
     }
 
     private struct PasteboardSnapshot {

--- a/Tests/AynaTests/DynamicTextEditorPasteTests.swift
+++ b/Tests/AynaTests/DynamicTextEditorPasteTests.swift
@@ -34,6 +34,10 @@
                     get: { state.pasteImportSessionID },
                     set: { state.pasteImportSessionID = $0 }
                 ),
+                isImportingPastedImages: Binding(
+                    get: { state.isImportingPastedImages },
+                    set: { state.isImportingPastedImages = $0 }
+                ),
                 onSubmit: {},
                 onPasteImages: { _ in },
                 accessibilityIdentifier: "test.dynamicTextEditor"
@@ -80,6 +84,7 @@
         var text = ""
         var isFirstResponder = false
         var pasteImportSessionID = UUID()
+        var isImportingPastedImages = false
     }
 
     private struct PasteboardSnapshot {

--- a/Tests/AynaTests/DynamicTextEditorPasteTests.swift
+++ b/Tests/AynaTests/DynamicTextEditorPasteTests.swift
@@ -151,7 +151,7 @@
         }
 
         @Test(.timeLimit(.minutes(1)))
-        func `rotating the paste session discards an in-flight image import`() async throws {
+        func `rotating the paste session discards every queued image import`() async throws {
             let pasteboard = NSPasteboard.general
             let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
             defer { snapshot.restore(to: pasteboard) }
@@ -164,6 +164,7 @@
 
             let state = EditorState()
             let hostedEditor = try Self.hostEditor(state: state)
+            hostedEditor.textView.paste(nil)
             hostedEditor.textView.paste(nil)
             #expect(state.isImportingPastedImages)
 

--- a/Tests/AynaTests/DynamicTextEditorPasteTests.swift
+++ b/Tests/AynaTests/DynamicTextEditorPasteTests.swift
@@ -1,0 +1,116 @@
+#if os(macOS)
+
+    import AppKit
+    @testable import Ayna
+    import SwiftUI
+    import Testing
+
+    @Suite("Dynamic Text Editor Paste Tests", .serialized)
+    @MainActor
+    struct DynamicTextEditorPasteTests {
+        @Test(.timeLimit(.minutes(1)))
+        func `image-only clipboard enables the Paste command`() throws {
+            let pasteboard = NSPasteboard.general
+            let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
+            defer { snapshot.restore(to: pasteboard) }
+
+            let imageData = try #require(Data(base64Encoded:
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="))
+            let image = try #require(NSImage(data: imageData))
+            pasteboard.clearContents()
+            #expect(pasteboard.writeObjects([image]))
+
+            let state = EditorState()
+            let editor = DynamicTextEditor(
+                text: Binding(
+                    get: { state.text },
+                    set: { state.text = $0 }
+                ),
+                isFirstResponder: Binding(
+                    get: { state.isFirstResponder },
+                    set: { state.isFirstResponder = $0 }
+                ),
+                pasteImportSessionID: Binding(
+                    get: { state.pasteImportSessionID },
+                    set: { state.pasteImportSessionID = $0 }
+                ),
+                onSubmit: {},
+                onPasteImages: { _ in },
+                accessibilityIdentifier: "test.dynamicTextEditor"
+            )
+            let host = NSHostingView(rootView: editor)
+            host.frame = NSRect(x: 0, y: 0, width: 480, height: 120)
+            let window = NSWindow(
+                contentRect: host.frame,
+                styleMask: [],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentView = host
+            host.layoutSubtreeIfNeeded()
+
+            let textView = try #require(Self.findTextView(in: host))
+            #expect(String(describing: type(of: textView)).contains("PasteAwareTextView"))
+
+            let pasteMenuItem = NSMenuItem(
+                title: "Paste",
+                action: #selector(NSText.paste(_:)),
+                keyEquivalent: "v"
+            )
+            #expect(textView.validateUserInterfaceItem(pasteMenuItem))
+        }
+
+        private static func findTextView(in view: NSView) -> NSTextView? {
+            if let scrollView = view as? NSScrollView,
+               let textView = scrollView.documentView as? NSTextView
+            {
+                return textView
+            }
+            for subview in view.subviews {
+                if let textView = findTextView(in: subview) {
+                    return textView
+                }
+            }
+            return nil
+        }
+    }
+
+    @MainActor
+    private final class EditorState {
+        var text = ""
+        var isFirstResponder = false
+        var pasteImportSessionID = UUID()
+    }
+
+    private struct PasteboardSnapshot {
+        private struct Item {
+            let values: [(type: NSPasteboard.PasteboardType, data: Data)]
+        }
+
+        private let items: [Item]
+
+        init(pasteboard: NSPasteboard) {
+            items = (pasteboard.pasteboardItems ?? []).map { item in
+                Item(values: item.types.compactMap { type in
+                    item.data(forType: type).map { (type, $0) }
+                })
+            }
+        }
+
+        func restore(to pasteboard: NSPasteboard) {
+            pasteboard.clearContents()
+            let pasteboardItems = items.compactMap { item -> NSPasteboardItem? in
+                guard !item.values.isEmpty else { return nil }
+                let pasteboardItem = NSPasteboardItem()
+                for value in item.values {
+                    pasteboardItem.setData(value.data, forType: value.type)
+                }
+                return pasteboardItem
+            }
+            if !pasteboardItems.isEmpty {
+                pasteboard.writeObjects(pasteboardItems)
+            }
+        }
+    }
+
+#endif

--- a/Tests/AynaTests/FileAttachmentIdentityTests.swift
+++ b/Tests/AynaTests/FileAttachmentIdentityTests.swift
@@ -1,0 +1,57 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+@Suite("File Attachment Identity Tests", .tags(.fast))
+struct FileAttachmentIdentityTests {
+    @Test
+    func `attachments with identical content have distinct identities`() {
+        let first = Message.FileAttachment(
+            fileName: "image.png",
+            mimeType: "image/png",
+            data: Data([0x89, 0x50, 0x4E, 0x47])
+        )
+        let second = Message.FileAttachment(
+            fileName: "image.png",
+            mimeType: "image/png",
+            data: Data([0x89, 0x50, 0x4E, 0x47])
+        )
+
+        #expect(first.id != second.id)
+    }
+
+    @Test
+    func `attachment identity survives coding round trip`() throws {
+        let attachment = Message.FileAttachment(
+            fileName: "image.png",
+            mimeType: "image/png",
+            data: Data([0x89, 0x50, 0x4E, 0x47])
+        )
+
+        let decoded = try JSONDecoder().decode(
+            Message.FileAttachment.self,
+            from: JSONEncoder().encode(attachment)
+        )
+
+        #expect(decoded == attachment)
+        #expect(decoded.id == attachment.id)
+    }
+
+    @Test
+    func `legacy attachment without identity remains decodable`() throws {
+        let legacyData = try JSONSerialization.data(withJSONObject: [
+            "fileName": "legacy.png",
+            "mimeType": "image/png",
+            "data": Data([0x89, 0x50, 0x4E, 0x47]).base64EncodedString(),
+        ])
+
+        let migrated = try JSONDecoder().decode(Message.FileAttachment.self, from: legacyData)
+        let persisted = try JSONDecoder().decode(
+            Message.FileAttachment.self,
+            from: JSONEncoder().encode(migrated)
+        )
+
+        #expect(migrated.fileName == "legacy.png")
+        #expect(persisted.id == migrated.id)
+    }
+}

--- a/Tests/AynaTests/IOSChatViewModelAttachmentHistoryTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelAttachmentHistoryTests.swift
@@ -50,6 +50,135 @@
             #expect(viewModel.errorMessage?.contains("does not support attachments") == true)
             #expect(!viewModel.isGenerating)
         }
+
+        @Test
+        func `apple Intelligence model-switch retry preserves the existing response`() {
+            let sourceModel = "openai-test"
+            let appleModel = "apple-test"
+            let priorImageMessage = Message(
+                role: .user,
+                content: "",
+                attachments: [Message.FileAttachment(
+                    fileName: "prior.png",
+                    mimeType: "image/png",
+                    data: Data([0x89, 0x50, 0x4E, 0x47])
+                )]
+            )
+            let assistantMessage = Message(
+                role: .assistant,
+                content: "Existing response",
+                model: sourceModel
+            )
+            let conversation = Conversation(
+                messages: [priorImageMessage, assistantMessage],
+                model: sourceModel,
+                systemPromptMode: .disabled
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = AIService(urlSession: URLSession(configuration: .ephemeral))
+            aiService.customModels = [sourceModel, appleModel]
+            aiService.selectedModel = sourceModel
+            aiService.modelProviders[sourceModel] = .openai
+            aiService.modelProviders[appleModel] = .appleIntelligence
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+
+            viewModel.switchModelAndRetry(beforeMessage: assistantMessage, newModel: appleModel)
+
+            #expect(manager.conversation(byId: conversation.id)?.messages.map(\.id) == [
+                priorImageMessage.id,
+                assistantMessage.id,
+            ])
+            #expect(viewModel.errorMessage?.contains("does not support attachments") == true)
+            #expect(!viewModel.isGenerating)
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `anthropic historical image is rejected before committing a text turn`() async throws {
+            let model = "claude-test"
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let storage = AttachmentStorage(
+                directoryURL: storageDirectory,
+                dataCache: AttachmentDataCache()
+            )
+            let storedPath = try storage.save(
+                data: Data(repeating: 0, count: 12),
+                extension: "heic"
+            )
+            let priorImageMessage = Message(
+                role: .user,
+                content: "Prior image",
+                attachments: [Message.FileAttachment(
+                    fileName: "prior.heic",
+                    mimeType: "image/heic",
+                    localPath: storedPath
+                )]
+            )
+            let priorResponse = Message(
+                role: .assistant,
+                content: "Prior response",
+                model: model
+            )
+            let conversation = Conversation(
+                messages: [priorImageMessage, priorResponse],
+                model: model,
+                systemPromptMode: .disabled
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = AIService(urlSession: URLSession(configuration: .ephemeral))
+            aiService.customModels = [model]
+            aiService.selectedModel = model
+            aiService.modelProviders[model] = .anthropic
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService,
+                attachmentStorage: storage
+            )
+            viewModel.messageText = "Continue without a new image"
+
+            viewModel.sendMessage()
+            #expect(await waitUntil {
+                viewModel.errorMessage?.contains("Unsupported image format") == true
+            })
+
+            #expect(manager.conversation(byId: conversation.id)?.messages.map(\.id) == [
+                priorImageMessage.id,
+                priorResponse.id,
+            ])
+            #expect(viewModel.messageText == "Continue without a new image")
+            #expect(!viewModel.isGenerating)
+            viewModel.cancelOwnedOperations()
+        }
+
+        private func waitUntil(
+            timeout: Duration = .seconds(2),
+            _ condition: @MainActor () -> Bool
+        ) async -> Bool {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while !condition(), clock.now < deadline {
+                await Task.yield()
+            }
+            return condition()
+        }
     }
 
 #endif

--- a/Tests/AynaTests/IOSChatViewModelAttachmentHistoryTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelAttachmentHistoryTests.swift
@@ -103,6 +103,58 @@
             #expect(!viewModel.isGenerating)
         }
 
+        @Test
+        func `image generation model-switch retry preserves an attachment response`() {
+            let sourceModel = "openai-test"
+            let imageModel = "image-test"
+            let userMessage = Message(
+                role: .user,
+                content: "",
+                attachments: [Message.FileAttachment(
+                    fileName: "prior.png",
+                    mimeType: "image/png",
+                    data: Data([0x89, 0x50, 0x4E, 0x47])
+                )]
+            )
+            let assistantMessage = Message(
+                role: .assistant,
+                content: "Existing response",
+                model: sourceModel
+            )
+            let conversation = Conversation(
+                messages: [userMessage, assistantMessage],
+                model: sourceModel,
+                systemPromptMode: .disabled
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = AIService(urlSession: URLSession(configuration: .ephemeral))
+            aiService.customModels = [sourceModel, imageModel]
+            aiService.selectedModel = sourceModel
+            aiService.modelProviders[sourceModel] = .openai
+            aiService.modelEndpointTypes[imageModel] = .imageGeneration
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+
+            viewModel.switchModelAndRetry(beforeMessage: assistantMessage, newModel: imageModel)
+
+            #expect(manager.conversation(byId: conversation.id)?.messages.map(\.id) == [
+                userMessage.id,
+                assistantMessage.id,
+            ])
+            #expect(viewModel.errorMessage?.contains("do not accept attachments") == true)
+            #expect(!viewModel.isGenerating)
+        }
+
         @Test(.timeLimit(.minutes(1)))
         func `anthropic historical image is rejected before committing a text turn`() async throws {
             let model = "claude-test"

--- a/Tests/AynaTests/IOSChatViewModelAttachmentHistoryTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelAttachmentHistoryTests.swift
@@ -168,6 +168,186 @@
             viewModel.cancelOwnedOperations()
         }
 
+        @Test(.timeLimit(.minutes(1)))
+        func `openAI corrupt historical image is rejected before committing a text turn`() async throws {
+            let model = "openai-test"
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let storage = AttachmentStorage(
+                directoryURL: storageDirectory,
+                dataCache: AttachmentDataCache()
+            )
+            let storedPath = try storage.save(
+                data: Data([0x89, 0x50, 0x4E, 0x47]),
+                extension: "png"
+            )
+            let priorImageMessage = Message(
+                role: .user,
+                content: "Prior image",
+                attachments: [Message.FileAttachment(
+                    fileName: "corrupt.png",
+                    mimeType: "image/png",
+                    localPath: storedPath
+                )]
+            )
+            let priorResponse = Message(
+                role: .assistant,
+                content: "Prior response",
+                model: model
+            )
+            let conversation = Conversation(
+                messages: [priorImageMessage, priorResponse],
+                model: model,
+                systemPromptMode: .disabled
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = AIService(urlSession: URLSession(configuration: .ephemeral))
+            aiService.customModels = [model]
+            aiService.selectedModel = model
+            aiService.modelProviders[model] = .openai
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService,
+                attachmentStorage: storage
+            )
+            viewModel.messageText = "Continue without a new image"
+
+            viewModel.sendMessage()
+            #expect(await waitUntil {
+                viewModel.errorMessage?.contains("invalid or corrupted") == true
+            })
+
+            #expect(manager.conversation(byId: conversation.id)?.messages.map(\.id) == [
+                priorImageMessage.id,
+                priorResponse.id,
+            ])
+            #expect(viewModel.messageText == "Continue without a new image")
+            #expect(!viewModel.isGenerating)
+            viewModel.cancelOwnedOperations()
+        }
+
+        @Test
+        func `anthropic image-limit model switch preserves the existing response`() {
+            let sourceModel = "openai-test"
+            let anthropicModel = "claude-test"
+            let imageAttachment = Message.FileAttachment(
+                fileName: "image.png",
+                mimeType: "image/png",
+                data: Data([0x89, 0x50, 0x4E, 0x47])
+            )
+            let userMessage = Message(
+                role: .user,
+                content: "Many images",
+                attachments: Array(
+                    repeating: imageAttachment,
+                    count: AnthropicRequestBuilder.maxImagesPerRequest + 1
+                )
+            )
+            let assistantMessage = Message(
+                role: .assistant,
+                content: "Existing response",
+                model: sourceModel
+            )
+            let conversation = Conversation(
+                messages: [userMessage, assistantMessage],
+                model: sourceModel,
+                systemPromptMode: .disabled
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = AIService(urlSession: URLSession(configuration: .ephemeral))
+            aiService.customModels = [sourceModel, anthropicModel]
+            aiService.selectedModel = sourceModel
+            aiService.modelProviders[sourceModel] = .openai
+            aiService.modelProviders[anthropicModel] = .anthropic
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+
+            viewModel.switchModelAndRetry(beforeMessage: assistantMessage, newModel: anthropicModel)
+
+            #expect(manager.conversation(byId: conversation.id)?.messages.map(\.id) == [
+                userMessage.id,
+                assistantMessage.id,
+            ])
+            #expect(viewModel.errorMessage?.contains("at most 20 images") == true)
+            #expect(!viewModel.isGenerating)
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `anthropic legacy retry validates stored image before removing the response`() async throws {
+            let model = "claude-test"
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let storage = AttachmentStorage(
+                directoryURL: storageDirectory,
+                dataCache: AttachmentDataCache()
+            )
+            let storedPath = try storage.save(
+                data: Data([0x89, 0x50, 0x4E, 0x47]),
+                extension: "png"
+            )
+            let userMessage = Message(
+                role: .user,
+                content: "Corrupt image",
+                attachments: [Message.FileAttachment(
+                    fileName: "corrupt.png",
+                    mimeType: "image/png",
+                    localPath: storedPath
+                )]
+            )
+            let assistantMessage = Message(role: .assistant, content: "Existing response")
+            let conversation = Conversation(
+                messages: [userMessage, assistantMessage],
+                model: model,
+                systemPromptMode: .disabled
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = AIService(urlSession: URLSession(configuration: .ephemeral))
+            aiService.customModels = [model]
+            aiService.selectedModel = model
+            aiService.modelProviders[model] = .anthropic
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService,
+                attachmentStorage: storage
+            )
+
+            viewModel.retryMessage(beforeMessage: assistantMessage)
+            #expect(await waitUntil {
+                viewModel.errorMessage?.contains("invalid or corrupted") == true
+            })
+
+            #expect(manager.conversation(byId: conversation.id)?.messages.map(\.id) == [
+                userMessage.id,
+                assistantMessage.id,
+            ])
+            #expect(!viewModel.isGenerating)
+            viewModel.cancelOwnedOperations()
+        }
+
         private func waitUntil(
             timeout: Duration = .seconds(2),
             _ condition: @MainActor () -> Bool

--- a/Tests/AynaTests/IOSChatViewModelAttachmentHistoryTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelAttachmentHistoryTests.swift
@@ -1,0 +1,55 @@
+#if os(iOS)
+
+    @testable import Ayna
+    import Foundation
+    import Testing
+
+    @Suite("iOS Attachment History Tests", .tags(.viewModel), .serialized)
+    @MainActor
+    struct IOSChatViewModelAttachmentHistoryTests {
+        @Test
+        func `apple Intelligence attachment history is rejected before committing a text turn`() {
+            let model = "apple-test"
+            let priorImageMessage = Message(
+                role: .user,
+                content: "",
+                attachments: [Message.FileAttachment(
+                    fileName: "prior.png",
+                    mimeType: "image/png",
+                    data: Data([0x89, 0x50, 0x4E, 0x47])
+                )]
+            )
+            let conversation = Conversation(
+                messages: [priorImageMessage],
+                model: model,
+                systemPromptMode: .disabled
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = AIService(urlSession: URLSession(configuration: .ephemeral))
+            aiService.customModels = [model]
+            aiService.selectedModel = model
+            aiService.modelProviders[model] = .appleIntelligence
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            viewModel.messageText = "Continue without images"
+
+            viewModel.sendMessage()
+
+            #expect(manager.conversation(byId: conversation.id)?.messages.map(\.id) == [priorImageMessage.id])
+            #expect(viewModel.messageText == "Continue without images")
+            #expect(viewModel.errorMessage?.contains("does not support attachments") == true)
+            #expect(!viewModel.isGenerating)
+        }
+    }
+
+#endif

--- a/Tests/AynaTests/IOSChatViewModelTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelTests.swift
@@ -115,6 +115,44 @@
             viewModel.cancelOwnedOperations()
         }
 
+        @Test
+        func `anthropic image limit is rejected before committing the message`() {
+            let model = "claude-test"
+            let conversation = Conversation(model: model, systemPromptMode: .disabled)
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = SendHistoryCapturingAIService()
+            configure(aiService, models: [model])
+            aiService.modelProviders[model] = .anthropic
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            viewModel.pastedImages = (0 ... ChatDraftContent.maximumImageCount).map { index in
+                PastedImage(
+                    data: Data([0x89, 0x50, 0x4E, UInt8(index)]),
+                    mimeType: "image/png",
+                    fileExtension: "png"
+                )
+            }
+
+            viewModel.sendMessage()
+
+            #expect(aiService.singleModelRequests.isEmpty)
+            #expect(manager.conversation(byId: conversation.id)?.messages.isEmpty == true)
+            #expect(viewModel.pastedImages.count == ChatDraftContent.maximumImageCount + 1)
+            #expect(viewModel.errorMessage?.contains("at most 20 images") == true)
+            #expect(!viewModel.isGenerating)
+            viewModel.cancelOwnedOperations()
+        }
+
         @Test(.timeLimit(.minutes(1)))
         func `multi-model send waits for lazy history and includes it in the request`() async throws {
             let priorUser = Message(role: .user, content: "Prior question")

--- a/Tests/AynaTests/IOSChatViewModelTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelTests.swift
@@ -153,6 +153,46 @@
             viewModel.cancelOwnedOperations()
         }
 
+        @Test
+        func `oversized anthropic file image is rejected before committing the message`() throws {
+            let model = "claude-test"
+            let conversation = Conversation(model: model, systemPromptMode: .disabled)
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = SendHistoryCapturingAIService()
+            configure(aiService, models: [model])
+            aiService.modelProviders[model] = .anthropic
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let fileURL = directory.appendingPathComponent("large.jpg")
+            var imageData = Data([0xFF, 0xD8, 0xFF, 0xE0, 0, 0, 0, 0, 0, 0, 0, 0])
+            imageData.append(Data(
+                repeating: 0,
+                count: AnthropicRequestBuilder.maxImageSizeBytes
+            ))
+            try imageData.write(to: fileURL)
+            viewModel.attachedFiles = [fileURL]
+
+            viewModel.sendMessage()
+
+            #expect(aiService.singleModelRequests.isEmpty)
+            #expect(manager.conversation(byId: conversation.id)?.messages.isEmpty == true)
+            #expect(viewModel.attachedFiles == [fileURL])
+            #expect(viewModel.errorMessage?.contains("Image too large") == true)
+            #expect(!viewModel.isGenerating)
+            viewModel.cancelOwnedOperations()
+        }
+
         @Test(.timeLimit(.minutes(1)))
         func `multi-model send waits for lazy history and includes it in the request`() async throws {
             let priorUser = Message(role: .user, content: "Prior question")
@@ -434,6 +474,9 @@
             viewModel.sendMessage()
             #expect(aiService.requests.count == 1)
             #expect(viewModel.pastedImages.isEmpty)
+            let committedUserMessage = try #require(
+                manager.conversation(byId: conversation.id)?.messages.first(where: { $0.role == .user })
+            )
 
             aiService.failLatestRequest()
             #expect(await waitUntil {
@@ -447,9 +490,17 @@
                 aiService.requests.last?.last(where: { $0.role == .user })
             )
             let retriedAttachment = try #require(retriedUserMessage.attachments?.first)
+            let persistedUserMessages = try #require(
+                manager.conversation(byId: conversation.id)?.messages.filter { $0.role == .user }
+            )
+            let requestedUserMessages = try #require(
+                aiService.requests.last?.filter { $0.role == .user }
+            )
             #expect(retriedAttachment.fileName == pastedImage.fileName)
             #expect(retriedAttachment.mimeType == pastedImage.mimeType)
             #expect(retriedAttachment.data == pastedImage.data)
+            #expect(persistedUserMessages.map(\.id) == [committedUserMessage.id])
+            #expect(requestedUserMessages.map(\.id) == [committedUserMessage.id])
             #expect(viewModel.pastedImages.isEmpty)
             #expect(viewModel.failedMessage == nil)
             viewModel.cancelOwnedOperations()

--- a/Tests/AynaTests/IOSChatViewModelTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelTests.swift
@@ -875,27 +875,171 @@
             )
         }
 
-        private func configure(_ service: AIService, models: [String]) {
-            service.customModels = models
-            service.selectedModel = models[0]
-            for model in models {
-                service.modelProviders[model] = .openai
-                service.modelAPIKeys[model] = "sk-unit-test"
-            }
+    }
+
+    @Suite("iOS Chat View Model Regression Tests", .tags(.viewModel), .serialized)
+    @MainActor
+    struct IOSChatViewModelRegressionTests {
+        @Test
+        func `attachment-incompatible edit preserves the existing transcript`() {
+            let model = "apple-test"
+            let userMessage = Message(
+                role: .user,
+                content: "Original question",
+                attachments: [Message.FileAttachment(
+                    fileName: "image.png",
+                    mimeType: "image/png",
+                    data: Data([0x89, 0x50, 0x4E, 0x47])
+                )]
+            )
+            let assistantMessage = Message(role: .assistant, content: "Existing answer")
+            let conversation = Conversation(
+                messages: [userMessage, assistantMessage],
+                model: model,
+                systemPromptMode: .disabled
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = SendHistoryCapturingAIService()
+            configure(aiService, models: [model])
+            aiService.modelProviders[model] = .appleIntelligence
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+
+            viewModel.editMessageAndResend(
+                userMessage,
+                newContent: "Replacement question"
+            )
+
+            #expect(manager.conversation(byId: conversation.id)?.messages == [
+                userMessage,
+                assistantMessage,
+            ])
+            #expect(viewModel.errorMessage?.contains("does not support attachments") == true)
+            #expect(aiService.singleModelRequests.isEmpty)
+            #expect(!viewModel.isGenerating)
         }
 
-        private func waitUntil(
-            timeout: Duration = .seconds(1),
-            condition: @MainActor () -> Bool
-        ) async -> Bool {
-            let clock = ContinuousClock()
-            let deadline = clock.now.advanced(by: timeout)
-            while !condition() {
-                guard clock.now < deadline else { return false }
-                try? await Task.sleep(for: .milliseconds(5))
-            }
-            return true
+        @Test(.timeLimit(.minutes(1)))
+        func `failed single-model new chat stays on its retry screen`() async throws {
+            let model = "model-a"
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            let aiService = ControllableErrorAIService()
+            configure(aiService, models: [model])
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let viewModel = IOSChatViewModel(
+                conversationManager: manager,
+                aiService: aiService,
+                attachmentStorage: AttachmentStorage(
+                    directoryURL: storageDirectory,
+                    dataCache: AttachmentDataCache()
+                )
+            )
+            var createdConversationID: UUID?
+            viewModel.onConversationCreated = { createdConversationID = $0 }
+            viewModel.selectedModel = model
+            viewModel.selectedModels = [model]
+            viewModel.messageText = "Retry this new chat"
+            viewModel.pastedImages = [PastedImage(
+                data: Data([0x89, 0x50, 0x4E, 0x47, 0x04]),
+                mimeType: "image/png",
+                fileExtension: "png"
+            )]
+
+            viewModel.sendMessage()
+            #expect(await waitUntil { aiService.requests.count == 1 })
+            aiService.failLatestRequest()
+            #expect(await waitUntil {
+                !viewModel.isGenerating && viewModel.failedMessage == "Retry this new chat"
+            })
+
+            #expect(createdConversationID == nil)
+            #expect(manager.conversations.count == 1)
+            viewModel.cancelOwnedOperations()
         }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `all-failed multi-model new chat stays on its retry screen`() async throws {
+            let models = ["model-a", "model-b"]
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            let aiService = ControllableMultiModelErrorAIService()
+            configure(aiService, models: models)
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let viewModel = IOSChatViewModel(
+                conversationManager: manager,
+                aiService: aiService,
+                attachmentStorage: AttachmentStorage(
+                    directoryURL: storageDirectory,
+                    dataCache: AttachmentDataCache()
+                )
+            )
+            var createdConversationID: UUID?
+            viewModel.onConversationCreated = { createdConversationID = $0 }
+            viewModel.selectedModel = models[0]
+            viewModel.selectedModels = Set(models)
+            viewModel.messageText = "Compare this new chat"
+            viewModel.pastedImages = [PastedImage(
+                data: Data([0x89, 0x50, 0x4E, 0x47, 0x05]),
+                mimeType: "image/png",
+                fileExtension: "png"
+            )]
+
+            viewModel.sendMessage()
+            #expect(await waitUntil { aiService.requests.count == 1 })
+            aiService.failAllModelsInLatestRequest()
+            #expect(await waitUntil {
+                !viewModel.isGenerating && viewModel.failedMessage == "Compare this new chat"
+            })
+
+            #expect(createdConversationID == nil)
+            #expect(viewModel.errorMessage == "All models failed")
+            #expect(manager.conversations.count == 1)
+            viewModel.cancelOwnedOperations()
+        }
+
+    }
+
+    @MainActor
+    private func configure(_ service: AIService, models: [String]) {
+        service.customModels = models
+        service.selectedModel = models[0]
+        for model in models {
+            service.modelProviders[model] = .openai
+            service.modelAPIKeys[model] = "sk-unit-test"
+        }
+    }
+
+    @MainActor
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        condition: @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !condition() {
+            guard clock.now < deadline else { return false }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return true
     }
 
     private actor IOSConversationLoadGate {

--- a/Tests/AynaTests/IOSChatViewModelTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelTests.swift
@@ -49,6 +49,34 @@
         }
 
         @Test(.timeLimit(.minutes(1)))
+        func `accepted send rotates the paste import session before lazy history finishes`() async {
+            let conversation = Conversation(model: "model-a", systemPromptMode: .disabled)
+            let gate = IOSConversationLoadGate(result: conversation)
+            let manager = makeMetadataManager(conversation: conversation, gate: gate)
+            await manager.loadingTask?.value
+
+            let aiService = SendHistoryCapturingAIService()
+            configure(aiService, models: [conversation.model])
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            viewModel.messageText = "Send while paste import is pending"
+            let initialSessionID = viewModel.pasteImportSessionID
+
+            viewModel.sendMessage()
+
+            #expect(viewModel.pasteImportSessionID != initialSessionID)
+            await gate.waitUntilStarted()
+            #expect(aiService.singleModelRequests.isEmpty)
+
+            await gate.release()
+            #expect(await waitUntil { aiService.singleModelRequests.count == 1 })
+            viewModel.cancelOwnedOperations()
+        }
+
+        @Test(.timeLimit(.minutes(1)))
         func `multi-model send waits for lazy history and includes it in the request`() async throws {
             let priorUser = Message(role: .user, content: "Prior question")
             let priorAssistant = Message(role: .assistant, content: "Prior answer")
@@ -91,6 +119,61 @@
             #expect(request.map(\.content) == ["Prior question", "Prior answer", "New comparison"])
             #expect(!request.contains { $0.role == .assistant && $0.content.isEmpty })
             #expect(viewModel.messageText == "Later comparison draft")
+            viewModel.cancelOwnedOperations()
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `attachment-only multi-model send preserves the captured paste`() async throws {
+            let models = ["model-a", "model-b"]
+            let conversation = Conversation(
+                messages: [Message(role: .user, content: "Prior question")],
+                model: models[0],
+                systemPromptMode: .disabled,
+                multiModelEnabled: true,
+                activeModels: models
+            )
+            let gate = IOSConversationLoadGate(result: conversation)
+            let manager = makeMetadataManager(conversation: conversation, gate: gate)
+            await manager.loadingTask?.value
+
+            let aiService = SendHistoryCapturingAIService()
+            configure(aiService, models: models)
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            let capturedPaste = PastedImage(
+                data: Data([0x89, 0x50, 0x4E, 0x47]),
+                mimeType: "image/png",
+                fileExtension: "png"
+            )
+            let laterPaste = PastedImage(
+                data: Data([0xFF, 0xD8, 0xFF, 0xE0]),
+                mimeType: "image/jpeg",
+                fileExtension: "jpg"
+            )
+            viewModel.selectedModels = Set(models)
+            viewModel.pastedImages = [capturedPaste]
+
+            viewModel.sendMessage()
+            await gate.waitUntilStarted()
+
+            #expect(aiService.multiModelRequests.isEmpty)
+            viewModel.pastedImages.append(laterPaste)
+
+            await gate.release()
+            #expect(await waitUntil { aiService.multiModelRequests.count == 1 })
+
+            let request = try #require(aiService.multiModelRequests.first)
+            let sentMessage = try #require(request.last(where: { $0.role == .user }))
+            let attachment = try #require(sentMessage.attachments?.first)
+            #expect(sentMessage.content.isEmpty)
+            #expect(sentMessage.attachments?.count == 1)
+            #expect(attachment.fileName == capturedPaste.fileName)
+            #expect(attachment.mimeType == capturedPaste.mimeType)
+            #expect(attachment.data == capturedPaste.data)
+            #expect(viewModel.pastedImages == [laterPaste])
             viewModel.cancelOwnedOperations()
         }
 
@@ -182,6 +265,36 @@
 
             let request = try #require(aiService.singleModelRequests.first)
             #expect(request.map(\.content) == ["Send now"])
+            viewModel.cancelOwnedOperations()
+        }
+
+        @Test
+        func `reset for new chat clears pasted images and rotates the paste import session`() {
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            let aiService = SendHistoryCapturingAIService()
+            configure(aiService, models: ["model-a"])
+            let viewModel = IOSChatViewModel(
+                conversationManager: manager,
+                aiService: aiService
+            )
+            viewModel.pastedImages = [
+                PastedImage(
+                    data: Data([0x89, 0x50, 0x4E, 0x47]),
+                    mimeType: "image/png",
+                    fileExtension: "png"
+                )
+            ]
+            let initialSessionID = viewModel.pasteImportSessionID
+
+            viewModel.resetForNewChat()
+
+            #expect(viewModel.pastedImages.isEmpty)
+            #expect(viewModel.pasteImportSessionID != initialSessionID)
             viewModel.cancelOwnedOperations()
         }
 

--- a/Tests/AynaTests/IOSChatViewModelTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelTests.swift
@@ -76,6 +76,45 @@
             viewModel.cancelOwnedOperations()
         }
 
+        @Test
+        func `send is ignored while a pasted image import is pending`() {
+            let conversation = Conversation(model: "model-a", systemPromptMode: .disabled)
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = SendHistoryCapturingAIService()
+            configure(aiService, models: [conversation.model])
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            let pastedImage = PastedImage(
+                data: Data([0x89, 0x50, 0x4E, 0x47]),
+                mimeType: "image/png",
+                fileExtension: "png"
+            )
+            viewModel.messageText = "Wait for the paste"
+            viewModel.pastedImages = [pastedImage]
+            viewModel.isImportingPastedImages = true
+            let initialSessionID = viewModel.pasteImportSessionID
+
+            viewModel.sendMessage()
+
+            #expect(aiService.singleModelRequests.isEmpty)
+            #expect(manager.conversation(byId: conversation.id)?.messages.isEmpty == true)
+            #expect(viewModel.messageText == "Wait for the paste")
+            #expect(viewModel.pastedImages == [pastedImage])
+            #expect(viewModel.pasteImportSessionID == initialSessionID)
+            #expect(!viewModel.isGenerating)
+            viewModel.cancelOwnedOperations()
+        }
+
         @Test(.timeLimit(.minutes(1)))
         func `multi-model send waits for lazy history and includes it in the request`() async throws {
             let priorUser = Message(role: .user, content: "Prior question")
@@ -326,6 +365,176 @@
             #expect(viewModel.messageText == "Keep this draft")
             #expect(viewModel.attachedFiles == [attachment])
             #expect(viewModel.errorMessage != nil)
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `failed send retry restores pasted images`() async throws {
+            let conversation = Conversation(model: "model-a", systemPromptMode: .disabled)
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = ControllableErrorAIService()
+            configure(aiService, models: [conversation.model])
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            let pastedImage = PastedImage(
+                data: Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A]),
+                mimeType: "image/png",
+                fileExtension: "png"
+            )
+            viewModel.messageText = "Retry this image"
+            viewModel.pastedImages = [pastedImage]
+
+            viewModel.sendMessage()
+            #expect(aiService.requests.count == 1)
+            #expect(viewModel.pastedImages.isEmpty)
+
+            aiService.failLatestRequest()
+            #expect(await waitUntil {
+                !viewModel.isGenerating && viewModel.failedMessage == "Retry this image"
+            })
+
+            viewModel.retryFailedMessage()
+
+            #expect(aiService.requests.count == 2)
+            let retriedUserMessage = try #require(
+                aiService.requests.last?.last(where: { $0.role == .user })
+            )
+            let retriedAttachment = try #require(retriedUserMessage.attachments?.first)
+            #expect(retriedAttachment.fileName == pastedImage.fileName)
+            #expect(retriedAttachment.mimeType == pastedImage.mimeType)
+            #expect(retriedAttachment.data == pastedImage.data)
+            #expect(viewModel.pastedImages.isEmpty)
+            #expect(viewModel.failedMessage == nil)
+            viewModel.cancelOwnedOperations()
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `failed send retry preserves a newer composer draft`() async throws {
+            let conversation = Conversation(model: "model-a", systemPromptMode: .disabled)
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = ControllableErrorAIService()
+            configure(aiService, models: [conversation.model])
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            let failedPaste = PastedImage(
+                data: Data([0x89, 0x50, 0x4E, 0x47, 0x01]),
+                mimeType: "image/png",
+                fileExtension: "png"
+            )
+            let laterPaste = PastedImage(
+                data: Data([0xFF, 0xD8, 0xFF, 0xE0, 0x02]),
+                mimeType: "image/jpeg",
+                fileExtension: "jpg"
+            )
+            viewModel.messageText = "Retry the failed image"
+            viewModel.pastedImages = [failedPaste]
+
+            viewModel.sendMessage()
+            #expect(aiService.requests.count == 1)
+            viewModel.messageText = "Keep this newer draft"
+            viewModel.pastedImages = [laterPaste]
+
+            aiService.failLatestRequest()
+            #expect(await waitUntil {
+                !viewModel.isGenerating && viewModel.failedMessage == "Retry the failed image"
+            })
+            #expect(viewModel.messageText == "Keep this newer draft")
+            #expect(viewModel.pastedImages == [laterPaste])
+
+            viewModel.retryFailedMessage()
+
+            #expect(aiService.requests.count == 2)
+            let retriedUserMessage = try #require(
+                aiService.requests.last?.last(where: { $0.role == .user })
+            )
+            let retriedAttachment = try #require(retriedUserMessage.attachments?.first)
+            #expect(retriedUserMessage.content == "Retry the failed image")
+            #expect(retriedUserMessage.attachments?.count == 1)
+            #expect(retriedAttachment.fileName == failedPaste.fileName)
+            #expect(retriedAttachment.mimeType == failedPaste.mimeType)
+            #expect(retriedAttachment.data == failedPaste.data)
+            #expect(viewModel.messageText == "Keep this newer draft")
+            #expect(viewModel.pastedImages == [laterPaste])
+            #expect(viewModel.failedMessage == nil)
+            viewModel.cancelOwnedOperations()
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `all-failed multi-model send retains its pasted image for retry`() async throws {
+            let models = ["model-a", "model-b"]
+            let conversation = Conversation(
+                model: models[0],
+                systemPromptMode: .disabled,
+                multiModelEnabled: true,
+                activeModels: models
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = ControllableMultiModelErrorAIService()
+            configure(aiService, models: models)
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            let pastedImage = PastedImage(
+                data: Data([0x89, 0x50, 0x4E, 0x47, 0x03]),
+                mimeType: "image/png",
+                fileExtension: "png"
+            )
+            viewModel.selectedModels = Set(models)
+            viewModel.messageText = "Compare this image"
+            viewModel.pastedImages = [pastedImage]
+
+            viewModel.sendMessage()
+            #expect(aiService.requests.count == 1)
+            #expect(viewModel.pastedImages.isEmpty)
+
+            aiService.failAllModelsInLatestRequest()
+            #expect(await waitUntil {
+                !viewModel.isGenerating && viewModel.failedMessage == "Compare this image"
+            })
+            #expect(viewModel.errorMessage == "All models failed")
+
+            viewModel.retryFailedMessage()
+
+            #expect(aiService.requests.count == 2)
+            let retriedUserMessage = try #require(
+                aiService.requests.last?.last(where: { $0.role == .user })
+            )
+            let retriedAttachment = try #require(retriedUserMessage.attachments?.first)
+            #expect(retriedUserMessage.content == "Compare this image")
+            #expect(retriedUserMessage.attachments?.count == 1)
+            #expect(retriedAttachment.fileName == pastedImage.fileName)
+            #expect(retriedAttachment.mimeType == pastedImage.mimeType)
+            #expect(retriedAttachment.data == pastedImage.data)
+            #expect(viewModel.failedMessage == nil)
+            viewModel.cancelOwnedOperations()
         }
 
         @Test(.timeLimit(.minutes(1)))
@@ -619,6 +828,115 @@
     private struct CapturedRetryRequest {
         let model: String
         let provider: AIProvider
+    }
+
+    private enum ControllableSendError: Error {
+        case failed
+    }
+
+    @MainActor
+    private final class ControllableErrorAIService: AIService {
+        private(set) var requests: [[Message]] = []
+        private var errorCallbacks: [@Sendable (Error) -> Void] = []
+
+        init() {
+            super.init(responseSimulator: { _, _ in })
+        }
+
+        override func sendMessage(
+            messages: [Message],
+            model: String?,
+            temperature: Double?,
+            stream: Bool,
+            tools: [[String: Any]]?,
+            conversationId: UUID?,
+            requestLane: AITextRequestLane,
+            isMultiModelRequest: Bool,
+            onChunk: @escaping @Sendable (String) -> Void,
+            onComplete: @escaping @Sendable () -> Void,
+            onError: @escaping @Sendable (Error) -> Void,
+            onToolCall: (@Sendable (String, String, [String: Any]) async -> String)?,
+            onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?,
+            onReasoning: (@Sendable (String) -> Void)?,
+            requestFlightID: RequestFlightID?
+        ) -> AITextRequest {
+            requests.append(messages)
+            errorCallbacks.append(onError)
+            return super.sendMessage(
+                messages: messages,
+                model: model,
+                temperature: temperature,
+                stream: stream,
+                tools: tools,
+                conversationId: conversationId,
+                requestLane: requestLane,
+                isMultiModelRequest: isMultiModelRequest,
+                onChunk: onChunk,
+                onComplete: onComplete,
+                onError: onError,
+                onToolCall: onToolCall,
+                onToolCallRequested: onToolCallRequested,
+                onReasoning: onReasoning,
+                requestFlightID: requestFlightID
+            )
+        }
+
+        func failLatestRequest() {
+            errorCallbacks.last?(ControllableSendError.failed)
+        }
+    }
+
+    @MainActor
+    private final class ControllableMultiModelErrorAIService: AIService {
+        private(set) var requests: [[Message]] = []
+        private var requestModels: [[String]] = []
+        private var errorCallbacks: [@Sendable (String, Error) -> Void] = []
+        private var allCompleteCallbacks: [@Sendable () -> Void] = []
+
+        init() {
+            super.init(responseSimulator: { _, _ in })
+        }
+
+        override func sendToMultipleModels(
+            messages: [Message],
+            models: [String],
+            temperature: Double?,
+            onChunk: @escaping @Sendable (String, String) -> Void,
+            onModelComplete: @escaping @Sendable (String) -> Void,
+            onAllComplete: @escaping @Sendable () -> Void,
+            onError: @escaping @Sendable (String, Error) -> Void,
+            onPendingToolCall: (@Sendable (String, String, String, [String: Any]) -> Void)?,
+            onReasoning: (@Sendable (String, String) -> Void)?
+        ) -> AITextBatchRequest {
+            requests.append(messages)
+            requestModels.append(models)
+            errorCallbacks.append(onError)
+            allCompleteCallbacks.append(onAllComplete)
+            return super.sendToMultipleModels(
+                messages: messages,
+                models: [],
+                temperature: temperature,
+                onChunk: { _, _ in },
+                onModelComplete: { _ in },
+                onAllComplete: {},
+                onError: { _, _ in },
+                onPendingToolCall: nil,
+                onReasoning: nil
+            )
+        }
+
+        func failAllModelsInLatestRequest() {
+            guard let models = requestModels.last,
+                  let onError = errorCallbacks.last,
+                  let onAllComplete = allCompleteCallbacks.last
+            else {
+                return
+            }
+            for model in models {
+                onError(model, ControllableSendError.failed)
+            }
+            onAllComplete()
+        }
     }
 
     @MainActor

--- a/Tests/AynaTests/IOSChatViewModelTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelTests.swift
@@ -115,8 +115,8 @@
             viewModel.cancelOwnedOperations()
         }
 
-        @Test
-        func `anthropic image limit is rejected before committing the message`() {
+        @Test(.timeLimit(.minutes(1)))
+        func `anthropic image limit is rejected before committing the message`() async throws {
             let model = "claude-test"
             let conversation = Conversation(model: model, systemPromptMode: .disabled)
             let manager = ConversationManager(
@@ -130,31 +130,38 @@
             let aiService = SendHistoryCapturingAIService()
             configure(aiService, models: [model])
             aiService.modelProviders[model] = .anthropic
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let storage = AttachmentStorage(
+                directoryURL: storageDirectory,
+                dataCache: AttachmentDataCache()
+            )
             let viewModel = IOSChatViewModel(
                 conversationId: conversation.id,
                 conversationManager: manager,
-                aiService: aiService
+                aiService: aiService,
+                attachmentStorage: storage
             )
             viewModel.pastedImages = (0 ... ChatDraftContent.maximumImageCount).map { index in
                 PastedImage(
-                    data: Data([0x89, 0x50, 0x4E, UInt8(index)]),
+                    data: Data([0x89, 0x50, 0x4E, 0x47, UInt8(index), 0, 0, 0, 0, 0, 0, 0]),
                     mimeType: "image/png",
                     fileExtension: "png"
                 )
             }
 
             viewModel.sendMessage()
+            #expect(await waitUntil { viewModel.errorMessage?.contains("at most 20 images") == true })
 
             #expect(aiService.singleModelRequests.isEmpty)
             #expect(manager.conversation(byId: conversation.id)?.messages.isEmpty == true)
             #expect(viewModel.pastedImages.count == ChatDraftContent.maximumImageCount + 1)
-            #expect(viewModel.errorMessage?.contains("at most 20 images") == true)
             #expect(!viewModel.isGenerating)
+            #expect(try FileManager.default.contentsOfDirectory(atPath: storageDirectory.path).isEmpty)
             viewModel.cancelOwnedOperations()
         }
 
-        @Test
-        func `oversized anthropic file image is rejected before committing the message`() throws {
+        @Test(.timeLimit(.minutes(1)))
+        func `oversized anthropic file image is rejected before committing the message`() async throws {
             let model = "claude-test"
             let conversation = Conversation(model: model, systemPromptMode: .disabled)
             let manager = ConversationManager(
@@ -168,10 +175,16 @@
             let aiService = SendHistoryCapturingAIService()
             configure(aiService, models: [model])
             aiService.modelProviders[model] = .anthropic
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let storage = AttachmentStorage(
+                directoryURL: storageDirectory,
+                dataCache: AttachmentDataCache()
+            )
             let viewModel = IOSChatViewModel(
                 conversationId: conversation.id,
                 conversationManager: manager,
-                aiService: aiService
+                aiService: aiService,
+                attachmentStorage: storage
             )
             let directory = try TestHelpers.makeTemporaryDirectory()
             let fileURL = directory.appendingPathComponent("large.jpg")
@@ -184,12 +197,13 @@
             viewModel.attachedFiles = [fileURL]
 
             viewModel.sendMessage()
+            #expect(await waitUntil { viewModel.errorMessage?.contains("Image too large") == true })
 
             #expect(aiService.singleModelRequests.isEmpty)
             #expect(manager.conversation(byId: conversation.id)?.messages.isEmpty == true)
             #expect(viewModel.attachedFiles == [fileURL])
-            #expect(viewModel.errorMessage?.contains("Image too large") == true)
             #expect(!viewModel.isGenerating)
+            #expect(try FileManager.default.contentsOfDirectory(atPath: storageDirectory.path).isEmpty)
             viewModel.cancelOwnedOperations()
         }
 
@@ -255,10 +269,16 @@
 
             let aiService = SendHistoryCapturingAIService()
             configure(aiService, models: models)
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let storage = AttachmentStorage(
+                directoryURL: storageDirectory,
+                dataCache: AttachmentDataCache()
+            )
             let viewModel = IOSChatViewModel(
                 conversationId: conversation.id,
                 conversationManager: manager,
-                aiService: aiService
+                aiService: aiService,
+                attachmentStorage: storage
             )
             let capturedPaste = PastedImage(
                 data: Data([0x89, 0x50, 0x4E, 0x47]),
@@ -289,7 +309,9 @@
             #expect(sentMessage.attachments?.count == 1)
             #expect(attachment.fileName == capturedPaste.fileName)
             #expect(attachment.mimeType == capturedPaste.mimeType)
-            #expect(attachment.data == capturedPaste.data)
+            #expect(attachment.data == nil)
+            let localPath = try #require(attachment.localPath)
+            #expect(storage.load(path: localPath) == capturedPaste.data)
             #expect(viewModel.pastedImages == [laterPaste])
             viewModel.cancelOwnedOperations()
         }
@@ -458,10 +480,16 @@
 
             let aiService = ControllableErrorAIService()
             configure(aiService, models: [conversation.model])
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let storage = AttachmentStorage(
+                directoryURL: storageDirectory,
+                dataCache: AttachmentDataCache()
+            )
             let viewModel = IOSChatViewModel(
                 conversationId: conversation.id,
                 conversationManager: manager,
-                aiService: aiService
+                aiService: aiService,
+                attachmentStorage: storage
             )
             let pastedImage = PastedImage(
                 data: Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A]),
@@ -472,7 +500,7 @@
             viewModel.pastedImages = [pastedImage]
 
             viewModel.sendMessage()
-            #expect(aiService.requests.count == 1)
+            #expect(await waitUntil { aiService.requests.count == 1 })
             #expect(viewModel.pastedImages.isEmpty)
             let committedUserMessage = try #require(
                 manager.conversation(byId: conversation.id)?.messages.first(where: { $0.role == .user })
@@ -485,7 +513,7 @@
 
             viewModel.retryFailedMessage()
 
-            #expect(aiService.requests.count == 2)
+            #expect(await waitUntil { aiService.requests.count == 2 })
             let retriedUserMessage = try #require(
                 aiService.requests.last?.last(where: { $0.role == .user })
             )
@@ -498,7 +526,9 @@
             )
             #expect(retriedAttachment.fileName == pastedImage.fileName)
             #expect(retriedAttachment.mimeType == pastedImage.mimeType)
-            #expect(retriedAttachment.data == pastedImage.data)
+            #expect(retriedAttachment.data == nil)
+            let localPath = try #require(retriedAttachment.localPath)
+            #expect(storage.load(path: localPath) == pastedImage.data)
             #expect(persistedUserMessages.map(\.id) == [committedUserMessage.id])
             #expect(requestedUserMessages.map(\.id) == [committedUserMessage.id])
             #expect(viewModel.pastedImages.isEmpty)
@@ -519,10 +549,16 @@
 
             let aiService = ControllableErrorAIService()
             configure(aiService, models: [conversation.model])
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let storage = AttachmentStorage(
+                directoryURL: storageDirectory,
+                dataCache: AttachmentDataCache()
+            )
             let viewModel = IOSChatViewModel(
                 conversationId: conversation.id,
                 conversationManager: manager,
-                aiService: aiService
+                aiService: aiService,
+                attachmentStorage: storage
             )
             let failedPaste = PastedImage(
                 data: Data([0x89, 0x50, 0x4E, 0x47, 0x01]),
@@ -538,7 +574,7 @@
             viewModel.pastedImages = [failedPaste]
 
             viewModel.sendMessage()
-            #expect(aiService.requests.count == 1)
+            #expect(await waitUntil { aiService.requests.count == 1 })
             viewModel.messageText = "Keep this newer draft"
             viewModel.pastedImages = [laterPaste]
 
@@ -551,7 +587,7 @@
 
             viewModel.retryFailedMessage()
 
-            #expect(aiService.requests.count == 2)
+            #expect(await waitUntil { aiService.requests.count == 2 })
             let retriedUserMessage = try #require(
                 aiService.requests.last?.last(where: { $0.role == .user })
             )
@@ -560,7 +596,9 @@
             #expect(retriedUserMessage.attachments?.count == 1)
             #expect(retriedAttachment.fileName == failedPaste.fileName)
             #expect(retriedAttachment.mimeType == failedPaste.mimeType)
-            #expect(retriedAttachment.data == failedPaste.data)
+            #expect(retriedAttachment.data == nil)
+            let localPath = try #require(retriedAttachment.localPath)
+            #expect(storage.load(path: localPath) == failedPaste.data)
             #expect(viewModel.messageText == "Keep this newer draft")
             #expect(viewModel.pastedImages == [laterPaste])
             #expect(viewModel.failedMessage == nil)
@@ -586,10 +624,16 @@
 
             let aiService = ControllableMultiModelErrorAIService()
             configure(aiService, models: models)
+            let storageDirectory = try TestHelpers.makeTemporaryDirectory()
+            let storage = AttachmentStorage(
+                directoryURL: storageDirectory,
+                dataCache: AttachmentDataCache()
+            )
             let viewModel = IOSChatViewModel(
                 conversationId: conversation.id,
                 conversationManager: manager,
-                aiService: aiService
+                aiService: aiService,
+                attachmentStorage: storage
             )
             let pastedImage = PastedImage(
                 data: Data([0x89, 0x50, 0x4E, 0x47, 0x03]),
@@ -601,7 +645,7 @@
             viewModel.pastedImages = [pastedImage]
 
             viewModel.sendMessage()
-            #expect(aiService.requests.count == 1)
+            #expect(await waitUntil { aiService.requests.count == 1 })
             #expect(viewModel.pastedImages.isEmpty)
 
             aiService.failAllModelsInLatestRequest()
@@ -612,7 +656,7 @@
 
             viewModel.retryFailedMessage()
 
-            #expect(aiService.requests.count == 2)
+            #expect(await waitUntil { aiService.requests.count == 2 })
             let retriedUserMessage = try #require(
                 aiService.requests.last?.last(where: { $0.role == .user })
             )
@@ -621,7 +665,9 @@
             #expect(retriedUserMessage.attachments?.count == 1)
             #expect(retriedAttachment.fileName == pastedImage.fileName)
             #expect(retriedAttachment.mimeType == pastedImage.mimeType)
-            #expect(retriedAttachment.data == pastedImage.data)
+            #expect(retriedAttachment.data == nil)
+            let localPath = try #require(retriedAttachment.localPath)
+            #expect(storage.load(path: localPath) == pastedImage.data)
             #expect(viewModel.failedMessage == nil)
             viewModel.cancelOwnedOperations()
         }

--- a/Tests/AynaTests/PastedImageTests.swift
+++ b/Tests/AynaTests/PastedImageTests.swift
@@ -22,6 +22,17 @@ import Testing
         }
 
         @Test
+        func `importing labels the image from its decoded format`() throws {
+            let pngData = try Self.encodedImage(as: .png)
+
+            let pastedImage = try PastedImage.importing(data: pngData, contentType: .jpeg)
+
+            #expect(pastedImage.data == pngData)
+            #expect(pastedImage.mimeType == "image/png")
+            #expect(pastedImage.fileExtension == "png")
+        }
+
+        @Test
         func `importing supported PNG rejects bytes that cannot decode`() throws {
             let completePNG = try #require(Data(base64Encoded:
                 "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="))
@@ -91,6 +102,30 @@ import Testing
         }
 
         @Test
+        func `converting applies EXIF orientation to the image pixels`() throws {
+            let orientedTIFF = try Self.encodedImage(
+                as: .tiff,
+                width: 96,
+                height: 64,
+                properties: [kCGImagePropertyOrientation: 6]
+            )
+            let originalSource = try #require(CGImageSourceCreateWithData(orientedTIFF as CFData, nil))
+            let originalProperties = try #require(
+                CGImageSourceCopyPropertiesAtIndex(originalSource, 0, nil) as NSDictionary?
+            )
+            #expect((originalProperties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue == 96)
+            #expect((originalProperties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue == 64)
+            #expect((originalProperties[kCGImagePropertyOrientation] as? NSNumber)?.intValue == 6)
+
+            let pastedImage = try PastedImage.importing(data: orientedTIFF, contentType: .tiff)
+
+            let convertedSource = try #require(CGImageSourceCreateWithData(pastedImage.data as CFData, nil))
+            let convertedImage = try #require(CGImageSourceCreateImageAtIndex(convertedSource, 0, nil))
+            #expect(convertedImage.width == 64)
+            #expect(convertedImage.height == 96)
+        }
+
+        @Test
         func `importing invalid bytes rejects the image`() {
             do {
                 _ = try PastedImage.importing(
@@ -111,7 +146,8 @@ import Testing
         private static func encodedImage(
             as contentType: UTType,
             width: Int = 96,
-            height: Int = 64
+            height: Int = 64,
+            properties: [CFString: Any]? = nil
         ) throws -> Data {
             let bitmapInfo = CGBitmapInfo.byteOrder32Big.rawValue
                 | CGImageAlphaInfo.premultipliedLast.rawValue
@@ -145,7 +181,11 @@ import Testing
             ) else {
                 throw PastedImageFixtureError.destinationCreationFailed
             }
-            CGImageDestinationAddImage(destination, image, nil)
+            CGImageDestinationAddImage(
+                destination,
+                image,
+                properties.map { $0 as CFDictionary }
+            )
             guard CGImageDestinationFinalize(destination) else {
                 throw PastedImageFixtureError.encodingFailed
             }

--- a/Tests/AynaTests/PastedImageTests.swift
+++ b/Tests/AynaTests/PastedImageTests.swift
@@ -1,0 +1,162 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+#if !os(watchOS)
+    import CoreGraphics
+    import ImageIO
+    import UniformTypeIdentifiers
+
+    @Suite("PastedImage Tests", .tags(.fast))
+    struct PastedImageTests {
+        @Test
+        func `importing supported PNG preserves original bytes`() throws {
+            let pngData = try Self.encodedImage(as: .png)
+
+            let pastedImage = try PastedImage.importing(data: pngData, contentType: .png)
+
+            #expect(pastedImage.data == pngData)
+            #expect(pastedImage.mimeType == "image/png")
+            #expect(pastedImage.fileExtension == "png")
+            #expect(pastedImage.data.count <= PastedImage.maximumByteCount)
+        }
+
+        @Test
+        func `importing supported PNG rejects bytes that cannot decode`() throws {
+            let completePNG = try #require(Data(base64Encoded:
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="))
+            let truncatedPNG = Data(completePNG.prefix(40))
+            let source = try #require(CGImageSourceCreateWithData(truncatedPNG as CFData, nil))
+            #expect(CGImageSourceGetCount(source) == 1)
+            #expect(CGImageSourceCreateImageAtIndex(source, 0, nil) == nil)
+
+            do {
+                _ = try PastedImage.importing(data: truncatedPNG, contentType: .png)
+                Issue.record("Expected undecodable PNG bytes to be rejected")
+            } catch let error as PastedImage.ImportError {
+                guard case .invalidImage = error else {
+                    Issue.record("Expected invalidImage, got \(error)")
+                    return
+                }
+            } catch {
+                Issue.record("Expected PastedImage.ImportError, got \(error)")
+            }
+        }
+
+        @Test
+        func `importing oversized supported PNG resizes instead of preserving bytes`() throws {
+            let oversizedPNG = try Self.encodedImage(as: .png, width: 4096, height: 128)
+            let originalSource = try #require(CGImageSourceCreateWithData(oversizedPNG as CFData, nil))
+            let originalImage = try #require(CGImageSourceCreateImageAtIndex(originalSource, 0, nil))
+            #expect(max(originalImage.width, originalImage.height) > 2048)
+            #expect(oversizedPNG.count <= PastedImage.maximumByteCount)
+
+            let pastedImage = try PastedImage.importing(data: oversizedPNG, contentType: .png)
+
+            #expect(pastedImage.data != oversizedPNG)
+            #expect(pastedImage.data.count <= PastedImage.maximumByteCount)
+            #expect(["image/png", "image/jpeg"].contains(pastedImage.mimeType))
+            #expect(["png", "jpg"].contains(pastedImage.fileExtension))
+            let resizedSource = try #require(CGImageSourceCreateWithData(pastedImage.data as CFData, nil))
+            let resizedImage = try #require(CGImageSourceCreateImageAtIndex(resizedSource, 0, nil))
+            #expect(max(resizedImage.width, resizedImage.height) <= 2048)
+        }
+
+        @Test
+        func `importing TIFF converts to a provider-safe image`() throws {
+            let tiffData = try Self.encodedImage(as: .tiff)
+
+            let pastedImage = try PastedImage.importing(data: tiffData, contentType: .tiff)
+
+            #expect(pastedImage.data != tiffData)
+            #expect(!pastedImage.data.isEmpty)
+            #expect(pastedImage.data.count <= PastedImage.maximumByteCount)
+
+            let expectedContentType: UTType
+            switch pastedImage.mimeType {
+            case "image/png":
+                #expect(pastedImage.fileExtension == "png")
+                expectedContentType = .png
+            case "image/jpeg":
+                #expect(pastedImage.fileExtension == "jpg")
+                expectedContentType = .jpeg
+            default:
+                Issue.record("Expected a PNG or JPEG conversion, got \(pastedImage.mimeType)")
+                return
+            }
+
+            let source = try #require(CGImageSourceCreateWithData(pastedImage.data as CFData, nil))
+            #expect(CGImageSourceGetCount(source) == 1)
+            #expect(CGImageSourceGetType(source) as String? == expectedContentType.identifier)
+        }
+
+        @Test
+        func `importing invalid bytes rejects the image`() {
+            do {
+                _ = try PastedImage.importing(
+                    data: Data("not an image".utf8),
+                    contentType: .png
+                )
+                Issue.record("Expected invalid image bytes to be rejected")
+            } catch let error as PastedImage.ImportError {
+                guard case .invalidImage = error else {
+                    Issue.record("Expected invalidImage, got \(error)")
+                    return
+                }
+            } catch {
+                Issue.record("Expected PastedImage.ImportError, got \(error)")
+            }
+        }
+
+        private static func encodedImage(
+            as contentType: UTType,
+            width: Int = 96,
+            height: Int = 64
+        ) throws -> Data {
+            let bitmapInfo = CGBitmapInfo.byteOrder32Big.rawValue
+                | CGImageAlphaInfo.premultipliedLast.rawValue
+            guard let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: bitmapInfo
+            ) else {
+                throw PastedImageFixtureError.contextCreationFailed
+            }
+
+            context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 0.75))
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+            context.setFillColor(CGColor(red: 0.9, green: 0.2, blue: 0.1, alpha: 0.5))
+            context.fill(CGRect(x: 24, y: 16, width: 48, height: 32))
+
+            guard let image = context.makeImage() else {
+                throw PastedImageFixtureError.imageCreationFailed
+            }
+
+            let output = NSMutableData()
+            guard let destination = CGImageDestinationCreateWithData(
+                output,
+                contentType.identifier as CFString,
+                1,
+                nil
+            ) else {
+                throw PastedImageFixtureError.destinationCreationFailed
+            }
+            CGImageDestinationAddImage(destination, image, nil)
+            guard CGImageDestinationFinalize(destination) else {
+                throw PastedImageFixtureError.encodingFailed
+            }
+            return output as Data
+        }
+    }
+
+    private enum PastedImageFixtureError: Error {
+        case contextCreationFailed
+        case imageCreationFailed
+        case destinationCreationFailed
+        case encodingFailed
+    }
+#endif

--- a/Tests/AynaTests/WatchDataModelHostTests.swift
+++ b/Tests/AynaTests/WatchDataModelHostTests.swift
@@ -42,6 +42,24 @@ struct WatchDataModelHostTests {
     }
 
     @Test
+    func `Watch message renders attachment-only user content as an image placeholder`() {
+        var original = Message(role: .user, content: "")
+        original.attachments = [
+            Message.FileAttachment(
+                fileName: "pasted-image.png",
+                mimeType: "image/png",
+                data: Data([0x89]),
+                localPath: nil
+            ),
+        ]
+
+        let converted = WatchMessage(from: original)
+
+        #expect(converted.content == "[Image]")
+        #expect(converted.visibleContent == "[Image]")
+    }
+
+    @Test
     func `Watch message exposes reasoning when final content is empty`() {
         let reasoningOnly = WatchMessage(
             id: UUID(),


### PR DESCRIPTION
## Summary

- add clipboard image import on macOS and iOS with validation, resizing, compression, previews, and multiple-image support
- allow attachment-only messages and persist/render pasted images in conversation history
- prevent paste races across send/reset lifecycle changes and reject attachments for unsupported providers
- explicitly enable Paste responder actions for image-only clipboards on macOS and iOS

## Testing

- `swift test --filter DynamicTextEditorPasteTests` (1 test passed)
- `swift test --filter "DynamicTextEditorPasteTests|PastedImageTests"` (6 tests passed)
- `swift build --triple arm64-apple-ios26.0 --sdk "$(xcrun --sdk iphoneos --show-sdk-path)" --scratch-path .build/paste-fix-ios-final`
- `swift build --triple arm64-apple-watchos26.0`
- `swiftlint --strict`
- `swiftformat --lint Tests/AynaTests/DynamicTextEditorPasteTests.swift`
- `git diff --check`
- macOS app smoke test: image-only clipboard enables Edit > Paste and creates a Pasted image attachment chip

## Notes

The full macOS suite compiled, but unrelated existing timing-sensitive tests failed under the highly parallel run; all paste-image-focused tests passed.
