### PR TITLE
feat: add model-aware chat reasoning controls

### DIFF
--- a/Sources/Ayna/Models/Conversation.swift
+++ b/Sources/Ayna/Models/Conversation.swift
@@ -75,6 +75,7 @@ struct Conversation: Identifiable, Equatable, Sendable {
     var model: String
     var systemPromptMode: SystemPromptMode
     var temperature: Double
+    var reasoningConfiguration: ModelReasoningConfiguration
 
     // Multi-model support
     var multiModelEnabled: Bool
@@ -97,6 +98,7 @@ struct Conversation: Identifiable, Equatable, Sendable {
         model: String = "gpt-4o",
         systemPromptMode: SystemPromptMode = .inheritGlobal,
         temperature: Double = 0.7,
+        reasoningConfiguration: ModelReasoningConfiguration = .automatic,
         multiModelEnabled: Bool = false,
         activeModels: [String] = [],
         responseGroups: [ResponseGroup] = [],
@@ -110,6 +112,7 @@ struct Conversation: Identifiable, Equatable, Sendable {
         self.model = model
         self.systemPromptMode = systemPromptMode
         self.temperature = temperature
+        self.reasoningConfiguration = reasoningConfiguration
         self.multiModelEnabled = multiModelEnabled
         self.activeModels = activeModels
         self.responseGroups = responseGroups
@@ -120,7 +123,7 @@ struct Conversation: Identifiable, Equatable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case id, title, messages, createdAt, updatedAt, model
-        case systemPromptMode, temperature
+        case systemPromptMode, temperature, reasoningConfiguration
         case multiModelEnabled, activeModels, responseGroups
     }
 
@@ -149,6 +152,10 @@ struct Conversation: Identifiable, Equatable, Sendable {
             }
         }
         temperature = try container.decode(Double.self, forKey: .temperature)
+        reasoningConfiguration = try container.decodeIfPresent(
+            ModelReasoningConfiguration.self,
+            forKey: .reasoningConfiguration
+        ) ?? .automatic
         // Provide defaults for new multi-model fields (backward compatibility)
         multiModelEnabled = try container.decodeIfPresent(Bool.self, forKey: .multiModelEnabled) ?? false
         activeModels = try container.decodeIfPresent([String].self, forKey: .activeModels) ?? []

--- a/Sources/Ayna/Models/ConversationMetadata.swift
+++ b/Sources/Ayna/Models/ConversationMetadata.swift
@@ -15,6 +15,7 @@ struct ConversationMetadata: Identifiable, Codable, Equatable, Sendable {
     var model: String
     var systemPromptMode: SystemPromptMode
     var temperature: Double
+    var reasoningConfiguration: ModelReasoningConfiguration
     var multiModelEnabled: Bool
     var activeModels: [String]
     var messageCount: Int
@@ -31,6 +32,7 @@ struct ConversationMetadata: Identifiable, Codable, Equatable, Sendable {
         model: String,
         systemPromptMode: SystemPromptMode,
         temperature: Double,
+        reasoningConfiguration: ModelReasoningConfiguration = .automatic,
         multiModelEnabled: Bool,
         activeModels: [String],
         messageCount: Int,
@@ -46,6 +48,7 @@ struct ConversationMetadata: Identifiable, Codable, Equatable, Sendable {
         self.model = model
         self.systemPromptMode = systemPromptMode
         self.temperature = temperature
+        self.reasoningConfiguration = reasoningConfiguration
         self.multiModelEnabled = multiModelEnabled
         self.activeModels = activeModels
         self.messageCount = messageCount
@@ -64,6 +67,7 @@ struct ConversationMetadata: Identifiable, Codable, Equatable, Sendable {
             model: conversation.model,
             systemPromptMode: conversation.systemPromptMode,
             temperature: conversation.temperature,
+            reasoningConfiguration: conversation.reasoningConfiguration,
             multiModelEnabled: conversation.multiModelEnabled,
             activeModels: conversation.activeModels,
             messageCount: conversation.messages.count,
@@ -75,7 +79,7 @@ struct ConversationMetadata: Identifiable, Codable, Equatable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case id, title, createdAt, updatedAt, model
-        case systemPromptMode, temperature, multiModelEnabled, activeModels
+        case systemPromptMode, temperature, reasoningConfiguration, multiModelEnabled, activeModels
         case messageCount, responseGroupCount, lastMessagePreview, searchableText
     }
 
@@ -88,6 +92,10 @@ struct ConversationMetadata: Identifiable, Codable, Equatable, Sendable {
         model = try container.decode(String.self, forKey: .model)
         systemPromptMode = try container.decode(SystemPromptMode.self, forKey: .systemPromptMode)
         temperature = try container.decode(Double.self, forKey: .temperature)
+        reasoningConfiguration = try container.decodeIfPresent(
+            ModelReasoningConfiguration.self,
+            forKey: .reasoningConfiguration
+        ) ?? .automatic
         multiModelEnabled = try container.decode(Bool.self, forKey: .multiModelEnabled)
         activeModels = try container.decode([String].self, forKey: .activeModels)
         messageCount = try container.decode(Int.self, forKey: .messageCount)
@@ -108,6 +116,7 @@ struct ConversationMetadata: Identifiable, Codable, Equatable, Sendable {
         try container.encode(model, forKey: .model)
         try container.encode(systemPromptMode, forKey: .systemPromptMode)
         try container.encode(temperature, forKey: .temperature)
+        try container.encode(reasoningConfiguration, forKey: .reasoningConfiguration)
         try container.encode(multiModelEnabled, forKey: .multiModelEnabled)
         try container.encode(activeModels, forKey: .activeModels)
         try container.encode(messageCount, forKey: .messageCount)

--- a/Sources/Ayna/Models/ConversationMetadata.swift
+++ b/Sources/Ayna/Models/ConversationMetadata.swift
@@ -118,8 +118,8 @@ struct ConversationMetadata: Identifiable, Codable, Equatable, Sendable {
 
     private static func previewText(from conversation: Conversation) -> String {
         let previewSource = conversation.messages.last
-        guard let content = previewSource?.content, !content.isEmpty else { return "" }
-        return String(content.prefix(240))
+        guard let previewText = previewSource?.previewText else { return "" }
+        return String(previewText.prefix(240))
     }
 
     private static func searchText(from conversation: Conversation) -> String {
@@ -174,6 +174,12 @@ struct ConversationMetadata: Identifiable, Codable, Equatable, Sendable {
         for message in conversation.messages {
             append("\n")
             append(message.content)
+            if let reasoning = message.reasoning,
+               !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                append("\n")
+                append(reasoning)
+            }
         }
 
         return exceededLimit ? "\(head)\n…\n\(tail)" : completeText

--- a/Sources/Ayna/Models/Message.swift
+++ b/Sources/Ayna/Models/Message.swift
@@ -30,7 +30,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
     var content: String
     let timestamp: Date
     var isLiked: Bool
-        var toolCalls: [MCPToolCall]?
+    var toolCalls: [MCPToolCall]?
     var model: String? // Track which model generated this message
 
     // Multi-model response support
@@ -50,6 +50,29 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
 
     /// Reasoning/thinking support for o1/o3 models
     var reasoning: String?
+
+    /// Opaque provider state needed to continue reasoning across tool calls and
+    /// later turns. This is never rendered as user-visible reasoning text.
+    var reasoningContinuation: ReasoningContinuationState?
+
+    /// Text suitable for compact conversation previews.
+    /// Final answer content takes precedence, with reasoning as a fallback for reasoning-only responses.
+    var previewText: String? {
+        if !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return content
+        }
+        guard let reasoning,
+              !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+        return reasoning
+    }
+
+    mutating func appendReasoning(_ chunk: String) {
+        guard !chunk.isEmpty else { return }
+        reasoning = (reasoning ?? "") + chunk
+    }
 
     /// Web search citation support
     var citations: [CitationReference]?
@@ -71,7 +94,9 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
         /// Helper to get data regardless of storage method
         @MainActor
         var content: Data? {
-            if let data { return data }
+            if let data {
+                return data
+            }
             if let path = localPath {
                 return Message.attachmentLoader?(path)
             }
@@ -80,8 +105,12 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
 
         /// Async loader that avoids blocking the current actor on disk I/O.
         func loadContent() async -> Data? {
-            if let data { return data }
-            guard let path = localPath else { return nil }
+            if let data {
+                return data
+            }
+            guard let path = localPath else {
+                return nil
+            }
             return await Message.loadAttachmentData(at: path)
         }
     }
@@ -109,6 +138,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
             imagePath: String? = nil,
             attachments: [FileAttachment]? = nil,
             reasoning: String? = nil,
+            reasoningContinuation: ReasoningContinuationState? = nil,
             citations: [CitationReference]? = nil,
             isEdited: Bool = false,
             editedAt: Date? = nil
@@ -127,6 +157,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
             self.imagePath = imagePath
             self.attachments = attachments
             self.reasoning = reasoning
+            self.reasoningContinuation = reasoningContinuation
             self.citations = citations
             self.isEdited = isEdited
             self.editedAt = editedAt
@@ -148,6 +179,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
             imagePath: String? = nil,
             attachments: [FileAttachment]? = nil,
             reasoning: String? = nil,
+            reasoningContinuation: ReasoningContinuationState? = nil,
             citations: [CitationReference]? = nil,
             isEdited: Bool = false,
             editedAt: Date? = nil
@@ -167,6 +199,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
             self.imagePath = imagePath
             self.attachments = attachments
             self.reasoning = reasoning
+            self.reasoningContinuation = reasoningContinuation
             self.citations = citations
             self.isEdited = isEdited
             self.editedAt = editedAt
@@ -179,7 +212,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case id, role, content, timestamp, isLiked, toolCalls, model
             case responseGroupId, isSelectedResponse
-            case mediaType, imageData, imagePath, attachments, reasoning, citations
+            case mediaType, imageData, imagePath, attachments, reasoning, reasoningContinuation, citations
             case isEdited, editedAt
         }
 
@@ -201,6 +234,10 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
             imagePath = try container.decodeIfPresent(String.self, forKey: .imagePath)
             attachments = try container.decodeIfPresent([FileAttachment].self, forKey: .attachments)
             reasoning = try container.decodeIfPresent(String.self, forKey: .reasoning)
+            reasoningContinuation = try container.decodeIfPresent(
+                ReasoningContinuationState.self,
+                forKey: .reasoningContinuation
+            )
             citations = try container.decodeIfPresent([CitationReference].self, forKey: .citations)
             // Edit tracking (backward compatibility - defaults to false for old messages)
             isEdited = try container.decodeIfPresent(Bool.self, forKey: .isEdited) ?? false
@@ -210,7 +247,7 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case id, role, content, timestamp, isLiked, toolCalls, model
             case responseGroupId, isSelectedResponse, pendingToolCalls
-            case mediaType, imageData, imagePath, attachments, reasoning, citations
+            case mediaType, imageData, imagePath, attachments, reasoning, reasoningContinuation, citations
             case isEdited, editedAt
         }
 
@@ -233,6 +270,10 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
             imagePath = try container.decodeIfPresent(String.self, forKey: .imagePath)
             attachments = try container.decodeIfPresent([FileAttachment].self, forKey: .attachments)
             reasoning = try container.decodeIfPresent(String.self, forKey: .reasoning)
+            reasoningContinuation = try container.decodeIfPresent(
+                ReasoningContinuationState.self,
+                forKey: .reasoningContinuation
+            )
             citations = try container.decodeIfPresent([CitationReference].self, forKey: .citations)
             // Edit tracking (backward compatibility - defaults to false for old messages)
             isEdited = try container.decodeIfPresent(Bool.self, forKey: .isEdited) ?? false
@@ -243,7 +284,9 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
     /// Helper to get image data regardless of storage method
     @MainActor
     var effectiveImageData: Data? {
-        if let data = imageData { return data }
+        if let data = imageData {
+            return data
+        }
         if let path = imagePath {
             return Message.attachmentLoader?(path)
         }
@@ -252,8 +295,12 @@ struct Message: Identifiable, Codable, Equatable, Sendable {
 
     /// Async loader that avoids blocking the current actor on attachment I/O.
     func loadEffectiveImageData() async -> Data? {
-        if let data = imageData { return data }
-        guard let path = imagePath else { return nil }
+        if let data = imageData {
+            return data
+        }
+        guard let path = imagePath else {
+            return nil
+        }
         return await Message.loadAttachmentData(at: path)
     }
 

--- a/Sources/Ayna/Models/ModelReasoningSettingsPresentation.swift
+++ b/Sources/Ayna/Models/ModelReasoningSettingsPresentation.swift
@@ -177,3 +177,76 @@ struct ModelReasoningSettingsPresentation: Equatable, Sendable {
         return normalized
     }
 }
+
+struct ChatReasoningModelContext: Equatable, Sendable {
+    let model: String
+    let provider: AIProvider
+    let endpointType: APIEndpointType
+    let endpoint: String?
+}
+
+/// Capability intersection for one conversation's selected models.
+///
+/// A conversation stores one reasoning configuration, so multi-model controls
+/// must expose only values that every selected model accepts.
+struct ChatReasoningSettingsPresentation: Equatable, Sendable {
+    let models: [ChatReasoningModelContext]
+    let individualPresentations: [ModelReasoningSettingsPresentation]
+    let isAvailable: Bool
+    let activationOptions: [ReasoningActivationMode]
+    let effortOptions: [ReasoningEffort]
+
+    init(
+        models: [ChatReasoningModelContext],
+        configuration: ModelReasoningConfiguration
+    ) {
+        self.models = models
+        let presentations = models.map { context in
+            ModelReasoningSettingsPresentation(
+                model: context.model,
+                provider: context.provider,
+                endpointType: context.endpointType,
+                endpoint: context.endpoint,
+                configuration: configuration
+            )
+        }
+        individualPresentations = presentations
+        isAvailable = !presentations.isEmpty && presentations.allSatisfy(\.isActivationEnabled)
+        activationOptions = ReasoningActivationMode.allCases.filter { activation in
+            !presentations.isEmpty && presentations.allSatisfy {
+                $0.activationOptions.contains(activation)
+            }
+        }
+        if let first = presentations.first?.effortOptions {
+            effortOptions = first.filter { effort in
+                presentations.dropFirst().allSatisfy { $0.effortOptions.contains(effort) }
+            }
+        } else {
+            effortOptions = []
+        }
+    }
+
+    func normalizedConfiguration(
+        _ configuration: ModelReasoningConfiguration
+    ) -> ModelReasoningConfiguration {
+        guard let first = models.first else { return configuration }
+        if models.count == 1 {
+            return ModelReasoningSettingsPresentation.normalizedConfiguration(
+                model: first.model,
+                provider: first.provider,
+                endpointType: first.endpointType,
+                endpoint: first.endpoint,
+                configuration: configuration
+            )
+        }
+
+        var normalized = configuration
+        if !activationOptions.contains(normalized.activation) {
+            normalized.activation = .automatic
+        }
+        if let effort = normalized.effort, !effortOptions.contains(effort) {
+            normalized.effort = nil
+        }
+        return normalized
+    }
+}

--- a/Sources/Ayna/Models/ModelReasoningSettingsPresentation.swift
+++ b/Sources/Ayna/Models/ModelReasoningSettingsPresentation.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+/// Provider-aware presentation policy for per-model reasoning settings.
+///
+/// The activation control is always rendered by the settings UI. Additional
+/// fields are exposed only when they map to the configured provider dialect.
+struct ModelReasoningSettingsPresentation: Equatable, Sendable {
+    let isActivationEnabled: Bool
+    let activationOptions: [ReasoningActivationMode]
+    let effortOptions: [ReasoningEffort]
+    let openAIModeOptions: [OpenAIReasoningMode]
+    let openAIContextOptions: [OpenAIReasoningContext]
+    let summaryOptions: [ReasoningSummaryPreference]
+    let anthropicModeOptions: [AnthropicThinkingMode]
+    let showsEffort: Bool
+    let showsOpenAIMode: Bool
+    let showsOpenAIContext: Bool
+    let showsSummary: Bool
+    let showsAnthropicMode: Bool
+    let showsAnthropicDisplay: Bool
+    let showsLegacyBudget: Bool
+    let unavailableDescription: String?
+
+    init(
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        endpoint: String?,
+        configuration: ModelReasoningConfiguration
+    ) {
+        guard provider != .appleIntelligence, endpointType != .imageGeneration else {
+            isActivationEnabled = false
+            activationOptions = [.automatic, .disabled, .enabled]
+            effortOptions = []
+            openAIModeOptions = []
+            openAIContextOptions = []
+            summaryOptions = []
+            anthropicModeOptions = []
+            showsEffort = false
+            showsOpenAIMode = false
+            showsOpenAIContext = false
+            showsSummary = false
+            showsAnthropicMode = false
+            showsAnthropicDisplay = false
+            showsLegacyBudget = false
+            unavailableDescription = provider == .appleIntelligence
+                ? "Apple Intelligence does not expose provider reasoning request controls."
+                : "Reasoning request controls are unavailable for image generation models."
+            return
+        }
+
+        isActivationEnabled = true
+        let modelPolicy = ReasoningCapabilityResolver.modelPolicy(
+            model: model,
+            provider: provider,
+            endpointType: endpointType,
+            anthropicMode: configuration.anthropicMode
+        )
+        let supportsExplicitDisable = switch modelPolicy?.explicitDisableSupport {
+        case .supported?, .supportedWithEfforts?:
+            true
+        case .unknown?, .unsupported?, nil:
+            false
+        }
+        activationOptions = ReasoningActivationMode.allCases.filter {
+            $0 != .explicitlyDisabled || supportsExplicitDisable
+        }
+
+        let capabilities = configuration.activation == .explicitlyDisabled
+            ? modelPolicy
+            : ReasoningCapabilityResolver.capabilities(
+                model: model,
+                provider: provider,
+                endpointType: endpointType,
+                endpoint: endpoint,
+                configuration: configuration
+            )
+        guard let capabilities else {
+            effortOptions = []
+            openAIModeOptions = []
+            openAIContextOptions = []
+            summaryOptions = []
+            anthropicModeOptions = []
+            showsEffort = false
+            showsOpenAIMode = false
+            showsOpenAIContext = false
+            showsSummary = false
+            showsAnthropicMode = false
+            showsAnthropicDisplay = false
+            showsLegacyBudget = false
+            unavailableDescription = configuration.activation == .automatic
+                ? "Automatic reasoning is unavailable for this model or endpoint. Choose On to configure provider-compatible controls."
+                : nil
+            return
+        }
+
+        let disableEfforts: [ReasoningEffort] = switch capabilities.explicitDisableSupport {
+        case .supported where provider == .anthropic:
+            capabilities.supportedEfforts
+        case let .supportedWithEfforts(efforts) where provider == .anthropic:
+            efforts
+        case .unknown, .unsupported, .supported, .supportedWithEfforts:
+            []
+        }
+        effortOptions = configuration.activation == .explicitlyDisabled
+            ? disableEfforts
+            : capabilities.supportedEfforts
+        openAIModeOptions = capabilities.supportedOpenAIModes
+        openAIContextOptions = capabilities.supportedOpenAIContexts
+        summaryOptions = capabilities.supportedSummaries
+        anthropicModeOptions = capabilities.supportedAnthropicModes
+        let showsEnabledControls = configuration.activation != .explicitlyDisabled
+        showsEffort = !effortOptions.isEmpty
+        showsOpenAIMode = showsEnabledControls && !capabilities.supportedOpenAIModes.isEmpty
+        showsOpenAIContext = showsEnabledControls && !capabilities.supportedOpenAIContexts.isEmpty
+        showsSummary = showsEnabledControls && !capabilities.supportedSummaries.isEmpty
+        showsAnthropicMode = provider == .anthropic &&
+            configuration.activation == .enabled &&
+            capabilities.supportedAnthropicModes.count > 1
+        showsAnthropicDisplay = showsEnabledControls && provider == .anthropic
+        showsLegacyBudget = showsEnabledControls && capabilities.dialect == .anthropicExtended
+        unavailableDescription = nil
+    }
+
+    static func normalizedConfiguration(
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        endpoint: String?,
+        configuration: ModelReasoningConfiguration
+    ) -> ModelReasoningConfiguration {
+        var normalized = configuration
+        var presentation = ModelReasoningSettingsPresentation(
+            model: model,
+            provider: provider,
+            endpointType: endpointType,
+            endpoint: endpoint,
+            configuration: normalized
+        )
+
+        if !presentation.isActivationEnabled ||
+            !presentation.activationOptions.contains(normalized.activation)
+        {
+            normalized.activation = .automatic
+            presentation = ModelReasoningSettingsPresentation(
+                model: model,
+                provider: provider,
+                endpointType: endpointType,
+                endpoint: endpoint,
+                configuration: normalized
+            )
+        }
+
+        if let effort = normalized.effort,
+           !presentation.effortOptions.contains(effort)
+        {
+            normalized.effort = nil
+        }
+        if let openAIMode = normalized.openAIMode,
+           !presentation.openAIModeOptions.contains(openAIMode)
+        {
+            normalized.openAIMode = nil
+        }
+        if !presentation.openAIContextOptions.contains(normalized.openAIContext) {
+            normalized.openAIContext = .automatic
+        }
+        if !presentation.summaryOptions.contains(normalized.summary) {
+            normalized.summary = .automatic
+        }
+        if !presentation.anthropicModeOptions.contains(normalized.anthropicMode) {
+            normalized.anthropicMode = presentation.anthropicModeOptions.first ?? .adaptive
+        }
+        normalized.legacyBudgetTokens = max(
+            normalized.legacyBudgetTokens,
+            ModelReasoningConfiguration.minimumLegacyBudgetTokens
+        )
+        return normalized
+    }
+}

--- a/Sources/Ayna/Models/ReasoningConfiguration.swift
+++ b/Sources/Ayna/Models/ReasoningConfiguration.swift
@@ -1,0 +1,1086 @@
+import Foundation
+
+/// User intent for requesting provider reasoning.
+///
+/// Automatic mode only sends reasoning parameters when Ayna can identify a
+/// first-party model and request dialect conservatively. Explicit mode allows
+/// custom endpoints and deployment aliases to opt in without relying on their
+/// names. Provider Default omits controls, while Off emits a provider disable
+/// directive only when Ayna knows that the configured model supports one.
+enum ReasoningActivationMode: String, Codable, CaseIterable, Sendable {
+    case automatic
+    case disabled
+    case explicitlyDisabled
+    case enabled
+
+    var displayName: String {
+        switch self {
+        case .automatic: "Automatic"
+        case .disabled: "Provider Default"
+        case .explicitlyDisabled: "Off"
+        case .enabled: "On"
+        }
+    }
+}
+
+/// Union of reasoning effort values currently used by supported providers.
+/// Individual models may accept only a subset, so automatic mode never invents
+/// an effort value and explicit selections are treated as user overrides.
+enum ReasoningEffort: String, Codable, CaseIterable, Sendable {
+    case none
+    case minimal
+    case low
+    case medium
+    case high
+    case xhigh
+    case max
+
+    var displayName: String {
+        switch self {
+        case .none: "None"
+        case .minimal: "Minimal"
+        case .low: "Low"
+        case .medium: "Medium"
+        case .high: "High"
+        case .xhigh: "Extra High"
+        case .max: "Maximum"
+        }
+    }
+
+    static let anthropicValues: [ReasoningEffort] = [.low, .medium, .high, .xhigh, .max]
+}
+
+enum OpenAIReasoningMode: String, Codable, CaseIterable, Sendable {
+    case standard
+    case pro
+
+    var displayName: String {
+        switch self {
+        case .standard: "Standard"
+        case .pro: "Pro"
+        }
+    }
+}
+
+enum OpenAIReasoningContext: String, Codable, CaseIterable, Sendable {
+    case automatic = "auto"
+    case currentTurn = "current_turn"
+    case allTurns = "all_turns"
+
+    var displayName: String {
+        switch self {
+        case .automatic: "Model Default"
+        case .currentTurn: "Current Turn"
+        case .allTurns: "All Turns"
+        }
+    }
+
+    var wireValue: String? {
+        self == .automatic ? nil : rawValue
+    }
+}
+
+enum ReasoningSummaryPreference: String, Codable, CaseIterable, Sendable {
+    case none
+    case automatic = "auto"
+    case concise
+    case detailed
+
+    var displayName: String {
+        switch self {
+        case .none: "None"
+        case .automatic: "Automatic"
+        case .concise: "Concise"
+        case .detailed: "Detailed"
+        }
+    }
+
+    var wireValue: String? {
+        self == .none ? nil : rawValue
+    }
+}
+
+enum AnthropicThinkingMode: String, Codable, CaseIterable, Sendable {
+    case adaptive
+    case extended
+
+    var displayName: String {
+        switch self {
+        case .adaptive: "Adaptive"
+        case .extended: "Extended (Legacy)"
+        }
+    }
+}
+
+enum AnthropicThinkingDisplay: String, Codable, CaseIterable, Sendable {
+    case providerDefault
+    case summarized
+    case omitted
+
+    var displayName: String {
+        switch self {
+        case .providerDefault: "Provider Default"
+        case .summarized: "Show Summary"
+        case .omitted: "Hide Summary"
+        }
+    }
+
+    var wireValue: String? {
+        self == .providerDefault ? nil : rawValue
+    }
+}
+
+/// Persisted reasoning settings for one configured model.
+struct ModelReasoningConfiguration: Codable, Equatable, Sendable {
+    static let minimumLegacyBudgetTokens = 1024
+    static let defaultLegacyBudgetTokens = 4096
+
+    var activation: ReasoningActivationMode
+    var effort: ReasoningEffort?
+    var openAIMode: OpenAIReasoningMode?
+    var openAIContext: OpenAIReasoningContext
+    var summary: ReasoningSummaryPreference
+    var anthropicMode: AnthropicThinkingMode
+    var anthropicDisplay: AnthropicThinkingDisplay
+    var legacyBudgetTokens: Int
+
+    init(
+        activation: ReasoningActivationMode = .automatic,
+        effort: ReasoningEffort? = nil,
+        openAIMode: OpenAIReasoningMode? = nil,
+        openAIContext: OpenAIReasoningContext = .automatic,
+        summary: ReasoningSummaryPreference = .automatic,
+        anthropicMode: AnthropicThinkingMode = .adaptive,
+        anthropicDisplay: AnthropicThinkingDisplay = .providerDefault,
+        legacyBudgetTokens: Int = defaultLegacyBudgetTokens
+    ) {
+        self.activation = activation
+        self.effort = effort
+        self.openAIMode = openAIMode
+        self.openAIContext = openAIContext
+        self.summary = summary
+        self.anthropicMode = anthropicMode
+        self.anthropicDisplay = anthropicDisplay
+        self.legacyBudgetTokens = max(legacyBudgetTokens, Self.minimumLegacyBudgetTokens)
+    }
+
+    static let automatic = ModelReasoningConfiguration()
+}
+
+/// Provider request dialect selected after combining persisted user intent with
+/// the configured provider, endpoint, and conservative first-party inference.
+enum ResolvedReasoningDialect: String, Codable, Equatable, Sendable {
+    case openAIChat
+    case openAIResponses
+    case anthropicDisabled
+    case anthropicAdaptive
+    case anthropicExtended
+}
+
+struct ResolvedReasoningConfiguration: Codable, Equatable, Sendable {
+    let dialect: ResolvedReasoningDialect
+    let effort: ReasoningEffort?
+    let openAIMode: OpenAIReasoningMode?
+    let openAIContext: OpenAIReasoningContext
+    let summary: ReasoningSummaryPreference
+    let anthropicDisplay: AnthropicThinkingDisplay
+    let legacyBudgetTokens: Int
+
+    var requiresOpaqueStateReplay: Bool {
+        switch dialect {
+        case .openAIResponses, .anthropicAdaptive, .anthropicExtended:
+            true
+        case .openAIChat, .anthropicDisabled:
+            false
+        }
+    }
+}
+
+/// Request controls that Ayna can safely expose for one configured model.
+///
+/// Automatic mode returns a profile only for conservatively recognized
+/// first-party models. Explicit mode falls back to provider-level controls so
+/// custom deployment names and compatible gateways can opt in deliberately.
+struct ReasoningCapabilityProfile: Equatable, Sendable {
+    let dialect: ResolvedReasoningDialect
+    let supportedEfforts: [ReasoningEffort]
+    let supportedSummaries: [ReasoningSummaryPreference]
+    let supportedOpenAIContexts: [OpenAIReasoningContext]
+    let supportedOpenAIModes: [OpenAIReasoningMode]
+    let supportedAnthropicModes: [AnthropicThinkingMode]
+    let providerDefaultBehavior: ReasoningProviderDefaultBehavior
+    let explicitDisableSupport: ReasoningExplicitDisableSupport
+    let chatCompletionsToolPolicy: OpenAIChatCompletionsToolPolicy
+
+    init(
+        dialect: ResolvedReasoningDialect,
+        supportedEfforts: [ReasoningEffort],
+        supportedSummaries: [ReasoningSummaryPreference],
+        supportedOpenAIContexts: [OpenAIReasoningContext],
+        supportedOpenAIModes: [OpenAIReasoningMode],
+        supportedAnthropicModes: [AnthropicThinkingMode],
+        providerDefaultBehavior: ReasoningProviderDefaultBehavior = .unknown,
+        explicitDisableSupport: ReasoningExplicitDisableSupport = .unknown,
+        chatCompletionsToolPolicy: OpenAIChatCompletionsToolPolicy = .unrestricted
+    ) {
+        self.dialect = dialect
+        self.supportedEfforts = supportedEfforts
+        self.supportedSummaries = supportedSummaries
+        self.supportedOpenAIContexts = supportedOpenAIContexts
+        self.supportedOpenAIModes = supportedOpenAIModes
+        self.supportedAnthropicModes = supportedAnthropicModes
+        self.providerDefaultBehavior = providerDefaultBehavior
+        self.explicitDisableSupport = explicitDisableSupport
+        self.chatCompletionsToolPolicy = chatCompletionsToolPolicy
+    }
+
+    func allowsChatCompletionsTools(with effort: ReasoningEffort?) -> Bool {
+        chatCompletionsToolPolicy.allowsTools(with: effort)
+    }
+
+    func chatCompletionsEffort(
+        requested effort: ReasoningEffort?,
+        hasTools: Bool
+    ) -> ReasoningEffort? {
+        guard hasTools else { return effort }
+        switch chatCompletionsToolPolicy {
+        case .providerDefined, .unrestricted:
+            return effort
+        case let .requiresExplicitEffort(requiredEffort):
+            return requiredEffort
+        }
+    }
+}
+
+enum ReasoningProviderDefaultBehavior: String, Codable, Equatable, Sendable {
+    case unknown
+    case disabled
+    case enabled
+    case alwaysEnabled
+}
+
+enum ReasoningExplicitDisableSupport: Equatable, Sendable {
+    case unknown
+    case unsupported
+    case supported
+    case supportedWithEfforts([ReasoningEffort])
+}
+
+enum OpenAIChatCompletionsToolPolicy: Equatable, Sendable {
+    case providerDefined
+    case unrestricted
+    case requiresExplicitEffort(ReasoningEffort)
+
+    func allowsTools(with effort: ReasoningEffort?) -> Bool {
+        switch self {
+        case .providerDefined, .unrestricted:
+            true
+        case let .requiresExplicitEffort(requiredEffort):
+            effort == requiredEffort
+        }
+    }
+}
+
+enum ReasoningCapabilityResolver {
+    static func capabilities(
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        endpoint: String?,
+        configuration: ModelReasoningConfiguration
+    ) -> ReasoningCapabilityProfile? {
+        guard endpointType != .imageGeneration,
+              provider != .appleIntelligence
+        else {
+            return nil
+        }
+
+        switch configuration.activation {
+        case .automatic:
+            return automaticCapabilities(
+                model: model,
+                provider: provider,
+                endpointType: endpointType,
+                endpoint: endpoint
+            )
+        case .enabled:
+            return explicitlyEnabledCapabilities(
+                model: model,
+                provider: provider,
+                endpointType: endpointType,
+                anthropicMode: configuration.anthropicMode
+            )
+        case .disabled, .explicitlyDisabled:
+            return nil
+        }
+    }
+
+    static func modelPolicy(
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        anthropicMode: AnthropicThinkingMode = .adaptive
+    ) -> ReasoningCapabilityProfile? {
+        knownCapabilities(
+            model: model,
+            provider: provider,
+            endpointType: endpointType,
+            anthropicMode: anthropicMode
+        )
+    }
+
+    static func resolve(
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        endpoint: String?,
+        configuration: ModelReasoningConfiguration
+    ) -> ResolvedReasoningConfiguration? {
+        guard endpointType != .imageGeneration,
+              provider != .appleIntelligence
+        else {
+            return nil
+        }
+
+        if configuration.activation == .explicitlyDisabled {
+            return explicitDisableConfiguration(
+                model: model,
+                provider: provider,
+                endpointType: endpointType,
+                requestedEffort: configuration.effort,
+                anthropicMode: configuration.anthropicMode,
+                anthropicDisplay: configuration.anthropicDisplay,
+                legacyBudgetTokens: configuration.legacyBudgetTokens
+            )
+        }
+
+        let capabilities: ReasoningCapabilityProfile? = switch configuration.activation {
+        case .disabled, .explicitlyDisabled:
+            nil
+        case .enabled:
+            explicitlyEnabledCapabilities(
+                model: model,
+                provider: provider,
+                endpointType: endpointType,
+                anthropicMode: configuration.anthropicMode
+            )
+        case .automatic:
+            automaticCapabilities(
+                model: model,
+                provider: provider,
+                endpointType: endpointType,
+                endpoint: endpoint
+            )
+        }
+
+        guard let capabilities else { return nil }
+        let effort = configuration.effort.flatMap {
+            capabilities.supportedEfforts.contains($0) ? $0 : nil
+        }
+        let summary = safeSummary(configuration.summary, capabilities: capabilities)
+        let openAIContext = !capabilities.supportedOpenAIContexts.contains(configuration.openAIContext)
+            ? .automatic
+            : configuration.openAIContext
+        let openAIMode = configuration.openAIMode.flatMap {
+            capabilities.supportedOpenAIModes.contains($0) ? $0 : nil
+        }
+
+        return ResolvedReasoningConfiguration(
+            dialect: capabilities.dialect,
+            effort: effort,
+            openAIMode: openAIMode,
+            openAIContext: openAIContext,
+            summary: summary,
+            anthropicDisplay: configuration.anthropicDisplay,
+            legacyBudgetTokens: max(
+                configuration.legacyBudgetTokens,
+                ModelReasoningConfiguration.minimumLegacyBudgetTokens
+            )
+        )
+    }
+
+    private static func explicitDisableConfiguration(
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        requestedEffort: ReasoningEffort?,
+        anthropicMode: AnthropicThinkingMode,
+        anthropicDisplay: AnthropicThinkingDisplay,
+        legacyBudgetTokens: Int
+    ) -> ResolvedReasoningConfiguration? {
+        guard let capabilities = knownCapabilities(
+            model: model,
+            provider: provider,
+            endpointType: endpointType,
+            anthropicMode: anthropicMode
+        ) else {
+            return nil
+        }
+
+        let effort: ReasoningEffort?
+        switch capabilities.explicitDisableSupport {
+        case .supported:
+            effort = provider == .openai
+                ? ReasoningEffort.none
+                : requestedEffort.flatMap { capabilities.supportedEfforts.contains($0) ? $0 : nil }
+        case let .supportedWithEfforts(supportedEfforts):
+            effort = requestedEffort.flatMap { supportedEfforts.contains($0) ? $0 : nil }
+        case .unknown, .unsupported:
+            return nil
+        }
+
+        return ResolvedReasoningConfiguration(
+            dialect: provider == .anthropic ? .anthropicDisabled : capabilities.dialect,
+            effort: effort,
+            openAIMode: nil,
+            openAIContext: .automatic,
+            summary: .none,
+            anthropicDisplay: anthropicDisplay,
+            legacyBudgetTokens: max(
+                legacyBudgetTokens,
+                ModelReasoningConfiguration.minimumLegacyBudgetTokens
+            )
+        )
+    }
+
+    private static func safeSummary(
+        _ requested: ReasoningSummaryPreference,
+        capabilities: ReasoningCapabilityProfile
+    ) -> ReasoningSummaryPreference {
+        if capabilities.supportedSummaries.contains(requested) {
+            return requested
+        }
+        if capabilities.supportedSummaries.contains(.automatic) {
+            return .automatic
+        }
+        return .none
+    }
+
+    private static func explicitlyEnabledCapabilities(
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        anthropicMode: AnthropicThinkingMode
+    ) -> ReasoningCapabilityProfile? {
+        if let knownCapabilities = knownCapabilities(
+            model: model,
+            provider: provider,
+            endpointType: endpointType,
+            anthropicMode: anthropicMode
+        ) {
+            return knownCapabilities
+        }
+
+        // A recognized first-party model must not fall through to the generic
+        // compatible-provider profile when its documented endpoint is not
+        // supported. Custom deployment names and aliases remain explicit opt-ins.
+        if provider == .openai, isKnownOpenAIModel(model) {
+            return nil
+        }
+
+        return providerFallbackCapabilities(
+            provider: provider,
+            endpointType: endpointType,
+            anthropicMode: anthropicMode
+        )
+    }
+
+    private static func providerFallbackCapabilities(
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        anthropicMode: AnthropicThinkingMode
+    ) -> ReasoningCapabilityProfile? {
+        switch provider {
+        case .openai:
+            switch endpointType {
+            case .chatCompletions:
+                ReasoningCapabilityProfile(
+                    dialect: .openAIChat,
+                    supportedEfforts: ReasoningEffort.allCases,
+                    supportedSummaries: [],
+                    supportedOpenAIContexts: [],
+                    supportedOpenAIModes: [],
+                    supportedAnthropicModes: [],
+                    providerDefaultBehavior: .unknown,
+                    explicitDisableSupport: .unknown,
+                    chatCompletionsToolPolicy: .providerDefined
+                )
+            case .responses:
+                ReasoningCapabilityProfile(
+                    dialect: .openAIResponses,
+                    supportedEfforts: ReasoningEffort.allCases,
+                    supportedSummaries: ReasoningSummaryPreference.allCases,
+                    supportedOpenAIContexts: OpenAIReasoningContext.allCases,
+                    supportedOpenAIModes: OpenAIReasoningMode.allCases,
+                    supportedAnthropicModes: [],
+                    providerDefaultBehavior: .unknown,
+                    explicitDisableSupport: .unknown,
+                    chatCompletionsToolPolicy: .providerDefined
+                )
+            case .imageGeneration: nil
+            }
+        case .anthropic:
+            ReasoningCapabilityProfile(
+                dialect: anthropicMode == .adaptive ? .anthropicAdaptive : .anthropicExtended,
+                supportedEfforts: ReasoningEffort.anthropicValues,
+                supportedSummaries: [],
+                supportedOpenAIContexts: [],
+                supportedOpenAIModes: [],
+                supportedAnthropicModes: AnthropicThinkingMode.allCases,
+                providerDefaultBehavior: .unknown,
+                explicitDisableSupport: .unknown,
+                chatCompletionsToolPolicy: .providerDefined
+            )
+        case .appleIntelligence:
+            nil
+        }
+    }
+
+    private static func automaticCapabilities(
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        endpoint: String?
+    ) -> ReasoningCapabilityProfile? {
+        switch provider {
+        case .openai:
+            guard isOfficialOpenAIEndpoint(endpoint) else {
+                return nil
+            }
+            return knownOpenAICapabilities(model: model, endpointType: endpointType)
+        case .anthropic:
+            guard isOfficialAnthropicEndpoint(endpoint) else {
+                return nil
+            }
+            return knownAnthropicCapabilities(model: model, requestedMode: nil)
+        case .appleIntelligence:
+            return nil
+        }
+    }
+
+    private static func knownCapabilities(
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        anthropicMode: AnthropicThinkingMode
+    ) -> ReasoningCapabilityProfile? {
+        switch provider {
+        case .openai:
+            knownOpenAICapabilities(model: model, endpointType: endpointType)
+        case .anthropic:
+            knownAnthropicCapabilities(model: model, requestedMode: anthropicMode)
+        case .appleIntelligence:
+            nil
+        }
+    }
+
+    private static func knownOpenAICapabilities(
+        model: String,
+        endpointType: APIEndpointType
+    ) -> ReasoningCapabilityProfile? {
+        guard endpointType != .imageGeneration else { return nil }
+        let normalized = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        return knownGPT5Capabilities(model: normalized, endpointType: endpointType) ??
+            knownOpenAIReasoningSeriesCapabilities(model: normalized, endpointType: endpointType)
+    }
+
+    // The exact-ID switch intentionally keeps the documented GPT-5 catalog together.
+    // swiftlint:disable:next function_body_length
+    private static func knownGPT5Capabilities(
+        model: String,
+        endpointType: APIEndpointType
+    ) -> ReasoningCapabilityProfile? {
+        switch model {
+        case "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [.none, .low, .medium, .high, .xhigh, .max],
+                responsesEfforts: [.none, .low, .medium, .high, .xhigh, .max],
+                responseContexts: OpenAIReasoningContext.allCases,
+                responseModes: OpenAIReasoningMode.allCases,
+                providerDefaultBehavior: .enabled,
+                chatToolPolicy: .requiresExplicitEffort(.none)
+            )
+
+        case "gpt-5.6-cyber":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [],
+                supportsSummary: false,
+                providerDefaultBehavior: .alwaysEnabled
+            )
+
+        case "gpt-5.5", "gpt-5.5-2026-04-23":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [.none, .low, .medium, .high, .xhigh],
+                responsesEfforts: [.none, .low, .medium, .high, .xhigh],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "gpt-5.5-pro", "gpt-5.5-pro-2026-04-23":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [.medium, .high, .xhigh],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "gpt-5.4",
+             "gpt-5.4-2026-03-05",
+             "gpt-5.4-mini",
+             "gpt-5.4-mini-2026-03-17",
+             "gpt-5.4-nano",
+             "gpt-5.4-nano-2026-03-17":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [.none, .low, .medium, .high, .xhigh],
+                responsesEfforts: [.none, .low, .medium, .high, .xhigh],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .disabled
+            )
+
+        case "gpt-5.4-pro", "gpt-5.4-pro-2026-03-05":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [.medium, .high, .xhigh],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "gpt-5.3-codex":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [.low, .medium, .high, .xhigh],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "gpt-5.2", "gpt-5.2-2025-12-11":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [.none, .low, .medium, .high, .xhigh],
+                responsesEfforts: [.none, .low, .medium, .high, .xhigh],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .disabled
+            )
+
+        case "gpt-5.2-pro", "gpt-5.2-pro-2025-12-11":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [.medium, .high, .xhigh],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "gpt-5.2-codex":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [.low, .medium, .high, .xhigh],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "gpt-5.1", "gpt-5.1-2025-11-13":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [.none, .low, .medium, .high],
+                responsesEfforts: [.none, .low, .medium, .high],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .disabled
+            )
+
+        case "gpt-5.1-codex", "gpt-5.1-codex-mini":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [.none, .low, .medium, .high],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .disabled
+            )
+
+        case "gpt-5.1-codex-max":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [.none, .low, .medium, .high, .xhigh],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .disabled
+            )
+
+        case "gpt-5",
+             "gpt-5-2025-08-07",
+             "gpt-5-mini",
+             "gpt-5-mini-2025-08-07",
+             "gpt-5-nano",
+             "gpt-5-nano-2025-08-07":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [.minimal, .low, .medium, .high],
+                responsesEfforts: [.minimal, .low, .medium, .high],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "gpt-5-pro", "gpt-5-pro-2025-10-06":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [.high],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .alwaysEnabled
+            )
+
+        case "gpt-5-codex":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [.low, .medium, .high],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .enabled
+            )
+
+        default:
+            nil
+        }
+    }
+
+    private static func knownOpenAIReasoningSeriesCapabilities(
+        model: String,
+        endpointType: APIEndpointType
+    ) -> ReasoningCapabilityProfile? {
+        switch model {
+        case "o1-mini", "o1-mini-2024-09-12":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [],
+                responsesEfforts: nil,
+                supportsSummary: false,
+                providerDefaultBehavior: .alwaysEnabled
+            )
+
+        case "o1", "o1-2024-12-17":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [.low, .medium, .high],
+                responsesEfforts: [.low, .medium, .high],
+                supportsSummary: false,
+                providerDefaultBehavior: .enabled
+            )
+
+        case "o1-pro", "o1-pro-2025-03-19":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [],
+                supportsSummary: false,
+                providerDefaultBehavior: .alwaysEnabled
+            )
+
+        case "o3", "o3-2025-04-16":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [.low, .medium, .high],
+                responsesEfforts: [.low, .medium, .high],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "o3-mini", "o3-mini-2025-01-31":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [.low, .medium, .high],
+                responsesEfforts: [.low, .medium, .high],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "o3-pro", "o3-pro-2025-06-10":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [],
+                supportsSummary: false,
+                providerDefaultBehavior: .alwaysEnabled
+            )
+
+        case "o4-mini", "o4-mini-2025-04-16":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: [.low, .medium, .high],
+                responsesEfforts: [.low, .medium, .high],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "codex-mini-latest":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [.low, .medium, .high],
+                responseContexts: [.automatic, .currentTurn],
+                providerDefaultBehavior: .enabled
+            )
+
+        case "o3-deep-research",
+             "o3-deep-research-2025-06-26",
+             "o4-mini-deep-research",
+             "o4-mini-deep-research-2025-06-26":
+            openAIProfile(
+                endpointType: endpointType,
+                chatEfforts: nil,
+                responsesEfforts: [],
+                supportsSummary: false,
+                providerDefaultBehavior: .alwaysEnabled
+            )
+
+        default:
+            nil
+        }
+    }
+
+    private static func isKnownOpenAIModel(_ model: String) -> Bool {
+        knownOpenAICapabilities(model: model, endpointType: .chatCompletions) != nil ||
+            knownOpenAICapabilities(model: model, endpointType: .responses) != nil
+    }
+
+    private static func openAIProfile(
+        endpointType: APIEndpointType,
+        chatEfforts: [ReasoningEffort]?,
+        responsesEfforts: [ReasoningEffort]?,
+        supportsSummary: Bool = true,
+        responseContexts: [OpenAIReasoningContext] = [],
+        responseModes: [OpenAIReasoningMode] = [],
+        providerDefaultBehavior: ReasoningProviderDefaultBehavior = .unknown,
+        chatToolPolicy: OpenAIChatCompletionsToolPolicy = .unrestricted
+    ) -> ReasoningCapabilityProfile? {
+        let dialect: ResolvedReasoningDialect
+        let efforts: [ReasoningEffort]
+        let summaries: [ReasoningSummaryPreference]
+        let contexts: [OpenAIReasoningContext]
+        let modes: [OpenAIReasoningMode]
+
+        switch endpointType {
+        case .chatCompletions:
+            guard let chatEfforts else { return nil }
+            dialect = .openAIChat
+            efforts = chatEfforts
+            summaries = []
+            contexts = []
+            modes = []
+        case .responses:
+            guard let responsesEfforts else { return nil }
+            dialect = .openAIResponses
+            efforts = responsesEfforts
+            summaries = supportsSummary ? [.none, .automatic] : []
+            contexts = responseContexts
+            modes = responseModes
+        case .imageGeneration:
+            return nil
+        }
+
+        return ReasoningCapabilityProfile(
+            dialect: dialect,
+            supportedEfforts: efforts,
+            supportedSummaries: summaries,
+            supportedOpenAIContexts: contexts,
+            supportedOpenAIModes: modes,
+            supportedAnthropicModes: [],
+            providerDefaultBehavior: providerDefaultBehavior,
+            explicitDisableSupport: efforts.contains(.none) ? .supported : .unsupported,
+            chatCompletionsToolPolicy: dialect == .openAIChat ? chatToolPolicy : .unrestricted
+        )
+    }
+
+    private enum AnthropicThinkingSupport: Equatable {
+        case adaptiveOnly
+        case adaptiveAndExtended
+        case extendedOnly
+
+        var modes: [AnthropicThinkingMode] {
+            switch self {
+            case .adaptiveOnly:
+                [.adaptive]
+            case .adaptiveAndExtended:
+                AnthropicThinkingMode.allCases
+            case .extendedOnly:
+                [.extended]
+            }
+        }
+
+        func resolvedMode(requested: AnthropicThinkingMode?) -> AnthropicThinkingMode {
+            if let requested, modes.contains(requested) {
+                return requested
+            }
+            return self == .extendedOnly ? .extended : .adaptive
+        }
+    }
+
+    private static func knownAnthropicCapabilities(
+        model: String,
+        requestedMode: AnthropicThinkingMode?
+    ) -> ReasoningCapabilityProfile? {
+        let normalized = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let support: AnthropicThinkingSupport
+        let efforts: [ReasoningEffort]
+        let providerDefaultBehavior: ReasoningProviderDefaultBehavior
+        let explicitDisableSupport: ReasoningExplicitDisableSupport
+
+        switch normalized {
+        case "claude-fable-5",
+             "claude-mythos-5":
+            support = .adaptiveOnly
+            efforts = [.low, .medium, .high, .xhigh, .max]
+            providerDefaultBehavior = .alwaysEnabled
+            explicitDisableSupport = .unsupported
+
+        case "claude-mythos-preview":
+            support = .adaptiveAndExtended
+            efforts = [.low, .medium, .high, .max]
+            providerDefaultBehavior = .alwaysEnabled
+            explicitDisableSupport = .unsupported
+
+        case "claude-opus-5":
+            support = .adaptiveOnly
+            efforts = [.low, .medium, .high, .xhigh, .max]
+            providerDefaultBehavior = .enabled
+            explicitDisableSupport = .supportedWithEfforts([.low, .medium, .high])
+
+        case "claude-sonnet-5":
+            support = .adaptiveOnly
+            efforts = [.low, .medium, .high, .xhigh, .max]
+            providerDefaultBehavior = .enabled
+            explicitDisableSupport = .supported
+
+        case "claude-opus-4-8",
+             "claude-opus-4-7":
+            support = .adaptiveOnly
+            efforts = [.low, .medium, .high, .xhigh, .max]
+            providerDefaultBehavior = .disabled
+            explicitDisableSupport = .supported
+
+        case "claude-opus-4-6",
+             "claude-sonnet-4-6":
+            support = .adaptiveAndExtended
+            efforts = [.low, .medium, .high, .max]
+            providerDefaultBehavior = .disabled
+            explicitDisableSupport = .supported
+
+        case "claude-opus-4-5",
+             "claude-opus-4-5-20251101":
+            support = .extendedOnly
+            efforts = [.low, .medium, .high]
+            providerDefaultBehavior = .disabled
+            explicitDisableSupport = .supported
+
+        case "claude-haiku-4-5",
+             "claude-haiku-4-5-20251001",
+             "claude-sonnet-4-5",
+             "claude-sonnet-4-5-20250929":
+            support = .extendedOnly
+            efforts = []
+            providerDefaultBehavior = .disabled
+            explicitDisableSupport = .supported
+
+        default:
+            return nil
+        }
+
+        let mode = support.resolvedMode(requested: requestedMode)
+        return ReasoningCapabilityProfile(
+            dialect: mode == .adaptive ? .anthropicAdaptive : .anthropicExtended,
+            supportedEfforts: efforts,
+            supportedSummaries: [],
+            supportedOpenAIContexts: [],
+            supportedOpenAIModes: [],
+            supportedAnthropicModes: support.modes,
+            providerDefaultBehavior: providerDefaultBehavior,
+            explicitDisableSupport: explicitDisableSupport,
+            chatCompletionsToolPolicy: .unrestricted
+        )
+    }
+
+    private static func isOfficialOpenAIEndpoint(_ endpoint: String?) -> Bool {
+        guard let endpoint = normalizedEndpoint(endpoint) else { return true }
+        return endpoint == "api.openai.com"
+    }
+
+    private static func isOfficialAnthropicEndpoint(_ endpoint: String?) -> Bool {
+        guard let endpoint = normalizedEndpoint(endpoint) else { return true }
+        return endpoint == "api.anthropic.com"
+    }
+
+    private static func normalizedEndpoint(_ endpoint: String?) -> String? {
+        guard let trimmed = endpoint?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+        if let host = URL(string: trimmed)?.host?.lowercased() {
+            return host
+        }
+        return trimmed.lowercased()
+    }
+}
+
+/// Opaque provider state that must be replayed unchanged to continue reasoning
+/// across tool calls and later turns. This is intentionally distinct from the
+/// user-visible reasoning summary stored in `Message.reasoning`.
+struct ReasoningContinuationState: Codable, Equatable, Sendable {
+    enum Format: String, Codable, Sendable {
+        case openAIResponses
+        case anthropicMessages
+    }
+
+    let format: Format
+    let items: [AnyCodable]
+    let model: String?
+    let requestConfiguration: ResolvedReasoningConfiguration?
+    private let requestConfigurationCaptured: Bool?
+
+    init(
+        format: Format,
+        items: [AnyCodable],
+        model: String? = nil,
+        requestConfiguration: ResolvedReasoningConfiguration? = nil,
+        requestConfigurationCaptured: Bool? = nil
+    ) {
+        self.format = format
+        self.items = items
+        self.model = model
+        self.requestConfiguration = requestConfiguration
+        self.requestConfigurationCaptured = requestConfigurationCaptured ??
+            (requestConfiguration == nil ? nil : true)
+    }
+
+    var isEmpty: Bool {
+        items.isEmpty
+    }
+
+    /// Whether the originating request's reasoning controls were captured.
+    ///
+    /// A captured `nil` configuration means the provider default was
+    /// intentionally used. This must remain distinct from older continuation
+    /// payloads that never recorded request configuration at all.
+    var hasRequestConfigurationSnapshot: Bool {
+        requestConfigurationCaptured == true || requestConfiguration != nil
+    }
+
+    func attaching(
+        model: String,
+        requestConfiguration: ResolvedReasoningConfiguration?
+    ) -> ReasoningContinuationState {
+        ReasoningContinuationState(
+            format: format,
+            items: items,
+            model: model,
+            requestConfiguration: requestConfiguration,
+            requestConfigurationCaptured: true
+        )
+    }
+}

--- a/Sources/Ayna/Models/WatchDataModels.swift
+++ b/Sources/Ayna/Models/WatchDataModels.swift
@@ -422,6 +422,7 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
     var role: String
     var content: String
     var reasoning: String?
+    var reasoningContinuation: ReasoningContinuationState?
     var timestamp: Date
     var model: String?
     var toolCalls: [MCPToolCall]?
@@ -432,6 +433,7 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
         role: String,
         content: String,
         reasoning: String? = nil,
+        reasoningContinuation: ReasoningContinuationState? = nil,
         timestamp: Date,
         model: String? = nil,
         toolCalls: [MCPToolCall]? = nil,
@@ -441,6 +443,7 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
         self.role = role
         self.content = content
         self.reasoning = reasoning
+        self.reasoningContinuation = reasoningContinuation
         self.timestamp = timestamp
         self.model = model
         self.toolCalls = toolCalls
@@ -452,6 +455,7 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
         role = message.role.rawValue
         content = message.content
         reasoning = message.reasoning
+        reasoningContinuation = message.reasoningContinuation
         timestamp = message.timestamp
         model = message.model
         toolCalls = message.toolCalls
@@ -480,21 +484,28 @@ struct WatchMessage: Codable, Equatable, Identifiable, Sendable {
             toolCalls: toolCalls,
             model: model,
             reasoning: reasoning,
+            reasoningContinuation: reasoningContinuation,
             citations: citations
         )
     }
 
-    /// Text shown when a reasoning-only response has no final answer content.
+    /// Text shown in the Watch transcript, including reasoning when the response also has a final answer.
     var visibleContent: String {
-        if !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return content
+        let visibleAnswer = content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : content
+        let visibleReasoning = reasoning.flatMap { reasoning in
+            reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : reasoning
         }
-        guard let reasoning,
-              !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else {
+
+        switch (visibleReasoning, visibleAnswer) {
+        case let (reasoning?, answer?):
+            return "\(reasoning)\n\n\(answer)"
+        case let (reasoning?, nil):
+            return reasoning
+        case let (nil, answer?):
+            return answer
+        case (nil, nil):
             return ""
         }
-        return reasoning
     }
 }
 

--- a/Sources/Ayna/Models/WatchDataModels.swift
+++ b/Sources/Ayna/Models/WatchDataModels.swift
@@ -13,17 +13,20 @@ struct WatchConversationRequestConfiguration: Codable, Equatable, Identifiable, 
     let id: UUID
     var model: String
     var temperature: Double
+    var reasoningConfiguration: ModelReasoningConfiguration
     var resolvedSystemPrompt: String?
 
     init(
         id: UUID,
         model: String,
         temperature: Double,
+        reasoningConfiguration: ModelReasoningConfiguration = .automatic,
         resolvedSystemPrompt: String?
     ) {
         self.id = id
         self.model = model
         self.temperature = temperature
+        self.reasoningConfiguration = reasoningConfiguration
         self.resolvedSystemPrompt = resolvedSystemPrompt?.nilIfEmpty
     }
 
@@ -32,6 +35,7 @@ struct WatchConversationRequestConfiguration: Codable, Equatable, Identifiable, 
             id: conversation.id,
             model: conversation.model,
             temperature: conversation.temperature,
+            reasoningConfiguration: conversation.reasoningConfiguration,
             resolvedSystemPrompt: resolvedSystemPrompt
         )
     }
@@ -40,7 +44,40 @@ struct WatchConversationRequestConfiguration: Codable, Equatable, Identifiable, 
         guard conversation.id == id else { return }
         conversation.model = model
         conversation.temperature = temperature
+        conversation.reasoningConfiguration = reasoningConfiguration
         conversation.resolvedSystemPrompt = resolvedSystemPrompt?.nilIfEmpty
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case model
+        case temperature
+        case reasoningConfiguration
+        case resolvedSystemPrompt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        model = try container.decode(String.self, forKey: .model)
+        temperature = try container.decodeIfPresent(Double.self, forKey: .temperature) ?? 0.7
+        reasoningConfiguration = try container.decodeIfPresent(
+            ModelReasoningConfiguration.self,
+            forKey: .reasoningConfiguration
+        ) ?? .automatic
+        resolvedSystemPrompt = try container.decodeIfPresent(
+            String.self,
+            forKey: .resolvedSystemPrompt
+        )?.nilIfEmpty
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(model, forKey: .model)
+        try container.encode(temperature, forKey: .temperature)
+        try container.encode(reasoningConfiguration, forKey: .reasoningConfiguration)
+        try container.encodeIfPresent(resolvedSystemPrompt, forKey: .resolvedSystemPrompt)
     }
 }
 
@@ -57,6 +94,7 @@ struct WatchConversation: Codable, Equatable, Identifiable, Sendable {
     var updatedAt: Date
     var createdAt: Date
     var temperature: Double
+    var reasoningConfiguration: ModelReasoningConfiguration
     var resolvedSystemPrompt: String?
     var watchRevision: UInt64
 
@@ -68,6 +106,7 @@ struct WatchConversation: Codable, Equatable, Identifiable, Sendable {
         updatedAt: Date,
         createdAt: Date,
         temperature: Double = 0.7,
+        reasoningConfiguration: ModelReasoningConfiguration = .automatic,
         resolvedSystemPrompt: String? = nil,
         watchRevision: UInt64 = 0
     ) {
@@ -78,6 +117,7 @@ struct WatchConversation: Codable, Equatable, Identifiable, Sendable {
         self.updatedAt = updatedAt
         self.createdAt = createdAt
         self.temperature = temperature
+        self.reasoningConfiguration = reasoningConfiguration
         self.resolvedSystemPrompt = resolvedSystemPrompt
         self.watchRevision = watchRevision
     }
@@ -107,6 +147,7 @@ struct WatchConversation: Codable, Equatable, Identifiable, Sendable {
         updatedAt = conversation.updatedAt
         createdAt = conversation.createdAt
         temperature = conversation.temperature
+        reasoningConfiguration = conversation.reasoningConfiguration
         self.resolvedSystemPrompt = resolvedSystemPrompt?.nilIfEmpty
         self.watchRevision = watchRevision
 
@@ -124,7 +165,8 @@ struct WatchConversation: Codable, Equatable, Identifiable, Sendable {
             createdAt: createdAt,
             model: model,
             systemPromptMode: .inheritGlobal,
-            temperature: temperature
+            temperature: temperature,
+            reasoningConfiguration: reasoningConfiguration
         )
         conversation.updatedAt = updatedAt
         conversation.messages = messages.map { $0.toMessage() }
@@ -171,6 +213,7 @@ struct WatchConversation: Codable, Equatable, Identifiable, Sendable {
         case updatedAt
         case createdAt
         case temperature
+        case reasoningConfiguration
         case resolvedSystemPrompt
         case watchRevision
     }
@@ -184,6 +227,10 @@ struct WatchConversation: Codable, Equatable, Identifiable, Sendable {
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         temperature = try container.decodeIfPresent(Double.self, forKey: .temperature) ?? 0.7
+        reasoningConfiguration = try container.decodeIfPresent(
+            ModelReasoningConfiguration.self,
+            forKey: .reasoningConfiguration
+        ) ?? .automatic
         resolvedSystemPrompt = try container.decodeIfPresent(String.self, forKey: .resolvedSystemPrompt)?.nilIfEmpty
         watchRevision = try container.decodeIfPresent(UInt64.self, forKey: .watchRevision) ?? 0
     }

--- a/Sources/Ayna/Services/AIService+ModelIdentity.swift
+++ b/Sources/Ayna/Services/AIService+ModelIdentity.swift
@@ -1,0 +1,64 @@
+//
+//  AIService+ModelIdentity.swift
+//  ayna
+//
+
+import Foundation
+
+enum ModelRenameResult: Equatable {
+    case unchanged
+    case renamed
+    case sourceMissing
+    case destinationExists
+}
+
+@MainActor
+extension AIService {
+    @discardableResult
+    func renameConfiguredModel(from oldName: String, to newName: String) -> ModelRenameResult {
+        guard let modelIndex = customModels.firstIndex(of: oldName) else { return .sourceMissing }
+        guard oldName != newName else { return .unchanged }
+        guard !customModels.contains(newName) else { return .destinationExists }
+
+        customModels[modelIndex] = newName
+        modelProviders = modelProviders.rekeyingValue(from: oldName, to: newName)
+        modelEndpoints = modelEndpoints.rekeyingValue(from: oldName, to: newName)
+        modelAPIKeys = modelAPIKeys.rekeyingValue(from: oldName, to: newName)
+        modelEndpointTypes = modelEndpointTypes.rekeyingValue(from: oldName, to: newName)
+        modelReasoningConfigurations = modelReasoningConfigurations.rekeyingValue(
+            from: oldName,
+            to: newName
+        )
+
+        if selectedModel == oldName {
+            selectedModel = newName
+        }
+
+        return .renamed
+    }
+
+    func removeConfiguredModel(_ model: String) {
+        customModels.removeAll { $0 == model }
+        modelProviders.removeValue(forKey: model)
+        modelEndpoints.removeValue(forKey: model)
+        modelAPIKeys.removeValue(forKey: model)
+        modelEndpointTypes.removeValue(forKey: model)
+        modelReasoningConfigurations.removeValue(forKey: model)
+
+        if selectedModel == model {
+            selectedModel = customModels.first ?? ""
+        }
+    }
+}
+
+private extension Dictionary where Key == String {
+    func rekeyingValue(from oldKey: String, to newKey: String) -> Self {
+        var values = self
+        let movedValue = values.removeValue(forKey: oldKey)
+        values.removeValue(forKey: newKey)
+        if let movedValue {
+            values[newKey] = movedValue
+        }
+        return values
+    }
+}

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -39,6 +39,22 @@ struct RequestFlightID: Hashable, Sendable {
     private let rawValue = UUID()
 }
 
+struct AIReasoningRequestSnapshot: Sendable {
+    let configuration: ResolvedReasoningConfiguration?
+}
+
+private struct ToolContinuationReasoningSnapshot: Equatable, Sendable {
+    let model: String
+    let provider: AIProvider
+    let endpointType: APIEndpointType
+    let configuration: ResolvedReasoningConfiguration?
+}
+
+private struct ToolContinuationRound {
+    let assistant: Message
+    let completedToolCallIDs: [String]
+}
+
 enum AITextRequestLane: Sendable {
     case foreground
     case background
@@ -242,6 +258,7 @@ private enum AnthropicFlightCallback: @unchecked Sendable {
     case error(Error)
     case toolRequest(id: String, name: String, arguments: [String: Any])
     case reasoning(String)
+    case reasoningContinuation(ReasoningContinuationState)
 }
 
 private enum MultiModelBatchCallback: @unchecked Sendable {
@@ -250,6 +267,45 @@ private enum MultiModelBatchCallback: @unchecked Sendable {
     case error(Error)
     case toolRequest(id: String, name: String, arguments: [String: Any])
     case reasoning(String)
+    case reasoningContinuation(ReasoningContinuationState)
+}
+
+private struct PersistedModelReasoningConfigurations: Decodable {
+    private struct ModelKey: CodingKey {
+        let stringValue: String
+        let intValue: Int? = nil
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(intValue _: Int) {
+            nil
+        }
+    }
+
+    let values: [String: ModelReasoningConfiguration]
+    let invalidModelIDs: [String]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: ModelKey.self)
+        var decodedValues: [String: ModelReasoningConfiguration] = [:]
+        var invalidModelIDs: [String] = []
+
+        for key in container.allKeys {
+            do {
+                decodedValues[key.stringValue] = try container.decode(
+                    ModelReasoningConfiguration.self,
+                    forKey: key
+                )
+            } catch {
+                invalidModelIDs.append(key.stringValue)
+            }
+        }
+
+        values = decodedValues
+        self.invalidModelIDs = invalidModelIDs.sorted()
+    }
 }
 
 #if !os(watchOS)
@@ -376,6 +432,9 @@ class AIService: ObservableObject {
     private var unrecognizedProviderValues: [String: String] = [:]
     private var unrecognizedDefaultProviderValue: String?
     private var modelsInheritingUnrecognizedDefaultProvider: Set<String> = []
+    private var toolContinuationReasoningSnapshots: [String: ToolContinuationReasoningSnapshot] = [:]
+    private var toolContinuationReasoningSnapshotOrder: [String] = []
+    private static let maximumToolContinuationReasoningSnapshots = 256
     #if !os(watchOS)
         private let injectedAppleIntelligenceService: (any AppleIntelligenceServing)?
     #endif
@@ -442,6 +501,24 @@ class AIService: ObservableObject {
                 // iCloud sync disabled for free developer account
                 // NSUbiquitousKeyValueStore.default.set(modelEndpoints, forKey: "modelEndpoints")
                 // NSUbiquitousKeyValueStore.default.synchronize()
+            #endif
+        }
+    }
+
+    @Published var modelReasoningConfigurations: [String: ModelReasoningConfiguration] {
+        didSet {
+            #if !os(watchOS)
+                do {
+                    let data = try JSONEncoder().encode(modelReasoningConfigurations)
+                    AppPreferences.storage.set(data, forKey: "modelReasoningConfigurations")
+                } catch {
+                    DiagnosticsLogger.log(
+                        .aiService,
+                        level: .error,
+                        message: "Failed to persist model reasoning configurations",
+                        metadata: ["error": error.localizedDescription]
+                    )
+                }
             #endif
         }
     }
@@ -551,6 +628,7 @@ class AIService: ObservableObject {
         let savedCustomModels = AppPreferences.storage.array(forKey: "customModels") as? [String] ?? []
         let savedEndpointTypeValues = AppPreferences.storage.dictionary(forKey: "modelEndpointTypes") as? [String: String]
         let savedEndpointValues = AppPreferences.storage.dictionary(forKey: "modelEndpoints") as? [String: String]
+        let savedReasoningData = AppPreferences.storage.data(forKey: "modelReasoningConfigurations")
 
         unrecognizedProviderValues = savedProviderValues?.filter {
             AIProvider(rawValue: $0.value) == nil
@@ -634,6 +712,36 @@ class AIService: ObservableObject {
         // Load custom endpoints mapping
         let loadedEndpoints = savedEndpointValues ?? [:]
         modelEndpoints = loadedEndpoints
+
+        if let savedReasoningData {
+            do {
+                let persistedConfigurations = try JSONDecoder().decode(
+                    PersistedModelReasoningConfigurations.self,
+                    from: savedReasoningData
+                )
+                modelReasoningConfigurations = persistedConfigurations.values
+                if !persistedConfigurations.invalidModelIDs.isEmpty {
+                    DiagnosticsLogger.log(
+                        .aiService,
+                        level: .error,
+                        message: "Ignored invalid per-model reasoning configurations during load",
+                        metadata: [
+                            "models": persistedConfigurations.invalidModelIDs.joined(separator: ", ")
+                        ]
+                    )
+                }
+            } catch {
+                modelReasoningConfigurations = [:]
+                DiagnosticsLogger.log(
+                    .aiService,
+                    level: .error,
+                    message: "Ignored invalid model reasoning configurations during load",
+                    metadata: ["error": error.localizedDescription]
+                )
+            }
+        } else {
+            modelReasoningConfigurations = [:]
+        }
 
         // Load per-model API keys
         let (loadedAPIKeys, loadSuccess) = AIService.loadModelAPIKeys()
@@ -821,6 +929,206 @@ class AIService: ObservableObject {
         }
 
         return (endpoint, normalizedName)
+    }
+
+    func reasoningConfiguration(for model: String) -> ModelReasoningConfiguration {
+        modelReasoningConfigurations[model] ?? .automatic
+    }
+
+    private func resolvedReasoningConfiguration(
+        for model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType,
+        endpoint: String?,
+        messages: [Message]
+    ) throws -> ResolvedReasoningConfiguration? {
+        if let continuationRound = toolContinuationRound(in: messages) {
+            if let continuationSnapshot = try opaqueToolContinuationReasoningSnapshot(
+                in: continuationRound,
+                model: model,
+                provider: provider,
+                endpointType: endpointType
+            ) {
+                return continuationSnapshot.configuration
+            }
+
+            if let continuationSnapshot = try cachedToolContinuationReasoningSnapshot(
+                in: continuationRound,
+                model: model,
+                provider: provider,
+                endpointType: endpointType
+            ) {
+                return continuationSnapshot.configuration
+            }
+        }
+
+        return ReasoningCapabilityResolver.resolve(
+            model: model,
+            provider: provider,
+            endpointType: endpointType,
+            endpoint: endpoint,
+            configuration: reasoningConfiguration(for: model)
+        )
+    }
+
+    private func toolContinuationRound(in messages: [Message]) -> ToolContinuationRound? {
+        var index = messages.count - 1
+        while index >= 0, messages[index].role == .system {
+            index -= 1
+        }
+        guard index >= 0, messages[index].role == .tool else { return nil }
+
+        let trailingToolEnd = index
+        while index >= 0, messages[index].role == .tool {
+            index -= 1
+        }
+        guard index >= 0 else { return nil }
+
+        let assistant = messages[index]
+        guard assistant.role == .assistant,
+              let assistantToolCalls = assistant.toolCalls,
+              !assistantToolCalls.isEmpty
+        else {
+            return nil
+        }
+
+        let assistantToolCallIDs = Set(assistantToolCalls.map(\.id))
+        let completedToolCallIDs = messages[(index + 1) ... trailingToolEnd]
+            .flatMap { $0.toolCalls ?? [] }
+            .map(\.id)
+            .filter { assistantToolCallIDs.contains($0) }
+
+        return ToolContinuationRound(
+            assistant: assistant,
+            completedToolCallIDs: Array(Set(completedToolCallIDs)).sorted()
+        )
+    }
+
+    private func opaqueToolContinuationReasoningSnapshot(
+        in continuationRound: ToolContinuationRound,
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType
+    ) throws -> AIReasoningRequestSnapshot? {
+        let assistant = continuationRound.assistant
+        guard assistant.model == nil || assistant.model == model,
+              let state = assistant.reasoningContinuation,
+              state.model == model
+        else {
+            return nil
+        }
+
+        switch state.format {
+        case .openAIResponses:
+            try validateToolContinuationIdentity(
+                originatingProvider: .openai,
+                originatingEndpointType: .responses,
+                currentProvider: provider,
+                currentEndpointType: endpointType
+            )
+        case .anthropicMessages:
+            try validateToolContinuationIdentity(
+                originatingProvider: .anthropic,
+                originatingEndpointType: .chatCompletions,
+                currentProvider: provider,
+                currentEndpointType: endpointType
+            )
+        }
+
+        guard state.hasRequestConfigurationSnapshot else { return nil }
+        let configuration = state.requestConfiguration
+
+        switch state.format {
+        case .openAIResponses:
+            if let configuration, configuration.dialect != .openAIResponses {
+                return nil
+            }
+        case .anthropicMessages:
+            if let configuration,
+               configuration.dialect != .anthropicDisabled,
+               configuration.dialect != .anthropicAdaptive,
+               configuration.dialect != .anthropicExtended
+            {
+                return nil
+            }
+        }
+        return AIReasoningRequestSnapshot(configuration: configuration)
+    }
+
+    private func cachedToolContinuationReasoningSnapshot(
+        in continuationRound: ToolContinuationRound,
+        model: String,
+        provider: AIProvider,
+        endpointType: APIEndpointType
+    ) throws -> AIReasoningRequestSnapshot? {
+        guard continuationRound.assistant.model == nil || continuationRound.assistant.model == model else {
+            return nil
+        }
+
+        let snapshots = continuationRound.completedToolCallIDs.compactMap {
+            toolContinuationReasoningSnapshots[$0]
+        }.filter { $0.model == model }
+        guard let snapshot = snapshots.first else { return nil }
+
+        if snapshots.contains(where: { $0 != snapshot }) {
+            throw AIError.apiError(
+                "Tool results originated from different model configurations. Please retry the tool request."
+            )
+        }
+
+        try validateToolContinuationIdentity(
+            originatingProvider: snapshot.provider,
+            originatingEndpointType: snapshot.endpointType,
+            currentProvider: provider,
+            currentEndpointType: endpointType
+        )
+        return AIReasoningRequestSnapshot(configuration: snapshot.configuration)
+    }
+
+    private func validateToolContinuationIdentity(
+        originatingProvider: AIProvider,
+        originatingEndpointType: APIEndpointType,
+        currentProvider: AIProvider,
+        currentEndpointType: APIEndpointType
+    ) throws {
+        guard originatingProvider == currentProvider,
+              originatingEndpointType == currentEndpointType
+        else {
+            throw AIError.apiError(
+                "The model provider or endpoint type changed during a tool request. Please retry."
+            )
+        }
+    }
+
+    private func toolCallRequestedCallback(
+        for snapshot: ToolContinuationReasoningSnapshot,
+        forwarding callback: (@Sendable (String, String, [String: Any]) -> Void)?
+    ) -> (@Sendable (String, String, [String: Any]) -> Void)? {
+        guard let callback else { return nil }
+        return { [weak self] toolCallID, toolName, arguments in
+            let arguments = UncheckedSendableWrapper(arguments)
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.rememberToolContinuationReasoningSnapshot(snapshot, for: toolCallID)
+                callback(toolCallID, toolName, arguments.value)
+            }
+        }
+    }
+
+    private func rememberToolContinuationReasoningSnapshot(
+        _ snapshot: ToolContinuationReasoningSnapshot,
+        for toolCallID: String
+    ) {
+        guard !toolCallID.isEmpty else { return }
+
+        toolContinuationReasoningSnapshots[toolCallID] = snapshot
+        toolContinuationReasoningSnapshotOrder.removeAll { $0 == toolCallID }
+        toolContinuationReasoningSnapshotOrder.append(toolCallID)
+
+        while toolContinuationReasoningSnapshotOrder.count > Self.maximumToolContinuationReasoningSnapshots {
+            let expiredToolCallID = toolContinuationReasoningSnapshotOrder.removeFirst()
+            toolContinuationReasoningSnapshots.removeValue(forKey: expiredToolCallID)
+        }
     }
 
     private func isAzureEndpoint(_ endpoint: String?) -> Bool {
@@ -1310,7 +1618,9 @@ class AIService: ObservableObject {
         onToolCall: (@Sendable (String, String, [String: Any]) async -> String)? = nil,
         onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)? = nil,
         onReasoning: (@Sendable (String) -> Void)? = nil,
-        requestFlightID: RequestFlightID? = nil
+        onReasoningContinuation: (@Sendable (ReasoningContinuationState) -> Void)? = nil,
+        requestFlightID: RequestFlightID? = nil,
+        reasoningSnapshot: AIReasoningRequestSnapshot? = nil
     ) -> AITextRequest {
         let flightID = requestFlightID ?? RequestFlightID()
         let requestHandle = AITextRequest(service: self, flightID: flightID)
@@ -1390,6 +1700,35 @@ class AIService: ObservableObject {
         }
         let endpointInfo = customEndpoint(for: requestModel)
         let usesAzureEndpoint = endpointInfo.map { isAzureEndpoint($0.endpoint) } ?? false
+        let endpointType = modelEndpointTypes[requestModel] ?? .chatCompletions
+        let requestReasoningSnapshot: AIReasoningRequestSnapshot
+        do {
+            if let reasoningSnapshot {
+                requestReasoningSnapshot = reasoningSnapshot
+            } else {
+                requestReasoningSnapshot = try AIReasoningRequestSnapshot(
+                    configuration: resolvedReasoningConfiguration(
+                        for: requestModel,
+                        provider: effectiveProvider,
+                        endpointType: endpointType,
+                        endpoint: endpointInfo?.endpoint,
+                        messages: messages
+                    )
+                )
+            }
+        } catch {
+            onError(error)
+            return requestHandle
+        }
+        let trackedToolCallRequested = toolCallRequestedCallback(
+            for: ToolContinuationReasoningSnapshot(
+                model: requestModel,
+                provider: effectiveProvider,
+                endpointType: endpointType,
+                configuration: requestReasoningSnapshot.configuration
+            ),
+            forwarding: onToolCallRequested
+        )
 
         DiagnosticsLogger.log(
             .aiService,
@@ -1453,8 +1792,16 @@ class AIService: ObservableObject {
                 onChunk: onChunk,
                 onComplete: onComplete,
                 onError: onError,
-                onToolCallRequested: onToolCallRequested,
-                onReasoning: onReasoning
+                onToolCallRequested: trackedToolCallRequested,
+                onReasoning: onReasoning,
+                onReasoningContinuation: { state in
+                    onReasoningContinuation?(
+                        state.attaching(
+                            model: requestModel,
+                            requestConfiguration: requestReasoningSnapshot.configuration
+                        )
+                    )
+                }
             )
             handleAnthropicRequest(
                 messages: messages,
@@ -1465,6 +1812,7 @@ class AIService: ObservableObject {
                 requestLane: requestLane,
                 isMultiModelRequest: isMultiModelRequest,
                 callbacks: anthropicCallbacks,
+                reasoningConfiguration: requestReasoningSnapshot.configuration,
                 flightID: flightID
             )
             return requestHandle
@@ -1481,7 +1829,6 @@ class AIService: ObservableObject {
         let modelAPIKey = getAPIKey(for: requestModel)
 
         // Check if this model should use the Responses API.
-        let endpointType = modelEndpointTypes[requestModel] ?? .chatCompletions
         if endpointType == .responses {
             responsesAPIRequest(
                 messages: messages,
@@ -1490,8 +1837,10 @@ class AIService: ObservableObject {
                 onChunk: onChunk,
                 onComplete: onComplete,
                 onError: onError,
-                onToolCallRequested: onToolCallRequested,
+                onToolCallRequested: trackedToolCallRequested,
                 onReasoning: onReasoning,
+                onReasoningContinuation: onReasoningContinuation,
+                reasoningConfiguration: requestReasoningSnapshot.configuration,
                 requestLane: requestLane,
                 isMultiModelRequest: isMultiModelRequest,
                 initialFlightID: flightID
@@ -1574,7 +1923,8 @@ class AIService: ObservableObject {
                 tools: toolDefinitions,
                 apiKey: needsAuth ? modelAPIKey : "",
                 isAzure: usesAzureEndpoint,
-                supportsParallelToolCalls: supportsParallelToolCalls
+                supportsParallelToolCalls: supportsParallelToolCalls,
+                reasoning: requestReasoningSnapshot.configuration
             )
 
             guard self.clearRequestBuildFlight(
@@ -1613,7 +1963,7 @@ class AIService: ObservableObject {
                     onComplete: onComplete,
                     onError: onError,
                     onToolCall: onToolCall,
-                    onToolCallRequested: onToolCallRequested,
+                    onToolCallRequested: trackedToolCallRequested,
                     onReasoning: onReasoning
                 )
                 self.streamResponse(
@@ -1675,7 +2025,8 @@ class AIService: ObservableObject {
         onAllComplete: @escaping @Sendable () -> Void,
         onError: @escaping @Sendable (String, Error) -> Void,
         onPendingToolCall: (@Sendable (String, String, String, [String: Any]) -> Void)? = nil,
-        onReasoning: (@Sendable (String, String) -> Void)? = nil
+        onReasoning: (@Sendable (String, String) -> Void)? = nil,
+        onReasoningContinuation: (@Sendable (String, ReasoningContinuationState) -> Void)? = nil
     ) -> AITextBatchRequest {
         let flightID = RequestFlightID()
         let requestHandle = AITextBatchRequest(service: self, flightID: flightID)
@@ -1713,6 +2064,26 @@ class AIService: ObservableObject {
             rejectBatch(error)
             return requestHandle
         }
+
+        var requestReasoningSnapshots: [String: AIReasoningRequestSnapshot] = [:]
+        do {
+            for model in requestModels {
+                guard let effectiveProvider = requestProviders[model] else { continue }
+                requestReasoningSnapshots[model] = try AIReasoningRequestSnapshot(
+                    configuration: resolvedReasoningConfiguration(
+                        for: model,
+                        provider: effectiveProvider,
+                        endpointType: modelEndpointTypes[model] ?? .chatCompletions,
+                        endpoint: customEndpoint(for: model)?.endpoint,
+                        messages: messages
+                    )
+                )
+            }
+        } catch {
+            rejectBatch(error)
+            return requestHandle
+        }
+        let frozenReasoningSnapshots = requestReasoningSnapshots
 
         DiagnosticsLogger.log(
             .aiService,
@@ -1847,6 +2218,10 @@ class AIService: ObservableObject {
                                 case let .reasoning(reasoning):
                                     guard !completion.isFinished else { return }
                                     onReasoning?(callbackModel, reasoning)
+
+                                case let .reasoningContinuation(state):
+                                    guard !completion.isFinished else { return }
+                                    onReasoningContinuation?(callbackModel, state)
                                 }
                             }
 
@@ -1893,7 +2268,11 @@ class AIService: ObservableObject {
                                 onReasoning: { reasoning in
                                     callbackForwarder.enqueue(.reasoning(reasoning))
                                 },
-                                requestFlightID: flightID
+                                onReasoningContinuation: { state in
+                                    callbackForwarder.enqueue(.reasoningContinuation(state))
+                                },
+                                requestFlightID: flightID,
+                                reasoningSnapshot: frozenReasoningSnapshots[model]
                             )
                         }
                     }
@@ -2230,6 +2609,8 @@ class AIService: ObservableObject {
         onError: @escaping @Sendable (Error) -> Void,
         onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)? = nil,
         onReasoning: (@Sendable (String) -> Void)? = nil,
+        onReasoningContinuation: (@Sendable (ReasoningContinuationState) -> Void)? = nil,
+        reasoningConfiguration: ResolvedReasoningConfiguration? = nil,
         requestLane: AITextRequestLane = .foreground,
         isMultiModelRequest: Bool = false,
         attempt: Int = 0,
@@ -2334,7 +2715,8 @@ class AIService: ObservableObject {
                 tools: toolDefinitions,
                 apiKey: modelAPIKey,
                 isAzure: usesAzureEndpoint,
-                supportsParallelToolCalls: supportsParallelToolCalls
+                supportsParallelToolCalls: supportsParallelToolCalls,
+                reasoning: reasoningConfiguration
             )
 
             guard self.clearRequestBuildFlight(
@@ -2422,6 +2804,8 @@ class AIService: ObservableObject {
                                     onError: onError,
                                     onToolCallRequested: onToolCallRequested,
                                     onReasoning: onReasoning,
+                                    onReasoningContinuation: onReasoningContinuation,
+                                    reasoningConfiguration: reasoningConfiguration,
                                     requestLane: requestLane,
                                     isMultiModelRequest: isMultiModelRequest,
                                     attempt: attempt + 1,
@@ -2498,6 +2882,22 @@ class AIService: ObservableObject {
                                         return
                                     }
                                     onReasoning?(reasoning)
+                                },
+                                onReasoningContinuation: { state in
+                                    guard self.ownsDataFlight(
+                                        flightID,
+                                        requestLane: requestLane,
+                                        isMultiModelRequest: isMultiModelRequest,
+                                        modelName: model
+                                    ) else {
+                                        return
+                                    }
+                                    onReasoningContinuation?(
+                                        state.attaching(
+                                            model: model,
+                                            requestConfiguration: reasoningConfiguration
+                                        )
+                                    )
                                 },
                                 onToolCallRequested: { toolID, toolName, arguments in
                                     guard self.ownsDataFlight(
@@ -3603,12 +4003,6 @@ class AIService: ObservableObject {
                             foundReasoning = reasoning
                         } else if let reasoning = message["reasoning_content"] as? String {
                             foundReasoning = reasoning
-                        } else if let usage = json?["usage"] as? [String: Any],
-                                  let details = usage["completion_tokens_details"] as? [String: Any],
-                                  let reasoningTokens = details["reasoning_tokens"] as? Int, reasoningTokens > 0
-                        {
-                            // Show reasoning token count
-                            foundReasoning = "💭 Reasoning tokens used: \(reasoningTokens)"
                         }
 
                         // Handle reasoning content if found
@@ -4391,7 +4785,7 @@ class AIService: ObservableObject {
         return currentAnthropicProvider.clear(ifOwnedBy: flightID)
     }
 
-    // swiftlint:disable:next function_parameter_count
+    // swiftlint:disable:next function_parameter_count function_body_length
     private func handleAnthropicRequest(
         messages: [Message],
         model: String,
@@ -4401,6 +4795,7 @@ class AIService: ObservableObject {
         requestLane: AITextRequestLane,
         isMultiModelRequest: Bool,
         callbacks: AIProviderStreamCallbacks,
+        reasoningConfiguration: ResolvedReasoningConfiguration?,
         flightID: RequestFlightID = RequestFlightID()
     ) {
         let modelAPIKey = getAPIKey(for: model)
@@ -4412,14 +4807,21 @@ class AIService: ObservableObject {
             return
         }
 
+        let anthropicReasoning = anthropicReasoningConfiguration(from: reasoningConfiguration)
+        let maximumTokens: Int? = if case let .enabled(budgetTokens, _, _, _) = anthropicReasoning {
+            max(4096, budgetTokens + 1024)
+        } else {
+            nil
+        }
+
         // Build provider config
         let config = AIProviderRequestConfig(
             model: model,
             apiKey: modelAPIKey,
             customEndpoint: endpointInfo?.endpoint,
-            maxTokens: nil, // Use provider default
+            maxTokens: maximumTokens,
             temperature: nil, // Use provider default
-            thinkingBudget: nil // TODO: Add UI for thinking budget
+            anthropicReasoning: anthropicReasoning
         )
 
         // Inject memory context into messages
@@ -4527,6 +4929,17 @@ class AIService: ObservableObject {
                     return
                 }
                 callbacks.onReasoning?(reasoning)
+
+            case let .reasoningContinuation(state):
+                guard self.ownsAnthropicFlight(
+                    flightID,
+                    requestLane: requestLane,
+                    isMultiModelRequest: isMultiModelRequest,
+                    model: model
+                ) else {
+                    return
+                }
+                callbacks.onReasoningContinuation?(state)
             }
         }
 
@@ -4537,7 +4950,8 @@ class AIService: ObservableObject {
             onToolCallRequested: { toolID, toolName, arguments in
                 forwarder.enqueue(.toolRequest(id: toolID, name: toolName, arguments: arguments))
             },
-            onReasoning: { forwarder.enqueue(.reasoning($0)) }
+            onReasoning: { forwarder.enqueue(.reasoning($0)) },
+            onReasoningContinuation: { forwarder.enqueue(.reasoningContinuation($0)) }
         )
 
         provider.sendMessage(
@@ -4547,6 +4961,33 @@ class AIService: ObservableObject {
             tools: tools,
             callbacks: wrappedCallbacks
         )
+    }
+
+    private func anthropicReasoningConfiguration(
+        from reasoning: ResolvedReasoningConfiguration?
+    ) -> AnthropicReasoningConfiguration? {
+        guard let reasoning else { return nil }
+        let effort = reasoning.effort.flatMap {
+            AnthropicReasoningConfiguration.Effort(rawValue: $0.rawValue)
+        }
+        let display = reasoning.anthropicDisplay.wireValue.flatMap(
+            AnthropicReasoningConfiguration.Display.init(rawValue:)
+        )
+
+        switch reasoning.dialect {
+        case .anthropicDisabled:
+            return .disabled(effort: effort)
+        case .anthropicAdaptive:
+            return .adaptive(effort: effort, display: display)
+        case .anthropicExtended:
+            return .enabled(
+                budgetTokens: reasoning.legacyBudgetTokens,
+                effort: effort,
+                display: display
+            )
+        case .openAIChat, .openAIResponses:
+            return nil
+        }
     }
 
     /// Retry logic delegated to AIRetryPolicy

--- a/Sources/Ayna/Services/AIService.swift
+++ b/Sources/Ayna/Services/AIService.swift
@@ -940,7 +940,8 @@ class AIService: ObservableObject {
         provider: AIProvider,
         endpointType: APIEndpointType,
         endpoint: String?,
-        messages: [Message]
+        messages: [Message],
+        requestedConfiguration: ModelReasoningConfiguration?
     ) throws -> ResolvedReasoningConfiguration? {
         if let continuationRound = toolContinuationRound(in: messages) {
             if let continuationSnapshot = try opaqueToolContinuationReasoningSnapshot(
@@ -967,7 +968,7 @@ class AIService: ObservableObject {
             provider: provider,
             endpointType: endpointType,
             endpoint: endpoint,
-            configuration: reasoningConfiguration(for: model)
+            configuration: requestedConfiguration ?? reasoningConfiguration(for: model)
         )
     }
 
@@ -1620,6 +1621,7 @@ class AIService: ObservableObject {
         onReasoning: (@Sendable (String) -> Void)? = nil,
         onReasoningContinuation: (@Sendable (ReasoningContinuationState) -> Void)? = nil,
         requestFlightID: RequestFlightID? = nil,
+        reasoningConfiguration: ModelReasoningConfiguration? = nil,
         reasoningSnapshot: AIReasoningRequestSnapshot? = nil
     ) -> AITextRequest {
         let flightID = requestFlightID ?? RequestFlightID()
@@ -1712,7 +1714,8 @@ class AIService: ObservableObject {
                         provider: effectiveProvider,
                         endpointType: endpointType,
                         endpoint: endpointInfo?.endpoint,
-                        messages: messages
+                        messages: messages,
+                        requestedConfiguration: reasoningConfiguration
                     )
                 )
             }
@@ -2026,7 +2029,8 @@ class AIService: ObservableObject {
         onError: @escaping @Sendable (String, Error) -> Void,
         onPendingToolCall: (@Sendable (String, String, String, [String: Any]) -> Void)? = nil,
         onReasoning: (@Sendable (String, String) -> Void)? = nil,
-        onReasoningContinuation: (@Sendable (String, ReasoningContinuationState) -> Void)? = nil
+        onReasoningContinuation: (@Sendable (String, ReasoningContinuationState) -> Void)? = nil,
+        reasoningConfiguration: ModelReasoningConfiguration? = nil
     ) -> AITextBatchRequest {
         let flightID = RequestFlightID()
         let requestHandle = AITextBatchRequest(service: self, flightID: flightID)
@@ -2075,7 +2079,8 @@ class AIService: ObservableObject {
                         provider: effectiveProvider,
                         endpointType: modelEndpointTypes[model] ?? .chatCompletions,
                         endpoint: customEndpoint(for: model)?.endpoint,
-                        messages: messages
+                        messages: messages,
+                        requestedConfiguration: reasoningConfiguration
                     )
                 )
             }

--- a/Sources/Ayna/Services/AnthropicRequestBuilder.swift
+++ b/Sources/Ayna/Services/AnthropicRequestBuilder.swift
@@ -10,11 +10,15 @@ import os
 
 /// Configuration for Anthropic API requests
 struct AnthropicRequestConfig: Sendable {
+    static let interleavedThinkingBeta = "interleaved-thinking-2025-05-14"
+    private static let minimumLegacyResponseAllowance = 1024
+
     let model: String
     let apiKey: String
     let customEndpoint: String?
     let maxTokens: Int
     let budgetTokens: Int?
+    let reasoning: AnthropicReasoningConfiguration?
     let betaHeaders: [String]
     let isAzureEndpoint: Bool
 
@@ -24,17 +28,53 @@ struct AnthropicRequestConfig: Sendable {
         customEndpoint: String? = nil,
         maxTokens: Int = 4096,
         budgetTokens: Int? = nil,
+        reasoning: AnthropicReasoningConfiguration? = nil,
         betaHeaders: [String] = []
     ) {
+        let resolvedReasoning = reasoning ?? budgetTokens.map {
+            .enabled(budgetTokens: $0)
+        }
+
         self.model = model
         self.apiKey = apiKey
         self.customEndpoint = customEndpoint
-        self.maxTokens = maxTokens
         self.budgetTokens = budgetTokens
+        self.reasoning = resolvedReasoning
+        self.maxTokens = Self.adjustedMaxTokens(
+            requested: maxTokens,
+            reasoning: resolvedReasoning
+        )
         self.betaHeaders = betaHeaders
         // Detect Azure endpoints by URL pattern
         isAzureEndpoint = customEndpoint?.contains(".azure.com") == true ||
             customEndpoint?.contains("azure.") == true
+    }
+
+    private static func adjustedMaxTokens(
+        requested: Int,
+        reasoning: AnthropicReasoningConfiguration?
+    ) -> Int {
+        guard let reasoning,
+              case let .enabled(budgetTokens, _, _, _) = reasoning,
+              budgetTokens >= 1024,
+              requested <= budgetTokens
+        else {
+            return requested
+        }
+
+        let (adjusted, overflowed) = budgetTokens.addingReportingOverflow(
+            minimumLegacyResponseAllowance
+        )
+        return overflowed ? Int.max : adjusted
+    }
+
+    var effectiveBetaHeaders: [String] {
+        guard reasoning?.usesInterleavedThinkingBeta == true,
+              !betaHeaders.contains(Self.interleavedThinkingBeta)
+        else {
+            return betaHeaders
+        }
+        return betaHeaders + [Self.interleavedThinkingBeta]
     }
 }
 
@@ -150,8 +190,9 @@ enum AnthropicRequestBuilder {
         request.setValue(apiVersion, forHTTPHeaderField: "anthropic-version")
 
         // Add beta headers if any (only for non-Azure endpoints)
-        if !config.betaHeaders.isEmpty, !config.isAzureEndpoint {
-            let betaValue = config.betaHeaders.joined(separator: ",")
+        let betaHeaders = config.effectiveBetaHeaders
+        if !betaHeaders.isEmpty, !config.isAzureEndpoint {
+            let betaValue = betaHeaders.joined(separator: ",")
             request.setValue(betaValue, forHTTPHeaderField: "anthropic-beta")
         }
     }
@@ -173,7 +214,10 @@ enum AnthropicRequestBuilder {
     ) throws -> [String: Any] {
         try Task.checkCancellation()
         // Extract system prompt and convert remaining messages
-        let (systemPrompt, anthropicMessages) = try extractSystemAndConvertMessages(messages)
+        let (systemPrompt, anthropicMessages) = try extractSystemAndConvertMessages(
+            messages,
+            model: config.model
+        )
 
         var body: [String: Any] = [
             "model": config.model,
@@ -187,12 +231,8 @@ enum AnthropicRequestBuilder {
             body["system"] = system
         }
 
-        // Add extended thinking if budget_tokens is configured
-        if let budgetTokens = config.budgetTokens, budgetTokens >= 1024 {
-            body["thinking"] = [
-                "type": "enabled",
-                "budget_tokens": budgetTokens
-            ]
+        if let reasoning = config.reasoning {
+            addReasoningConfiguration(reasoning, to: &body)
         }
 
         // Convert and add tools if provided
@@ -209,6 +249,37 @@ enum AnthropicRequestBuilder {
         return body
     }
 
+    private static func addReasoningConfiguration(
+        _ reasoning: AnthropicReasoningConfiguration,
+        to body: inout [String: Any]
+    ) {
+        var thinking: [String: Any]
+
+        switch reasoning {
+        case .disabled:
+            thinking = ["type": "disabled"]
+
+        case .adaptive:
+            thinking = ["type": "adaptive"]
+
+        case let .enabled(budgetTokens, _, _, _):
+            guard budgetTokens >= 1024 else { return }
+            thinking = [
+                "type": "enabled",
+                "budget_tokens": budgetTokens
+            ]
+        }
+
+        if let display = reasoning.display {
+            thinking["display"] = display.rawValue
+        }
+        body["thinking"] = thinking
+
+        if let effort = reasoning.effort {
+            body["output_config"] = ["effort": effort.rawValue]
+        }
+    }
+
     // MARK: - Message Conversion
 
     /// Extract system prompt and convert messages to Anthropic format.
@@ -217,7 +288,8 @@ enum AnthropicRequestBuilder {
     /// - Returns: Tuple of (system prompt, converted messages)
     /// - Throws: `AynaError` if validation fails
     static func extractSystemAndConvertMessages(
-        _ messages: [Message]
+        _ messages: [Message],
+        model: String? = nil
     ) throws -> (systemPrompt: String?, messages: [[String: Any]]) {
         let sanitizedMessages = ToolTranscriptSanitizer.sanitize(messages)
         var systemPrompt: String?
@@ -304,7 +376,10 @@ enum AnthropicRequestBuilder {
                     // No valid tool calls - add assistant without tool_calls
                     var modifiedMessage = message
                     modifiedMessage.toolCalls = nil
-                    let (converted, msgImageCount) = try convertMessage(modifiedMessage)
+                    let (converted, msgImageCount) = try convertMessage(
+                        modifiedMessage,
+                        model: model
+                    )
                     imageCount += msgImageCount
                     if imageCount > maxImagesPerRequest {
                         throw AynaError.apiError(
@@ -317,7 +392,10 @@ enum AnthropicRequestBuilder {
                     // Some tool calls are orphaned - keep only valid ones
                     var modifiedMessage = message
                     modifiedMessage.toolCalls = validToolCalls
-                    let (converted, msgImageCount) = try convertMessage(modifiedMessage)
+                    let (converted, msgImageCount) = try convertMessage(
+                        modifiedMessage,
+                        model: model
+                    )
                     imageCount += msgImageCount
                     if imageCount > maxImagesPerRequest {
                         throw AynaError.apiError(
@@ -331,7 +409,7 @@ enum AnthropicRequestBuilder {
             }
 
             // Convert message
-            let (converted, msgImageCount) = try convertMessage(message)
+            let (converted, msgImageCount) = try convertMessage(message, model: model)
             imageCount += msgImageCount
 
             // Validate image count
@@ -350,7 +428,10 @@ enum AnthropicRequestBuilder {
     /// - Parameter message: Message to convert
     /// - Returns: Tuple of (converted message, image count in this message)
     /// - Throws: `AynaError` if validation fails
-    static func convertMessage(_ message: Message) throws -> (converted: [String: Any], imageCount: Int) {
+    static func convertMessage(
+        _ message: Message,
+        model: String? = nil
+    ) throws -> (converted: [String: Any], imageCount: Int) {
         try Task.checkCancellation()
         var payload: [String: Any] = [:]
         var imageCount = 0
@@ -366,6 +447,17 @@ enum AnthropicRequestBuilder {
             "user"
         }
         payload["role"] = role
+
+        if message.role == .assistant,
+           let continuationContent = anthropicContinuationContent(
+               from: message.reasoningContinuation,
+               messageModel: message.model,
+               requestModel: model
+           )
+        {
+            payload["content"] = continuationContent
+            return (payload, imageCount)
+        }
 
         // Check for attachments
         if let attachments = message.attachments, !attachments.isEmpty, message.role == .user {
@@ -431,6 +523,24 @@ enum AnthropicRequestBuilder {
 
         try Task.checkCancellation()
         return (payload, imageCount)
+    }
+
+    private static func anthropicContinuationContent(
+        from state: ReasoningContinuationState?,
+        messageModel: String?,
+        requestModel: String?
+    ) -> [[String: Any]]? {
+        guard let state,
+              state.format == .anthropicMessages,
+              !state.items.isEmpty,
+              requestModel == nil || state.model == requestModel,
+              requestModel == nil || messageModel == nil || messageModel == requestModel
+        else {
+            return nil
+        }
+
+        let blocks = state.items.compactMap { $0.value as? [String: Any] }
+        return blocks.count == state.items.count ? blocks : nil
     }
 
     // MARK: - Image Validation

--- a/Sources/Ayna/Services/AnthropicStreamParser.swift
+++ b/Sources/Ayna/Services/AnthropicStreamParser.swift
@@ -11,7 +11,7 @@ import os
 private enum AnthropicStreamParserLimits {
     static let initialBlockBufferCapacity = 1024
     static let maxToolInputSize = 10_485_760 // 10MB
-    static let maxSignatureSize = 65_536 // 64KB
+    static let maxSignatureSize = 65536 // 64KB
 }
 
 /// Result from parsing Anthropic SSE events
@@ -20,6 +20,7 @@ struct AnthropicStreamResult: Sendable {
     let content: String?
     let reasoning: String?
     let toolCall: AnthropicToolCall?
+    let reasoningContinuation: ReasoningContinuationState?
     let error: (any Error)?
 
     static var empty: AnthropicStreamResult {
@@ -28,6 +29,7 @@ struct AnthropicStreamResult: Sendable {
             content: nil,
             reasoning: nil,
             toolCall: nil,
+            reasoningContinuation: nil,
             error: nil
         )
     }
@@ -54,12 +56,23 @@ struct AnthropicBlockState {
     var buffer: Data
     var toolName: String?
     var toolId: String?
+    var contentBlock: [String: Any]
 
-    init(type: AnthropicContentBlockType, toolName: String? = nil, toolId: String? = nil) {
+    init(
+        type: AnthropicContentBlockType,
+        contentBlock: [String: Any],
+        toolName: String? = nil,
+        toolId: String? = nil
+    ) {
         self.type = type
         buffer = Data(capacity: AnthropicStreamParserLimits.initialBlockBufferCapacity)
         self.toolName = toolName
         self.toolId = toolId
+        self.contentBlock = contentBlock
+    }
+
+    mutating func append(_ fragment: String, to key: String) {
+        contentBlock[key] = (contentBlock[key] as? String ?? "") + fragment
     }
 }
 
@@ -90,6 +103,9 @@ final class AnthropicStreamParser {
     /// Active content blocks being accumulated
     private var activeBlocks: [Int: AnthropicBlockState] = [:]
 
+    /// Completed content blocks retained in wire order for exact replay.
+    private var completedContentBlocks: [Int: [String: Any]] = [:]
+
     /// Stop reason from message_delta
     private(set) var stopReason: String?
 
@@ -101,12 +117,14 @@ final class AnthropicStreamParser {
     typealias ChunkCallback = @Sendable (String) -> Void
     typealias ReasoningCallback = @Sendable (String) -> Void
     typealias ToolCallCallback = @Sendable (String, String, [String: AnyCodable]) -> Void
+    typealias ReasoningContinuationCallback = @Sendable (ReasoningContinuationState) -> Void
     typealias CompleteCallback = @Sendable () -> Void
     typealias ErrorCallback = @Sendable (any Error) -> Void
 
     private let onChunk: ChunkCallback?
     private let onReasoning: ReasoningCallback?
     private let onToolCallRequested: ToolCallCallback?
+    private let onReasoningContinuation: ReasoningContinuationCallback?
     private let onComplete: CompleteCallback?
     private let onError: ErrorCallback?
 
@@ -117,11 +135,13 @@ final class AnthropicStreamParser {
         onReasoning: ReasoningCallback? = nil,
         onToolCallRequested: ToolCallCallback? = nil,
         onComplete: CompleteCallback? = nil,
-        onError: ErrorCallback? = nil
+        onError: ErrorCallback? = nil,
+        onReasoningContinuation: ReasoningContinuationCallback? = nil
     ) {
         self.onChunk = onChunk
         self.onReasoning = onReasoning
         self.onToolCallRequested = onToolCallRequested
+        self.onReasoningContinuation = onReasoningContinuation
         self.onComplete = onComplete
         self.onError = onError
     }
@@ -268,6 +288,7 @@ final class AnthropicStreamParser {
     func reset() {
         pendingEventType = nil
         activeBlocks.removeAll()
+        completedContentBlocks.removeAll()
         stopReason = nil
         messageId = nil
     }
@@ -300,12 +321,17 @@ final class AnthropicStreamParser {
             return handleMessageDelta(json)
 
         case "message_stop":
+            let continuation = makeReasoningContinuation()
+            if let continuation {
+                onReasoningContinuation?(continuation)
+            }
             onComplete?()
             return AnthropicStreamResult(
                 shouldComplete: true,
                 content: nil,
                 reasoning: nil,
                 toolCall: nil,
+                reasoningContinuation: continuation,
                 error: nil
             )
 
@@ -338,9 +364,11 @@ final class AnthropicStreamParser {
             return .empty
         }
 
-        let blockType = AnthropicContentBlockType(rawValue: typeStr) ?? .text
+        guard let blockType = AnthropicContentBlockType(rawValue: typeStr) else {
+            return .empty
+        }
 
-        var state = AnthropicBlockState(type: blockType)
+        var state = AnthropicBlockState(type: blockType, contentBlock: contentBlock)
 
         // For tool_use, capture the tool name and ID
         if blockType == .toolUse {
@@ -368,12 +396,14 @@ final class AnthropicStreamParser {
         case "text_delta":
             if let text = delta["text"] as? String {
                 content = text
+                activeBlocks[index]?.append(text, to: "text")
                 onChunk?(text)
             }
 
         case "thinking_delta":
             if let thinking = delta["thinking"] as? String {
                 reasoning = thinking
+                activeBlocks[index]?.append(thinking, to: "thinking")
                 onReasoning?(thinking)
             }
 
@@ -388,12 +418,14 @@ final class AnthropicStreamParser {
             }
 
         case "signature_delta":
-            // Accumulate signature for redacted thinking
+            // A regular thinking block's signature arrives immediately before
+            // content_block_stop and must be replayed unchanged.
             if let signature = delta["signature"] as? String,
-               let sigData = signature.data(using: .utf8)
+               let signatureData = signature.data(using: .utf8),
+               activeBlocks[index]?.type == .thinking
             {
-                if (activeBlocks[index]?.buffer.count ?? 0) + sigData.count <= AnthropicStreamParserLimits.maxSignatureSize {
-                    activeBlocks[index]?.buffer.append(sigData)
+                if (activeBlocks[index]?.buffer.count ?? 0) + signatureData.count <= AnthropicStreamParserLimits.maxSignatureSize {
+                    activeBlocks[index]?.buffer.append(signatureData)
                 }
             }
 
@@ -406,18 +438,26 @@ final class AnthropicStreamParser {
             content: content,
             reasoning: reasoning,
             toolCall: nil,
+            reasoningContinuation: nil,
             error: nil
         )
     }
 
     private func handleContentBlockStop(_ json: [String: Any]) -> AnthropicStreamResult {
         guard let index = json["index"] as? Int,
-              let state = activeBlocks[index]
+              var state = activeBlocks[index]
         else {
             return .empty
         }
 
         var toolCall: AnthropicToolCall?
+
+        if state.type == .thinking,
+           !state.buffer.isEmpty,
+           let signature = String(data: state.buffer, encoding: .utf8)
+        {
+            state.contentBlock["signature"] = signature
+        }
 
         // If this was a tool_use block, parse the accumulated JSON
         if state.type == .toolUse,
@@ -425,12 +465,15 @@ final class AnthropicStreamParser {
            let toolName = state.toolName
         {
             if state.buffer.isEmpty {
-                // Empty input, use empty object
-                toolCall = AnthropicToolCall(id: toolId, name: toolName, input: [:])
+                let initialInput = state.contentBlock["input"] as? [String: Any] ?? [:]
+                let codableInput = initialInput.mapValues(AnyCodable.init)
+                toolCall = AnthropicToolCall(id: toolId, name: toolName, input: codableInput)
+                state.contentBlock["input"] = initialInput
             } else if let inputJson = try? JSONSerialization.jsonObject(with: state.buffer) as? [String: Any] {
                 // Convert [String: Any] to [String: AnyCodable] for Sendable safety
                 let codableInput = inputJson.mapValues { AnyCodable($0) }
                 toolCall = AnthropicToolCall(id: toolId, name: toolName, input: codableInput)
+                state.contentBlock["input"] = inputJson
             } else {
                 // JSON parse failure
                 let bufferPreview = String(data: state.buffer.prefix(200), encoding: .utf8) ?? ""
@@ -447,10 +490,15 @@ final class AnthropicStreamParser {
                     input: ["_error": AnyCodable("Failed to parse tool input")]
                 )
             }
+        }
 
-            if let call = toolCall {
-                onToolCallRequested?(call.id, call.name, call.input)
-            }
+        completedContentBlocks[index] = state.contentBlock
+        let continuation = state.type == .toolUse ? makeReasoningContinuation() : nil
+        if let continuation {
+            onReasoningContinuation?(continuation)
+        }
+        if let call = toolCall {
+            onToolCallRequested?(call.id, call.name, call.input)
         }
 
         // Clean up the block state
@@ -461,6 +509,7 @@ final class AnthropicStreamParser {
             content: nil,
             reasoning: nil,
             toolCall: toolCall,
+            reasoningContinuation: continuation,
             error: nil
         )
     }
@@ -489,7 +538,25 @@ final class AnthropicStreamParser {
             content: nil,
             reasoning: nil,
             toolCall: nil,
+            reasoningContinuation: nil,
             error: error
+        )
+    }
+
+    private func makeReasoningContinuation() -> ReasoningContinuationState? {
+        let orderedBlocks = completedContentBlocks.keys.sorted().compactMap {
+            completedContentBlocks[$0]
+        }
+        let containsReasoning = orderedBlocks.contains { block in
+            guard let type = block["type"] as? String else { return false }
+            return type == AnthropicContentBlockType.thinking.rawValue ||
+                type == AnthropicContentBlockType.redactedThinking.rawValue
+        }
+        guard containsReasoning else { return nil }
+
+        return ReasoningContinuationState(
+            format: .anthropicMessages,
+            items: orderedBlocks.map(AnyCodable.init)
         )
     }
 }
@@ -513,14 +580,16 @@ extension AnthropicStreamParser {
         onComplete: @escaping CompleteCallback,
         onError: @escaping ErrorCallback,
         onToolCallRequested: ToolCallCallback? = nil,
-        onReasoning: ReasoningCallback? = nil
+        onReasoning: ReasoningCallback? = nil,
+        onReasoningContinuation: ReasoningContinuationCallback? = nil
     ) -> AnthropicStreamParser {
         AnthropicStreamParser(
             onChunk: onChunk,
             onReasoning: onReasoning,
             onToolCallRequested: onToolCallRequested,
             onComplete: onComplete,
-            onError: onError
+            onError: onError,
+            onReasoningContinuation: onReasoningContinuation
         )
     }
 }

--- a/Sources/Ayna/Services/OpenAIRequestBuilder.swift
+++ b/Sources/Ayna/Services/OpenAIRequestBuilder.swift
@@ -189,7 +189,8 @@ enum OpenAIRequestBuilder {
         model: String,
         stream: Bool,
         tools: [[String: Any]]? = nil,
-        supportsParallelToolCalls: Bool = true
+        supportsParallelToolCalls: Bool = true,
+        reasoning: ResolvedReasoningConfiguration? = nil
     ) -> [String: Any] {
         let sanitizedMessages = ToolTranscriptSanitizer.sanitize(messages)
 
@@ -313,6 +314,20 @@ enum OpenAIRequestBuilder {
             "stream": stream
         ]
 
+        let requestedEffort = reasoning?.dialect == .openAIChat ? reasoning?.effort : nil
+        let profile = ReasoningCapabilityResolver.modelPolicy(
+            model: model,
+            provider: .openai,
+            endpointType: .chatCompletions
+        )
+        let effort = profile?.chatCompletionsEffort(
+            requested: requestedEffort,
+            hasTools: !(tools?.isEmpty ?? true)
+        ) ?? requestedEffort
+        if let effort {
+            body["reasoning_effort"] = effort.rawValue
+        }
+
         // Add tools if provided
         if let tools, !tools.isEmpty {
             body["tools"] = tools
@@ -339,7 +354,7 @@ enum OpenAIRequestBuilder {
     ///
     /// - Parameter messages: Messages to convert
     /// - Returns: Array of input items for the Responses API
-    static func buildResponsesInput(from messages: [Message]) -> [[String: Any]] {
+    static func buildResponsesInput(from messages: [Message], model: String? = nil) -> [[String: Any]] {
         let sanitizedMessages = ToolTranscriptSanitizer.sanitize(messages)
         var inputArray: [[String: Any]] = []
         var messageIndex = 0
@@ -360,16 +375,6 @@ enum OpenAIRequestBuilder {
             }
 
             if message.role == .assistant, let toolCalls = message.toolCalls, !toolCalls.isEmpty {
-                if !message.content.isEmpty {
-                    inputArray.append([
-                        "type": "message",
-                        "role": "assistant",
-                        "content": [
-                            ["type": "output_text", "text": message.content]
-                        ]
-                    ])
-                }
-
                 // Tool outputs belong to this round only while they are contiguous
                 // and immediately follow the assistant call.
                 var resultByCallID: [String: Message] = [:]
@@ -382,6 +387,33 @@ enum OpenAIRequestBuilder {
                         resultByCallID[callID] = resultMessage
                     }
                     nextIndex += 1
+                }
+
+                if let continuationItems = openAIResponsesContinuationItems(
+                    from: message,
+                    model: model
+                ) {
+                    inputArray.append(contentsOf: continuationItems)
+                    for toolCall in toolCalls {
+                        guard let resultMessage = resultByCallID[toolCall.id] else { continue }
+                        inputArray.append([
+                            "type": "function_call_output",
+                            "call_id": toolCall.id,
+                            "output": resultMessage.content
+                        ])
+                    }
+                    messageIndex = nextIndex
+                    continue
+                }
+
+                if !message.content.isEmpty {
+                    inputArray.append([
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            ["type": "output_text", "text": message.content]
+                        ]
+                    ])
                 }
 
                 var validCalls: [MCPToolCall] = []
@@ -422,6 +454,17 @@ enum OpenAIRequestBuilder {
                 continue
             }
 
+            if message.role == .assistant,
+               let continuationItems = openAIResponsesContinuationItems(
+                   from: message,
+                   model: model
+               )
+            {
+                inputArray.append(contentsOf: continuationItems)
+                messageIndex += 1
+                continue
+            }
+
             var messageItem: [String: Any] = [
                 "type": "message",
                 "role": message.role.rawValue
@@ -458,6 +501,23 @@ enum OpenAIRequestBuilder {
         }
 
         return inputArray
+    }
+
+    private static func openAIResponsesContinuationItems(
+        from message: Message,
+        model: String?
+    ) -> [[String: Any]]? {
+        guard let state = message.reasoningContinuation,
+              state.format == .openAIResponses,
+              !state.items.isEmpty,
+              model == nil || state.model == model,
+              model == nil || message.model == nil || message.model == model
+        else {
+            return nil
+        }
+
+        let items = state.items.compactMap { $0.value as? [String: Any] }
+        return items.count == state.items.count ? items : nil
     }
 
     /// Convert tools from Chat Completions format to Responses API format.
@@ -515,16 +575,34 @@ enum OpenAIRequestBuilder {
         model: String,
         messages: [Message],
         tools: [[String: Any]]? = nil,
-        supportsParallelToolCalls: Bool = true
+        supportsParallelToolCalls: Bool = true,
+        reasoning: ResolvedReasoningConfiguration? = nil
     ) -> [String: Any] {
-        let inputArray = buildResponsesInput(from: messages)
+        let inputArray = buildResponsesInput(from: messages, model: model)
 
         var body: [String: Any] = [
             "model": model,
-            "input": inputArray,
-            "reasoning": ["summary": "auto"],
-            "text": ["verbosity": "medium"]
+            "input": inputArray
         ]
+
+        if reasoning?.dialect == .openAIResponses {
+            var reasoningBody: [String: Any] = [:]
+            if let effort = reasoning?.effort {
+                reasoningBody["effort"] = effort.rawValue
+            }
+            if let summary = reasoning?.summary.wireValue {
+                reasoningBody["summary"] = summary
+            }
+            if let context = reasoning?.openAIContext.wireValue {
+                reasoningBody["context"] = context
+            }
+            if let mode = reasoning?.openAIMode {
+                reasoningBody["mode"] = mode.rawValue
+            }
+            if !reasoningBody.isEmpty {
+                body["reasoning"] = reasoningBody
+            }
+        }
 
         let instructions = messages
             .filter { $0.role == .system && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
@@ -560,6 +638,7 @@ enum OpenAIRequestBuilder {
     struct ResponsesOutputResult {
         let hasToolCalls: Bool
         let toolCalls: [ToolCallInfo]
+        let reasoningContinuation: ReasoningContinuationState?
     }
 
     /// Deliver output from the Responses API to callbacks.
@@ -579,9 +658,17 @@ enum OpenAIRequestBuilder {
         _ outputArray: [[String: Any]],
         onChunk: @escaping (String) -> Void,
         onReasoning: ((String) -> Void)?,
+        onReasoningContinuation: ((ReasoningContinuationState) -> Void)? = nil,
         onToolCallRequested: ((String, String, [String: Any]) -> Void)? = nil
     ) -> ResponsesOutputResult {
         var toolCalls: [ToolCallInfo] = []
+        let continuation = outputArray.isEmpty ? nil : ReasoningContinuationState(
+            format: .openAIResponses,
+            items: outputArray.map(AnyCodable.init)
+        )
+        if let continuation {
+            onReasoningContinuation?(continuation)
+        }
 
         for outputItem in outputArray {
             let itemType = outputItem["type"] as? String
@@ -647,7 +734,11 @@ enum OpenAIRequestBuilder {
             }
         }
 
-        return ResponsesOutputResult(hasToolCalls: !toolCalls.isEmpty, toolCalls: toolCalls)
+        return ResponsesOutputResult(
+            hasToolCalls: !toolCalls.isEmpty,
+            toolCalls: toolCalls,
+            reasoningContinuation: continuation
+        )
     }
 
     // MARK: - Request Configuration
@@ -685,6 +776,7 @@ enum OpenAIRequestBuilder {
         apiKey: String,
         isAzure: Bool,
         supportsParallelToolCalls: Bool = true,
+        reasoning: ResolvedReasoningConfiguration? = nil,
         attachmentDataLoader: RequestBuilderAttachmentResolver.AttachmentDataLoader? = nil
     ) async -> URLRequest? {
         let resolvedMessages: [Message]
@@ -706,7 +798,8 @@ enum OpenAIRequestBuilder {
                 tools: tools.value,
                 apiKey: apiKey,
                 isAzure: isAzure,
-                supportsParallelToolCalls: supportsParallelToolCalls
+                supportsParallelToolCalls: supportsParallelToolCalls,
+                reasoning: reasoning
             )
         }
 
@@ -741,7 +834,8 @@ enum OpenAIRequestBuilder {
         tools: [[String: Any]]? = nil,
         apiKey: String,
         isAzure: Bool,
-        supportsParallelToolCalls: Bool = true
+        supportsParallelToolCalls: Bool = true,
+        reasoning: ResolvedReasoningConfiguration? = nil
     ) -> URLRequest? {
         guard !Task.isCancelled else { return nil }
         var request = URLRequest(url: url)
@@ -752,7 +846,8 @@ enum OpenAIRequestBuilder {
             model: model,
             stream: stream,
             tools: tools,
-            supportsParallelToolCalls: supportsParallelToolCalls
+            supportsParallelToolCalls: supportsParallelToolCalls,
+            reasoning: reasoning
         )
 
         guard !Task.isCancelled else { return nil }
@@ -774,6 +869,7 @@ enum OpenAIRequestBuilder {
         apiKey: String,
         isAzure: Bool,
         supportsParallelToolCalls: Bool = true,
+        reasoning: ResolvedReasoningConfiguration? = nil,
         attachmentDataLoader: RequestBuilderAttachmentResolver.AttachmentDataLoader? = nil
     ) async -> URLRequest? {
         let resolvedMessages: [Message]
@@ -794,7 +890,8 @@ enum OpenAIRequestBuilder {
                 tools: tools.value,
                 apiKey: apiKey,
                 isAzure: isAzure,
-                supportsParallelToolCalls: supportsParallelToolCalls
+                supportsParallelToolCalls: supportsParallelToolCalls,
+                reasoning: reasoning
             )
         }
 
@@ -827,7 +924,8 @@ enum OpenAIRequestBuilder {
         tools: [[String: Any]]? = nil,
         apiKey: String,
         isAzure: Bool,
-        supportsParallelToolCalls: Bool = true
+        supportsParallelToolCalls: Bool = true,
+        reasoning: ResolvedReasoningConfiguration? = nil
     ) -> URLRequest? {
         guard !Task.isCancelled else { return nil }
         var request = URLRequest(url: url)
@@ -837,7 +935,8 @@ enum OpenAIRequestBuilder {
             model: model,
             messages: messages,
             tools: tools,
-            supportsParallelToolCalls: supportsParallelToolCalls
+            supportsParallelToolCalls: supportsParallelToolCalls,
+            reasoning: reasoning
         )
 
         guard !Task.isCancelled else { return nil }

--- a/Sources/Ayna/Services/Providers/AIProviderProtocol.swift
+++ b/Sources/Ayna/Services/Providers/AIProviderProtocol.swift
@@ -7,6 +7,63 @@
 
 import Foundation
 
+/// Anthropic-specific reasoning controls for a request.
+///
+/// Adaptive thinking lets the model decide when and how much to think. Legacy
+/// enabled thinking reserves a fixed token budget and can opt in to the
+/// interleaved-thinking beta explicitly for models that support it.
+enum AnthropicReasoningConfiguration: Equatable, Sendable {
+    enum Effort: String, Codable, CaseIterable, Sendable {
+        case low
+        case medium
+        case high
+        case xhigh
+        case max
+    }
+
+    enum Display: String, Codable, CaseIterable, Sendable {
+        case summarized
+        case omitted
+    }
+
+    case disabled(effort: Effort? = nil)
+    case adaptive(
+        effort: Effort? = nil,
+        display: Display? = nil
+    )
+    case enabled(
+        budgetTokens: Int,
+        interleaved: Bool = false,
+        effort: Effort? = nil,
+        display: Display? = nil
+    )
+
+    var effort: Effort? {
+        switch self {
+        case let .disabled(effort):
+            effort
+        case let .adaptive(effort, _), let .enabled(_, _, effort, _):
+            effort
+        }
+    }
+
+    var display: Display? {
+        switch self {
+        case .disabled:
+            nil
+        case let .adaptive(_, display), let .enabled(_, _, _, display):
+            display
+        }
+    }
+
+    var usesInterleavedThinkingBeta: Bool {
+        guard case let .enabled(_, interleaved, _, _) = self else {
+            return false
+        }
+        return interleaved
+    }
+}
+
 /// Configuration for an AI provider request
 struct AIProviderRequestConfig: Sendable {
     let model: String
@@ -23,6 +80,10 @@ struct AIProviderRequestConfig: Sendable {
     /// Budget tokens for extended thinking (Anthropic only)
     let thinkingBudget: Int?
 
+    /// Typed Anthropic reasoning controls. When present, this takes precedence
+    /// over the legacy `thinkingBudget` compatibility parameter.
+    let anthropicReasoning: AnthropicReasoningConfiguration?
+
     init(
         model: String,
         apiKey: String,
@@ -30,7 +91,8 @@ struct AIProviderRequestConfig: Sendable {
         azureAPIVersion: String = "2025-04-01-preview",
         maxTokens: Int? = nil,
         temperature: Double? = nil,
-        thinkingBudget: Int? = nil
+        thinkingBudget: Int? = nil,
+        anthropicReasoning: AnthropicReasoningConfiguration? = nil
     ) {
         self.model = model
         self.apiKey = apiKey
@@ -39,6 +101,9 @@ struct AIProviderRequestConfig: Sendable {
         self.maxTokens = maxTokens
         self.temperature = temperature
         self.thinkingBudget = thinkingBudget
+        self.anthropicReasoning = anthropicReasoning ?? thinkingBudget.map {
+            .enabled(budgetTokens: $0)
+        }
     }
 }
 
@@ -50,6 +115,7 @@ struct AIProviderStreamCallbacks: Sendable {
     let onToolCall: (@Sendable (String, String, [String: Any]) async -> String)?
     let onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?
     let onReasoning: (@Sendable (String) -> Void)?
+    let onReasoningContinuation: (@Sendable (ReasoningContinuationState) -> Void)?
 
     init(
         onChunk: @escaping @Sendable (String) -> Void,
@@ -57,7 +123,8 @@ struct AIProviderStreamCallbacks: Sendable {
         onError: @escaping @Sendable (Error) -> Void,
         onToolCall: (@Sendable (String, String, [String: Any]) async -> String)? = nil,
         onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)? = nil,
-        onReasoning: (@Sendable (String) -> Void)? = nil
+        onReasoning: (@Sendable (String) -> Void)? = nil,
+        onReasoningContinuation: (@Sendable (ReasoningContinuationState) -> Void)? = nil
     ) {
         self.onChunk = onChunk
         self.onComplete = onComplete
@@ -65,6 +132,7 @@ struct AIProviderStreamCallbacks: Sendable {
         self.onToolCall = onToolCall
         self.onToolCallRequested = onToolCallRequested
         self.onReasoning = onReasoning
+        self.onReasoningContinuation = onReasoningContinuation
     }
 }
 

--- a/Sources/Ayna/Services/Providers/AnthropicProvider.swift
+++ b/Sources/Ayna/Services/Providers/AnthropicProvider.swift
@@ -79,24 +79,13 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
             return
         }
 
-        // Determine beta headers based on model
-        var betaHeaders: [String] = []
-        if let thinkingBudget = config.thinkingBudget, thinkingBudget >= 1024 {
-            // Enable interleaved thinking for Claude 4+ models
-            let model = config.model.lowercased()
-            if model.contains("claude-4") || model.contains("claude-opus-4") || model.contains("claude-sonnet-4") {
-                betaHeaders.append("interleaved-thinking-2025-05-14")
-            }
-        }
-
         // Build request configuration
         let requestConfig = AnthropicRequestConfig(
             model: config.model,
             apiKey: config.apiKey,
             customEndpoint: config.customEndpoint,
             maxTokens: config.maxTokens ?? 4096,
-            budgetTokens: config.thinkingBudget,
-            betaHeaders: betaHeaders
+            reasoning: config.anthropicReasoning
         )
 
         currentRequestBuildTask?.cancel()
@@ -338,6 +327,11 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
         if let reasoning = result.reasoning {
             reasoningBuffer += reasoning
         }
+        if let continuation = result.reasoningContinuation {
+            await MainActor.run {
+                callbacks.onReasoningContinuation?(continuation)
+            }
+        }
         if let toolCall = result.toolCall {
             let anyInput = toolCall.input.mapValues { $0.value }
             await MainActor.run {
@@ -474,6 +468,7 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
             }
 
             if let content = json?["content"] as? [[String: Any]] {
+                emitReasoningContinuation(from: content, callbacks: callbacks)
                 parseContentBlocks(content, callbacks: callbacks)
             }
 
@@ -507,6 +502,24 @@ final class AnthropicProvider: AIProviderProtocol, @unchecked Sendable {
                 break
             }
         }
+    }
+
+    private func emitReasoningContinuation(
+        from content: [[String: Any]],
+        callbacks: AIProviderStreamCallbacks
+    ) {
+        let containsReasoning = content.contains { block in
+            guard let type = block["type"] as? String else { return false }
+            return type == "thinking" || type == "redacted_thinking"
+        }
+        guard containsReasoning else { return }
+
+        callbacks.onReasoningContinuation?(
+            ReasoningContinuationState(
+                format: .anthropicMessages,
+                items: content.map(AnyCodable.init)
+            )
+        )
     }
 
     // MARK: - Circuit Breaker

--- a/Sources/Ayna/Services/WatchConnectivityService.swift
+++ b/Sources/Ayna/Services/WatchConnectivityService.swift
@@ -356,17 +356,24 @@
                 let apiKeys = AIService.shared.modelAPIKeys.filter {
                     configured.contains($0.key) && !$0.value.isEmpty
                 }
+                let reasoningConfigurations = WatchModelReasoningConfigurationCodec.encode(
+                    AIService.shared.modelReasoningConfigurations.filter {
+                        configured.contains($0.key)
+                    }
+                )
                 return WatchModelMetadataInventory(
                     modelIDs: modelIDs,
                     providerModelIDs: providers.keys.sorted(),
                     endpointModelIDs: endpoints.keys.sorted(),
                     endpointTypeModelIDs: endpointTypes.keys.sorted(),
                     apiKeyModelIDs: apiKeys.keys.sorted(),
+                    reasoningConfigurationModelIDs: reasoningConfigurations.keys.sorted(),
                     valueDigests: WatchModelMetadataValueDigests.hashing(
                         providers: providers,
                         endpoints: endpoints,
                         endpointTypes: endpointTypes,
-                        apiKeys: apiKeys
+                        apiKeys: apiKeys,
+                        reasoningConfigurations: reasoningConfigurations
                     )
                 )
             }
@@ -424,11 +431,19 @@
                     WatchContextKeys.modelAPIKeys: modelPublication.metadataValues(
                         from: AIService.shared.modelAPIKeys
                     ),
+                    WatchContextKeys.modelReasoningConfigurations:
+                        WatchModelReasoningConfigurationCodec.encode(
+                            modelPublication.metadataValues(
+                                from: AIService.shared.modelReasoningConfigurations
+                            )
+                        ),
                     WatchContextKeys.removedModelDigests: options.modelRemovalPublication.removedModelDigests,
                     WatchContextKeys.removedModelProviderDigests: options.modelRemovalPublication.removedProviderDigests,
                     WatchContextKeys.removedModelEndpointDigests: options.modelRemovalPublication.removedEndpointDigests,
                     WatchContextKeys.removedModelEndpointTypeDigests: options.modelRemovalPublication.removedEndpointTypeDigests,
                     WatchContextKeys.removedModelAPIKeyDigests: options.modelRemovalPublication.removedAPIKeyDigests,
+                    WatchContextKeys.removedModelReasoningConfigurationDigests:
+                        options.modelRemovalPublication.removedReasoningConfigurationDigests,
                     WatchContextKeys.modelMetadataEpoch: options.modelMetadataEpoch.uuidString,
                     WatchContextKeys.modelMetadataComplete: modelMetadataComplete,
                     WatchContextKeys.tavilyAPIKey: TavilyService.shared.apiKey,
@@ -2099,7 +2114,8 @@
                     modelProviders: AIService.shared.modelProviders.mapValues(\.rawValue),
                     modelEndpoints: AIService.shared.modelEndpoints,
                     modelEndpointTypes: AIService.shared.modelEndpointTypes.mapValues(\.rawValue),
-                    modelAPIKeys: AIService.shared.modelAPIKeys
+                    modelAPIKeys: AIService.shared.modelAPIKeys,
+                    modelReasoningConfigurations: AIService.shared.modelReasoningConfigurations
                 )
             }
 
@@ -2123,6 +2139,7 @@
                     }
                 }
                 AIService.shared.modelAPIKeys = state.modelAPIKeys
+                AIService.shared.modelReasoningConfigurations = state.modelReasoningConfigurations
             }
 
             private func processTavilySettingsFromContext(

--- a/Sources/Ayna/Services/WatchConnectivitySupport.swift
+++ b/Sources/Ayna/Services/WatchConnectivitySupport.swift
@@ -863,11 +863,14 @@ enum WatchContextKeys {
     static let modelEndpoints = "modelEndpoints"
     static let modelEndpointTypes = "modelEndpointTypes"
     static let modelAPIKeys = "modelAPIKeys"
+    static let modelReasoningConfigurations = "modelReasoningConfigurations"
     static let removedModelDigests = "removedModelDigests"
     static let removedModelProviderDigests = "removedModelProviderDigests"
     static let removedModelEndpointDigests = "removedModelEndpointDigests"
     static let removedModelEndpointTypeDigests = "removedModelEndpointTypeDigests"
     static let removedModelAPIKeyDigests = "removedModelAPIKeyDigests"
+    static let removedModelReasoningConfigurationDigests =
+        "removedModelReasoningConfigurationDigests"
     static let modelMetadataEpoch = "modelMetadataEpoch"
     static let modelMetadataComplete = "modelMetadataComplete"
     static let tavilyAPIKey = "tavilyAPIKey"
@@ -1321,6 +1324,8 @@ final class WatchRecentAcknowledgementTracker {
 enum WatchConversationSyncObserver {
     static func observe(
         conversationManager: ConversationManager,
+        aiService: AIService = .shared,
+        serviceChangeDebounce: RunLoop.SchedulerTimeType.Stride = .seconds(1),
         onSync: @escaping @MainActor ([Conversation]) -> Void
     ) -> Set<AnyCancellable> {
         var cancellables = Set<AnyCancellable>()
@@ -1364,9 +1369,9 @@ enum WatchConversationSyncObserver {
             }
             .store(in: &cancellables)
 
-        AIService.shared.objectWillChange
+        aiService.objectWillChange
             .merge(with: TavilyService.shared.objectWillChange)
-            .debounce(for: .seconds(1), scheduler: RunLoop.main)
+            .debounce(for: serviceChangeDebounce, scheduler: RunLoop.main)
             .sink { [weak conversationManager] _ in
                 guard let conversationManager else { return }
                 onSync(conversationManager.durableConversationsForSync())
@@ -1558,24 +1563,103 @@ enum WatchModelIdentity {
     }
 }
 
+enum WatchModelReasoningConfigurationCodec {
+    static func encode(
+        _ configurations: [String: ModelReasoningConfiguration]
+    ) -> [String: String] {
+        configurations.reduce(into: [:]) { encoded, entry in
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            guard let data = try? encoder.encode(entry.value) else { return }
+            encoded[entry.key] = data.base64EncodedString()
+        }
+    }
+
+    static func decode(
+        _ configurations: [String: String]?
+    ) -> [String: ModelReasoningConfiguration]? {
+        guard let configurations else { return nil }
+        return configurations.reduce(into: [:]) { decoded, entry in
+            guard let data = Data(base64Encoded: entry.value),
+                  let configuration = try? JSONDecoder().decode(
+                      ModelReasoningConfiguration.self,
+                      from: data
+                  )
+            else {
+                return
+            }
+            decoded[entry.key] = configuration
+        }
+    }
+}
+
 struct WatchModelMetadataValueDigests: Codable, Equatable, Sendable {
     var providers: [String: String] = [:]
     var endpoints: [String: String] = [:]
     var endpointTypes: [String: String] = [:]
     var apiKeys: [String: String] = [:]
+    var reasoningConfigurations: [String: String] = [:]
 
     static func hashing(
         providers: [String: String],
         endpoints: [String: String],
         endpointTypes: [String: String],
-        apiKeys: [String: String]
+        apiKeys: [String: String],
+        reasoningConfigurations: [String: String] = [:]
     ) -> Self {
         Self(
             providers: digestValues(providers, value: { $0 }),
             endpoints: digestValues(endpoints, value: { $0 }),
             endpointTypes: digestValues(endpointTypes, value: { $0 }),
-            apiKeys: digestValues(apiKeys, value: { $0 })
+            apiKeys: digestValues(apiKeys, value: { $0 }),
+            reasoningConfigurations: digestValues(reasoningConfigurations, value: { $0 })
         )
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case providers
+        case endpoints
+        case endpointTypes
+        case apiKeys
+        case reasoningConfigurations
+    }
+
+    init(
+        providers: [String: String] = [:],
+        endpoints: [String: String] = [:],
+        endpointTypes: [String: String] = [:],
+        apiKeys: [String: String] = [:],
+        reasoningConfigurations: [String: String] = [:]
+    ) {
+        self.providers = providers
+        self.endpoints = endpoints
+        self.endpointTypes = endpointTypes
+        self.apiKeys = apiKeys
+        self.reasoningConfigurations = reasoningConfigurations
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        providers = try container.decodeIfPresent([String: String].self, forKey: .providers) ?? [:]
+        endpoints = try container.decodeIfPresent([String: String].self, forKey: .endpoints) ?? [:]
+        endpointTypes = try container.decodeIfPresent(
+            [String: String].self,
+            forKey: .endpointTypes
+        ) ?? [:]
+        apiKeys = try container.decodeIfPresent([String: String].self, forKey: .apiKeys) ?? [:]
+        reasoningConfigurations = try container.decodeIfPresent(
+            [String: String].self,
+            forKey: .reasoningConfigurations
+        ) ?? [:]
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(providers, forKey: .providers)
+        try container.encode(endpoints, forKey: .endpoints)
+        try container.encode(endpointTypes, forKey: .endpointTypes)
+        try container.encode(apiKeys, forKey: .apiKeys)
+        try container.encode(reasoningConfigurations, forKey: .reasoningConfigurations)
     }
 
     private static func digestValues<Value>(
@@ -1594,6 +1678,7 @@ struct WatchModelMetadataInventory: Equatable, Sendable {
     var endpointModelIDs: [String]
     var endpointTypeModelIDs: [String]
     var apiKeyModelIDs: [String]
+    var reasoningConfigurationModelIDs: [String] = []
     var valueDigests = WatchModelMetadataValueDigests()
 }
 
@@ -1603,6 +1688,7 @@ struct WatchModelRemovalPublication: Equatable, Sendable {
     let removedEndpointDigests: [String]
     let removedEndpointTypeDigests: [String]
     let removedAPIKeyDigests: [String]
+    let removedReasoningConfigurationDigests: [String]
 
     var isEmpty: Bool {
         removedModelDigests.isEmpty
@@ -1610,6 +1696,7 @@ struct WatchModelRemovalPublication: Equatable, Sendable {
             && removedEndpointDigests.isEmpty
             && removedEndpointTypeDigests.isEmpty
             && removedAPIKeyDigests.isEmpty
+            && removedReasoningConfigurationDigests.isEmpty
     }
 }
 
@@ -1621,6 +1708,7 @@ struct WatchModelRemovalTracker: Codable, Equatable, Sendable {
         let endpoints: Set<String>
         let endpointTypes: Set<String>
         let apiKeys: Set<String>
+        let reasoningConfigurations: Set<String>
     }
 
     private(set) var epoch: UUID
@@ -1634,6 +1722,8 @@ struct WatchModelRemovalTracker: Codable, Equatable, Sendable {
     private(set) var retiredEndpointTypeDigests: Set<String>
     private(set) var publishedAPIKeyDigests: Set<String>
     private(set) var retiredAPIKeyDigests: Set<String>
+    private(set) var publishedReasoningConfigurationDigests: Set<String>
+    private(set) var retiredReasoningConfigurationDigests: Set<String>
     private(set) var publishedValueDigests: WatchModelMetadataValueDigests?
 
     init(epoch: UUID = UUID()) {
@@ -1648,7 +1738,110 @@ struct WatchModelRemovalTracker: Codable, Equatable, Sendable {
         retiredEndpointTypeDigests = []
         publishedAPIKeyDigests = []
         retiredAPIKeyDigests = []
+        publishedReasoningConfigurationDigests = []
+        retiredReasoningConfigurationDigests = []
         publishedValueDigests = WatchModelMetadataValueDigests()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case epoch
+        case publishedDigests
+        case retiredDigests
+        case publishedProviderDigests
+        case retiredProviderDigests
+        case publishedEndpointDigests
+        case retiredEndpointDigests
+        case publishedEndpointTypeDigests
+        case retiredEndpointTypeDigests
+        case publishedAPIKeyDigests
+        case retiredAPIKeyDigests
+        case publishedReasoningConfigurationDigests
+        case retiredReasoningConfigurationDigests
+        case publishedValueDigests
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        epoch = try container.decodeIfPresent(UUID.self, forKey: .epoch) ?? UUID()
+        publishedDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .publishedDigests
+        ) ?? []
+        retiredDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .retiredDigests
+        ) ?? []
+        publishedProviderDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .publishedProviderDigests
+        ) ?? []
+        retiredProviderDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .retiredProviderDigests
+        ) ?? []
+        publishedEndpointDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .publishedEndpointDigests
+        ) ?? []
+        retiredEndpointDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .retiredEndpointDigests
+        ) ?? []
+        publishedEndpointTypeDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .publishedEndpointTypeDigests
+        ) ?? []
+        retiredEndpointTypeDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .retiredEndpointTypeDigests
+        ) ?? []
+        publishedAPIKeyDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .publishedAPIKeyDigests
+        ) ?? []
+        retiredAPIKeyDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .retiredAPIKeyDigests
+        ) ?? []
+        publishedReasoningConfigurationDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .publishedReasoningConfigurationDigests
+        ) ?? []
+        retiredReasoningConfigurationDigests = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .retiredReasoningConfigurationDigests
+        ) ?? []
+        publishedValueDigests = try container.decodeIfPresent(
+            WatchModelMetadataValueDigests.self,
+            forKey: .publishedValueDigests
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(epoch, forKey: .epoch)
+        try container.encode(publishedDigests, forKey: .publishedDigests)
+        try container.encode(retiredDigests, forKey: .retiredDigests)
+        try container.encode(publishedProviderDigests, forKey: .publishedProviderDigests)
+        try container.encode(retiredProviderDigests, forKey: .retiredProviderDigests)
+        try container.encode(publishedEndpointDigests, forKey: .publishedEndpointDigests)
+        try container.encode(retiredEndpointDigests, forKey: .retiredEndpointDigests)
+        try container.encode(
+            publishedEndpointTypeDigests,
+            forKey: .publishedEndpointTypeDigests
+        )
+        try container.encode(retiredEndpointTypeDigests, forKey: .retiredEndpointTypeDigests)
+        try container.encode(publishedAPIKeyDigests, forKey: .publishedAPIKeyDigests)
+        try container.encode(retiredAPIKeyDigests, forKey: .retiredAPIKeyDigests)
+        try container.encode(
+            publishedReasoningConfigurationDigests,
+            forKey: .publishedReasoningConfigurationDigests
+        )
+        try container.encode(
+            retiredReasoningConfigurationDigests,
+            forKey: .retiredReasoningConfigurationDigests
+        )
+        try container.encodeIfPresent(publishedValueDigests, forKey: .publishedValueDigests)
     }
 
     mutating func publication(
@@ -1708,6 +1901,16 @@ struct WatchModelRemovalTracker: Codable, Equatable, Sendable {
         publishedAPIKeyDigests = apiKeys.published
         retiredAPIKeyDigests = apiKeys.retired
 
+        let reasoningConfigurations = Self.advance(
+            currentModelIDs: inventory.reasoningConfigurationModelIDs,
+            published: publishedReasoningConfigurationDigests,
+            retired: retiredReasoningConfigurationDigests,
+            invalidated: valueChanges.reasoningConfigurations,
+            retainsCurrentTombstones: true
+        )
+        publishedReasoningConfigurationDigests = reasoningConfigurations.published
+        retiredReasoningConfigurationDigests = reasoningConfigurations.retired
+
         if retiredDigestCount > Self.maximumRetiredDigestCount {
             rotateEpoch(seeding: inventory)
             return WatchModelRemovalPublication(
@@ -1715,7 +1918,8 @@ struct WatchModelRemovalTracker: Codable, Equatable, Sendable {
                 removedProviderDigests: [],
                 removedEndpointDigests: [],
                 removedEndpointTypeDigests: [],
-                removedAPIKeyDigests: []
+                removedAPIKeyDigests: [],
+                removedReasoningConfigurationDigests: []
             )
         }
 
@@ -1724,7 +1928,8 @@ struct WatchModelRemovalTracker: Codable, Equatable, Sendable {
             removedProviderDigests: providers.retired.sorted(),
             removedEndpointDigests: endpoints.retired.sorted(),
             removedEndpointTypeDigests: endpointTypes.retired.sorted(),
-            removedAPIKeyDigests: apiKeys.retired.sorted()
+            removedAPIKeyDigests: apiKeys.retired.sorted(),
+            removedReasoningConfigurationDigests: reasoningConfigurations.retired.sorted()
         )
     }
 
@@ -1734,6 +1939,7 @@ struct WatchModelRemovalTracker: Codable, Equatable, Sendable {
             + retiredEndpointDigests.count
             + retiredEndpointTypeDigests.count
             + retiredAPIKeyDigests.count
+            + retiredReasoningConfigurationDigests.count
     }
 
     private mutating func rotateEpoch(seeding inventory: WatchModelMetadataInventory) {
@@ -1748,6 +1954,10 @@ struct WatchModelRemovalTracker: Codable, Equatable, Sendable {
         retiredEndpointTypeDigests = []
         publishedAPIKeyDigests = Self.digests(inventory.apiKeyModelIDs)
         retiredAPIKeyDigests = []
+        publishedReasoningConfigurationDigests = Self.digests(
+            inventory.reasoningConfigurationModelIDs
+        )
+        retiredReasoningConfigurationDigests = []
         publishedValueDigests = inventory.valueDigests
     }
 
@@ -1781,14 +1991,19 @@ struct WatchModelRemovalTracker: Codable, Equatable, Sendable {
                 providers: [],
                 endpoints: [],
                 endpointTypes: [],
-                apiKeys: []
+                apiKeys: [],
+                reasoningConfigurations: []
             )
         }
         return ChangedValueDigests(
             providers: changedModelDigests(from: previous.providers, to: current.providers),
             endpoints: changedModelDigests(from: previous.endpoints, to: current.endpoints),
             endpointTypes: changedModelDigests(from: previous.endpointTypes, to: current.endpointTypes),
-            apiKeys: changedModelDigests(from: previous.apiKeys, to: current.apiKeys)
+            apiKeys: changedModelDigests(from: previous.apiKeys, to: current.apiKeys),
+            reasoningConfigurations: changedModelDigests(
+                from: previous.reasoningConfigurations,
+                to: current.reasoningConfigurations
+            )
         )
     }
 
@@ -1816,6 +2031,7 @@ struct WatchModelMetadataState: Equatable, Sendable {
     var modelEndpoints: [String: String]
     var modelEndpointTypes: [String: String]
     var modelAPIKeys: [String: String]
+    var modelReasoningConfigurations: [String: ModelReasoningConfiguration] = [:]
 
     mutating func merge(_ page: WatchModelMetadataPage) {
         applyRemovals(from: page)
@@ -1835,6 +2051,7 @@ struct WatchModelMetadataState: Equatable, Sendable {
         mergeValues(page.modelEndpoints, into: &modelEndpoints)
         mergeValues(page.modelEndpointTypes, into: &modelEndpointTypes)
         mergeValues(page.modelAPIKeys, into: &modelAPIKeys)
+        mergeValues(page.modelReasoningConfigurations, into: &modelReasoningConfigurations)
     }
 
     mutating func replace(with page: WatchModelMetadataPage) {
@@ -1851,6 +2068,7 @@ struct WatchModelMetadataState: Equatable, Sendable {
         modelEndpoints = page.modelEndpoints ?? [:]
         modelEndpointTypes = page.modelEndpointTypes ?? [:]
         modelAPIKeys = page.modelAPIKeys ?? [:]
+        modelReasoningConfigurations = page.modelReasoningConfigurations ?? [:]
     }
 
     mutating func resetModelSpecificState() {
@@ -1861,6 +2079,7 @@ struct WatchModelMetadataState: Equatable, Sendable {
         modelEndpoints = [:]
         modelEndpointTypes = [:]
         modelAPIKeys = [:]
+        modelReasoningConfigurations = [:]
     }
 
     private mutating func applyRemovals(from page: WatchModelMetadataPage) {
@@ -1869,6 +2088,10 @@ struct WatchModelMetadataState: Equatable, Sendable {
         removeEntries(withDigests: page.removedModelEndpointDigests, from: &modelEndpoints)
         removeEntries(withDigests: page.removedModelEndpointTypeDigests, from: &modelEndpointTypes)
         removeEntries(withDigests: page.removedModelAPIKeyDigests, from: &modelAPIKeys)
+        removeEntries(
+            withDigests: page.removedModelReasoningConfigurationDigests,
+            from: &modelReasoningConfigurations
+        )
     }
 
     private func removeEntries(
@@ -1893,6 +2116,7 @@ struct WatchModelMetadataState: Equatable, Sendable {
         modelEndpoints = modelEndpoints.filter { isRetained($0.key) }
         modelEndpointTypes = modelEndpointTypes.filter { isRetained($0.key) }
         modelAPIKeys = modelAPIKeys.filter { isRetained($0.key) }
+        modelReasoningConfigurations = modelReasoningConfigurations.filter { isRetained($0.key) }
     }
 }
 
@@ -1905,11 +2129,13 @@ struct WatchModelMetadataPage: Equatable, Sendable {
     var modelEndpoints: [String: String]?
     var modelEndpointTypes: [String: String]?
     var modelAPIKeys: [String: String]?
+    var modelReasoningConfigurations: [String: ModelReasoningConfiguration]?
     var removedModelDigests: [String]?
     var removedModelProviderDigests: [String]?
     var removedModelEndpointDigests: [String]?
     var removedModelEndpointTypeDigests: [String]?
     var removedModelAPIKeyDigests: [String]?
+    var removedModelReasoningConfigurationDigests: [String]?
 
     init(
         selectedModel: String? = nil,
@@ -1920,11 +2146,13 @@ struct WatchModelMetadataPage: Equatable, Sendable {
         modelEndpoints: [String: String]? = nil,
         modelEndpointTypes: [String: String]? = nil,
         modelAPIKeys: [String: String]? = nil,
+        modelReasoningConfigurations: [String: ModelReasoningConfiguration]? = nil,
         removedModelDigests: [String]? = nil,
         removedModelProviderDigests: [String]? = nil,
         removedModelEndpointDigests: [String]? = nil,
         removedModelEndpointTypeDigests: [String]? = nil,
-        removedModelAPIKeyDigests: [String]? = nil
+        removedModelAPIKeyDigests: [String]? = nil,
+        removedModelReasoningConfigurationDigests: [String]? = nil
     ) {
         self.selectedModel = selectedModel
         self.availableModels = availableModels
@@ -1934,11 +2162,14 @@ struct WatchModelMetadataPage: Equatable, Sendable {
         self.modelEndpoints = modelEndpoints
         self.modelEndpointTypes = modelEndpointTypes
         self.modelAPIKeys = modelAPIKeys
+        self.modelReasoningConfigurations = modelReasoningConfigurations
         self.removedModelDigests = removedModelDigests
         self.removedModelProviderDigests = removedModelProviderDigests
         self.removedModelEndpointDigests = removedModelEndpointDigests
         self.removedModelEndpointTypeDigests = removedModelEndpointTypeDigests
         self.removedModelAPIKeyDigests = removedModelAPIKeyDigests
+        self.removedModelReasoningConfigurationDigests =
+            removedModelReasoningConfigurationDigests
     }
 
     init(context: [String: Any]) {
@@ -1951,11 +2182,17 @@ struct WatchModelMetadataPage: Equatable, Sendable {
             modelEndpoints: context[WatchContextKeys.modelEndpoints] as? [String: String],
             modelEndpointTypes: context[WatchContextKeys.modelEndpointTypes] as? [String: String],
             modelAPIKeys: context[WatchContextKeys.modelAPIKeys] as? [String: String],
+            modelReasoningConfigurations: WatchModelReasoningConfigurationCodec.decode(
+                context[WatchContextKeys.modelReasoningConfigurations] as? [String: String]
+            ),
             removedModelDigests: context[WatchContextKeys.removedModelDigests] as? [String],
             removedModelProviderDigests: context[WatchContextKeys.removedModelProviderDigests] as? [String],
             removedModelEndpointDigests: context[WatchContextKeys.removedModelEndpointDigests] as? [String],
             removedModelEndpointTypeDigests: context[WatchContextKeys.removedModelEndpointTypeDigests] as? [String],
-            removedModelAPIKeyDigests: context[WatchContextKeys.removedModelAPIKeyDigests] as? [String]
+            removedModelAPIKeyDigests: context[WatchContextKeys.removedModelAPIKeyDigests] as? [String],
+            removedModelReasoningConfigurationDigests: context[
+                WatchContextKeys.removedModelReasoningConfigurationDigests
+            ] as? [String]
         )
     }
 
@@ -1976,6 +2213,10 @@ struct WatchModelMetadataPage: Equatable, Sendable {
         mergeOptionalValues(page.modelEndpoints, into: &modelEndpoints)
         mergeOptionalValues(page.modelEndpointTypes, into: &modelEndpointTypes)
         mergeOptionalValues(page.modelAPIKeys, into: &modelAPIKeys)
+        mergeOptionalValues(
+            page.modelReasoningConfigurations,
+            into: &modelReasoningConfigurations
+        )
         if let removedModelDigests = page.removedModelDigests {
             self.removedModelDigests = mergingUnique(self.removedModelDigests ?? [], removedModelDigests)
         }
@@ -1990,6 +2231,12 @@ struct WatchModelMetadataPage: Equatable, Sendable {
         }
         if let removed = page.removedModelAPIKeyDigests {
             removedModelAPIKeyDigests = mergingUnique(removedModelAPIKeyDigests ?? [], removed)
+        }
+        if let removed = page.removedModelReasoningConfigurationDigests {
+            removedModelReasoningConfigurationDigests = mergingUnique(
+                removedModelReasoningConfigurationDigests ?? [],
+                removed
+            )
         }
     }
 }

--- a/Sources/Ayna/Services/WatchConnectivitySupport.swift
+++ b/Sources/Ayna/Services/WatchConnectivitySupport.swift
@@ -619,6 +619,7 @@ enum WatchLegacyConversationMerger {
         existingConversation.model = created.model
         existingConversation.systemPromptMode = created.systemPromptMode
         existingConversation.temperature = created.temperature
+        existingConversation.reasoningConfiguration = created.reasoningConfiguration
         existingConversation.createdAt = created.createdAt
         existingConversation.updatedAt = max(existingConversation.updatedAt, created.updatedAt)
 
@@ -786,6 +787,7 @@ enum WatchLegacyEchoReconciler {
     ) -> Bool {
         mutation.model == echo.model
             && mutation.temperature == echo.temperature
+            && mutation.reasoningConfiguration == echo.reasoningConfiguration
             && mutation.resolvedSystemPrompt == echo.resolvedSystemPrompt
     }
 }

--- a/Sources/Ayna/Services/WatchSyncProtocol.swift
+++ b/Sources/Ayna/Services/WatchSyncProtocol.swift
@@ -1277,6 +1277,8 @@ struct WatchSyncPayloadConfiguration: Equatable, Sendable {
     var maximumSystemPromptCharacters = 4000
     var maximumToolCallsPerMessage = 4
     var maximumToolMetadataBytes = 2048
+    /// Opaque provider continuation state is all-or-nothing and must never be truncated.
+    var maximumReasoningContinuationBytes = 8192
     var maximumCitationsPerMessage = 8
     var maximumCitationCharacters = 512
     var maximumAcknowledgements = 64
@@ -2299,6 +2301,10 @@ enum WatchSyncPayloadBuilder {
         result.reasoning = message.reasoning.map {
             bounded($0, maximum: configuration.maximumContentCharacters)
         }
+        result.reasoningContinuation = boundedReasoningContinuation(
+            message.reasoningContinuation,
+            maximumBytes: configuration.maximumReasoningContinuationBytes
+        )
         result.toolCalls = message.toolCalls.map { calls in
             Array(calls.prefix(max(0, configuration.maximumToolCallsPerMessage))).compactMap {
                 boundedToolCall($0, configuration: configuration)
@@ -2317,6 +2323,19 @@ enum WatchSyncPayloadBuilder {
             }
         }
         return result
+    }
+
+    private static func boundedReasoningContinuation(
+        _ continuation: ReasoningContinuationState?,
+        maximumBytes: Int
+    ) -> ReasoningContinuationState? {
+        guard let continuation, maximumBytes > 0,
+              let data = try? JSONEncoder().encode(continuation),
+              data.count <= maximumBytes
+        else {
+            return nil
+        }
+        return continuation
     }
 
     private static func boundedToolCall(

--- a/Sources/Ayna/Services/WatchSyncProtocol.swift
+++ b/Sources/Ayna/Services/WatchSyncProtocol.swift
@@ -895,6 +895,7 @@ enum PhoneWatchMutationReducer {
         if mutation.changesConfiguration(after: acknowledgedRevision) {
             merged.model = watch.model
             merged.temperature = watch.temperature
+            merged.reasoningConfiguration = watch.reasoningConfiguration
         }
         merged.updatedAt = max(phone.updatedAt, watch.updatedAt)
         return merged
@@ -1109,6 +1110,7 @@ enum WatchSnapshotReconciler {
             if draft.deferredFields.contains(.configuration) {
                 remoteConversation.model = draft.conversation.model
                 remoteConversation.temperature = draft.conversation.temperature
+                remoteConversation.reasoningConfiguration = draft.conversation.reasoningConfiguration
             }
             remoteConversation.messages = mergeWatchMessages(
                 remote: remoteConversation.messages,
@@ -1187,6 +1189,7 @@ enum WatchSnapshotReconciler {
         if changesConfiguration {
             current.model = local.model
             current.temperature = local.temperature
+            current.reasoningConfiguration = local.reasoningConfiguration
         }
         if changesCreate {
             current.resolvedSystemPrompt = local.resolvedSystemPrompt
@@ -2266,6 +2269,7 @@ enum WatchSyncPayloadBuilder {
             id: conversation.id,
             model: conversation.model,
             temperature: conversation.temperature,
+            reasoningConfiguration: conversation.reasoningConfiguration,
             resolvedSystemPrompt: resolvedSystemPrompt
         )
     }

--- a/Sources/Ayna/ViewModels/ConversationManager.swift
+++ b/Sources/Ayna/ViewModels/ConversationManager.swift
@@ -1417,6 +1417,7 @@ final class ConversationManager: ObservableObject {
             model: metadata.model,
             systemPromptMode: metadata.systemPromptMode,
             temperature: metadata.temperature,
+            reasoningConfiguration: metadata.reasoningConfiguration,
             multiModelEnabled: metadata.multiModelEnabled,
             activeModels: metadata.activeModels,
             responseGroups: [],
@@ -1512,6 +1513,7 @@ final class ConversationManager: ObservableObject {
             mergedConversation.model = proposedConversation.model
             mergedConversation.systemPromptMode = proposedConversation.systemPromptMode
             mergedConversation.temperature = proposedConversation.temperature
+            mergedConversation.reasoningConfiguration = proposedConversation.reasoningConfiguration
             mergedConversation.multiModelEnabled = proposedConversation.multiModelEnabled
             mergedConversation.activeModels = proposedConversation.activeModels
             mergedConversation.pendingAutoSendPrompt = proposedConversation.pendingAutoSendPrompt

--- a/Sources/Ayna/ViewModels/ConversationManager.swift
+++ b/Sources/Ayna/ViewModels/ConversationManager.swift
@@ -3237,6 +3237,7 @@ final class ConversationManager: ObservableObject {
             || (metadataSearchTextById[conversation.id]?.localizedCaseInsensitiveContains(query) ?? false)
             || conversation.messages.contains { message in
                 message.content.localizedCaseInsensitiveContains(query)
+                    || (message.reasoning?.localizedCaseInsensitiveContains(query) ?? false)
             }
     }
 

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -1033,6 +1033,44 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                             tools: toolsWrapper
                         )
                     }
+                },
+                onReasoning: { [weak self] reasoning in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId),
+                              self.activeAssistantMessageId == assistantMessageId
+                        else {
+                            return
+                        }
+                        self.conversationManager.updateMessage(
+                            conversationId: conversationId,
+                            messageId: assistantMessageId
+                        ) { message in
+                            message.appendReasoning(reasoning)
+                        }
+                    }
+                },
+                onReasoningContinuation: { [weak self] state in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId),
+                              self.activeAssistantMessageId == assistantMessageId
+                        else {
+                            return
+                        }
+                        guard self.conversationManager.updateMessage(
+                            conversationId: conversationId,
+                            messageId: assistantMessageId,
+                            update: { message in
+                                message.reasoningContinuation = state
+                            }
+                        ) else {
+                            return
+                        }
+                        if let conversation = self.conversationManager.conversation(byId: conversationId) {
+                            self.conversationManager.save(conversation)
+                        }
+                    }
                 }
             )
             coordinator.onCancel(for: operationID) {
@@ -1798,7 +1836,7 @@ extension IOSChatViewModel {
 
 extension IOSChatViewModel {
     /// Sends a message to multiple models in parallel for comparison
-    private func sendToMultipleModels(_ preparation: SendPreparation) {
+    private func sendToMultipleModels(_ preparation: SendPreparation) { // swiftlint:disable:this function_body_length
         guard !isGenerating else { return }
         let text = preparation.text
         guard !text.isEmpty else {
@@ -1943,6 +1981,26 @@ extension IOSChatViewModel {
                         messageIds: messageIdsByModel,
                         conversationId: conversationId
                     )
+                }
+            },
+            onReasoningContinuation: { [weak self] model, state in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
+                    guard let self,
+                          coordinator.owns(operationID, conversationID: conversationId),
+                          let messageId = messageIdsByModel[model],
+                          self.conversationManager.updateMessage(
+                              conversationId: conversationId,
+                              messageId: messageId,
+                              update: { message in
+                                  message.reasoningContinuation = state
+                              }
+                          )
+                    else {
+                        return
+                    }
+                    if let conversation = self.conversationManager.conversation(byId: conversationId) {
+                        self.conversationManager.save(conversation)
+                    }
                 }
             }
         )

--- a/Sources/Ayna/ViewModels/IOSChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/IOSChatViewModel.swift
@@ -118,6 +118,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         let selectedModel: String
         let selectedModels: Set<String>
         let requestModel: String
+        let reasoningConfiguration: ModelReasoningConfiguration
     }
 
     private var toolExecutionStates: [
@@ -138,6 +139,9 @@ typealias IOSBuiltInToolExecutor = @MainActor (
 
     /// Selected models for multi-model chat
     @Published var selectedModels: Set<String> = []
+
+    /// Reasoning controls for the active conversation or pending new chat.
+    @Published var reasoningConfiguration: ModelReasoningConfiguration = .automatic
 
     /// Callback when a new conversation is created and first response completes.
     /// Used by IOSNewChatView to navigate to IOSChatView.
@@ -172,8 +176,22 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                 arguments: arguments
             )
         }
-        selectedModel = resolvedAIService.selectedModel
-        selectedModels = [resolvedAIService.selectedModel]
+        let initialConversation = conversationManager.conversation(byId: conversationId)
+        let initialModel = initialConversation?.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        selectedModel = if let initialModel, !initialModel.isEmpty {
+            initialModel
+        } else {
+            resolvedAIService.selectedModel
+        }
+        if let initialConversation,
+           initialConversation.multiModelEnabled,
+           !initialConversation.activeModels.isEmpty
+        {
+            selectedModels = Set(initialConversation.activeModels)
+        } else {
+            selectedModels = selectedModel.isEmpty ? [] : [selectedModel]
+        }
+        reasoningConfiguration = initialConversation?.reasoningConfiguration ?? .automatic
     }
 
     /// Initialize for a new chat (no conversation yet).
@@ -224,9 +242,31 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             }
         conversationManager = manager
         self.conversationId = conversationId
+        if let conversation = manager.conversation(byId: conversationId) {
+            reasoningConfiguration = conversation.reasoningConfiguration
+            let model = conversation.model.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !model.isEmpty {
+                selectedModel = model
+            }
+            if conversation.multiModelEnabled, !conversation.activeModels.isEmpty {
+                selectedModels = Set(conversation.activeModels)
+            } else {
+                selectedModels = selectedModel.isEmpty ? [] : [selectedModel]
+            }
+        } else {
+            reasoningConfiguration = .automatic
+        }
 
         // Check for pending auto-send prompt (from deep link)
         checkAndProcessPendingPrompt()
+    }
+
+    func updateReasoningConfiguration(_ configuration: ModelReasoningConfiguration) {
+        reasoningConfiguration = configuration
+        guard var conversation else { return }
+        guard conversation.reasoningConfiguration != configuration else { return }
+        conversation.reasoningConfiguration = configuration
+        conversationManager.updateConversation(conversation)
     }
 
     /// The model to use for sending messages.
@@ -261,6 +301,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         attachedImages.removeAll()
         selectedModel = aiService.selectedModel
         selectedModels = [aiService.selectedModel]
+        reasoningConfiguration = .automatic
 
         DiagnosticsLogger.log(
             .chatView,
@@ -531,7 +572,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             attachedImages: attachedImages,
             selectedModel: selectedModel,
             selectedModels: selectedModels,
-            requestModel: currentConversation?.model ?? selectedModel
+            requestModel: currentConversation?.model ?? selectedModel,
+            reasoningConfiguration: reasoningConfiguration
         )
 
         DiagnosticsLogger.log(
@@ -681,6 +723,10 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         }
 
         let targetConversationId = targetConversation.id
+        var configuredConversation = conversationManager.conversation(byId: targetConversationId)
+            ?? targetConversation
+        configuredConversation.reasoningConfiguration = preparation.reasoningConfiguration
+        conversationManager.updateConversation(configuredConversation)
 
         DiagnosticsLogger.log(
             .chatView,
@@ -820,7 +866,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             model: requestModel,
             conversationId: targetConversationId,
             assistantMessageId: assistantMessage.id,
-            tools: tools
+            tools: tools,
+            reasoningConfiguration: preparation.reasoningConfiguration
         )
     }
     }
@@ -833,6 +880,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
         conversationId: UUID,
         assistantMessageId: UUID,
         tools: [[String: Any]]?,
+        reasoningConfiguration: ModelReasoningConfiguration,
         operationID existingOperationID: ToolChainCoordinator.OperationID? = nil
     ) {
         let toolsWrapper = UncheckedSendable(tools)
@@ -931,7 +979,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                             assistantMessageId: assistantMessageId,
                             model: model,
                             conversationId: conversationId,
-                            tools: toolsWrapper.value
+                            tools: toolsWrapper.value,
+                            reasoningConfiguration: reasoningConfiguration
                         )
                     }
                 },
@@ -1030,7 +1079,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                             assistantMessageId: assistantMessageId,
                             model: model,
                             conversationId: conversationId,
-                            tools: toolsWrapper
+                            tools: toolsWrapper,
+                            reasoningConfiguration: reasoningConfiguration
                         )
                     }
                 },
@@ -1071,7 +1121,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                             self.conversationManager.save(conversation)
                         }
                     }
-                }
+                },
+                reasoningConfiguration: reasoningConfiguration
             )
             coordinator.onCancel(for: operationID) {
                 request.cancel()
@@ -1089,7 +1140,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             assistantMessageId: UUID,
             model: String,
             conversationId: UUID,
-            tools: UncheckedSendable<[[String: Any]]?>
+            tools: UncheckedSendable<[[String: Any]]?>,
+            reasoningConfiguration: ModelReasoningConfiguration
         ) {
             let coordinator = toolChainCoordinator
             let roundCoordinator = toolCallRequestRoundCoordinator
@@ -1141,7 +1193,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                     assistantMessageId: assistantMessageId,
                     model: model,
                     conversationId: conversationId,
-                    tools: tools.value
+                    tools: tools.value,
+                    reasoningConfiguration: reasoningConfiguration
                 )
             }
         }
@@ -1152,7 +1205,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             assistantMessageId: UUID,
             model: String,
             conversationId: UUID,
-            tools: [[String: Any]]?
+            tools: [[String: Any]]?,
+            reasoningConfiguration: ModelReasoningConfiguration
         ) {
             guard toolChainCoordinator.owns(operationID, conversationID: conversationId),
                   activeAssistantMessageId == assistantMessageId
@@ -1176,7 +1230,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                     assistantMessageId: assistantMessageId,
                     model: model,
                     conversationId: conversationId,
-                    tools: tools
+                    tools: tools,
+                    reasoningConfiguration: reasoningConfiguration
                 )
             }
         }
@@ -1187,7 +1242,8 @@ typealias IOSBuiltInToolExecutor = @MainActor (
             assistantMessageId: UUID,
             model: String,
             conversationId: UUID,
-            tools: [[String: Any]]?
+            tools: [[String: Any]]?,
+            reasoningConfiguration: ModelReasoningConfiguration
         ) {
             guard continuation.operationID == operationID,
                   toolChainCoordinator.owns(operationID, conversationID: conversationId),
@@ -1255,6 +1311,7 @@ typealias IOSBuiltInToolExecutor = @MainActor (
                 conversationId: conversationId,
                 assistantMessageId: continuationAssistantMessage.id,
                 tools: tools,
+                reasoningConfiguration: reasoningConfiguration,
                 operationID: operationID
                                     )
                             }
@@ -1688,7 +1745,8 @@ extension IOSChatViewModel {
             model: retryModel,
             conversationId: targetConversationId,
             assistantMessageId: assistantMessage.id,
-            tools: tools
+            tools: tools,
+            reasoningConfiguration: updatedConversation.reasoningConfiguration
         )
     }
 
@@ -1746,7 +1804,8 @@ extension IOSChatViewModel {
             model: refreshed.model,
             conversationId: targetConversationId,
             assistantMessageId: assistantMessage.id,
-            tools: tools
+            tools: tools,
+            reasoningConfiguration: refreshed.reasoningConfiguration
         )
     }
 
@@ -1827,7 +1886,8 @@ extension IOSChatViewModel {
             model: newModel,
             conversationId: targetConversationId,
             assistantMessageId: assistantMessage.id,
-            tools: tools
+            tools: tools,
+            reasoningConfiguration: updatedConversation.reasoningConfiguration
         )
     }
 }
@@ -1852,6 +1912,9 @@ extension IOSChatViewModel {
         }
         let conversationId = targetConversation.id
         let models = Array(preparation.selectedModels)
+        var configuredConversation = targetConversation
+        configuredConversation.reasoningConfiguration = preparation.reasoningConfiguration
+        conversationManager.updateConversation(configuredConversation)
 
         // Check for image generation and route accordingly
         if let firstModel = preparation.selectedModels.sorted().first,
@@ -2002,7 +2065,8 @@ extension IOSChatViewModel {
                         self.conversationManager.save(conversation)
                     }
                 }
-            }
+            },
+            reasoningConfiguration: preparation.reasoningConfiguration
         )
             coordinator.onCancel(for: operationID) { [weak self] in
                 self?.finishAndPersistMultiModelReasoning(conversationId: conversationId)

--- a/Sources/Ayna/ViewModels/WatchChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/WatchChatViewModel.swift
@@ -133,6 +133,7 @@ enum WatchLiveModelPolicy {
             let messages: [Message]
             let model: String
             let temperature: Double
+            let reasoningConfiguration: ModelReasoningConfiguration
             let conversationID: UUID
         }
 
@@ -357,6 +358,7 @@ enum WatchLiveModelPolicy {
                 messages: requestConversation.effectiveHistory,
                 model: model,
                 temperature: requestConversation.temperature,
+                reasoningConfiguration: requestConversation.reasoningConfiguration,
                 conversationId: conversationId,
                 assistantMessageId: assistantMessage.id,
                 tools: tools,
@@ -380,6 +382,7 @@ enum WatchLiveModelPolicy {
             messages: [Message],
             model: String,
             temperature: Double,
+            reasoningConfiguration: ModelReasoningConfiguration,
             conversationId: UUID,
             assistantMessageId: UUID,
             tools: [[String: Any]]?,
@@ -407,6 +410,7 @@ enum WatchLiveModelPolicy {
                     messages: messages,
                     model: model,
                     temperature: temperature,
+                    reasoningConfiguration: reasoningConfiguration,
                     conversationID: conversationId
                 )
             )
@@ -460,6 +464,7 @@ enum WatchLiveModelPolicy {
                             assistantMessageId: assistantMessageId,
                             model: model,
                             temperature: temperature,
+                            reasoningConfiguration: reasoningConfiguration,
                             conversationId: conversationId,
                             tools: tools,
                             isFirstMessage: isFirstMessage,
@@ -557,6 +562,7 @@ enum WatchLiveModelPolicy {
                             assistantMessageId: assistantMessageId,
                             model: model,
                             temperature: temperature,
+                            reasoningConfiguration: reasoningConfiguration,
                             conversationId: conversationId,
                             tools: tools,
                             userContent: userContent
@@ -597,7 +603,8 @@ enum WatchLiveModelPolicy {
                             reasoningContinuation: state
                         )
                     }
-                }
+                },
+                reasoningConfiguration: reasoningConfiguration
             )
             coordinator.onCancel(for: operationID) {
                 request.cancel()
@@ -617,6 +624,7 @@ enum WatchLiveModelPolicy {
             assistantMessageId: UUID,
             model: String,
             temperature: Double,
+            reasoningConfiguration: ModelReasoningConfiguration,
             conversationId: UUID,
             tools: [[String: Any]]?,
             userContent: String
@@ -671,6 +679,7 @@ enum WatchLiveModelPolicy {
                     assistantMessageId: assistantMessageId,
                     model: model,
                     temperature: temperature,
+                    reasoningConfiguration: reasoningConfiguration,
                     conversationId: conversationId,
                     tools: tools,
                     isFirstMessage: false,
@@ -686,6 +695,7 @@ enum WatchLiveModelPolicy {
             assistantMessageId: UUID,
             model: String,
             temperature: Double,
+            reasoningConfiguration: ModelReasoningConfiguration,
             conversationId: UUID,
             tools: [[String: Any]]?,
             isFirstMessage: Bool,
@@ -715,6 +725,7 @@ enum WatchLiveModelPolicy {
                     assistantMessageId: assistantMessageId,
                     model: model,
                     temperature: temperature,
+                    reasoningConfiguration: reasoningConfiguration,
                     conversationId: conversationId,
                     tools: tools,
                     userContent: userContent
@@ -728,6 +739,7 @@ enum WatchLiveModelPolicy {
             assistantMessageId: UUID,
             model: String,
             temperature: Double,
+            reasoningConfiguration: ModelReasoningConfiguration,
             conversationId: UUID,
             tools: [[String: Any]]?,
             userContent: String
@@ -814,6 +826,7 @@ enum WatchLiveModelPolicy {
                 messages: continuationMessages,
                 model: model,
                 temperature: temperature,
+                reasoningConfiguration: reasoningConfiguration,
                 conversationId: conversationId,
                 assistantMessageId: continuationMessage.id,
                 tools: tools,

--- a/Sources/Ayna/ViewModels/WatchChatViewModel.swift
+++ b/Sources/Ayna/ViewModels/WatchChatViewModel.swift
@@ -582,6 +582,21 @@ enum WatchLiveModelPolicy {
                             )
                         }
                     }
+                },
+                onReasoningContinuation: { [weak self] state in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) { [weak self] in
+                        guard let self,
+                              coordinator.owns(operationID, conversationID: conversationId),
+                              self.activeAssistantMessageId == assistantMessageId
+                        else {
+                            return
+                        }
+                        self.updateAssistantMessage(
+                            assistantMessageId,
+                            in: conversationId,
+                            reasoningContinuation: state
+                        )
+                    }
                 }
             )
             coordinator.onCancel(for: operationID) {
@@ -1108,9 +1123,10 @@ enum WatchLiveModelPolicy {
             _ messageId: UUID,
             in conversationId: UUID,
             content: String? = nil,
-            reasoning: String? = nil
+            reasoning: String? = nil,
+            reasoningContinuation: ReasoningContinuationState? = nil
         ) -> Bool {
-            guard content != nil || reasoning != nil else { return true }
+            guard content != nil || reasoning != nil || reasoningContinuation != nil else { return true }
             guard var conversation = conversationStore.conversation(for: conversationId),
                   let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId })
             else {
@@ -1121,6 +1137,9 @@ enum WatchLiveModelPolicy {
             }
             if let reasoning {
                 conversation.messages[messageIndex].reasoning = reasoning
+            }
+            if let reasoningContinuation {
+                conversation.messages[messageIndex].reasoningContinuation = reasoningContinuation
             }
             return conversationStore.replaceConversation(conversation)
         }

--- a/Sources/Ayna/Views/Shared/ModelReasoningSettingsControls.swift
+++ b/Sources/Ayna/Views/Shared/ModelReasoningSettingsControls.swift
@@ -1,12 +1,13 @@
 import SwiftUI
 
-/// Shared controls used by the macOS and iOS model editors.
+/// Provider-aware reasoning controls used from the chat composer.
 struct ModelReasoningSettingsControls: View {
     @Binding var configuration: ModelReasoningConfiguration
     let model: String
     let provider: AIProvider
     let endpointType: APIEndpointType
     let endpoint: String?
+    var identifierPrefix = "chat.reasoning"
 
     private var presentation: ModelReasoningSettingsPresentation {
         ModelReasoningSettingsPresentation(
@@ -36,7 +37,7 @@ struct ModelReasoningSettingsControls: View {
             }
         }
         .disabled(!presentation.isActivationEnabled)
-        .accessibilityIdentifier("settings.reasoning.activation")
+        .accessibilityIdentifier("\(identifierPrefix).activation")
 
         if presentation.showsAnthropicMode {
             Picker("Thinking Mode", selection: $configuration.anthropicMode) {
@@ -44,7 +45,7 @@ struct ModelReasoningSettingsControls: View {
                     Text(mode.displayName).tag(mode)
                 }
             }
-            .accessibilityIdentifier("settings.reasoning.anthropicMode")
+            .accessibilityIdentifier("\(identifierPrefix).anthropicMode")
         }
 
         if presentation.showsEffort {
@@ -54,7 +55,7 @@ struct ModelReasoningSettingsControls: View {
                     Text(effort.displayName).tag(effort as ReasoningEffort?)
                 }
             }
-            .accessibilityIdentifier("settings.reasoning.effort")
+            .accessibilityIdentifier("\(identifierPrefix).effort")
         }
 
         if presentation.showsOpenAIMode {
@@ -64,7 +65,7 @@ struct ModelReasoningSettingsControls: View {
                     Text(mode.displayName).tag(mode as OpenAIReasoningMode?)
                 }
             }
-            .accessibilityIdentifier("settings.reasoning.openAIMode")
+            .accessibilityIdentifier("\(identifierPrefix).openAIMode")
         }
 
         if presentation.showsOpenAIContext {
@@ -73,7 +74,7 @@ struct ModelReasoningSettingsControls: View {
                     Text(context.displayName).tag(context)
                 }
             }
-            .accessibilityIdentifier("settings.reasoning.openAIContext")
+            .accessibilityIdentifier("\(identifierPrefix).openAIContext")
         }
 
         if presentation.showsSummary {
@@ -82,7 +83,7 @@ struct ModelReasoningSettingsControls: View {
                     Text(summary.displayName).tag(summary)
                 }
             }
-            .accessibilityIdentifier("settings.reasoning.summary")
+            .accessibilityIdentifier("\(identifierPrefix).summary")
         }
 
         if presentation.showsAnthropicDisplay {
@@ -91,7 +92,7 @@ struct ModelReasoningSettingsControls: View {
                     Text(display.displayName).tag(display)
                 }
             }
-            .accessibilityIdentifier("settings.reasoning.anthropicDisplay")
+            .accessibilityIdentifier("\(identifierPrefix).anthropicDisplay")
         }
 
         if presentation.showsLegacyBudget {
@@ -100,7 +101,7 @@ struct ModelReasoningSettingsControls: View {
                 value: legacyBudgetBinding,
                 step: 1024
             )
-            .accessibilityIdentifier("settings.reasoning.legacyBudget")
+            .accessibilityIdentifier("\(identifierPrefix).legacyBudget")
         }
 
         Text(guidanceText)
@@ -160,3 +161,229 @@ struct ModelReasoningSettingsControls: View {
         let anthropicMode: AnthropicThinkingMode
     }
 }
+
+// Compact conversation-level reasoning picker inspired by the inline effort
+// controls in modern chat composers.
+#if !os(watchOS)
+    struct ChatReasoningControl: View {
+        @Binding var configuration: ModelReasoningConfiguration
+        let selectedModels: Set<String>
+        let primaryModel: String
+        let identifier: String
+
+        @ObservedObject private var aiService = AIService.shared
+        @State private var isPresented = false
+
+        private var models: [String] {
+            let normalized = selectedModels
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .sorted()
+            if !normalized.isEmpty {
+                return normalized
+            }
+            let primary = primaryModel.trimmingCharacters(in: .whitespacesAndNewlines)
+            return primary.isEmpty ? [] : [primary]
+        }
+
+        private var presentation: ChatReasoningSettingsPresentation {
+            ChatReasoningSettingsPresentation(
+                models: models.map { model in
+                    ChatReasoningModelContext(
+                        model: model,
+                        provider: provider(for: model),
+                        endpointType: endpointType(for: model),
+                        endpoint: aiService.modelEndpoints[model]
+                    )
+                },
+                configuration: configuration
+            )
+        }
+
+        private var commonEffortOptions: [ReasoningEffort] {
+            presentation.effortOptions
+        }
+
+        private var commonActivationOptions: [ReasoningActivationMode] {
+            presentation.activationOptions
+        }
+
+        private var effortChoices: [ReasoningEffort?] {
+            [nil] + commonEffortOptions.map(Optional.some)
+        }
+
+        private var isAvailable: Bool {
+            presentation.isAvailable
+        }
+
+        private var controlMinimumHeight: CGFloat {
+            #if os(iOS)
+                44
+            #else
+                34
+            #endif
+        }
+
+        private var accessibilityLabel: String {
+            models.count > 1 ? "Reasoning effort for \(models.count) models" : "Reasoning effort"
+        }
+
+        private var compactLabel: String {
+            switch configuration.activation {
+            case .automatic:
+                configuration.effort?.displayName ?? "Auto"
+            case .disabled:
+                "Default"
+            case .explicitlyDisabled:
+                "Off"
+            case .enabled:
+                configuration.effort?.displayName ?? "On"
+            }
+        }
+
+        var body: some View {
+            if isAvailable {
+                Button {
+                    isPresented.toggle()
+                } label: {
+                    HStack(spacing: Spacing.xs) {
+                        Image(systemName: "brain")
+                            .font(.system(size: Typography.Size.caption))
+                        Text(compactLabel)
+                            .font(Typography.modelName)
+                            .lineLimit(1)
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: Typography.Size.xs))
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                    .foregroundStyle(Theme.textPrimary)
+                    .padding(.horizontal, Spacing.md)
+                    .frame(minHeight: controlMinimumHeight)
+                    .background(Theme.backgroundTertiary.opacity(0.8), in: Capsule())
+                    .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(accessibilityLabel)
+                .accessibilityValue(compactLabel)
+                .accessibilityIdentifier(identifier)
+                .popover(isPresented: $isPresented) {
+                    popoverContent
+                    #if os(iOS)
+                    .presentationCompactAdaptation(.popover)
+                    #endif
+                }
+                .onAppear {
+                    normalizeConfiguration()
+                }
+                .onChange(of: models) { _, _ in
+                    normalizeConfiguration()
+                }
+            }
+        }
+
+        private var popoverContent: some View {
+            VStack(alignment: .leading, spacing: Spacing.md) {
+                HStack {
+                    Text("Reasoning")
+                        .font(Typography.headline)
+                    Spacer()
+                    Text(compactLabel)
+                        .font(Typography.captionBold)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+
+                if effortChoices.count > 1 {
+                    VStack(alignment: .leading, spacing: Spacing.xs) {
+                        Slider(
+                            value: effortIndexBinding,
+                            in: 0 ... Double(effortChoices.count - 1),
+                            step: 1
+                        )
+                        .accessibilityLabel("Reasoning effort")
+                        .accessibilityValue(compactLabel)
+
+                        HStack {
+                            Text("Model default")
+                            Spacer()
+                            Text(commonEffortOptions.last?.displayName ?? "")
+                        }
+                        .font(Typography.footnote)
+                        .foregroundStyle(Theme.textSecondary)
+                    }
+                }
+
+                DisclosureGroup("Advanced") {
+                    VStack(alignment: .leading, spacing: Spacing.sm) {
+                        HStack {
+                            Text("Model")
+                            Spacer()
+                            Text(models.count == 1 ? models[0] : "\(models.count) models")
+                                .foregroundStyle(Theme.textSecondary)
+                                .lineLimit(1)
+                        }
+
+                        if models.count == 1, let model = models.first {
+                            ModelReasoningSettingsControls(
+                                configuration: $configuration,
+                                model: model,
+                                provider: provider(for: model),
+                                endpointType: endpointType(for: model),
+                                endpoint: aiService.modelEndpoints[model],
+                                identifierPrefix: identifier
+                            )
+                        } else {
+                            Picker("Activation", selection: $configuration.activation) {
+                                ForEach(commonActivationOptions, id: \.self) { activation in
+                                    Text(activation.displayName).tag(activation)
+                                }
+                            }
+
+                            if !commonEffortOptions.isEmpty {
+                                Picker("Effort", selection: $configuration.effort) {
+                                    Text("Model Default").tag(nil as ReasoningEffort?)
+                                    ForEach(commonEffortOptions, id: \.self) { effort in
+                                        Text(effort.displayName).tag(effort as ReasoningEffort?)
+                                    }
+                                }
+                            }
+
+                            Text("Only controls supported by every selected model are shown.")
+                                .font(Typography.caption)
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+                    }
+                    .padding(.top, Spacing.sm)
+                }
+            }
+            .padding()
+            .frame(minWidth: 300, idealWidth: 340)
+        }
+
+        private var effortIndexBinding: Binding<Double> {
+            Binding(
+                get: {
+                    Double(effortChoices.firstIndex(where: { $0 == configuration.effort }) ?? 0)
+                },
+                set: { newValue in
+                    let index = min(max(Int(newValue.rounded()), 0), effortChoices.count - 1)
+                    configuration.effort = effortChoices[index]
+                }
+            )
+        }
+
+        private func provider(for model: String) -> AIProvider {
+            aiService.modelProviders[model] ?? aiService.provider
+        }
+
+        private func endpointType(for model: String) -> APIEndpointType {
+            aiService.modelEndpointTypes[model] ?? .chatCompletions
+        }
+
+        private func normalizeConfiguration() {
+            let normalized = presentation.normalizedConfiguration(configuration)
+            if normalized != configuration {
+                configuration = normalized
+            }
+        }
+    }
+#endif

--- a/Sources/Ayna/Views/Shared/ModelReasoningSettingsControls.swift
+++ b/Sources/Ayna/Views/Shared/ModelReasoningSettingsControls.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+/// Shared controls used by the macOS and iOS model editors.
+struct ModelReasoningSettingsControls: View {
+    @Binding var configuration: ModelReasoningConfiguration
+    let model: String
+    let provider: AIProvider
+    let endpointType: APIEndpointType
+    let endpoint: String?
+
+    private var presentation: ModelReasoningSettingsPresentation {
+        ModelReasoningSettingsPresentation(
+            model: model,
+            provider: provider,
+            endpointType: endpointType,
+            endpoint: endpoint,
+            configuration: configuration
+        )
+    }
+
+    private var normalizationInput: NormalizationInput {
+        NormalizationInput(
+            model: model,
+            provider: provider,
+            endpointType: endpointType,
+            endpoint: endpoint,
+            activation: configuration.activation,
+            anthropicMode: configuration.anthropicMode
+        )
+    }
+
+    var body: some View {
+        Picker("Activation", selection: $configuration.activation) {
+            ForEach(presentation.activationOptions, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+            }
+        }
+        .disabled(!presentation.isActivationEnabled)
+        .accessibilityIdentifier("settings.reasoning.activation")
+
+        if presentation.showsAnthropicMode {
+            Picker("Thinking Mode", selection: $configuration.anthropicMode) {
+                ForEach(presentation.anthropicModeOptions, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+            .accessibilityIdentifier("settings.reasoning.anthropicMode")
+        }
+
+        if presentation.showsEffort {
+            Picker("Effort", selection: $configuration.effort) {
+                Text("Model Default").tag(nil as ReasoningEffort?)
+                ForEach(presentation.effortOptions, id: \.self) { effort in
+                    Text(effort.displayName).tag(effort as ReasoningEffort?)
+                }
+            }
+            .accessibilityIdentifier("settings.reasoning.effort")
+        }
+
+        if presentation.showsOpenAIMode {
+            Picker("Reasoning Mode", selection: $configuration.openAIMode) {
+                Text("Model Default").tag(nil as OpenAIReasoningMode?)
+                ForEach(presentation.openAIModeOptions, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode as OpenAIReasoningMode?)
+                }
+            }
+            .accessibilityIdentifier("settings.reasoning.openAIMode")
+        }
+
+        if presentation.showsOpenAIContext {
+            Picker("Reasoning Context", selection: $configuration.openAIContext) {
+                ForEach(presentation.openAIContextOptions, id: \.self) { context in
+                    Text(context.displayName).tag(context)
+                }
+            }
+            .accessibilityIdentifier("settings.reasoning.openAIContext")
+        }
+
+        if presentation.showsSummary {
+            Picker("Reasoning Summary", selection: $configuration.summary) {
+                ForEach(presentation.summaryOptions, id: \.self) { summary in
+                    Text(summary.displayName).tag(summary)
+                }
+            }
+            .accessibilityIdentifier("settings.reasoning.summary")
+        }
+
+        if presentation.showsAnthropicDisplay {
+            Picker("Thinking Display", selection: $configuration.anthropicDisplay) {
+                ForEach(AnthropicThinkingDisplay.allCases, id: \.self) { display in
+                    Text(display.displayName).tag(display)
+                }
+            }
+            .accessibilityIdentifier("settings.reasoning.anthropicDisplay")
+        }
+
+        if presentation.showsLegacyBudget {
+            Stepper(
+                "Thinking Budget: \(configuration.legacyBudgetTokens) tokens",
+                value: legacyBudgetBinding,
+                step: 1024
+            )
+            .accessibilityIdentifier("settings.reasoning.legacyBudget")
+        }
+
+        Text(guidanceText)
+            .font(Typography.caption)
+            .foregroundStyle(Theme.textSecondary)
+            .onAppear {
+                normalizeConfiguration()
+            }
+            .onChange(of: normalizationInput) { _, _ in
+                normalizeConfiguration()
+            }
+    }
+
+    private func normalizeConfiguration() {
+        let normalized = ModelReasoningSettingsPresentation.normalizedConfiguration(
+            model: model,
+            provider: provider,
+            endpointType: endpointType,
+            endpoint: endpoint,
+            configuration: configuration
+        )
+        if normalized != configuration {
+            configuration = normalized
+        }
+    }
+
+    private var legacyBudgetBinding: Binding<Int> {
+        Binding(
+            get: {
+                max(
+                    configuration.legacyBudgetTokens,
+                    ModelReasoningConfiguration.minimumLegacyBudgetTokens
+                )
+            },
+            set: { newValue in
+                configuration.legacyBudgetTokens = max(
+                    newValue,
+                    ModelReasoningConfiguration.minimumLegacyBudgetTokens
+                )
+            }
+        )
+    }
+
+    private var guidanceText: String {
+        if let unavailableDescription = presentation.unavailableDescription {
+            return unavailableDescription
+        }
+        return "Automatic enables supported controls for recognized first-party models. Provider Default omits reasoning controls; some models still reason by default. Use On for compatible custom endpoints or deployment aliases."
+    }
+
+    private struct NormalizationInput: Equatable {
+        let model: String
+        let provider: AIProvider
+        let endpointType: APIEndpointType
+        let endpoint: String?
+        let activation: ReasoningActivationMode
+        let anthropicMode: AnthropicThinkingMode
+    }
+}

--- a/Sources/Ayna/Views/iOS/IOSChatView.swift
+++ b/Sources/Ayna/Views/iOS/IOSChatView.swift
@@ -195,6 +195,12 @@ struct IOSChatView: View {
                 errorMessage: $viewModel.errorMessage,
                 attachedFiles: $viewModel.attachedFiles,
                 attachedImages: $viewModel.attachedImages,
+                reasoningConfiguration: Binding(
+                    get: { viewModel.reasoningConfiguration },
+                    set: { viewModel.updateReasoningConfiguration($0) }
+                ),
+                selectedModels: viewModel.selectedModels,
+                primaryModel: conversation?.model ?? viewModel.selectedModel,
                 errorRecoverySuggestion: viewModel.errorRecoverySuggestion,
                 onRetry: viewModel.failedMessage != nil ? { viewModel.retryFailedMessage() } : nil,
                 showAttachmentButton: true,

--- a/Sources/Ayna/Views/iOS/IOSContentView.swift
+++ b/Sources/Ayna/Views/iOS/IOSContentView.swift
@@ -286,6 +286,12 @@ struct IOSNewChatView: View {
                 errorMessage: $viewModel.errorMessage,
                 attachedFiles: $viewModel.attachedFiles,
                 attachedImages: $viewModel.attachedImages,
+                reasoningConfiguration: Binding(
+                    get: { viewModel.reasoningConfiguration },
+                    set: { viewModel.updateReasoningConfiguration($0) }
+                ),
+                selectedModels: viewModel.selectedModels,
+                primaryModel: viewModel.selectedModel,
                 errorRecoverySuggestion: viewModel.errorRecoverySuggestion,
                 onRetry: viewModel.failedMessage != nil ? { viewModel.retryFailedMessage() } : nil,
                 showAttachmentButton: true,

--- a/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
+++ b/Sources/Ayna/Views/iOS/IOSMessageComposer.swift
@@ -20,6 +20,10 @@ struct IOSMessageComposer: View {
     @Binding var errorMessage: String?
     @Binding var attachedFiles: [URL]
     @Binding var attachedImages: [UIImage]
+    @Binding var reasoningConfiguration: ModelReasoningConfiguration
+
+    let selectedModels: Set<String>
+    let primaryModel: String
 
     /// Optional recovery suggestion for the current error
     var errorRecoverySuggestion: String?
@@ -97,6 +101,9 @@ struct IOSMessageComposer: View {
         errorMessage: Binding<String?>,
         attachedFiles: Binding<[URL]> = .constant([]),
         attachedImages: Binding<[UIImage]> = .constant([]),
+        reasoningConfiguration: Binding<ModelReasoningConfiguration>,
+        selectedModels: Set<String>,
+        primaryModel: String,
         errorRecoverySuggestion: String? = nil,
         onRetry: (() -> Void)? = nil,
         showAttachmentButton: Bool = true,
@@ -112,6 +119,9 @@ struct IOSMessageComposer: View {
         _errorMessage = errorMessage
         _attachedFiles = attachedFiles
         _attachedImages = attachedImages
+        _reasoningConfiguration = reasoningConfiguration
+        self.selectedModels = selectedModels
+        self.primaryModel = primaryModel
         self.errorRecoverySuggestion = errorRecoverySuggestion
         self.onRetry = onRetry
         self.showAttachmentButton = showAttachmentButton
@@ -155,6 +165,17 @@ struct IOSMessageComposer: View {
                 }
                 .accessibilityIdentifier("\(identifierPrefix).attachmentsList")
             }
+
+            HStack {
+                ChatReasoningControl(
+                    configuration: $reasoningConfiguration,
+                    selectedModels: selectedModels,
+                    primaryModel: primaryModel,
+                    identifier: "\(identifierPrefix).reasoning"
+                )
+                Spacer()
+            }
+            .padding(.horizontal, Spacing.md)
 
             // Input bar - iMessage style
             HStack(alignment: .center, spacing: Spacing.sm) {

--- a/Sources/Ayna/Views/iOS/IOSSettingsView.swift
+++ b/Sources/Ayna/Views/iOS/IOSSettingsView.swift
@@ -237,18 +237,7 @@ struct IOSSettingsView: View {
             message: "🗑️ Removing model",
             metadata: ["model": model]
         )
-        if let index = aiService.customModels.firstIndex(of: model) {
-            aiService.customModels.remove(at: index)
-            aiService.modelProviders.removeValue(forKey: model)
-            aiService.modelEndpoints.removeValue(forKey: model)
-            aiService.modelAPIKeys.removeValue(forKey: model)
-            aiService.modelEndpointTypes.removeValue(forKey: model)
-
-            // If we removed the selected model, select the first available one
-            if aiService.selectedModel == model, let first = aiService.customModels.first {
-                aiService.selectedModel = first
-            }
-        }
+        aiService.removeConfiguredModel(model)
     }
 
     private func duplicateModel(_ model: String) {
@@ -282,6 +271,9 @@ struct IOSSettingsView: View {
         }
         if let endpointType = aiService.modelEndpointTypes[model] {
             aiService.modelEndpointTypes[newName] = endpointType
+        }
+        if let reasoningConfiguration = aiService.modelReasoningConfigurations[model] {
+            aiService.modelReasoningConfigurations[newName] = reasoningConfiguration
         }
     }
 }
@@ -363,6 +355,8 @@ struct IOSModelEditView: View {
     @State private var apiKey = ""
     @State private var endpoint = ""
     @State private var endpointType: APIEndpointType = .chatCompletions
+    @State private var reasoningConfiguration = ModelReasoningConfiguration.automatic
+    @State private var saveErrorMessage: String?
 
     init(modelName: String, isNew: Bool) {
         _modelName = State(initialValue: modelName)
@@ -433,6 +427,16 @@ struct IOSModelEditView: View {
                         .foregroundStyle(Theme.textSecondary)
                 }
             }
+
+            Section("Reasoning") {
+                ModelReasoningSettingsControls(
+                    configuration: $reasoningConfiguration,
+                    model: modelName,
+                    provider: provider,
+                    endpointType: endpointType,
+                    endpoint: endpoint
+                )
+            }
         }
         .navigationTitle(isNew ? "Add Model" : "Edit Model")
         .toolbar {
@@ -447,11 +451,12 @@ struct IOSModelEditView: View {
 
             ToolbarItem(placement: .confirmationAction) {
                 Button("Save") {
-                    saveModel()
-                    dismiss()
+                    if saveModel() {
+                        dismiss()
+                    }
                 }
                 .disabled(
-                    modelName.isEmpty ||
+                    modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
                         (provider == .anthropic && apiKey.isEmpty)
                 )
                 .accessibilityIdentifier("settings.addModel.saveButton")
@@ -461,6 +466,23 @@ struct IOSModelEditView: View {
             if !isNew {
                 loadModelData()
             }
+        }
+        .alert(
+            "Unable to Save Model",
+            isPresented: Binding(
+                get: { saveErrorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        saveErrorMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                saveErrorMessage = nil
+            }
+        } message: {
+            Text(saveErrorMessage ?? "")
         }
     }
 
@@ -483,11 +505,18 @@ struct IOSModelEditView: View {
         if let savedType = aiService.modelEndpointTypes[modelName] {
             endpointType = savedType
         }
+        reasoningConfiguration = aiService.reasoningConfiguration(for: modelName)
     }
 
-    private func saveModel() {
+    private func saveModel() -> Bool {
         let trimmedName = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
         let isRename = !isNew && trimmedName != originalModelName
+        saveErrorMessage = nil
+
+        guard !trimmedName.isEmpty else {
+            saveErrorMessage = "Model name is required."
+            return false
+        }
 
         DiagnosticsLogger.log(
             .aiService,
@@ -509,7 +538,8 @@ struct IOSModelEditView: View {
                     message: "⚠️ Duplicate model name, skipping",
                     metadata: ["model": trimmedName]
                 )
-                return
+                saveErrorMessage = "A model named \(trimmedName) already exists."
+                return false
             }
             aiService.customModels.append(trimmedName)
         } else if isRename {
@@ -521,27 +551,36 @@ struct IOSModelEditView: View {
                     message: "⚠️ Model name already exists, skipping rename",
                     metadata: ["model": trimmedName]
                 )
-                return
+                saveErrorMessage = "A model named \(trimmedName) already exists."
+                return false
             }
 
-            // Update the model list: replace old name with new name
-            if let index = aiService.customModels.firstIndex(of: originalModelName) {
-                aiService.customModels[index] = trimmedName
-            }
-
-            // Remove old model settings
-            aiService.modelProviders.removeValue(forKey: originalModelName)
-            aiService.modelAPIKeys.removeValue(forKey: originalModelName)
-            aiService.modelEndpoints.removeValue(forKey: originalModelName)
-            aiService.modelEndpointTypes.removeValue(forKey: originalModelName)
-
-            // Update selected model if it was the renamed one
-            if aiService.selectedModel == originalModelName {
-                aiService.selectedModel = trimmedName
+            switch aiService.renameConfiguredModel(from: originalModelName, to: trimmedName) {
+            case .renamed, .unchanged:
+                break
+            case .destinationExists:
+                DiagnosticsLogger.log(
+                    .aiService,
+                    level: .default,
+                    message: "⚠️ Model name already exists, skipping rename",
+                    metadata: ["model": trimmedName]
+                )
+                saveErrorMessage = "A model named \(trimmedName) already exists."
+                return false
+            case .sourceMissing:
+                DiagnosticsLogger.log(
+                    .aiService,
+                    level: .error,
+                    message: "Failed to rename missing model",
+                    metadata: ["model": originalModelName]
+                )
+                saveErrorMessage = "The model being edited no longer exists."
+                return false
             }
         }
 
         aiService.modelProviders[trimmedName] = provider
+        aiService.modelReasoningConfigurations[trimmedName] = reasoningConfiguration
 
         if provider == .openai {
             if !apiKey.isEmpty {
@@ -552,6 +591,7 @@ struct IOSModelEditView: View {
             }
             aiService.modelEndpointTypes[trimmedName] = endpointType
         } else if provider == .anthropic {
+            aiService.modelEndpointTypes.removeValue(forKey: trimmedName)
             if !apiKey.isEmpty {
                 aiService.modelAPIKeys[trimmedName] = apiKey
             }
@@ -564,6 +604,7 @@ struct IOSModelEditView: View {
         if aiService.customModels.count == 1 {
             aiService.selectedModel = trimmedName
         }
+        return true
     }
 }
 

--- a/Sources/Ayna/Views/iOS/IOSSettingsView.swift
+++ b/Sources/Ayna/Views/iOS/IOSSettingsView.swift
@@ -355,7 +355,6 @@ struct IOSModelEditView: View {
     @State private var apiKey = ""
     @State private var endpoint = ""
     @State private var endpointType: APIEndpointType = .chatCompletions
-    @State private var reasoningConfiguration = ModelReasoningConfiguration.automatic
     @State private var saveErrorMessage: String?
 
     init(modelName: String, isNew: Bool) {
@@ -428,15 +427,6 @@ struct IOSModelEditView: View {
                 }
             }
 
-            Section("Reasoning") {
-                ModelReasoningSettingsControls(
-                    configuration: $reasoningConfiguration,
-                    model: modelName,
-                    provider: provider,
-                    endpointType: endpointType,
-                    endpoint: endpoint
-                )
-            }
         }
         .navigationTitle(isNew ? "Add Model" : "Edit Model")
         .toolbar {
@@ -505,7 +495,6 @@ struct IOSModelEditView: View {
         if let savedType = aiService.modelEndpointTypes[modelName] {
             endpointType = savedType
         }
-        reasoningConfiguration = aiService.reasoningConfiguration(for: modelName)
     }
 
     private func saveModel() -> Bool {
@@ -580,7 +569,6 @@ struct IOSModelEditView: View {
         }
 
         aiService.modelProviders[trimmedName] = provider
-        aiService.modelReasoningConfigurations[trimmedName] = reasoningConfiguration
 
         if provider == .openai {
             if !apiKey.isEmpty {

--- a/Sources/Ayna/Views/iOS/IOSSidebarView.swift
+++ b/Sources/Ayna/Views/iOS/IOSSidebarView.swift
@@ -421,7 +421,7 @@
         }()
 
         var lastMessagePreview: String {
-            conversation.metadataPreview ?? conversation.messages.last?.content ?? "No messages"
+            conversation.metadataPreview ?? conversation.messages.last?.previewText ?? "No messages"
         }
 
         var timeString: String {

--- a/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
+++ b/Sources/Ayna/Views/macOS/Chat/ChatInputArea.swift
@@ -20,11 +20,13 @@ struct ChatInputArea: View {
     @Binding var selectedModel: String
     @Binding var showModelSelector: Bool
     @Binding var isToolSectionExpanded: Bool
+    @Binding var reasoningConfiguration: ModelReasoningConfiguration
 
     let isGenerating: Bool
     let composerModelLabel: String
     var textEditorIdentifier: String = TestIdentifiers.ChatComposer.textEditor
     var sendButtonIdentifier: String = TestIdentifiers.ChatComposer.sendButton
+    var reasoningControlIdentifier = "chat.composer.reasoning"
     let onSendMessage: () -> Void
     let onAttachFile: () -> Void
     let onShowAppContentPicker: () -> Void
@@ -54,6 +56,13 @@ struct ChatInputArea: View {
             // Main input row
             HStack(spacing: 0) {
                 textEditorWithAttachButton(textHeight: textHeight)
+                ChatReasoningControl(
+                    configuration: $reasoningConfiguration,
+                    selectedModels: selectedModels,
+                    primaryModel: selectedModel,
+                    identifier: reasoningControlIdentifier
+                )
+                .padding(.horizontal, Spacing.xs)
                 modelSelectorButton(textHeight: textHeight)
                 sendButton(textHeight: textHeight)
             }

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+ImageGeneration.swift
@@ -425,7 +425,8 @@ extension MacChatView {
     func sendMultiModelMessage(
         userMessageId: UUID,
         models: [String],
-        temperature: Double
+        temperature: Double,
+        reasoningConfiguration: ModelReasoningConfiguration
     ) {
         logChat(
             "🔀 Starting multi-model request",
@@ -586,7 +587,8 @@ extension MacChatView {
                 coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
                     bufferMultiModelReasoning(reasoning, model: model, messageIdsByModel: messageIdsByModel, conversationId: conversationId)
                 }
-            }
+            },
+            reasoningConfiguration: reasoningConfiguration
         )
         coordinator.onCancel(for: operationID) {
             finishAndPersistMultiModelReasoning(conversationId: conversationId)

--- a/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
+++ b/Sources/Ayna/Views/macOS/Chat/MacChatView+Retry.swift
@@ -141,6 +141,7 @@ extension MacChatView {
             model: updatedConversation.model,
             temperature: updatedConversation.temperature,
             tools: tools,
+            reasoningConfiguration: updatedConversation.reasoningConfiguration,
             isInitialRequest: true,
             assistantMessageID: assistantMessage.id
         )
@@ -193,6 +194,7 @@ extension MacChatView {
             model: model,
             temperature: updatedConversation.temperature,
             tools: tools,
+            reasoningConfiguration: updatedConversation.reasoningConfiguration,
             isInitialRequest: true,
             assistantMessageID: assistantMessage.id
         )

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -1144,7 +1144,7 @@ struct MacChatView: View {
     }
 
     // Helper function to send messages with automatic tool call handling
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     func sendMessageWithToolSupport(
         messages: [Message],
         model: String,
@@ -1416,6 +1416,40 @@ struct MacChatView: View {
                             )
                         }
                     }
+            },
+            onReasoning: { reasoning in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                    guard coordinator.owns(operationID, conversationID: conversationId),
+                          activeAssistantMessageID == assistantMessageID
+                    else {
+                        return
+                    }
+                    conversationManager.updateMessage(
+                        conversationId: conversationId,
+                        messageId: assistantMessageID
+                    ) { message in
+                        message.appendReasoning(reasoning)
+                    }
+                }
+            },
+            onReasoningContinuation: { state in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                    guard coordinator.owns(operationID, conversationID: conversationId),
+                          activeAssistantMessageID == assistantMessageID,
+                          conversationManager.updateMessage(
+                              conversationId: conversationId,
+                              messageId: assistantMessageID,
+                              update: { message in
+                                  message.reasoningContinuation = state
+                              }
+                          )
+                    else {
+                        return
+                    }
+                    if let conversation = conversationManager.conversation(byId: conversationId) {
+                        conversationManager.save(conversation)
+                    }
+                }
                 }
             )
             coordinator.track(request, for: operationID)

--- a/Sources/Ayna/Views/macOS/MacChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacChatView.swift
@@ -121,6 +121,17 @@ struct MacChatView: View {
         let selectedModel: String
         let selectedModels: Set<String>
         let activeModel: String?
+        let reasoningConfiguration: ModelReasoningConfiguration
+    }
+
+    private struct ToolContinuationContext: Sendable {
+        let operationID: ToolChainCoordinator.OperationID
+        let sourceAssistantMessageID: UUID
+        let conversationID: UUID
+        let model: String
+        let temperature: Double
+        let tools: UncheckedSendableWrapper<[[String: Any]]?>
+        let reasoningConfiguration: ModelReasoningConfiguration
     }
 
     let conversation: Conversation
@@ -128,6 +139,7 @@ struct MacChatView: View {
     init(conversation: Conversation) {
         self.conversation = conversation
         _selectedModel = State(initialValue: conversation.model)
+        _reasoningConfiguration = State(initialValue: conversation.reasoningConfiguration)
         // Initialize selectedModels with the conversation's active models if available, otherwise fallback to single model
         if conversation.multiModelEnabled, !conversation.activeModels.isEmpty {
             _selectedModels = State(initialValue: Set(conversation.activeModels))
@@ -146,6 +158,7 @@ struct MacChatView: View {
     @State var errorRecoverySuggestion: String?
     @State private var failedMessage: String?
     @State private var selectedModel: String
+    @State private var reasoningConfiguration: ModelReasoningConfiguration
     @State private var attachedFiles: [URL] = []
     @State var toolCallDepth = 0
     @State private var currentToolName: String?
@@ -339,9 +352,10 @@ struct MacChatView: View {
                     selectedModel: $selectedModel,
                     showModelSelector: $showModelSelector,
                     isToolSectionExpanded: $isToolSectionExpanded,
+                    reasoningConfiguration: $reasoningConfiguration,
                     isGenerating: isGenerating,
                     composerModelLabel: composerModelLabel,
-                        onSendMessage: { beginSendMessage() },
+                    onSendMessage: { beginSendMessage() },
                     onAttachFile: attachFile,
                     onShowAppContentPicker: { showAppContentPicker = true },
                     onToggleModelSelection: toggleModelSelection,
@@ -404,6 +418,20 @@ struct MacChatView: View {
         .onAppear {
             isComposerFocused = true
             checkAndProcessPendingPrompt()
+        }
+        .onChange(of: reasoningConfiguration) { _, configuration in
+            guard var current = conversationManager.conversation(byId: conversation.id),
+                  current.reasoningConfiguration != configuration
+            else {
+                return
+            }
+            current.reasoningConfiguration = configuration
+            conversationManager.updateConversation(current)
+        }
+        .onChange(of: currentConversation.reasoningConfiguration) { _, configuration in
+            if reasoningConfiguration != configuration {
+                reasoningConfiguration = configuration
+            }
         }
         .onDisappear {
                 cancelOwnedGenerationForLifecycle()
@@ -486,8 +514,9 @@ struct MacChatView: View {
             model: currentConversation.model,
             temperature: currentConversation.temperature,
             tools: tools,
-                isInitialRequest: true,
-                assistantMessageID: assistantMessage.id
+            reasoningConfiguration: currentConversation.reasoningConfiguration,
+            isInitialRequest: true,
+            assistantMessageID: assistantMessage.id
         )
     }
 
@@ -824,7 +853,8 @@ struct MacChatView: View {
                 appContent: attachedAppContent,
                 selectedModel: selectedModel,
                 selectedModels: selectedModels,
-                activeModel: resolveModelForSending(selection: selectedModel)
+                activeModel: resolveModelForSending(selection: selectedModel),
+                reasoningConfiguration: reasoningConfiguration
             )
             let preparationID = UUID()
             sendPreparationID = preparationID
@@ -961,6 +991,13 @@ struct MacChatView: View {
                 return
             }
 
+            if var configuredConversation = conversationManager.conversation(byId: conversation.id),
+               configuredConversation.reasoningConfiguration != preparation.reasoningConfiguration
+            {
+                configuredConversation.reasoningConfiguration = preparation.reasoningConfiguration
+                conversationManager.updateConversation(configuredConversation)
+            }
+
             guard await ConversationSendPreflight.loadConversationHistory(
                 conversationId: conversation.id,
                 manager: conversationManager
@@ -1050,8 +1087,9 @@ struct MacChatView: View {
                 handedOff = true
             sendMultiModelMessage(
                 userMessageId: userMessage.id,
-                    models: Array(selectedModelsToSend),
-                temperature: updatedConversation.temperature
+                models: Array(selectedModelsToSend),
+                temperature: updatedConversation.temperature,
+                reasoningConfiguration: preparation.reasoningConfiguration
             )
             return
         }
@@ -1138,6 +1176,7 @@ struct MacChatView: View {
             model: activeModel,
             temperature: updatedConversation.temperature,
             tools: tools,
+            reasoningConfiguration: preparation.reasoningConfiguration,
             isInitialRequest: true,
             assistantMessageID: assistantMessage.id
         )
@@ -1150,6 +1189,7 @@ struct MacChatView: View {
         model: String,
         temperature: Double,
         tools: [[String: Any]]?,
+        reasoningConfiguration: ModelReasoningConfiguration,
         isInitialRequest _: Bool,
         assistantMessageID requestedAssistantMessageID: UUID? = nil,
         operationID existingOperationID: ToolChainCoordinator.OperationID? = nil
@@ -1189,6 +1229,15 @@ struct MacChatView: View {
                 return
             }
             let toolCallAdmissionGate = ToolCallRequestAdmissionGate()
+            let continuationContext = ToolContinuationContext(
+                operationID: operationID,
+                sourceAssistantMessageID: assistantMessageID,
+                conversationID: conversationId,
+                model: model,
+                temperature: temperature,
+                tools: toolsWrapper,
+                reasoningConfiguration: reasoningConfiguration
+            )
 
             let request = aiService.sendMessage(
             messages: messages,
@@ -1262,12 +1311,7 @@ struct MacChatView: View {
                         )
                         handleToolRoundResolution(
                             resolution,
-                            operationID: operationID,
-                            sourceAssistantMessageID: assistantMessageID,
-                            conversationID: conversationId,
-                            model: model,
-                            temperature: temperature,
-                            tools: toolsWrapper.value
+                            context: continuationContext
                         )
                 }
             },
@@ -1407,12 +1451,7 @@ struct MacChatView: View {
                             let resolution = requestRounds.toolDidComplete(token, result: result)
                             handleToolRoundResolution(
                                 resolution,
-                                operationID: operationID,
-                                sourceAssistantMessageID: assistantMessageID,
-                                conversationID: conversationId,
-                                model: model,
-                                temperature: temperature,
-                                tools: toolsWrapper.value
+                                context: continuationContext
                             )
                         }
                     }
@@ -1450,19 +1489,15 @@ struct MacChatView: View {
                         conversationManager.save(conversation)
                     }
                 }
-                }
+                },
+                reasoningConfiguration: reasoningConfiguration
             )
             coordinator.track(request, for: operationID)
         }
 
         private func handleToolRoundResolution(
             _ resolution: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Resolution,
-            operationID: ToolChainCoordinator.OperationID,
-            sourceAssistantMessageID: UUID,
-            conversationID: UUID,
-            model: String,
-            temperature: Double,
-            tools: [[String: Any]]?
+            context: ToolContinuationContext
         ) {
             switch resolution {
             case .pending:
@@ -1472,7 +1507,7 @@ struct MacChatView: View {
             case .responseCompleted:
                 toolChainTimeoutTask?.cancel()
                 toolChainTimeoutTask = nil
-                guard toolChainCoordinator.finishOperation(operationID) else { return }
+                guard toolChainCoordinator.finishOperation(context.operationID) else { return }
                 activeAssistantMessageID = nil
                 currentToolName = nil
                 toolCallDepth = 0
@@ -1483,29 +1518,22 @@ struct MacChatView: View {
                 toolChainTimeoutTask = nil
                 launchToolContinuation(
                     continuation,
-                    operationID: operationID,
-                    sourceAssistantMessageID: sourceAssistantMessageID,
-                    conversationID: conversationID,
-                    model: model,
-                    temperature: temperature,
-                    tools: tools
+                    context: context
                 )
             }
         }
 
         private func launchToolContinuation(
             _ continuation: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Continuation,
-            operationID: ToolChainCoordinator.OperationID,
-            sourceAssistantMessageID: UUID,
-            conversationID: UUID,
-            model: String,
-            temperature: Double,
-            tools: [[String: Any]]?
+            context: ToolContinuationContext
         ) {
-            guard toolChainCoordinator.owns(operationID, conversationID: conversationID),
-                  continuation.operationID == operationID,
-                  activeAssistantMessageID == sourceAssistantMessageID,
-                  let conversation = conversationManager.conversation(byId: conversationID)
+            guard toolChainCoordinator.owns(
+                context.operationID,
+                conversationID: context.conversationID
+            ),
+            continuation.operationID == context.operationID,
+            activeAssistantMessageID == context.sourceAssistantMessageID,
+            let conversation = conversationManager.conversation(byId: context.conversationID)
             else {
                 return
             }
@@ -1517,13 +1545,16 @@ struct MacChatView: View {
 
             let citations = ToolExecutionResult.combinedCitations(from: results)
             let continuationMessage = ToolCallHandler.createContinuationMessage(
-                model: model,
+                model: context.model,
                 citations: citations.isEmpty ? nil : citations
             )
             conversationManager.addMessage(to: conversation, message: continuationMessage)
 
-            guard let conversationWithAssistant = conversationManager.conversation(byId: conversationID),
-                  toolChainCoordinator.owns(operationID, conversationID: conversationID)
+            guard let conversationWithAssistant = conversationManager.conversation(byId: context.conversationID),
+                  toolChainCoordinator.owns(
+                      context.operationID,
+                      conversationID: context.conversationID
+                  )
             else {
                 return
             }
@@ -1538,12 +1569,13 @@ struct MacChatView: View {
             currentToolName = nil
             sendMessageWithToolSupport(
                 messages: continuationMessages,
-                model: model,
-                temperature: temperature,
-                tools: tools,
+                model: context.model,
+                temperature: context.temperature,
+                tools: context.tools.value,
+                reasoningConfiguration: context.reasoningConfiguration,
                 isInitialRequest: false,
                 assistantMessageID: continuationMessage.id,
-                operationID: operationID
+                operationID: context.operationID
             )
         }
     }

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -9,6 +9,8 @@ import Combine
 import OSLog
 import SwiftUI
 
+// swiftlint:disable file_length
+
 // swiftlint:disable:next type_body_length
 struct MacNewChatView: View {
     @EnvironmentObject var conversationManager: ConversationManager
@@ -859,6 +861,7 @@ struct MacNewChatView: View {
         selectedConversationId = conversationID
     }
 
+    // swiftlint:disable:next function_body_length
     private func sendMultiModelMessage(
         userMessageId: UUID,
         models: [String],
@@ -1005,6 +1008,25 @@ struct MacNewChatView: View {
                             conversationManager.save(conversation)
                         }
                     }.append(reasoning)
+                }
+            },
+            onReasoningContinuation: { model, state in
+                coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                    guard coordinator.owns(operationID, conversationID: conversationId),
+                          let messageId = messageIdsByModel[model],
+                          conversationManager.updateMessage(
+                              conversationId: conversationId,
+                              messageId: messageId,
+                              update: { message in
+                                  message.reasoningContinuation = state
+                              }
+                          )
+                    else {
+                        return
+                    }
+                    if let conversation = conversationManager.conversation(byId: conversationId) {
+                        conversationManager.save(conversation)
+                    }
                 }
             }
         )
@@ -1254,7 +1276,25 @@ struct MacNewChatView: View {
                             conversationId: conversationId,
                             messageId: assistantMessageID
                         ) { message in
-                            message.reasoning = (message.reasoning ?? "") + reasoning
+                            message.appendReasoning(reasoning)
+                        }
+                    }
+                },
+                onReasoningContinuation: { state in
+                    coordinator.enqueueCallback(for: operationID, conversationID: conversationId) {
+                        guard activeAssistantMessageID == assistantMessageID,
+                              conversationManager.updateMessage(
+                                  conversationId: conversationId,
+                                  messageId: assistantMessageID,
+                                  update: { message in
+                                      message.reasoningContinuation = state
+                                  }
+                              )
+                        else {
+                            return
+                        }
+                        if let conversation = conversationManager.conversation(byId: conversationId) {
+                            conversationManager.save(conversation)
                         }
                     }
                 }

--- a/Sources/Ayna/Views/macOS/MacNewChatView.swift
+++ b/Sources/Ayna/Views/macOS/MacNewChatView.swift
@@ -13,6 +13,16 @@ import SwiftUI
 
 // swiftlint:disable:next type_body_length
 struct MacNewChatView: View {
+    private struct ToolContinuationContext: Sendable {
+        let operationID: ToolChainCoordinator.OperationID
+        let sourceAssistantMessageID: UUID
+        let conversationID: UUID
+        let model: String
+        let temperature: Double
+        let tools: UncheckedSendableWrapper<[[String: Any]]?>
+        let reasoningConfiguration: ModelReasoningConfiguration
+    }
+
     @EnvironmentObject var conversationManager: ConversationManager
     @ObservedObject var aiService = AIService.shared
     @Binding var selectedConversationId: UUID?
@@ -22,6 +32,7 @@ struct MacNewChatView: View {
     @State var isGenerating = false
     @State var currentConversationId: UUID?
     @State private var selectedModel = AIService.shared.selectedModel
+    @State private var reasoningConfiguration = ModelReasoningConfiguration.automatic
         @State var toolCallDepth = 0
         @State var currentToolName: String?
         @State var activeAssistantMessageID: UUID?
@@ -141,9 +152,13 @@ struct MacNewChatView: View {
                                                             in: conversation,
                                                             messageId: message.id,
                                                             newContent: newContent
-                                                    )
+                                                        )
                                                         if edited {
-                                                            sendMessageForConversation(conversation, model: conversation.model)
+                                                            sendMessageForConversation(
+                                                                conversation,
+                                                                model: conversation.model,
+                                                                reasoningConfiguration: conversation.reasoningConfiguration
+                                                            )
                                                         }
                                                     }
                                                 } : nil
@@ -219,6 +234,19 @@ struct MacNewChatView: View {
         .onAppear {
             syncSelectedModelState()
         }
+        .onChange(of: reasoningConfiguration) { _, configuration in
+            guard var conversation = currentConversation,
+                  conversation.reasoningConfiguration != configuration
+            else {
+                return
+            }
+            conversation.reasoningConfiguration = configuration
+            conversationManager.updateConversation(conversation)
+        }
+        .onChange(of: currentConversation?.reasoningConfiguration) { _, configuration in
+            guard let configuration, reasoningConfiguration != configuration else { return }
+            reasoningConfiguration = configuration
+        }
         .onDisappear {
                 cancelOwnedGenerationForLifecycle()
         }
@@ -255,11 +283,13 @@ struct MacNewChatView: View {
             selectedModel: $selectedModel,
             showModelSelector: $showModelSelector,
             isToolSectionExpanded: $isToolSectionExpanded,
+            reasoningConfiguration: $reasoningConfiguration,
             isGenerating: isGenerating,
             composerModelLabel: composerModelLabel,
             textEditorIdentifier: TestIdentifiers.NewChatComposer.textEditor,
             sendButtonIdentifier: TestIdentifiers.NewChatComposer.sendButton,
-                onSendMessage: { beginSendMessage() },
+            reasoningControlIdentifier: "newchat.composer.reasoning",
+            onSendMessage: { beginSendMessage() },
             onAttachFile: attachFile,
             onShowAppContentPicker: { showAppContentPicker = true },
             onToggleModelSelection: toggleModelSelection,
@@ -419,11 +449,15 @@ struct MacNewChatView: View {
         }
 
             let preparationID = UUID()
+            let requestReasoningConfiguration = reasoningConfiguration
             sendPreparationID = preparationID
             isGenerating = true
             let task = Task { @MainActor in
                 guard !Task.isCancelled, sendPreparationID == preparationID else { return }
-                await sendMessage(preparationID: preparationID)
+                await sendMessage(
+                    preparationID: preparationID,
+                    reasoningConfiguration: requestReasoningConfiguration
+                )
             }
             sendPreparationTask = task
         }
@@ -434,7 +468,10 @@ struct MacNewChatView: View {
             sendPreparationID = nil
         }
 
-        private func sendMessage(preparationID: UUID) async {
+        private func sendMessage(
+            preparationID: UUID,
+            reasoningConfiguration requestReasoningConfiguration: ModelReasoningConfiguration
+        ) async {
             var handedOff = false
             defer {
                 if sendPreparationID == preparationID {
@@ -508,6 +545,7 @@ struct MacNewChatView: View {
         var updatedConversation = conversation
         updatedConversation.activeModels = Array(selectedModels)
         updatedConversation.multiModelEnabled = selectedModels.count > 1
+        updatedConversation.reasoningConfiguration = requestReasoningConfiguration
         conversationManager.updateConversation(updatedConversation)
 
             if appContentToSend != nil {
@@ -557,15 +595,24 @@ struct MacNewChatView: View {
             sendMultiModelMessage(
                 userMessageId: userMessage.id,
                 models: Array(selectedModels),
-                temperature: conversation.temperature
+                temperature: conversation.temperature,
+                reasoningConfiguration: requestReasoningConfiguration
             )
         } else {
                 handedOff = true
-            sendMessageForConversation(conversation, model: activeModel)
+            sendMessageForConversation(
+                conversation,
+                model: activeModel,
+                reasoningConfiguration: requestReasoningConfiguration
+            )
         }
     }
 
-    private func sendMessageForConversation(_ conversation: Conversation, model: String) {
+    private func sendMessageForConversation(
+        _ conversation: Conversation,
+        model: String,
+        reasoningConfiguration: ModelReasoningConfiguration
+    ) {
         // Get the conversation with the user message we just added
         guard
             let updatedConversation = conversationManager.conversations.first(where: {
@@ -602,8 +649,9 @@ struct MacNewChatView: View {
             messages: currentMessages,
             model: activeModel,
             temperature: updatedConversation.temperature,
-                tools: tools,
-                assistantMessageID: assistantMessage.id
+            tools: tools,
+            reasoningConfiguration: reasoningConfiguration,
+            assistantMessageID: assistantMessage.id
         )
     }
 
@@ -865,7 +913,8 @@ struct MacNewChatView: View {
     private func sendMultiModelMessage(
         userMessageId: UUID,
         models: [String],
-        temperature: Double
+        temperature: Double,
+        reasoningConfiguration: ModelReasoningConfiguration
     ) {
         logNewChat(
             "🔀 Starting multi-model request",
@@ -1028,7 +1077,8 @@ struct MacNewChatView: View {
                         conversationManager.save(conversation)
                     }
                 }
-            }
+            },
+            reasoningConfiguration: reasoningConfiguration
         )
             coordinator.onCancel(for: operationID) {
                 multiModelReasoningBuffer.finishAll()
@@ -1046,6 +1096,7 @@ struct MacNewChatView: View {
         model: String,
         temperature: Double,
         tools: [[String: Any]]?,
+        reasoningConfiguration: ModelReasoningConfiguration,
         assistantMessageID requestedAssistantMessageID: UUID? = nil,
         operationID existingOperationID: ToolChainCoordinator.OperationID? = nil
     ) {
@@ -1081,6 +1132,15 @@ struct MacNewChatView: View {
                 return
             }
             let toolCallAdmissionGate = ToolCallRequestAdmissionGate()
+            let continuationContext = ToolContinuationContext(
+                operationID: operationID,
+                sourceAssistantMessageID: assistantMessageID,
+                conversationID: conversationId,
+                model: model,
+                temperature: temperature,
+                tools: toolsWrapper,
+                reasoningConfiguration: reasoningConfiguration
+            )
 
             let request = aiService.sendMessage(
             messages: messages,
@@ -1121,12 +1181,7 @@ struct MacNewChatView: View {
                         )
                         handleNewChatToolRoundResolution(
                             resolution,
-                            operationID: operationID,
-                            sourceAssistantMessageID: assistantMessageID,
-                            conversationID: conversationId,
-                            model: model,
-                            temperature: temperature,
-                            tools: toolsWrapper.value
+                            context: continuationContext
                         )
                 }
             },
@@ -1259,13 +1314,8 @@ struct MacNewChatView: View {
                             let resolution = requestRounds.toolDidComplete(token, result: result)
                             handleNewChatToolRoundResolution(
                                 resolution,
-                                operationID: operationID,
-                                sourceAssistantMessageID: assistantMessageID,
-                                conversationID: conversationId,
-                                    model: model,
-                                    temperature: temperature,
-                                    tools: toolsWrapper.value
-                                )
+                                context: continuationContext
+                            )
                             }
                     }
                 },
@@ -1297,25 +1347,21 @@ struct MacNewChatView: View {
                             conversationManager.save(conversation)
                         }
                     }
-                }
+                },
+                reasoningConfiguration: reasoningConfiguration
                                 )
             coordinator.track(request, for: operationID)
                             }
 
         private func handleNewChatToolRoundResolution(
             _ resolution: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Resolution,
-            operationID: ToolChainCoordinator.OperationID,
-            sourceAssistantMessageID: UUID,
-            conversationID: UUID,
-            model: String,
-            temperature: Double,
-            tools: [[String: Any]]?
+            context: ToolContinuationContext
         ) {
             switch resolution {
             case .pending, .ignored:
                 return
             case .responseCompleted:
-                guard toolChainCoordinator.finishOperation(operationID) else { return }
+                guard toolChainCoordinator.finishOperation(context.operationID) else { return }
                 activeAssistantMessageID = nil
                     currentToolName = nil
                 toolCallDepth = 0
@@ -1323,35 +1369,28 @@ struct MacNewChatView: View {
                     logNewChat(
                     "✅ Initial message finished streaming, switching to ChatView",
                         level: .info,
-                    metadata: ["conversationId": conversationID.uuidString]
+                    metadata: ["conversationId": context.conversationID.uuidString]
                     )
-                selectedConversationId = conversationID
+                selectedConversationId = context.conversationID
             case let .launchContinuation(continuation):
                 launchNewChatToolContinuation(
                     continuation,
-                    operationID: operationID,
-                    sourceAssistantMessageID: sourceAssistantMessageID,
-                    conversationID: conversationID,
-                    model: model,
-                    temperature: temperature,
-                    tools: tools
+                    context: context
                 )
             }
         }
 
         private func launchNewChatToolContinuation(
             _ continuation: ToolCallRequestRoundCoordinator<ToolExecutionResult>.Continuation,
-            operationID: ToolChainCoordinator.OperationID,
-            sourceAssistantMessageID: UUID,
-            conversationID: UUID,
-            model: String,
-            temperature: Double,
-            tools: [[String: Any]]?
+            context: ToolContinuationContext
         ) {
-            guard toolChainCoordinator.owns(operationID, conversationID: conversationID),
-                  continuation.operationID == operationID,
-                  activeAssistantMessageID == sourceAssistantMessageID,
-                  let conversation = conversationManager.conversation(byId: conversationID)
+            guard toolChainCoordinator.owns(
+                context.operationID,
+                conversationID: context.conversationID
+            ),
+            continuation.operationID == context.operationID,
+            activeAssistantMessageID == context.sourceAssistantMessageID,
+            let conversation = conversationManager.conversation(byId: context.conversationID)
             else {
                 return
                 }
@@ -1362,14 +1401,17 @@ struct MacNewChatView: View {
                     }
 
             let citations = ToolExecutionResult.combinedCitations(from: results)
-            var continuationMessage = Message(role: .assistant, content: "", model: model)
+            var continuationMessage = Message(role: .assistant, content: "", model: context.model)
             if !citations.isEmpty {
                 continuationMessage.citations = citations
                 }
             conversationManager.addMessage(to: conversation, message: continuationMessage)
 
-            guard let conversationWithAssistant = conversationManager.conversation(byId: conversationID),
-                  toolChainCoordinator.owns(operationID, conversationID: conversationID)
+            guard let conversationWithAssistant = conversationManager.conversation(byId: context.conversationID),
+                  toolChainCoordinator.owns(
+                      context.operationID,
+                      conversationID: context.conversationID
+                  )
             else {
                 return
             }
@@ -1384,11 +1426,12 @@ struct MacNewChatView: View {
             sendMessageWithToolSupport(
                 conversation: conversationWithAssistant,
                 messages: continuationMessages,
-                model: model,
-                temperature: temperature,
-                tools: tools,
+                model: context.model,
+                temperature: context.temperature,
+                tools: context.tools.value,
+                reasoningConfiguration: context.reasoningConfiguration,
                 assistantMessageID: continuationMessage.id,
-                operationID: operationID
+                operationID: context.operationID
         )
     }
 

--- a/Sources/Ayna/Views/macOS/MacSettingsView.swift
+++ b/Sources/Ayna/Views/macOS/MacSettingsView.swift
@@ -849,7 +849,6 @@ struct APISettingsView: View {
     @State private var tempModelName = ""
     @State private var selectedModelName: String?
     @State private var tempEndpointType: APIEndpointType = .chatCompletions
-    @State private var tempReasoningConfiguration = ModelReasoningConfiguration.automatic
     @State private var isValidating = false
     @State private var validationStatus: ValidationStatus = .notChecked
 
@@ -1217,8 +1216,6 @@ struct APISettingsView: View {
                                                 // Update provider and endpoint type
                                                 aiService.modelProviders[modelName] = .openai
                                                 aiService.modelEndpointTypes[modelName] = tempEndpointType
-                                                aiService.modelReasoningConfigurations[modelName] =
-                                                    tempReasoningConfiguration
 
                                                 // Update per-model API key
                                                 if !apiKey.isEmpty {
@@ -1261,8 +1258,6 @@ struct APISettingsView: View {
                                                 aiService.customModels.append(modelName)
                                                 aiService.modelProviders[modelName] = .openai
                                                 aiService.modelEndpointTypes[modelName] = tempEndpointType
-                                                aiService.modelReasoningConfigurations[modelName] =
-                                                    tempReasoningConfiguration
 
                                                 // Save per-model API key if provided
                                                 if !apiKey.isEmpty {
@@ -1388,8 +1383,6 @@ struct APISettingsView: View {
                                             if !aiService.customModels.contains(finalModelName) {
                                                 aiService.customModels.append(finalModelName)
                                                 aiService.modelProviders[finalModelName] = .appleIntelligence
-                                                aiService.modelReasoningConfigurations[finalModelName] =
-                                                    tempReasoningConfiguration
                                                 if aiService.customModels.count == 1 {
                                                     aiService.selectedModel = finalModelName
                                                 }
@@ -1415,33 +1408,12 @@ struct APISettingsView: View {
                                 tempModelName: $tempModelName,
                                 tempAPIKey: $tempAPIKey,
                                 tempEndpoint: $tempEndpoint,
-                                tempReasoningConfiguration: $tempReasoningConfiguration,
                                 showAPIKey: $showAPIKey,
                                 selectedModelName: $selectedModelName,
                                 validationStatus: $validationStatus
                             )
                             .padding(.horizontal)
                         }
-
-                        VStack(alignment: .leading, spacing: Spacing.lg) {
-                            Text("Reasoning")
-                                .font(Typography.headline)
-                                .foregroundStyle(.primary)
-
-                            VStack(alignment: .leading, spacing: Spacing.md) {
-                                ModelReasoningSettingsControls(
-                                    configuration: $tempReasoningConfiguration,
-                                    model: tempModelName,
-                                    provider: aiService.provider,
-                                    endpointType: tempEndpointType,
-                                    endpoint: tempEndpoint
-                                )
-                            }
-                            .padding(Spacing.lg)
-                            .background(Theme.backgroundSecondary)
-                            .clipShape(.rect(cornerRadius: Spacing.CornerRadius.md))
-                        }
-                        .padding(.horizontal)
 
                         // Status Section
                         if aiService.provider != .appleIntelligence, aiService.provider != .anthropic
@@ -1552,7 +1524,6 @@ struct APISettingsView: View {
         // For others, use OpenAI endpoint
         tempEndpoint = aiService.provider == .anthropic ? "" : "https://api.openai.com/"
         tempEndpointType = .chatCompletions
-        tempReasoningConfiguration = .automatic
         validationStatus = .notChecked
     }
 
@@ -1672,7 +1643,6 @@ struct APISettingsView: View {
         // Load per-model API key if available
         tempAPIKey = aiService.modelAPIKeys[model] ?? ""
         tempEndpointType = aiService.modelEndpointTypes[model] ?? .chatCompletions
-        tempReasoningConfiguration = aiService.reasoningConfiguration(for: model)
 
         // Load endpoint based on provider
         switch aiService.provider {
@@ -1796,7 +1766,6 @@ struct AnthropicConfigurationView: View {
     @Binding var tempModelName: String
     @Binding var tempAPIKey: String
     @Binding var tempEndpoint: String
-    @Binding var tempReasoningConfiguration: ModelReasoningConfiguration
     @Binding var showAPIKey: Bool
     @Binding var selectedModelName: String?
     @Binding var validationStatus: APISettingsView.ValidationStatus
@@ -2144,7 +2113,6 @@ struct AnthropicConfigurationView: View {
         aiService.modelProviders[modelName] = .anthropic
         aiService.modelAPIKeys[modelName] = apiKey
         aiService.modelEndpointTypes.removeValue(forKey: modelName)
-        aiService.modelReasoningConfigurations[modelName] = tempReasoningConfiguration
 
         if !endpoint.isEmpty {
             aiService.modelEndpoints[modelName] = endpoint

--- a/Sources/Ayna/Views/macOS/MacSettingsView.swift
+++ b/Sources/Ayna/Views/macOS/MacSettingsView.swift
@@ -849,6 +849,7 @@ struct APISettingsView: View {
     @State private var tempModelName = ""
     @State private var selectedModelName: String?
     @State private var tempEndpointType: APIEndpointType = .chatCompletions
+    @State private var tempReasoningConfiguration = ModelReasoningConfiguration.automatic
     @State private var isValidating = false
     @State private var validationStatus: ValidationStatus = .notChecked
 
@@ -1191,28 +1192,33 @@ struct APISettingsView: View {
                                             let apiKey = tempAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
 
                                             if !modelName.isEmpty {
-                                                // Remove old model data if name changed
+                                                // Rename before applying edited settings so a collision cannot
+                                                // delete the source model or overwrite the destination model.
                                                 if selectedName != modelName {
-                                                    aiService.customModels.removeAll { $0 == selectedName }
-                                                    aiService.modelProviders.removeValue(forKey: selectedName)
-                                                    aiService.modelAPIKeys.removeValue(forKey: selectedName)
-                                                    aiService.modelEndpoints.removeValue(forKey: selectedName)
-                                                    aiService.modelEndpointTypes.removeValue(forKey: selectedName)
-
-                                                    // Add new model name if not already present
-                                                    if !aiService.customModels.contains(modelName) {
-                                                        aiService.customModels.append(modelName)
-                                                    }
-
-                                                    // Update selected model if it was the renamed one
-                                                    if aiService.selectedModel == selectedName {
-                                                        aiService.selectedModel = modelName
+                                                    switch aiService.renameConfiguredModel(
+                                                        from: selectedName,
+                                                        to: modelName
+                                                    ) {
+                                                    case .renamed, .unchanged:
+                                                        break
+                                                    case .destinationExists:
+                                                        validationStatus = .invalid(
+                                                            "A model named \(modelName) already exists"
+                                                        )
+                                                        return
+                                                    case .sourceMissing:
+                                                        validationStatus = .invalid(
+                                                            "The model being edited no longer exists"
+                                                        )
+                                                        return
                                                     }
                                                 }
 
                                                 // Update provider and endpoint type
                                                 aiService.modelProviders[modelName] = .openai
                                                 aiService.modelEndpointTypes[modelName] = tempEndpointType
+                                                aiService.modelReasoningConfigurations[modelName] =
+                                                    tempReasoningConfiguration
 
                                                 // Update per-model API key
                                                 if !apiKey.isEmpty {
@@ -1255,6 +1261,8 @@ struct APISettingsView: View {
                                                 aiService.customModels.append(modelName)
                                                 aiService.modelProviders[modelName] = .openai
                                                 aiService.modelEndpointTypes[modelName] = tempEndpointType
+                                                aiService.modelReasoningConfigurations[modelName] =
+                                                    tempReasoningConfiguration
 
                                                 // Save per-model API key if provided
                                                 if !apiKey.isEmpty {
@@ -1380,6 +1388,8 @@ struct APISettingsView: View {
                                             if !aiService.customModels.contains(finalModelName) {
                                                 aiService.customModels.append(finalModelName)
                                                 aiService.modelProviders[finalModelName] = .appleIntelligence
+                                                aiService.modelReasoningConfigurations[finalModelName] =
+                                                    tempReasoningConfiguration
                                                 if aiService.customModels.count == 1 {
                                                     aiService.selectedModel = finalModelName
                                                 }
@@ -1405,12 +1415,33 @@ struct APISettingsView: View {
                                 tempModelName: $tempModelName,
                                 tempAPIKey: $tempAPIKey,
                                 tempEndpoint: $tempEndpoint,
+                                tempReasoningConfiguration: $tempReasoningConfiguration,
                                 showAPIKey: $showAPIKey,
                                 selectedModelName: $selectedModelName,
                                 validationStatus: $validationStatus
                             )
                             .padding(.horizontal)
                         }
+
+                        VStack(alignment: .leading, spacing: Spacing.lg) {
+                            Text("Reasoning")
+                                .font(Typography.headline)
+                                .foregroundStyle(.primary)
+
+                            VStack(alignment: .leading, spacing: Spacing.md) {
+                                ModelReasoningSettingsControls(
+                                    configuration: $tempReasoningConfiguration,
+                                    model: tempModelName,
+                                    provider: aiService.provider,
+                                    endpointType: tempEndpointType,
+                                    endpoint: tempEndpoint
+                                )
+                            }
+                            .padding(Spacing.lg)
+                            .background(Theme.backgroundSecondary)
+                            .clipShape(.rect(cornerRadius: Spacing.CornerRadius.md))
+                        }
+                        .padding(.horizontal)
 
                         // Status Section
                         if aiService.provider != .appleIntelligence, aiService.provider != .anthropic
@@ -1503,7 +1534,10 @@ struct APISettingsView: View {
         }
         .onChange(of: aiService.provider) { _, newProvider in
             // Reset to a new-model state when switching to Anthropic.
-            if newProvider == .anthropic {
+            let isLoadingSelectedModel = selectedModelName.flatMap {
+                aiService.modelProviders[$0]
+            } == newProvider
+            if newProvider == .anthropic, !isLoadingSelectedModel {
                 createNewModel()
             }
         }
@@ -1518,6 +1552,7 @@ struct APISettingsView: View {
         // For others, use OpenAI endpoint
         tempEndpoint = aiService.provider == .anthropic ? "" : "https://api.openai.com/"
         tempEndpointType = .chatCompletions
+        tempReasoningConfiguration = .automatic
         validationStatus = .notChecked
     }
 
@@ -1637,6 +1672,7 @@ struct APISettingsView: View {
         // Load per-model API key if available
         tempAPIKey = aiService.modelAPIKeys[model] ?? ""
         tempEndpointType = aiService.modelEndpointTypes[model] ?? .chatCompletions
+        tempReasoningConfiguration = aiService.reasoningConfiguration(for: model)
 
         // Load endpoint based on provider
         switch aiService.provider {
@@ -1651,21 +1687,7 @@ struct APISettingsView: View {
     }
 
     private func removeModel(_ model: String) {
-        aiService.customModels.removeAll { $0 == model }
-        // Also remove from provider mapping and per-model settings
-        aiService.modelProviders.removeValue(forKey: model)
-        aiService.modelEndpoints.removeValue(forKey: model)
-        aiService.modelAPIKeys.removeValue(forKey: model)
-        aiService.modelEndpointTypes.removeValue(forKey: model)
-
-        // If we removed the selected default model, pick the next available one or clear it
-        if aiService.selectedModel == model {
-            if let nextModel = aiService.customModels.first {
-                aiService.selectedModel = nextModel
-            } else {
-                aiService.selectedModel = ""
-            }
-        }
+        aiService.removeConfiguredModel(model)
 
         if selectedModelName == model {
             selectedModelName = nil
@@ -1705,6 +1727,9 @@ struct APISettingsView: View {
         }
         // Always copy endpoint type, defaulting to chatCompletions if not set
         aiService.modelEndpointTypes[newName] = aiService.modelEndpointTypes[model] ?? .chatCompletions
+        if let reasoningConfiguration = aiService.modelReasoningConfigurations[model] {
+            aiService.modelReasoningConfigurations[newName] = reasoningConfiguration
+        }
 
         // Select the new model for editing
         selectedModelName = newName
@@ -1771,6 +1796,7 @@ struct AnthropicConfigurationView: View {
     @Binding var tempModelName: String
     @Binding var tempAPIKey: String
     @Binding var tempEndpoint: String
+    @Binding var tempReasoningConfiguration: ModelReasoningConfiguration
     @Binding var showAPIKey: Bool
     @Binding var selectedModelName: String?
     @Binding var validationStatus: APISettingsView.ValidationStatus
@@ -2092,13 +2118,22 @@ struct AnthropicConfigurationView: View {
 
         guard !modelName.isEmpty, !apiKey.isEmpty else { return }
 
-        // Remove old model if updating
+        // Rename before applying edited settings so a collision cannot delete
+        // the source model or overwrite the destination model.
         if let oldName = selectedModelName, oldName != modelName {
-            aiService.customModels.removeAll { $0 == oldName }
-            aiService.modelProviders.removeValue(forKey: oldName)
-            aiService.modelAPIKeys.removeValue(forKey: oldName)
-            aiService.modelEndpoints.removeValue(forKey: oldName)
-            aiService.modelEndpointTypes.removeValue(forKey: oldName)
+            switch aiService.renameConfiguredModel(from: oldName, to: modelName) {
+            case .renamed, .unchanged:
+                break
+            case .destinationExists:
+                validationStatus = .invalid("A model named \(modelName) already exists")
+                return
+            case .sourceMissing:
+                validationStatus = .invalid("The model being edited no longer exists")
+                return
+            }
+        } else if selectedModelName == nil, aiService.customModels.contains(modelName) {
+            validationStatus = .invalid("A model named \(modelName) already exists")
+            return
         }
 
         // Add or update model
@@ -2108,6 +2143,8 @@ struct AnthropicConfigurationView: View {
 
         aiService.modelProviders[modelName] = .anthropic
         aiService.modelAPIKeys[modelName] = apiKey
+        aiService.modelEndpointTypes.removeValue(forKey: modelName)
+        aiService.modelReasoningConfigurations[modelName] = tempReasoningConfiguration
 
         if !endpoint.isEmpty {
             aiService.modelEndpoints[modelName] = endpoint

--- a/Sources/Ayna/Views/macOS/MacSidebarView.swift
+++ b/Sources/Ayna/Views/macOS/MacSidebarView.swift
@@ -266,7 +266,7 @@
         }()
 
         private var lastMessagePreview: String {
-            conversation.metadataPreview ?? conversation.messages.last?.content ?? "No messages"
+            conversation.metadataPreview ?? conversation.messages.last?.previewText ?? "No messages"
         }
 
         private var timeString: String {

--- a/Tests/AynaTests/AIServiceModelIdentityTests.swift
+++ b/Tests/AynaTests/AIServiceModelIdentityTests.swift
@@ -1,0 +1,147 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+extension AIServiceGlobalStateTests {
+    @Suite("AIService Model Identity Tests", .tags(.fast), .serialized)
+    @MainActor
+    struct AIServiceModelIdentityTests {
+        private let previousDefaults: UserDefaults
+        private let previousKeychain: KeychainStoring
+
+        init() {
+            previousDefaults = AppPreferences.storage
+            previousKeychain = AIService.keychain
+
+            let suiteName = "AIServiceModelIdentityTests"
+            guard let defaults = UserDefaults(suiteName: suiteName) else {
+                fatalError("Failed to create UserDefaults suite for \(suiteName)")
+            }
+            defaults.removePersistentDomain(forName: suiteName)
+            AppPreferences.use(defaults)
+            AIService.keychain = InMemoryKeychainStorage()
+        }
+
+        @Test
+        func `rename collision preserves both models and their settings`() {
+            defer { restoreGlobalState() }
+            let service = makeService()
+            let source = "source-model"
+            let destination = "destination-model"
+            let sourceReasoning = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .high,
+                summary: .detailed
+            )
+            let destinationReasoning = ModelReasoningConfiguration(
+                activation: .disabled,
+                effort: .low,
+                summary: .automatic
+            )
+
+            service.customModels = [source, destination]
+            service.selectedModel = source
+            service.modelProviders = [source: .openai, destination: .anthropic]
+            service.modelEndpoints = [source: "https://source.example", destination: "https://destination.example"]
+            service.modelAPIKeys = [source: "source-key", destination: "destination-key"]
+            service.modelEndpointTypes = [source: .responses, destination: .chatCompletions]
+            service.modelReasoningConfigurations = [
+                source: sourceReasoning,
+                destination: destinationReasoning,
+            ]
+
+            let expectedModels = service.customModels
+            let expectedProviders = service.modelProviders
+            let expectedEndpoints = service.modelEndpoints
+            let expectedAPIKeys = service.modelAPIKeys
+            let expectedEndpointTypes = service.modelEndpointTypes
+            let expectedReasoning = service.modelReasoningConfigurations
+
+            let result = service.renameConfiguredModel(from: source, to: destination)
+
+            #expect(result == .destinationExists)
+            #expect(service.customModels == expectedModels)
+            #expect(service.selectedModel == source)
+            #expect(service.modelProviders == expectedProviders)
+            #expect(service.modelEndpoints == expectedEndpoints)
+            #expect(service.modelAPIKeys == expectedAPIKeys)
+            #expect(service.modelEndpointTypes == expectedEndpointTypes)
+            #expect(service.modelReasoningConfigurations == expectedReasoning)
+        }
+
+        @Test
+        func `renaming the selected Anthropic model updates selection and settings keys`() {
+            defer { restoreGlobalState() }
+            let service = makeService()
+            let oldName = "claude-old"
+            let newName = "claude-new"
+            let otherModel = "other-model"
+            let reasoning = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .high,
+                summary: .detailed
+            )
+
+            service.customModels = [oldName, otherModel]
+            service.selectedModel = oldName
+            service.modelProviders = [oldName: .anthropic, otherModel: .openai]
+            service.modelEndpoints = [oldName: "https://anthropic.example"]
+            service.modelAPIKeys = [oldName: "anthropic-key"]
+            service.modelEndpointTypes = [otherModel: .responses]
+            service.modelReasoningConfigurations = [oldName: reasoning]
+
+            let result = service.renameConfiguredModel(from: oldName, to: newName)
+
+            #expect(result == .renamed)
+            #expect(service.customModels == [newName, otherModel])
+            #expect(service.selectedModel == newName)
+            #expect(service.modelProviders[oldName] == nil)
+            #expect(service.modelProviders[newName] == .anthropic)
+            #expect(service.modelEndpoints[oldName] == nil)
+            #expect(service.modelEndpoints[newName] == "https://anthropic.example")
+            #expect(service.modelAPIKeys[oldName] == nil)
+            #expect(service.modelAPIKeys[newName] == "anthropic-key")
+            #expect(service.modelReasoningConfigurations[oldName] == nil)
+            #expect(service.modelReasoningConfigurations[newName] == reasoning)
+        }
+
+        @Test
+        func `removing the final selected model clears selection and per-model settings`() {
+            defer { restoreGlobalState() }
+            let service = makeService()
+            let model = "only-model"
+            let reasoning = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .medium,
+                summary: .automatic
+            )
+
+            service.customModels = [model]
+            service.selectedModel = model
+            service.modelProviders = [model: .openai]
+            service.modelEndpoints = [model: "https://only.example"]
+            service.modelAPIKeys = [model: "only-key"]
+            service.modelEndpointTypes = [model: .responses]
+            service.modelReasoningConfigurations = [model: reasoning]
+
+            service.removeConfiguredModel(model)
+
+            #expect(service.customModels.isEmpty)
+            #expect(service.selectedModel.isEmpty)
+            #expect(service.modelProviders[model] == nil)
+            #expect(service.modelEndpoints[model] == nil)
+            #expect(service.modelAPIKeys[model] == nil)
+            #expect(service.modelEndpointTypes[model] == nil)
+            #expect(service.modelReasoningConfigurations[model] == nil)
+        }
+
+        private func makeService() -> AIService {
+            AIService(urlSession: URLSession(configuration: .ephemeral))
+        }
+
+        private func restoreGlobalState() {
+            AppPreferences.use(previousDefaults)
+            AIService.keychain = previousKeychain
+        }
+    }
+}

--- a/Tests/AynaTests/AIServiceReasoningTests.swift
+++ b/Tests/AynaTests/AIServiceReasoningTests.swift
@@ -1,0 +1,571 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+// swiftformat:disable swiftTestingTestCaseNames
+
+extension AIServiceTests {
+    @Test("Invalid persisted reasoning entry does not erase valid models")
+    func invalidPersistedReasoningEntryDoesNotEraseValidModels() throws {
+        let validModel = "gpt-5.6-valid"
+        let invalidModel = "gpt-5.6-invalid"
+        let validConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .high,
+            summary: .detailed
+        )
+        let validData = try JSONEncoder().encode(validConfiguration)
+        let validObject = try JSONSerialization.jsonObject(with: validData)
+        let persistedObject: [String: Any] = [
+            validModel: validObject,
+            invalidModel: "not-a-reasoning-configuration"
+        ]
+        let persistedData = try JSONSerialization.data(withJSONObject: persistedObject)
+        AppPreferences.storage.set(
+            persistedData,
+            forKey: "modelReasoningConfigurations"
+        )
+
+        let service = AIService(urlSession: URLSession(configuration: .ephemeral))
+
+        #expect(service.modelReasoningConfigurations[validModel] == validConfiguration)
+        #expect(service.modelReasoningConfigurations[invalidModel] == nil)
+    }
+
+    @Test("Multi-model requests freeze reasoning settings at dispatch", .timeLimit(.minutes(1)))
+    func multiModelRequestsFreezeReasoningSettingsAtDispatch() async throws {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: configuration))
+        let model = "gpt-5.6-sol"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelEndpointTypes[model] = .responses
+        service.modelAPIKeys[model] = "sk-unit-test"
+
+        var initialReasoning = ModelReasoningConfiguration.automatic
+        initialReasoning.effort = .high
+        initialReasoning.summary = .automatic
+        service.modelReasoningConfigurations[model] = initialReasoning
+
+        let completed = FlightTestSignal()
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Solve this")],
+            models: [model],
+            onChunk: { _, _ in },
+            onModelComplete: { _ in },
+            onAllComplete: { completed.signal() },
+            onError: { _, error in Issue.record("Unexpected error: \(error)") }
+        )
+
+        var replacementReasoning = ModelReasoningConfiguration.automatic
+        replacementReasoning.activation = .disabled
+        service.modelReasoningConfigurations[model] = replacementReasoning
+
+        let exchange = await server.exchange(at: 0)
+        let body = try requestBody(from: exchange.request)
+        let reasoning = try #require(body["reasoning"] as? [String: Any])
+        #expect(reasoning["effort"] as? String == "high")
+        #expect(reasoning["summary"] as? String == "auto")
+
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        exchange.send(Data(#"{"output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}]}"#.utf8))
+        exchange.finish()
+        #expect(await completed.wait(timeout: .seconds(1)))
+    }
+
+    @Test("Tool continuation reuses opaque state and request settings for the same model", .timeLimit(.minutes(1)))
+    func toolContinuationReusesStateForSameModel() async throws {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: configuration))
+        let model = "gpt-5.6-tool-continuation"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelEndpointTypes[model] = .responses
+        service.modelAPIKeys[model] = "sk-unit-test"
+
+        var disabledReasoning = ModelReasoningConfiguration.automatic
+        disabledReasoning.activation = .disabled
+        service.modelReasoningConfigurations[model] = disabledReasoning
+
+        let continuedConfiguration = ResolvedReasoningConfiguration(
+            dialect: .openAIResponses,
+            effort: .high,
+            openAIMode: nil,
+            openAIContext: .currentTurn,
+            summary: .automatic,
+            anthropicDisplay: .summarized,
+            legacyBudgetTokens: 4096
+        )
+        let messages = toolContinuationMessages(
+            assistantModel: model,
+            continuationModel: model,
+            requestConfiguration: continuedConfiguration
+        )
+
+        let completed = FlightTestSignal()
+        service.sendMessage(
+            messages: messages,
+            model: model,
+            stream: false,
+            onChunk: { _ in },
+            onComplete: { completed.signal() },
+            onError: { error in Issue.record("Unexpected error: \(error)") }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        let body = try requestBody(from: exchange.request)
+        let reasoning = try #require(body["reasoning"] as? [String: Any])
+        #expect(reasoning["effort"] as? String == "high")
+        #expect(reasoning["summary"] as? String == "auto")
+        #expect(reasoning["context"] as? String == "current_turn")
+
+        let input = try #require(body["input"] as? [[String: Any]])
+        #expect(input.map { $0["type"] as? String } == [
+            "reasoning", "function_call", "function_call_output"
+        ])
+        #expect(input[0]["encrypted_content"] as? String == "opaque-token")
+
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        exchange.send(Data(#"{"output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}]}"#.utf8))
+        exchange.finish()
+        #expect(await completed.wait(timeout: .seconds(1)))
+    }
+
+    @Test("Tool continuation does not cross model boundaries", .timeLimit(.minutes(1)))
+    func toolContinuationDoesNotCrossModelBoundaries() async throws {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: configuration))
+        let oldModel = "gpt-5.6-old"
+        let newModel = "gpt-5.6-new"
+        service.customModels = [newModel]
+        service.selectedModel = newModel
+        service.modelProviders[newModel] = .openai
+        service.modelEndpointTypes[newModel] = .responses
+        service.modelAPIKeys[newModel] = "sk-unit-test"
+
+        var disabledReasoning = ModelReasoningConfiguration.automatic
+        disabledReasoning.activation = .disabled
+        service.modelReasoningConfigurations[newModel] = disabledReasoning
+
+        let oldConfiguration = ResolvedReasoningConfiguration(
+            dialect: .openAIResponses,
+            effort: .high,
+            openAIMode: nil,
+            openAIContext: .currentTurn,
+            summary: .automatic,
+            anthropicDisplay: .summarized,
+            legacyBudgetTokens: 4096
+        )
+        let messages = toolContinuationMessages(
+            assistantModel: oldModel,
+            continuationModel: oldModel,
+            requestConfiguration: oldConfiguration
+        )
+
+        let completed = FlightTestSignal()
+        service.sendMessage(
+            messages: messages,
+            model: newModel,
+            stream: false,
+            onChunk: { _ in },
+            onComplete: { completed.signal() },
+            onError: { error in Issue.record("Unexpected error: \(error)") }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        let body = try requestBody(from: exchange.request)
+        #expect(body["reasoning"] == nil)
+
+        let input = try #require(body["input"] as? [[String: Any]])
+        #expect(input.map { $0["type"] as? String } == ["function_call", "function_call_output"])
+        #expect(!input.contains { $0["encrypted_content"] != nil })
+
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        exchange.send(Data(#"{"output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}]}"#.utf8))
+        exchange.finish()
+        #expect(await completed.wait(timeout: .seconds(1)))
+    }
+
+    @Test("Tool continuation preserves a captured provider-default request", .timeLimit(.minutes(1)))
+    func toolContinuationPreservesProviderDefault() async throws {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: configuration))
+        let model = "provider-default-tool-continuation"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelEndpointTypes[model] = .responses
+        service.modelAPIKeys[model] = "sk-unit-test"
+
+        var newlyEnabledReasoning = ModelReasoningConfiguration.automatic
+        newlyEnabledReasoning.activation = .enabled
+        newlyEnabledReasoning.effort = .high
+        newlyEnabledReasoning.summary = .automatic
+        service.modelReasoningConfigurations[model] = newlyEnabledReasoning
+
+        let messages = toolContinuationMessages(
+            assistantModel: model,
+            continuationModel: model,
+            requestConfiguration: nil
+        )
+
+        let completed = FlightTestSignal()
+        service.sendMessage(
+            messages: messages,
+            model: model,
+            stream: false,
+            onChunk: { _ in },
+            onComplete: { completed.signal() },
+            onError: { error in Issue.record("Unexpected error: \(error)") }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        let body = try requestBody(from: exchange.request)
+        #expect(body["reasoning"] == nil)
+
+        let input = try #require(body["input"] as? [[String: Any]])
+        #expect(input.map { $0["type"] as? String } == [
+            "reasoning", "function_call", "function_call_output"
+        ])
+        #expect(input[0]["encrypted_content"] as? String == "opaque-token")
+
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        exchange.send(Data(#"{"output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}]}"#.utf8))
+        exchange.finish()
+        #expect(await completed.wait(timeout: .seconds(1)))
+    }
+
+    @Test("Chat Completions tool continuations freeze the originating reasoning settings", .timeLimit(.minutes(1)))
+    func chatCompletionsToolContinuationFreezesReasoningSettings() async throws {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: configuration))
+        let model = "custom-chat-tool-reasoning"
+        configureOpenAIChatService(service, model: model)
+
+        var initialReasoning = ModelReasoningConfiguration.automatic
+        initialReasoning.activation = .enabled
+        initialReasoning.effort = .high
+        service.modelReasoningConfigurations[model] = initialReasoning
+
+        let messages = try await registerOpenAIChatToolRequest(
+            service: service,
+            server: server,
+            model: model,
+            toolCallID: "chat-freeze-call"
+        )
+
+        service.modelReasoningConfigurations[model] = ModelReasoningConfiguration(
+            activation: .disabled
+        )
+
+        let completed = FlightTestSignal()
+        service.sendMessage(
+            messages: messages,
+            model: model,
+            stream: false,
+            onChunk: { _ in },
+            onComplete: { completed.signal() },
+            onError: { error in Issue.record("Unexpected error: \(error)") }
+        )
+
+        let continuation = await server.exchange(at: 1)
+        let body = try requestBody(from: continuation.request)
+        #expect(body["reasoning_effort"] as? String == "high")
+        continuation.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        continuation.send(Data(#"{"choices":[{"message":{"content":"done"}}]}"#.utf8))
+        continuation.finish()
+        #expect(await completed.wait(timeout: .seconds(1)))
+    }
+
+    @Test("Anthropic tool-only continuations freeze settings without thinking blocks", .timeLimit(.minutes(1)))
+    func anthropicToolOnlyContinuationFreezesReasoningSettings() async throws {
+        let factory = ReasoningTestAnthropicProviderFactory()
+        let service = AIService(anthropicProviderFactory: { _ in factory.makeProvider() })
+        let model = "claude-tool-only-reasoning"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .anthropic
+        service.modelAPIKeys[model] = "sk-ant-unit-test"
+
+        var initialReasoning = ModelReasoningConfiguration.automatic
+        initialReasoning.activation = .enabled
+        initialReasoning.effort = .high
+        service.modelReasoningConfigurations[model] = initialReasoning
+
+        let toolRequested = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Use a tool")],
+            model: model,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { error in Issue.record("Unexpected error: \(error)") },
+            onToolCallRequested: { _, _, _ in toolRequested.signal() }
+        )
+        let firstProvider = try #require(factory.providers.first)
+        firstProvider.emitToolRequest(id: "anthropic-tool-only-call", name: "web_search")
+        #expect(await toolRequested.wait(timeout: .seconds(1)))
+
+        service.modelReasoningConfigurations[model] = ModelReasoningConfiguration(
+            activation: .disabled
+        )
+        let completed = FlightTestSignal()
+        service.sendMessage(
+            messages: toolResultMessages(model: model, toolCallID: "anthropic-tool-only-call"),
+            model: model,
+            onChunk: { _ in },
+            onComplete: { completed.signal() },
+            onError: { error in Issue.record("Unexpected error: \(error)") }
+        )
+
+        let continuationProvider = try #require(factory.providers.last)
+        guard case let .adaptive(effort, _) = continuationProvider.config?.anthropicReasoning else {
+            Issue.record("Expected the originating adaptive reasoning configuration")
+            return
+        }
+        #expect(effort == .high)
+        continuationProvider.complete()
+        #expect(await completed.wait(timeout: .seconds(1)))
+    }
+
+    @Test("Tool continuations reject provider and endpoint changes", .timeLimit(.minutes(1)))
+    func toolContinuationsRejectProviderAndEndpointChanges() async throws {
+        for mutation in ToolConfigurationMutation.allCases {
+            let server = FlightTestURLProtocolServer()
+            FlightTestURLProtocol.install(server: server)
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.protocolClasses = [FlightTestURLProtocol.self]
+            let service = AIService(urlSession: URLSession(configuration: configuration))
+            let model = "tool-drift-\(mutation.rawValue)"
+            configureOpenAIChatService(service, model: model)
+
+            var initialReasoning = ModelReasoningConfiguration.automatic
+            initialReasoning.activation = .enabled
+            initialReasoning.effort = .high
+            service.modelReasoningConfigurations[model] = initialReasoning
+            let messages = try await registerOpenAIChatToolRequest(
+                service: service,
+                server: server,
+                model: model,
+                toolCallID: "drift-\(mutation.rawValue)"
+            )
+
+            switch mutation {
+            case .provider:
+                service.modelProviders[model] = .anthropic
+            case .endpoint:
+                service.modelEndpointTypes[model] = .responses
+            }
+
+            let errorBox = FlightTestBox<String?>(nil)
+            let failed = FlightTestSignal()
+            service.sendMessage(
+                messages: messages,
+                model: model,
+                stream: false,
+                onChunk: { _ in },
+                onComplete: { Issue.record("Drifted continuation must not complete") },
+                onError: {
+                    errorBox.value = $0.localizedDescription
+                    failed.signal()
+                }
+            )
+
+            #expect(await failed.wait(timeout: .seconds(1)))
+            #expect(errorBox.value?.contains("provider or endpoint type changed") == true)
+            #expect(await !(server.waitForRequestCount(2, timeout: .milliseconds(50))))
+        }
+    }
+
+    private enum ToolConfigurationMutation: String, CaseIterable {
+        case provider
+        case endpoint
+    }
+
+    private func configureOpenAIChatService(_ service: AIService, model: String) {
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelEndpointTypes[model] = .chatCompletions
+        service.modelAPIKeys[model] = "sk-unit-test"
+    }
+
+    private func registerOpenAIChatToolRequest(
+        service: AIService,
+        server: FlightTestURLProtocolServer,
+        model: String,
+        toolCallID: String
+    ) async throws -> [Message] {
+        let toolRequested = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Use a tool")],
+            model: model,
+            onChunk: { _ in },
+            onComplete: {},
+            onError: { error in Issue.record("Unexpected error: \(error)") },
+            onToolCallRequested: { id, _, _ in
+                #expect(id == toolCallID)
+                toolRequested.signal()
+            }
+        )
+
+        let exchange = await server.exchange(at: 0)
+        let body = try requestBody(from: exchange.request)
+        #expect(body["reasoning_effort"] as? String == "high")
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream"])
+        exchange.send(Data(
+            #"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"\#(toolCallID)","function":{"name":"web_search","arguments":"{}"}}]}}]}"#.utf8
+        ))
+        exchange.send(Data("\n".utf8))
+        exchange.send(Data(#"data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#.utf8))
+        exchange.send(Data("\n".utf8))
+        #expect(await toolRequested.wait(timeout: .seconds(1)))
+        exchange.send(Data("data: [DONE]\n".utf8))
+        exchange.finish()
+        return toolResultMessages(model: model, toolCallID: toolCallID)
+    }
+
+    private func toolResultMessages(model: String, toolCallID: String) -> [Message] {
+        let toolCall = MCPToolCall(
+            id: toolCallID,
+            toolName: "web_search",
+            arguments: [:]
+        )
+        var assistant = Message(role: .assistant, content: "", model: model)
+        assistant.toolCalls = [toolCall]
+        var result = Message(role: .tool, content: "Sunny")
+        result.toolCalls = [
+            MCPToolCall(
+                id: toolCallID,
+                toolName: toolCall.toolName,
+                arguments: toolCall.arguments,
+                result: "Sunny"
+            )
+        ]
+        return [assistant, result]
+    }
+
+    private func requestBody(from request: URLRequest) throws -> [String: Any] {
+        var data = request.httpBody
+        if data == nil, let stream = request.httpBodyStream {
+            stream.open()
+            defer { stream.close() }
+
+            var streamedData = Data()
+            let bufferSize = 4096
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+            defer { buffer.deallocate() }
+
+            while stream.hasBytesAvailable {
+                let count = stream.read(buffer, maxLength: bufferSize)
+                guard count > 0 else { break }
+                streamedData.append(buffer, count: count)
+            }
+            data = streamedData
+        }
+
+        let bodyData = try #require(data)
+        return try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+    }
+
+    private func toolContinuationMessages(
+        assistantModel: String,
+        continuationModel: String,
+        requestConfiguration: ResolvedReasoningConfiguration?
+    ) -> [Message] {
+        let toolCall = MCPToolCall(
+            id: "call-1",
+            toolName: "web_search",
+            arguments: ["query": AnyCodable("weather")]
+        )
+        var assistant = Message(role: .assistant, content: "", model: assistantModel)
+        assistant.toolCalls = [toolCall]
+        assistant.reasoningContinuation = ReasoningContinuationState(
+            format: .openAIResponses,
+            items: [
+                AnyCodable([
+                    "type": "reasoning",
+                    "id": "reasoning-1",
+                    "encrypted_content": "opaque-token"
+                ]),
+                AnyCodable([
+                    "type": "function_call",
+                    "id": "function-call-1",
+                    "call_id": toolCall.id,
+                    "name": toolCall.toolName,
+                    "arguments": "{\"query\":\"weather\"}"
+                ])
+            ]
+        ).attaching(
+            model: continuationModel,
+            requestConfiguration: requestConfiguration
+        )
+
+        var result = Message(role: .tool, content: "Sunny")
+        result.toolCalls = [
+            MCPToolCall(
+                id: toolCall.id,
+                toolName: toolCall.toolName,
+                arguments: toolCall.arguments,
+                result: "Sunny"
+            )
+        ]
+        return [assistant, result]
+    }
+}
+
+@MainActor
+private final class ReasoningTestAnthropicProvider: AIProviderProtocol, @unchecked Sendable {
+    let providerType: AIProvider = .anthropic
+    let requiresAPIKey = true
+    private(set) var config: AIProviderRequestConfig?
+    private var callbacks: AIProviderStreamCallbacks?
+
+    func sendMessage(
+        messages _: [Message],
+        config: AIProviderRequestConfig,
+        stream _: Bool,
+        tools _: [[String: Any]]?,
+        callbacks: AIProviderStreamCallbacks
+    ) {
+        self.config = config
+        self.callbacks = callbacks
+    }
+
+    func cancelRequest() {}
+
+    func emitToolRequest(id: String, name: String) {
+        callbacks?.onToolCallRequested?(id, name, [:])
+    }
+
+    func complete() {
+        callbacks?.onComplete()
+    }
+}
+
+@MainActor
+private final class ReasoningTestAnthropicProviderFactory {
+    private(set) var providers: [ReasoningTestAnthropicProvider] = []
+
+    func makeProvider() -> ReasoningTestAnthropicProvider {
+        let provider = ReasoningTestAnthropicProvider()
+        providers.append(provider)
+        return provider
+    }
+}

--- a/Tests/AynaTests/AIServiceReasoningTests.swift
+++ b/Tests/AynaTests/AIServiceReasoningTests.swift
@@ -32,6 +32,51 @@ extension AIServiceTests {
         #expect(service.modelReasoningConfigurations[invalidModel] == nil)
     }
 
+    @Test("Single-model request prefers an explicit conversation reasoning configuration", .timeLimit(.minutes(1)))
+    func singleModelRequestPrefersExplicitConversationReasoning() async throws {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: configuration))
+        let model = "gpt-5.6-sol"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelEndpointTypes[model] = .responses
+        service.modelAPIKeys[model] = "sk-unit-test"
+        service.modelReasoningConfigurations[model] = ModelReasoningConfiguration(
+            activation: .disabled
+        )
+        let conversationConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .high,
+            summary: .automatic
+        )
+
+        let completed = FlightTestSignal()
+        service.sendMessage(
+            messages: [Message(role: .user, content: "Solve this")],
+            model: model,
+            stream: false,
+            onChunk: { _ in },
+            onComplete: { completed.signal() },
+            onError: { error in Issue.record("Unexpected error: \(error)") },
+            reasoningConfiguration: conversationConfiguration
+        )
+
+        let exchange = await server.exchange(at: 0)
+        let body = try requestBody(from: exchange.request)
+        let reasoning = try #require(body["reasoning"] as? [String: Any])
+        #expect(reasoning["effort"] as? String == "high")
+        #expect(reasoning["summary"] as? String == "auto")
+
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        exchange.send(Data(#"{"output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}]}"#.utf8))
+        exchange.finish()
+        #expect(await completed.wait(timeout: .seconds(1)))
+    }
+
     @Test("Multi-model requests freeze reasoning settings at dispatch", .timeLimit(.minutes(1)))
     func multiModelRequestsFreezeReasoningSettingsAtDispatch() async throws {
         let server = FlightTestURLProtocolServer()
@@ -69,6 +114,56 @@ extension AIServiceTests {
         let body = try requestBody(from: exchange.request)
         let reasoning = try #require(body["reasoning"] as? [String: Any])
         #expect(reasoning["effort"] as? String == "high")
+        #expect(reasoning["summary"] as? String == "auto")
+
+        exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
+        exchange.send(Data(#"{"output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}]}"#.utf8))
+        exchange.finish()
+        #expect(await completed.wait(timeout: .seconds(1)))
+    }
+
+    @Test("Multi-model requests freeze an explicit conversation override", .timeLimit(.minutes(1)))
+    func multiModelRequestsFreezeExplicitConversationOverride() async throws {
+        let server = FlightTestURLProtocolServer()
+        FlightTestURLProtocol.install(server: server)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FlightTestURLProtocol.self]
+        let service = AIService(urlSession: URLSession(configuration: configuration))
+        let model = "gpt-5.6-sol"
+        service.customModels = [model]
+        service.selectedModel = model
+        service.modelProviders[model] = .openai
+        service.modelEndpointTypes[model] = .responses
+        service.modelAPIKeys[model] = "sk-unit-test"
+        service.modelReasoningConfigurations[model] = ModelReasoningConfiguration(
+            activation: .disabled
+        )
+        let conversationConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .medium,
+            summary: .automatic
+        )
+
+        let completed = FlightTestSignal()
+        service.sendToMultipleModels(
+            messages: [Message(role: .user, content: "Compare this")],
+            models: [model],
+            onChunk: { _, _ in },
+            onModelComplete: { _ in },
+            onAllComplete: { completed.signal() },
+            onError: { _, error in Issue.record("Unexpected error: \(error)") },
+            reasoningConfiguration: conversationConfiguration
+        )
+
+        service.modelReasoningConfigurations[model] = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .max
+        )
+
+        let exchange = await server.exchange(at: 0)
+        let body = try requestBody(from: exchange.request)
+        let reasoning = try #require(body["reasoning"] as? [String: Any])
+        #expect(reasoning["effort"] as? String == "medium")
         #expect(reasoning["summary"] as? String == "auto")
 
         exchange.sendResponse(statusCode: 200, headers: ["Content-Type": "application/json"])
@@ -249,8 +344,8 @@ extension AIServiceTests {
         #expect(await completed.wait(timeout: .seconds(1)))
     }
 
-    @Test("Chat Completions tool continuations freeze the originating reasoning settings", .timeLimit(.minutes(1)))
-    func chatCompletionsToolContinuationFreezesReasoningSettings() async throws {
+    @Test("Chat Completions tool continuations freeze explicit conversation reasoning", .timeLimit(.minutes(1)))
+    func chatCompletionsToolContinuationFreezesExplicitConversationReasoning() async throws {
         let server = FlightTestURLProtocolServer()
         FlightTestURLProtocol.install(server: server)
         let configuration = URLSessionConfiguration.ephemeral
@@ -262,16 +357,19 @@ extension AIServiceTests {
         var initialReasoning = ModelReasoningConfiguration.automatic
         initialReasoning.activation = .enabled
         initialReasoning.effort = .high
-        service.modelReasoningConfigurations[model] = initialReasoning
+        service.modelReasoningConfigurations[model] = ModelReasoningConfiguration(
+            activation: .disabled
+        )
 
         let messages = try await registerOpenAIChatToolRequest(
             service: service,
             server: server,
             model: model,
-            toolCallID: "chat-freeze-call"
+            toolCallID: "chat-freeze-call",
+            reasoningConfiguration: initialReasoning
         )
 
-        service.modelReasoningConfigurations[model] = ModelReasoningConfiguration(
+        let changedConversationConfiguration = ModelReasoningConfiguration(
             activation: .disabled
         )
 
@@ -282,7 +380,8 @@ extension AIServiceTests {
             stream: false,
             onChunk: { _ in },
             onComplete: { completed.signal() },
-            onError: { error in Issue.record("Unexpected error: \(error)") }
+            onError: { error in Issue.record("Unexpected error: \(error)") },
+            reasoningConfiguration: changedConversationConfiguration
         )
 
         let continuation = await server.exchange(at: 1)
@@ -410,7 +509,8 @@ extension AIServiceTests {
         service: AIService,
         server: FlightTestURLProtocolServer,
         model: String,
-        toolCallID: String
+        toolCallID: String,
+        reasoningConfiguration: ModelReasoningConfiguration? = nil
     ) async throws -> [Message] {
         let toolRequested = FlightTestSignal()
         service.sendMessage(
@@ -422,7 +522,8 @@ extension AIServiceTests {
             onToolCallRequested: { id, _, _ in
                 #expect(id == toolCallID)
                 toolRequested.signal()
-            }
+            },
+            reasoningConfiguration: reasoningConfiguration
         )
 
         let exchange = await server.exchange(at: 0)

--- a/Tests/AynaTests/AnthropicProviderTests.swift
+++ b/Tests/AynaTests/AnthropicProviderTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @Suite("AnthropicProvider Tests", .serialized)
 @MainActor
+// swiftlint:disable:next type_body_length
 struct AnthropicProviderTests {
     init() {
         AnthropicMockURLProtocol.reset()
@@ -29,14 +30,16 @@ struct AnthropicProviderTests {
         apiKey: String = "test-api-key",
         customEndpoint: String? = nil,
         maxTokens: Int? = nil,
-        thinkingBudget: Int? = nil
+        thinkingBudget: Int? = nil,
+        anthropicReasoning: AnthropicReasoningConfiguration? = nil
     ) -> AIProviderRequestConfig {
         AIProviderRequestConfig(
             model: model,
             apiKey: apiKey,
             customEndpoint: customEndpoint,
             maxTokens: maxTokens,
-            thinkingBudget: thinkingBudget
+            thinkingBudget: thinkingBudget,
+            anthropicReasoning: anthropicReasoning
         )
     }
 
@@ -894,9 +897,9 @@ struct AnthropicProviderTests {
     }
 
     @Test(.timeLimit(.minutes(1)))
-    func `thinking budget adds beta header for Claude 4 models`() async {
+    func `legacy thinking budget does not infer beta header from model name`() async throws {
         let provider = makeProvider()
-        let config = makeConfig(model: "claude-4-opus-20250514", thinkingBudget: 2048)
+        let config = makeConfig(model: "claude-4-opus-20250514", thinkingBudget: 4096)
         let messages = [Message(role: .user, content: "Hello")]
 
         let responseBody = """
@@ -904,9 +907,11 @@ struct AnthropicProviderTests {
         """
 
         var capturedRequest: URLRequest?
+        var capturedBodyData: Data?
 
         AnthropicMockURLProtocol.requestHandler = { request in
             capturedRequest = request
+            capturedBodyData = requestBodyData(request)
             let response = HTTPURLResponse(
                 url: URL(string: "https://api.anthropic.com/v1/messages")!,
                 statusCode: 200,
@@ -937,7 +942,118 @@ struct AnthropicProviderTests {
         let request = capturedRequest
         #expect(request != nil)
         let betaHeader = request?.value(forHTTPHeaderField: "anthropic-beta")
-        #expect(betaHeader?.contains("interleaved-thinking") == true)
+        #expect(betaHeader == nil)
+        let bodyData = try #require(capturedBodyData)
+        let body = try #require(
+            try JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+        )
+        let thinking = try #require(body["thinking"] as? [String: Any])
+        #expect(thinking["budget_tokens"] as? Int == 4096)
+        #expect((body["max_tokens"] as? Int ?? 0) > 4096)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `explicit interleaved reasoning adds beta header for custom model alias`() async {
+        let provider = makeProvider()
+        let config = makeConfig(
+            model: "custom-deployment-alias",
+            anthropicReasoning: .enabled(budgetTokens: 2048, interleaved: true)
+        )
+        let messages = [Message(role: .user, content: "Hello")]
+
+        let responseBody = """
+        {"id":"msg_123","type":"message","role":"assistant","content":[{"type":"text","text":"Hi"}],"stop_reason":"end_turn"}
+        """
+        var capturedRequest: URLRequest?
+        AnthropicMockURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(
+                url: URL(string: "https://api.anthropic.com/v1/messages")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(responseBody.utf8))
+        }
+
+        let callbackWaiter = TestCallbackWaiter()
+        await confirmation("Response completes") { completed in
+            provider.sendMessage(
+                messages: messages,
+                config: config,
+                stream: false,
+                tools: nil,
+                callbacks: AIProviderStreamCallbacks(
+                    onChunk: { _ in },
+                    onComplete: { completed(); callbackWaiter.signal() },
+                    onError: { error in Issue.record("Unexpected error: \(error)") }
+                )
+            )
+            await callbackWaiter.wait()
+        }
+
+        #expect(
+            capturedRequest?.value(forHTTPHeaderField: "anthropic-beta") ==
+                AnthropicRequestConfig.interleavedThinkingBeta
+        )
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `non-streaming response emits exact continuation before tool callback`() async throws {
+        let provider = makeProvider()
+        let config = makeConfig(anthropicReasoning: .adaptive())
+        let callbackOrder = CallbackOrderCollector()
+        let continuationCollector = ContinuationCollector()
+        let responseBody = """
+        {
+          "id":"msg_123",
+          "type":"message",
+          "role":"assistant",
+          "content":[
+            {"type":"thinking","thinking":"Use lookup","signature":"signed-value"},
+            {"type":"redacted_thinking","data":"opaque-redaction"},
+            {"type":"tool_use","id":"toolu_123","name":"lookup","input":{"query":"weather"}}
+          ],
+          "stop_reason":"tool_use"
+        }
+        """
+        AnthropicMockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(responseBody.utf8))
+        }
+
+        let callbackWaiter = TestCallbackWaiter()
+        await confirmation("Response completes") { completed in
+            provider.sendMessage(
+                messages: [Message(role: .user, content: "Use the tool")],
+                config: config,
+                stream: false,
+                tools: nil,
+                callbacks: AIProviderStreamCallbacks(
+                    onChunk: { _ in },
+                    onComplete: { completed(); callbackWaiter.signal() },
+                    onError: { error in Issue.record("Unexpected error: \(error)") },
+                    onToolCallRequested: { _, _, _ in callbackOrder.append("tool") },
+                    onReasoningContinuation: { continuation in
+                        continuationCollector.store(continuation)
+                        callbackOrder.append("continuation")
+                    }
+                )
+            )
+            await callbackWaiter.wait()
+        }
+
+        #expect(callbackOrder.events == ["continuation", "tool"])
+        let continuation = try #require(continuationCollector.value)
+        let blocks = continuation.items.compactMap { $0.value as? [String: Any] }
+        #expect(blocks.count == 3)
+        #expect(blocks[0]["signature"] as? String == "signed-value")
+        #expect(blocks[1]["data"] as? String == "opaque-redaction")
     }
 }
 
@@ -987,6 +1103,28 @@ private final class AnthropicMockURLProtocol: URLProtocol, @unchecked Sendable {
     override func stopLoading() {}
 }
 
+private func requestBodyData(_ request: URLRequest) -> Data? {
+    if let body = request.httpBody {
+        return body
+    }
+    guard let stream = request.httpBodyStream else { return nil }
+
+    stream.open()
+    defer { stream.close() }
+
+    var data = Data()
+    let bufferSize = 4096
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+
+    while stream.hasBytesAvailable {
+        let count = stream.read(buffer, maxLength: bufferSize)
+        guard count > 0 else { break }
+        data.append(buffer, count: count)
+    }
+    return data
+}
+
 private final class ChunkCollector: @unchecked Sendable {
     private var chunks: [String] = []
     private let lock = NSLock()
@@ -1018,5 +1156,22 @@ private final class CallbackOrderCollector: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return recordedEvents
+    }
+}
+
+private final class ContinuationCollector: @unchecked Sendable {
+    private var storedValue: ReasoningContinuationState?
+    private let lock = NSLock()
+
+    func store(_ value: ReasoningContinuationState) {
+        lock.lock()
+        defer { lock.unlock() }
+        storedValue = value
+    }
+
+    var value: ReasoningContinuationState? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedValue
     }
 }

--- a/Tests/AynaTests/AnthropicRequestBuilderTests.swift
+++ b/Tests/AynaTests/AnthropicRequestBuilderTests.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Testing
 
+// swiftformat:disable swiftTestingTestCaseNames
+
 @Suite("AnthropicRequestBuilder Tests")
 @MainActor
 struct AnthropicRequestBuilderTests {
@@ -59,6 +61,34 @@ struct AnthropicRequestBuilderTests {
         AnthropicRequestBuilder.configureHeaders(&request, config: config)
 
         #expect(request.value(forHTTPHeaderField: "anthropic-beta") == nil)
+    }
+
+    @Test("Interleaved thinking beta requires explicit legacy opt-in")
+    func interleavedThinkingBetaRequiresExplicitOptIn() throws {
+        var explicitRequest = try URLRequest(url: #require(URL(string: "https://api.anthropic.com/v1/messages")))
+        let explicitConfig = AnthropicRequestConfig(
+            model: "deployment-alias",
+            apiKey: "test-api-key",
+            reasoning: .enabled(budgetTokens: 2048, interleaved: true)
+        )
+
+        AnthropicRequestBuilder.configureHeaders(&explicitRequest, config: explicitConfig)
+
+        #expect(
+            explicitRequest.value(forHTTPHeaderField: "anthropic-beta") ==
+                AnthropicRequestConfig.interleavedThinkingBeta
+        )
+
+        var inferredRequest = try URLRequest(url: #require(URL(string: "https://api.anthropic.com/v1/messages")))
+        let legacyConfig = AnthropicRequestConfig(
+            model: "claude-opus-4-20250514",
+            apiKey: "test-api-key",
+            budgetTokens: 2048
+        )
+
+        AnthropicRequestBuilder.configureHeaders(&inferredRequest, config: legacyConfig)
+
+        #expect(inferredRequest.value(forHTTPHeaderField: "anthropic-beta") == nil)
     }
 
     // MARK: - System Prompt Extraction Tests
@@ -251,6 +281,207 @@ struct AnthropicRequestBuilderTests {
         )
 
         #expect(body["thinking"] == nil)
+    }
+
+    @Test("Adaptive thinking encodes effort and display")
+    func adaptiveThinkingEncodesEffortAndDisplay() throws {
+        let config = AnthropicRequestConfig(
+            model: "claude-opus-4-8",
+            apiKey: "test-key",
+            reasoning: .adaptive(effort: .xhigh, display: .summarized)
+        )
+
+        let body = try AnthropicRequestBuilder.buildMessagesBody(
+            messages: [Message(role: .user, content: "Hello!")],
+            config: config,
+            stream: false,
+            tools: nil
+        )
+
+        let thinking = body["thinking"] as? [String: Any]
+        let outputConfig = body["output_config"] as? [String: Any]
+        #expect(thinking?["type"] as? String == "adaptive")
+        #expect(thinking?["display"] as? String == "summarized")
+        #expect(thinking?["budget_tokens"] == nil)
+        #expect(outputConfig?["effort"] as? String == "xhigh")
+    }
+
+    @Test("Explicitly disabled thinking encodes a disabled directive")
+    func explicitlyDisabledThinkingEncodesDisabledDirective() throws {
+        let config = AnthropicRequestConfig(
+            model: "claude-sonnet-5",
+            apiKey: "test-key",
+            reasoning: .disabled()
+        )
+
+        let body = try AnthropicRequestBuilder.buildMessagesBody(
+            messages: [Message(role: .user, content: "Hello!")],
+            config: config,
+            stream: false,
+            tools: nil
+        )
+
+        let thinking = body["thinking"] as? [String: Any]
+        #expect(thinking?["type"] as? String == "disabled")
+        #expect(thinking?["display"] == nil)
+        #expect(body["output_config"] == nil)
+    }
+
+    @Test("Disabled thinking preserves a safe effort ceiling")
+    func disabledThinkingEncodesEffort() throws {
+        let config = AnthropicRequestConfig(
+            model: "claude-opus-5",
+            apiKey: "test-key",
+            reasoning: .disabled(effort: .high)
+        )
+
+        let body = try AnthropicRequestBuilder.buildMessagesBody(
+            messages: [Message(role: .user, content: "Hello!")],
+            config: config,
+            stream: false,
+            tools: nil
+        )
+
+        let thinking = body["thinking"] as? [String: Any]
+        let outputConfig = body["output_config"] as? [String: Any]
+        #expect(thinking?["type"] as? String == "disabled")
+        #expect(outputConfig?["effort"] as? String == "high")
+    }
+
+    @Test("Typed legacy thinking encodes budget effort and display")
+    func typedLegacyThinkingEncodesBudgetEffortAndDisplay() throws {
+        let config = AnthropicRequestConfig(
+            model: "custom-model-alias",
+            apiKey: "test-key",
+            reasoning: .enabled(
+                budgetTokens: 4096,
+                effort: .medium,
+                display: .omitted
+            )
+        )
+
+        let body = try AnthropicRequestBuilder.buildMessagesBody(
+            messages: [Message(role: .user, content: "Hello!")],
+            config: config,
+            stream: false,
+            tools: nil
+        )
+
+        let thinking = body["thinking"] as? [String: Any]
+        let outputConfig = body["output_config"] as? [String: Any]
+        #expect(thinking?["type"] as? String == "enabled")
+        #expect(thinking?["budget_tokens"] as? Int == 4096)
+        #expect(thinking?["display"] as? String == "omitted")
+        #expect(outputConfig?["effort"] as? String == "medium")
+        #expect((body["max_tokens"] as? Int ?? 0) > 4096)
+    }
+
+    @Test("Anthropic continuation blocks replay unchanged")
+    func anthropicContinuationBlocksReplayUnchanged() throws {
+        let toolCall = MCPToolCall(
+            id: "toolu_123",
+            toolName: "lookup",
+            arguments: ["query": AnyCodable("weather")]
+        )
+        let originalBlocks: [[String: Any]] = [
+            [
+                "type": "thinking",
+                "thinking": "Check the tool.",
+                "signature": "signed-thinking"
+            ],
+            [
+                "type": "redacted_thinking",
+                "data": "encrypted-redaction"
+            ],
+            [
+                "type": "text",
+                "text": "I will look that up."
+            ],
+            [
+                "type": "tool_use",
+                "id": toolCall.id,
+                "name": toolCall.toolName,
+                "input": ["query": "weather"]
+            ]
+        ]
+        let continuation = ReasoningContinuationState(
+            format: .anthropicMessages,
+            items: originalBlocks.map(AnyCodable.init)
+        )
+        let assistant = Message(
+            role: .assistant,
+            content: "Reconstructed text must not replace the wire blocks.",
+            toolCalls: [toolCall],
+            reasoningContinuation: continuation
+        )
+        let toolResult = Message(
+            role: .tool,
+            content: "sunny",
+            toolCalls: [MCPToolCall(
+                id: toolCall.id,
+                toolName: toolCall.toolName,
+                arguments: [:],
+                result: "sunny"
+            )]
+        )
+
+        let converted = try AnthropicRequestBuilder.extractSystemAndConvertMessages([assistant, toolResult]).messages
+        let replayedBlocks = try #require(converted.first?["content"] as? [[String: Any]])
+        let replayedData = try JSONSerialization.data(withJSONObject: replayedBlocks, options: [.sortedKeys])
+        let originalData = try JSONSerialization.data(withJSONObject: originalBlocks, options: [.sortedKeys])
+
+        #expect(replayedData == originalData)
+        #expect(converted.count == 2)
+    }
+
+    @Test("Opaque thinking state is not replayed across Anthropic model changes")
+    func reasoningContinuationDoesNotCrossModelBoundaries() throws {
+        let toolCall = MCPToolCall(
+            id: "call-1",
+            toolName: "web_search",
+            arguments: ["query": AnyCodable("weather")]
+        )
+        var assistant = Message(
+            role: .assistant,
+            content: "I will look that up.",
+            toolCalls: [toolCall],
+            model: "claude-opus-4-8"
+        )
+        assistant.reasoningContinuation = ReasoningContinuationState(
+            format: .anthropicMessages,
+            items: [AnyCodable([
+                "type": "thinking",
+                "thinking": "Private summary",
+                "signature": "signed-thinking"
+            ])],
+            model: "claude-opus-4-8"
+        )
+        let toolResult = Message(
+            role: .tool,
+            content: "sunny",
+            toolCalls: [MCPToolCall(
+                id: toolCall.id,
+                toolName: toolCall.toolName,
+                arguments: [:],
+                result: "sunny"
+            )]
+        )
+        let config = AnthropicRequestConfig(
+            model: "claude-sonnet-5",
+            apiKey: "test-key"
+        )
+
+        let body = try AnthropicRequestBuilder.buildMessagesBody(
+            messages: [assistant, toolResult],
+            config: config,
+            stream: false,
+            tools: nil
+        )
+        let messages = try #require(body["messages"] as? [[String: Any]])
+        let blocks = try #require(messages.first?["content"] as? [[String: Any]])
+
+        #expect(!blocks.contains { $0["signature"] != nil })
+        #expect(blocks.contains { $0["type"] as? String == "tool_use" })
     }
 
     // MARK: - Tool Conversion Tests

--- a/Tests/AynaTests/AnthropicStreamParserTests.swift
+++ b/Tests/AynaTests/AnthropicStreamParserTests.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Testing
 
+// swiftformat:disable swiftTestingTestCaseNames
+
 @Suite("AnthropicStreamParser Tests")
 struct AnthropicStreamParserTests {
     // MARK: - Basic Parsing Tests
@@ -148,6 +150,67 @@ struct AnthropicStreamParserTests {
         """)
 
         #expect(result.reasoning == nil)
+    }
+
+    @Test("Thinking signatures and redacted blocks are preserved for tool replay")
+    func thinkingStatePreservedForToolReplay() throws {
+        let parser = AnthropicStreamParser()
+
+        _ = parser.processLine("""
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+        """)
+        _ = parser.processLine("""
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"First "}}
+        """)
+        _ = parser.processLine("""
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"thought"}}
+        """)
+        _ = parser.processLine("""
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"signed-value"}}
+        """)
+        _ = parser.processLine("""
+        data: {"type":"content_block_stop","index":0}
+        """)
+
+        _ = parser.processLine("""
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"redacted_thinking","data":"opaque-redaction"}}
+        """)
+        _ = parser.processLine("""
+        data: {"type":"content_block_stop","index":1}
+        """)
+
+        _ = parser.processLine("""
+        data: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}
+        """)
+        _ = parser.processLine("""
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Calling tool"}}
+        """)
+        _ = parser.processLine("""
+        data: {"type":"content_block_stop","index":2}
+        """)
+
+        _ = parser.processLine("""
+        data: {"type":"content_block_start","index":3,"content_block":{"type":"tool_use","id":"toolu_123","name":"lookup","input":{}}}
+        """)
+        _ = parser.processLine("""
+        data: {"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":"{\\"query\\":\\"weather\\"}"}}
+        """)
+        let result = parser.processLine("""
+        data: {"type":"content_block_stop","index":3}
+        """)
+
+        let continuation = try #require(result.reasoningContinuation)
+        #expect(continuation.format == .anthropicMessages)
+        let blocks = continuation.items.compactMap { $0.value as? [String: Any] }
+        #expect(blocks.count == 4)
+        #expect(blocks[0]["type"] as? String == "thinking")
+        #expect(blocks[0]["thinking"] as? String == "First thought")
+        #expect(blocks[0]["signature"] as? String == "signed-value")
+        #expect(blocks[1]["type"] as? String == "redacted_thinking")
+        #expect(blocks[1]["data"] as? String == "opaque-redaction")
+        #expect(blocks[2]["text"] as? String == "Calling tool")
+        let toolInput = try #require(blocks[3]["input"] as? [String: Any])
+        #expect(toolInput["query"] as? String == "weather")
     }
 
     // MARK: - Tool Use Tests

--- a/Tests/AynaTests/ConversationCodableTests.swift
+++ b/Tests/AynaTests/ConversationCodableTests.swift
@@ -14,6 +14,7 @@ struct ConversationCodableTests {
 
         #expect(conversation.systemPromptMode == .custom("Answer concisely."))
         #expect(conversation.temperature == 0.25)
+        #expect(conversation.reasoningConfiguration == .automatic)
     }
 
     @Test(
@@ -26,6 +27,7 @@ struct ConversationCodableTests {
 
         #expect(conversation.systemPromptMode == .inheritGlobal)
         #expect(conversation.temperature == 0.25)
+        #expect(conversation.reasoningConfiguration == .automatic)
     }
 
     @Test
@@ -40,6 +42,13 @@ struct ConversationCodableTests {
             model: "gpt-5",
             systemPromptMode: .disabled,
             temperature: 0.5,
+            reasoningConfiguration: ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .xhigh,
+                openAIMode: .pro,
+                openAIContext: .allTurns,
+                summary: .detailed
+            ),
             multiModelEnabled: true,
             activeModels: ["gpt-5", "claude-sonnet-4"],
             responseGroups: []
@@ -49,6 +58,55 @@ struct ConversationCodableTests {
         let decoded = try JSONDecoder().decode(Conversation.self, from: data)
 
         #expect(decoded == original)
+    }
+
+    @Test
+    func `metadata round-trip preserves conversation reasoning`() throws {
+        let configuration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .high,
+            summary: .concise
+        )
+        let conversation = Conversation(
+            title: "Reasoning metadata",
+            model: "gpt-5.6",
+            reasoningConfiguration: configuration
+        )
+        let metadata = ConversationMetadata(conversation: conversation)
+
+        let data = try JSONEncoder().encode(metadata)
+        let decoded = try JSONDecoder().decode(ConversationMetadata.self, from: data)
+
+        #expect(metadata.reasoningConfiguration == configuration)
+        #expect(decoded.reasoningConfiguration == configuration)
+    }
+
+    @Test
+    func `legacy metadata without reasoning decodes as automatic`() throws {
+        let id = try #require(UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-FFFFFFFFFFFF"))
+        let data = Data(
+            """
+            {
+                "id": "\(id.uuidString)",
+                "title": "Legacy metadata",
+                "createdAt": 1000,
+                "updatedAt": 2000,
+                "model": "gpt-4o",
+                "systemPromptMode": {"type": "inheritGlobal"},
+                "temperature": 0.7,
+                "multiModelEnabled": false,
+                "activeModels": [],
+                "messageCount": 0,
+                "responseGroupCount": 0,
+                "lastMessagePreview": "",
+                "searchableText": "Legacy metadata"
+            }
+            """.utf8
+        )
+
+        let metadata = try JSONDecoder().decode(ConversationMetadata.self, from: data)
+
+        #expect(metadata.reasoningConfiguration == .automatic)
     }
 
     @Test

--- a/Tests/AynaTests/ConversationManagerTests.swift
+++ b/Tests/AynaTests/ConversationManagerTests.swift
@@ -4,994 +4,1023 @@ import Foundation
 import Testing
 
 // swiftlint:disable identifier_name
-@Suite("ConversationManager Tests", .tags(.viewModel, .persistence))
-// swiftlint:disable:next type_body_length
-struct ConversationManagerTests {
-    private var defaults: UserDefaults
+extension AIServiceGlobalStateTests {
+    @Suite("ConversationManager Tests", .tags(.viewModel, .persistence), .serialized)
+    // swiftlint:disable:next type_body_length
+    struct ConversationManagerTests {
+        private var defaults: UserDefaults
 
-    init() {
-        guard let suite = UserDefaults(suiteName: "ConversationManagerTests") else {
-            fatalError("Failed to create UserDefaults suite for tests")
-        }
-        defaults = suite
-        defaults.removePersistentDomain(forName: "ConversationManagerTests")
-        AppPreferences.use(defaults)
-        defaults.set(false, forKey: "autoGenerateTitle")
-    }
-
-    @Test
-    @MainActor
-    func `deferred manager initialization does not start loading`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(
-            directory: directory,
-            keychain: InMemoryKeychainStorage()
-        )
-        let probe = MetadataLoadInvocationProbe()
-        let manager = ConversationManager(
-            store: store,
-            conversationMetadataLoader: {
-                await probe.record()
-                return []
-            },
-            searchIndexWarmupEnabled: false,
-            startsLoadingImmediately: false
-        )
-
-        for _ in 0 ..< 20 {
-            await Task.yield()
-        }
-
-        #expect(manager.loadingTask == nil)
-        #expect(await probe.invocationCount == 0)
-    }
-
-    @MainActor
-    private func makeManager(
-        directory: URL,
-        keychain: KeychainStoring? = nil,
-        keyIdentifier: String? = nil,
-        startsLoadingImmediately: Bool = false
-    ) -> ConversationManager {
-        let keychainToUse = keychain ?? InMemoryKeychainStorage()
-        let keyId = keyIdentifier ?? UUID().uuidString
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychainToUse)
-        return ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            startsLoadingImmediately: startsLoadingImmediately
-        )
-    }
-
-    @MainActor
-    private func waitUntil(
-        timeout: Duration = .seconds(1),
-        condition: @escaping @MainActor () -> Bool
-    ) async -> Bool {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
-        while clock.now < deadline {
-            if condition() {
-                return true
+        init() {
+            guard let suite = UserDefaults(suiteName: "ConversationManagerTests") else {
+                fatalError("Failed to create UserDefaults suite for tests")
             }
-            try? await Task.sleep(for: .milliseconds(5))
-        }
-        return condition()
-    }
-
-    @Test
-    @MainActor
-    func `create new conversation uses selected model`() throws {
-        AIService.keychain = InMemoryKeychainStorage()
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let expectedModel = "unit-test-model"
-
-        AIService.shared.selectedModel = expectedModel
-        let manager = makeManager(directory: directory)
-        manager.createNewConversation()
-
-        #expect(manager.conversations.count == 1)
-        #expect(manager.conversations.first?.model == expectedModel)
-    }
-
-    @Test
-    @MainActor
-    func `add message appends and updates timestamp`() throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-
-        let manager = makeManager(directory: directory)
-        manager.createNewConversation()
-        let conversation = try #require(manager.conversations.first)
-
-        let message = Message(role: .user, content: "Ping")
-        manager.addMessage(to: conversation, message: message)
-
-        #expect(manager.conversations.first?.messages.count == 1)
-        #expect(manager.conversations.first?.messages.first?.content == "Ping")
-    }
-
-    @Test
-    @MainActor
-    func `search finds matches in title and messages`() throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-
-        let manager = makeManager(directory: directory)
-
-        var first = TestHelpers.sampleConversation(title: "Swift Tips")
-        first.messages[0].content = "How to use SwiftUI?"
-        var second = TestHelpers.sampleConversation(title: "Random Chat")
-        second.messages[0].content = "Discussing movies"
-        manager.conversations = [first, second]
-
-        let titleResults = manager.searchConversations(query: "Swift")
-        let bodyResults = manager.searchConversations(query: "movies")
-
-        #expect(titleResults.count == 1)
-        #expect(titleResults.first?.title == "Swift Tips")
-        #expect(bodyResults.count == 1)
-        #expect(bodyResults.first?.title == "Random Chat")
-    }
-
-    @Test
-    @MainActor
-    func `save immediately persists manual changes`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-key-id"
-        let manager = makeManager(directory: directory, keychain: keychain, keyIdentifier: keyId)
-
-        // Create conversation directly without triggering debounced save
-        let conversation = Conversation(title: "Test Conversation", model: "test-model")
-        manager.conversations.insert(conversation, at: 0)
-
-        // Manually update the conversation in the array (simulating what ChatView does with chunks)
-        if let index = manager.conversations.firstIndex(where: { $0.id == conversation.id }) {
-            manager.conversations[index].messages.append(Message(role: .assistant, content: "Partial content"))
+            defaults = suite
+            defaults.removePersistentDomain(forName: "ConversationManagerTests")
+            AppPreferences.use(defaults)
+            defaults.set(false, forKey: "autoGenerateTitle")
         }
 
-        // Save immediately
-        let saveTask = try manager.saveImmediately(#require(manager.conversations.first))
+        @Test
+        @MainActor
+        func `deferred manager initialization does not start loading`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(
+                directory: directory,
+                keychain: InMemoryKeychainStorage()
+            )
+            let probe = MetadataLoadInvocationProbe()
+            let manager = ConversationManager(
+                store: store,
+                conversationMetadataLoader: {
+                    await probe.record()
+                    return []
+                },
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
 
-        // Wait for the save task to complete
-        _ = await saveTask.value
-
-        // Create a new manager to load from disk using the SAME keychain and keyIdentifier
-        let newManager = makeManager(
-            directory: directory,
-            keychain: keychain,
-            keyIdentifier: keyId,
-            startsLoadingImmediately: true
-        )
-        _ = await newManager.loadingTask?.value
-
-        #expect(newManager.conversations.count == 1)
-        #expect(newManager.conversations.first?.messages.isEmpty == true)
-
-        let hydrated = await newManager.ensureConversationLoaded(conversation.id)
-        #expect(hydrated?.messages.last?.content == "Partial content")
-        #expect(newManager.conversations.first?.messages.last?.content == "Partial content")
-    }
-
-    @Test
-    @MainActor
-    func `later save inherits an outstanding immediate save requirement`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let manager = ConversationManager(store: store, saveDebounceDuration: .seconds(10))
-        _ = await manager.loadingTask?.value
-        var conversation = TestHelpers.sampleConversation(title: "Immediate")
-        manager.conversations = [conversation]
-
-        let immediateTask = manager.saveImmediately(conversation)
-        conversation.title = "Latest snapshot"
-        conversation.updatedAt = Date().addingTimeInterval(1)
-        manager.conversations = [conversation]
-        manager.save(conversation)
-        await immediateTask.value
-
-        for _ in 0 ..< 100 {
-            if try await store.loadConversation(id: conversation.id)?.title == "Latest snapshot" {
-                break
+            for _ in 0 ..< 20 {
+                await Task.yield()
             }
-            try await Task.sleep(for: .milliseconds(10))
+
+            #expect(manager.loadingTask == nil)
+            #expect(await probe.invocationCount == 0)
         }
 
-        #expect(try await store.loadConversation(id: conversation.id)?.title == "Latest snapshot")
-        manager.clearAllConversations()
-    }
-
-    @Test
-    @MainActor
-    func `flush waits for a save registered during the coordinator flush`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let conversation = TestHelpers.sampleConversation(title: "Before Flush")
-        try await store.save(conversation)
-
-        let metadataGate = ConversationMetadataLoadGate(store: store)
-        let flushGate = PersistenceFlushGate()
-        let completion = AsyncCompletionProbe()
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            conversationMetadataLoader: {
-                try await metadataGate.load()
-            },
-            beforePersistenceFlush: {
-                await flushGate.waitBeforeFlush()
-            }
-        )
-        await metadataGate.waitUntilStarted()
-        var placeholder = conversation
-        placeholder.messages = []
-        placeholder.metadataPreview = "Preview"
-        manager.conversations = [placeholder]
-
-        let flushTask = Task { @MainActor in
-            await manager.flushPendingSaves()
-            await completion.markComplete()
-        }
-        await flushGate.waitUntilStarted()
-
-        manager.renameConversation(placeholder, newTitle: "Saved During Flush")
-        await flushGate.release()
-
-        try await Task.sleep(for: .milliseconds(50))
-        #expect(await !(completion.isComplete()))
-
-        await metadataGate.release()
-        await flushTask.value
-
-        #expect(await completion.isComplete())
-        #expect(try await store.loadConversation(id: conversation.id)?.title == "Saved During Flush")
-    }
-
-    @Test
-    @MainActor
-    func `initial load uses metadata placeholders until conversation is selected`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-metadata-placeholder-key"
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
-        let conversation = TestHelpers.sampleConversation(title: "Metadata Only")
-        try await store.save(conversation)
-
-        let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
-        _ = await manager.loadingTask?.value
-
-        #expect(manager.conversations.count == 1)
-        #expect(manager.conversations.first?.id == conversation.id)
-        #expect(manager.conversations.first?.title == "Metadata Only")
-        #expect(manager.conversations.first?.messages.isEmpty == true)
-
-        let hydrated = await manager.ensureConversationLoaded(conversation.id)
-        #expect(hydrated?.messages.count == conversation.messages.count)
-        #expect(manager.conversations.first?.messages.count == conversation.messages.count)
-    }
-
-    @Test
-    @MainActor
-    func `hydrating metadata placeholder before export includes message history`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-export-hydration-key"
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
-        let conversation = TestHelpers.sampleConversation(title: "Export Hydration")
-        try await store.save(conversation)
-
-        let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
-        _ = await manager.loadingTask?.value
-
-        let placeholder = try #require(manager.conversations.first)
-        #expect(placeholder.messages.isEmpty == true)
-        #expect(ConversationExporter.generateMarkdown(for: placeholder).contains("Hello") == false)
-
-        let hydrated = try #require(await manager.ensureConversationLoaded(conversation.id))
-        let markdown = ConversationExporter.generateMarkdown(for: hydrated)
-
-        #expect(markdown.contains("Hello"))
-        #expect(markdown.contains("Hi there"))
-    }
-
-    @Test
-    @MainActor
-    func `metadata-only search preserves matches from the middle of long history`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        var conversation = Conversation(title: "Long Search")
-        conversation.addMessage(Message(role: .user, content: String(repeating: "head ", count: 2000)))
-        conversation.addMessage(Message(role: .assistant, content: "middle-only-needle"))
-        conversation.addMessage(Message(role: .user, content: String(repeating: "tail ", count: 2000)))
-        try await store.save(conversation)
-
-        let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
-        _ = await manager.loadingTask?.value
-        #expect(manager.searchConversations(query: "middle-only-needle").isEmpty)
-
-        let results = await manager.searchConversationsAsync(
-            query: "middle-only-needle",
-            conversations: manager.conversations
-        )
-
-        #expect(results.map(\.id) == [conversation.id])
-        #expect(results.first?.messages.isEmpty == true)
-    }
-
-    @Test
-    @MainActor
-    func `selecting metadata placeholder lazy loads full conversation`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-selected-lazy-load-key"
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
-        let conversation = TestHelpers.sampleConversation(title: "Lazy Selected")
-        try await store.save(conversation)
-
-        let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
-        _ = await manager.loadingTask?.value
-
-        #expect(manager.conversations.first?.messages.isEmpty == true)
-        manager.selectedConversationId = conversation.id
-
-        for _ in 0 ..< 20 {
-            if manager.conversations.first?.messages.count == conversation.messages.count {
-                break
-            }
-            try await Task.sleep(for: .milliseconds(25))
+        @MainActor
+        private func makeManager(
+            directory: URL,
+            keychain: KeychainStoring? = nil,
+            keyIdentifier: String? = nil,
+            startsLoadingImmediately: Bool = false
+        ) -> ConversationManager {
+            let keychainToUse = keychain ?? InMemoryKeychainStorage()
+            let keyId = keyIdentifier ?? UUID().uuidString
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychainToUse)
+            return ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                startsLoadingImmediately: startsLoadingImmediately
+            )
         }
 
-        #expect(manager.conversations.first?.messages.count == conversation.messages.count)
-    }
-
-    @Test
-    @MainActor
-    func `deleting during lazy hydration cannot recreate the conversation`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        var conversation = TestHelpers.sampleConversation(title: "Delete During Hydration")
-        conversation.model = "missing-model-for-delete-race"
-        try await store.save(conversation)
-        let loadGate = ConversationStaleLoadGate(store: store)
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            conversationLoader: { conversationId in
-                try await loadGate.load(conversationId)
+        @MainActor
+        private func waitUntil(
+            timeout: Duration = .seconds(1),
+            condition: @escaping @MainActor () -> Bool
+        ) async -> Bool {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                if condition() {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(5))
             }
-        )
-        _ = await manager.loadingTask?.value
-        let placeholder = try #require(manager.conversations.first)
-
-        _ = manager.conversation(byId: conversation.id)
-        await loadGate.waitUntilStarted()
-        manager.deleteConversation(placeholder)
-
-        for _ in 0 ..< 100 where try await store.loadConversation(id: conversation.id) != nil {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(try await store.loadConversation(id: conversation.id) == nil)
-
-        await loadGate.release()
-        try await Task.sleep(for: .milliseconds(100))
-
-        #expect(try await store.loadConversation(id: conversation.id) == nil)
-        #expect(!manager.conversations.contains { $0.id == conversation.id })
-    }
-
-    @Test
-    @MainActor
-    func `sync recreation authorization reaches the newest coalesced save`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let original = TestHelpers.sampleConversation(title: "Original")
-        try await store.save(original)
-
-        let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
-        _ = await manager.loadingTask?.value
-        let placeholder = try #require(manager.conversations.first)
-        manager.deleteConversation(placeholder)
-
-        var recreation = original
-        recreation.title = "Recreated from sync"
-        recreation.messages = []
-        manager.insertConversationFromSync(recreation, allowsRecreation: true)
-        let inserted = try #require(manager.conversation(byId: original.id))
-        manager.addMessage(to: inserted, message: Message(role: .user, content: "Synced message"))
-        await manager.flushPendingSaves()
-
-        let persisted = try #require(try await store.loadConversation(id: original.id))
-        #expect(persisted.title == "Recreated from sync")
-        #expect(persisted.messages.map(\.content) == ["Synced message"])
-    }
-
-    @Test
-    @MainActor
-    func `stale metadata reload preserves an authorized recreation`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let original = TestHelpers.sampleConversation(title: "Original Before Reload")
-        try await store.save(original)
-        let metadataGate = ConversationReloadMetadataGate(store: store)
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            conversationMetadataLoader: {
-                try await metadataGate.load()
-            }
-        )
-        _ = await manager.loadingTask?.value
-        let placeholder = try #require(manager.conversations.first)
-
-        let reloadTask = Task { @MainActor in
-            await manager.reloadConversations()
-        }
-        await metadataGate.waitUntilReloadStarted()
-
-        manager.deleteConversation(placeholder)
-        var recreation = original
-        recreation.title = "Recreated During Reload"
-        recreation.updatedAt = Date().addingTimeInterval(1)
-        manager.insertConversationFromSync(recreation, allowsRecreation: true)
-        await manager.flushPendingSaves()
-
-        await metadataGate.releaseReload()
-        await reloadTask.value
-
-        #expect(manager.conversation(byId: original.id)?.title == "Recreated During Reload")
-        #expect(try await store.loadConversation(id: original.id)?.title == "Recreated During Reload")
-    }
-
-    @Test
-    @MainActor
-    func `reload preserves a pending row whose save completes during metadata loading`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let metadataGate = ConversationReloadMetadataGate(store: store)
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .seconds(10),
-            conversationMetadataLoader: {
-                try await metadataGate.load()
-            }
-        )
-        _ = await manager.loadingTask?.value
-
-        manager.createNewConversation(title: "Saved During Reload")
-        let conversationId = try #require(manager.conversations.first?.id)
-        try await Task.sleep(for: .milliseconds(50))
-
-        let reloadTask = Task { @MainActor in
-            await manager.reloadConversations()
-        }
-        await metadataGate.waitUntilReloadStarted()
-
-        await manager.flushPendingSaves()
-        #expect(try await store.loadConversation(id: conversationId)?.title == "Saved During Reload")
-
-        await metadataGate.releaseReload()
-        await reloadTask.value
-
-        #expect(manager.conversation(byId: conversationId)?.title == "Saved During Reload")
-    }
-
-    @Test
-    @MainActor
-    func `metadata load started before clear cannot repopulate conversations`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let conversation = TestHelpers.sampleConversation(title: "Stale Metadata")
-        try await store.save(conversation)
-        let metadataGate = ConversationMetadataLoadGate(store: store)
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            conversationMetadataLoader: {
-                try await metadataGate.load()
-            }
-        )
-
-        await metadataGate.waitUntilStarted()
-        manager.clearAllConversations()
-        await metadataGate.release()
-        _ = await manager.loadingTask?.value
-
-        for _ in 0 ..< 100 where try await !(store.loadConversations().isEmpty) {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(try await store.loadConversations().isEmpty)
-        #expect(manager.conversations.isEmpty)
-    }
-
-    @Test
-    @MainActor
-    func `metadata load started before delete cannot restore the deleted row`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let conversation = TestHelpers.sampleConversation(title: "Stale Deleted Metadata")
-        try await store.save(conversation)
-        let metadataGate = ConversationMetadataLoadGate(store: store)
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            conversationMetadataLoader: {
-                try await metadataGate.load()
-            }
-        )
-
-        await metadataGate.waitUntilStarted()
-        manager.conversations = [conversation]
-        manager.deleteConversation(conversation)
-        await manager.flushPendingSaves()
-        #expect(try await store.loadConversation(id: conversation.id) == nil)
-
-        await metadataGate.release()
-        _ = await manager.loadingTask?.value
-
-        #expect(!manager.conversations.contains { $0.id == conversation.id })
-    }
-
-    @Test
-    @MainActor
-    func `deleting a new row during initial load preserves existing history`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let persisted = TestHelpers.sampleConversation(title: "Persisted Before Startup")
-        try await store.save(persisted)
-        let metadataGate = ConversationMetadataLoadGate(store: store)
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            conversationMetadataLoader: {
-                try await metadataGate.load()
-            }
-        )
-
-        await metadataGate.waitUntilStarted()
-        let local = TestHelpers.sampleConversation(title: "Created During Startup")
-        manager.conversations = [local]
-        manager.deleteConversation(local)
-        await manager.flushPendingSaves()
-
-        await metadataGate.release()
-        _ = await manager.loadingTask?.value
-
-        #expect(manager.conversations.contains { $0.id == persisted.id })
-        #expect(!manager.conversations.contains { $0.id == local.id })
-    }
-
-    @Test
-    @MainActor
-    func `metadata load schedules background search index warmup`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        var conversation = TestHelpers.sampleConversation(title: "Warm Search")
-        conversation.addMessage(Message(role: .assistant, content: "middle-only warmup content"))
-        try await store.save(conversation)
-        let searchIndexURL = store.searchIndexFileURL(for: conversation.id)
-        #expect(!FileManager.default.fileExists(atPath: searchIndexURL.path))
-
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            searchIndexWarmupDelay: .zero
-        )
-        _ = await manager.loadingTask?.value
-
-        for _ in 0 ..< 100 where !FileManager.default.fileExists(atPath: searchIndexURL.path) {
-            try await Task.sleep(for: .milliseconds(10))
+            return condition()
         }
 
-        #expect(FileManager.default.fileExists(atPath: searchIndexURL.path))
-        manager.clearAllConversations()
-        await manager.flushPendingSaves()
-    }
+        @Test
+        @MainActor
+        func `create new conversation uses selected model`() throws {
+            let previousKeychain = AIService.keychain
+            let previousSelectedModel = AIService.shared.selectedModel
+            defer {
+                AIService.keychain = previousKeychain
+                AIService.shared.selectedModel = previousSelectedModel
+            }
 
-    @Test
-    @MainActor
-    func `disabled search warmup leaves conversation indexes cold`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        var conversation = TestHelpers.sampleConversation(title: "Cold Search")
-        conversation.addMessage(Message(role: .assistant, content: "content that would be indexed"))
-        try await store.save(conversation)
-        let searchIndexURL = store.searchIndexFileURL(for: conversation.id)
+            AIService.keychain = InMemoryKeychainStorage()
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let expectedModel = "unit-test-model"
 
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            searchIndexWarmupDelay: .zero,
-            searchIndexWarmupEnabled: false
-        )
-        _ = await manager.loadingTask?.value
-        try await Task.sleep(for: .milliseconds(50))
+            AIService.shared.selectedModel = expectedModel
+            let manager = makeManager(directory: directory)
+            manager.createNewConversation()
 
-        #expect(!FileManager.default.fileExists(atPath: searchIndexURL.path))
-    }
+            #expect(manager.conversations.count == 1)
+            #expect(manager.conversations.first?.model == expectedModel)
+        }
 
-    @Test(.timeLimit(.minutes(1)))
-    @MainActor
-    func `background search warmup is bounded to recent conversations`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let baseDate = Date()
-        var conversations: [Conversation] = []
+        @Test
+        @MainActor
+        func `add message appends and updates timestamp`() throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
 
-        for index in 0 ..< 18 {
-            var conversation = TestHelpers.sampleConversation(title: "Warm \(index)")
-            conversation.updatedAt = baseDate.addingTimeInterval(Double(index))
-            conversations.append(conversation)
+            let manager = makeManager(directory: directory)
+            manager.createNewConversation()
+            let conversation = try #require(manager.conversations.first)
+
+            let message = Message(role: .user, content: "Ping")
+            manager.addMessage(to: conversation, message: message)
+
+            #expect(manager.conversations.first?.messages.count == 1)
+            #expect(manager.conversations.first?.messages.first?.content == "Ping")
+        }
+
+        @Test
+        @MainActor
+        func `search finds matches in title and messages`() throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+
+            let manager = makeManager(directory: directory)
+
+            var first = TestHelpers.sampleConversation(title: "Swift Tips")
+            first.messages[0].content = "How to use SwiftUI?"
+            var second = TestHelpers.sampleConversation(title: "Random Chat")
+            second.messages[0].content = "Discussing movies"
+            var third = TestHelpers.sampleConversation(title: "Reasoning Chat")
+            third.messages[0].content = "A short final answer"
+            third.messages[0].reasoning = "Hidden chain marker"
+            manager.conversations = [first, second, third]
+
+            let titleResults = manager.searchConversations(query: "Swift")
+            let bodyResults = manager.searchConversations(query: "movies")
+            let reasoningResults = manager.searchConversations(query: "chain marker")
+
+            #expect(titleResults.count == 1)
+            #expect(titleResults.first?.title == "Swift Tips")
+            #expect(bodyResults.count == 1)
+            #expect(bodyResults.first?.title == "Random Chat")
+            #expect(reasoningResults.count == 1)
+            #expect(reasoningResults.first?.title == "Reasoning Chat")
+        }
+
+        @Test
+        @MainActor
+        func `save immediately persists manual changes`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-key-id"
+            let manager = makeManager(directory: directory, keychain: keychain, keyIdentifier: keyId)
+
+            // Create conversation directly without triggering debounced save
+            let conversation = Conversation(title: "Test Conversation", model: "test-model")
+            manager.conversations.insert(conversation, at: 0)
+
+            // Manually update the conversation in the array (simulating what ChatView does with chunks)
+            if let index = manager.conversations.firstIndex(where: { $0.id == conversation.id }) {
+                manager.conversations[index].messages.append(Message(role: .assistant, content: "Partial content"))
+            }
+
+            // Save immediately
+            let saveTask = try manager.saveImmediately(#require(manager.conversations.first))
+
+            // Wait for the save task to complete
+            _ = await saveTask.value
+
+            // Create a new manager to load from disk using the SAME keychain and keyIdentifier
+            let newManager = makeManager(
+                directory: directory,
+                keychain: keychain,
+                keyIdentifier: keyId,
+                startsLoadingImmediately: true
+            )
+            _ = await newManager.loadingTask?.value
+
+            #expect(newManager.conversations.count == 1)
+            #expect(newManager.conversations.first?.messages.isEmpty == true)
+
+            let hydrated = await newManager.ensureConversationLoaded(conversation.id)
+            #expect(hydrated?.messages.last?.content == "Partial content")
+            #expect(newManager.conversations.first?.messages.last?.content == "Partial content")
+        }
+
+        @Test
+        @MainActor
+        func `later save inherits an outstanding immediate save requirement`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let manager = ConversationManager(store: store, saveDebounceDuration: .seconds(10))
+            _ = await manager.loadingTask?.value
+            var conversation = TestHelpers.sampleConversation(title: "Immediate")
+            manager.conversations = [conversation]
+
+            let immediateTask = manager.saveImmediately(conversation)
+            conversation.title = "Latest snapshot"
+            conversation.updatedAt = Date().addingTimeInterval(1)
+            manager.conversations = [conversation]
+            manager.save(conversation)
+            await immediateTask.value
+
+            for _ in 0 ..< 100 {
+                if try await store.loadConversation(id: conversation.id)?.title == "Latest snapshot" {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+
+            #expect(try await store.loadConversation(id: conversation.id)?.title == "Latest snapshot")
+            manager.clearAllConversations()
+        }
+
+        @Test
+        @MainActor
+        func `flush waits for a save registered during the coordinator flush`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let conversation = TestHelpers.sampleConversation(title: "Before Flush")
             try await store.save(conversation)
+
+            let metadataGate = ConversationMetadataLoadGate(store: store)
+            let flushGate = PersistenceFlushGate()
+            let completion = AsyncCompletionProbe()
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                conversationMetadataLoader: {
+                    try await metadataGate.load()
+                },
+                beforePersistenceFlush: {
+                    await flushGate.waitBeforeFlush()
+                }
+            )
+            await metadataGate.waitUntilStarted()
+            var placeholder = conversation
+            placeholder.messages = []
+            placeholder.metadataPreview = "Preview"
+            manager.conversations = [placeholder]
+
+            let flushTask = Task { @MainActor in
+                await manager.flushPendingSaves()
+                await completion.markComplete()
+            }
+            await flushGate.waitUntilStarted()
+
+            manager.renameConversation(placeholder, newTitle: "Saved During Flush")
+            await flushGate.release()
+
+            try await Task.sleep(for: .milliseconds(50))
+            #expect(await !(completion.isComplete()))
+
+            await metadataGate.release()
+            await flushTask.value
+
+            #expect(await completion.isComplete())
+            #expect(try await store.loadConversation(id: conversation.id)?.title == "Saved During Flush")
         }
 
-        let newest = conversations.sorted { $0.updatedAt > $1.updatedAt }
-        let expectedWarmIds = Set(newest.prefix(16).map(\.id))
-        let expectedColdIds = Set(newest.dropFirst(16).map(\.id))
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            searchIndexWarmupDelay: .zero
-        )
-        _ = await manager.loadingTask?.value
-        await manager.waitForSearchIndexWarmup()
+        @Test
+        @MainActor
+        func `initial load uses metadata placeholders until conversation is selected`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-metadata-placeholder-key"
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+            let conversation = TestHelpers.sampleConversation(title: "Metadata Only")
+            try await store.save(conversation)
 
-        #expect(expectedWarmIds.allSatisfy { conversationId in
-            FileManager.default.fileExists(atPath: store.searchIndexFileURL(for: conversationId).path)
-        })
-        #expect(expectedColdIds.allSatisfy { conversationId in
-            !FileManager.default.fileExists(atPath: store.searchIndexFileURL(for: conversationId).path)
-        })
+            let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
+            _ = await manager.loadingTask?.value
 
-        manager.clearAllConversations()
-        await manager.flushPendingSaves()
-    }
+            #expect(manager.conversations.count == 1)
+            #expect(manager.conversations.first?.id == conversation.id)
+            #expect(manager.conversations.first?.title == "Metadata Only")
+            #expect(manager.conversations.first?.messages.isEmpty == true)
 
-    @Test
-    @MainActor
-    func `clearing during lazy hydration cannot recreate the conversation`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        var conversation = TestHelpers.sampleConversation(title: "Clear During Hydration")
-        conversation.model = "missing-model-for-clear-race"
-        try await store.save(conversation)
-        let loadGate = ConversationStaleLoadGate(store: store)
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            conversationLoader: { conversationId in
-                try await loadGate.load(conversationId)
-            }
-        )
-        _ = await manager.loadingTask?.value
-
-        _ = manager.conversation(byId: conversation.id)
-        await loadGate.waitUntilStarted()
-        manager.clearAllConversations()
-
-        for _ in 0 ..< 100 where try await store.loadConversation(id: conversation.id) != nil {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(try await store.loadConversation(id: conversation.id) == nil)
-
-        await loadGate.release()
-        try await Task.sleep(for: .milliseconds(100))
-
-        #expect(try await store.loadConversation(id: conversation.id) == nil)
-        #expect(manager.conversations.isEmpty)
-    }
-
-    @Test
-    @MainActor
-    func `reload cancels stale lazy hydration before publishing messages`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        var original = TestHelpers.sampleConversation(title: "Hydration Version A")
-        original.messages = [Message(role: .user, content: "Version A")]
-        try await store.save(original)
-        let loadGate = ConversationStaleLoadGate(store: store)
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            conversationLoader: { conversationId in
-                try await loadGate.load(conversationId)
-            }
-        )
-        _ = await manager.loadingTask?.value
-
-        _ = manager.conversation(byId: original.id)
-        await loadGate.waitUntilStarted()
-
-        var updated = original
-        updated.title = "Hydration Version B"
-        updated.messages = [Message(role: .user, content: "Version B")]
-        updated.updatedAt = Date().addingTimeInterval(1)
-        try await store.save(updated)
-        await manager.reloadConversations()
-        await loadGate.release()
-        try await Task.sleep(for: .milliseconds(50))
-
-        #expect(manager.isMetadataOnlyConversation(original.id))
-        let hydrated = try #require(await manager.ensureConversationLoaded(original.id))
-        #expect(hydrated.messages.map(\.content) == ["Version B"])
-    }
-
-    @Test
-    @MainActor
-    func `concurrent lazy hydration callers share one store load`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let conversation = TestHelpers.sampleConversation(title: "Coalesced Hydration")
-        try await store.save(conversation)
-        let loadProbe = ConversationLoadProbe(store: store)
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            conversationLoader: { conversationId in
-                try await loadProbe.load(conversationId)
-            }
-        )
-        _ = await manager.loadingTask?.value
-
-        _ = manager.conversation(byId: conversation.id)
-        async let first = manager.ensureConversationLoaded(conversation.id)
-        async let second = manager.ensureConversationLoaded(conversation.id)
-        let loaded = await [first, second]
-
-        #expect(loaded.allSatisfy { $0?.messages.count == conversation.messages.count })
-        #expect(await loadProbe.loadCount() == 1)
-    }
-
-    @Test
-    @MainActor
-    func `lazy hydration repairs unavailable model`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-lazy-model-repair-key"
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
-        let defaultModel = AIService.shared.selectedModel.isEmpty
-            ? "available-model"
-            : AIService.shared.selectedModel
-        let unavailableModel = "removed-\(UUID().uuidString)"
-
-        if !AIService.shared.customModels.contains(defaultModel) {
-            AIService.shared.customModels.insert(defaultModel, at: 0)
-        }
-        AIService.shared.selectedModel = defaultModel
-
-        let conversation = TestHelpers.sampleConversation(title: "Repair", model: unavailableModel)
-        try await store.save(conversation)
-
-        let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
-        _ = await manager.loadingTask?.value
-
-        #expect(manager.conversations.first?.model != unavailableModel)
-        let hydrated = await manager.ensureConversationLoaded(conversation.id)
-
-        #expect(hydrated?.model != unavailableModel)
-        #expect(manager.conversations.first?.model != unavailableModel)
-        await manager.flushPendingSaves()
-        let persisted = try #require(try await store.loadConversation(id: conversation.id))
-        #expect(persisted.model != unavailableModel)
-    }
-
-    @Test
-    @MainActor
-    func `saving metadata placeholder does not persist synthetic preview message`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-synthetic-preview-save-key"
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
-        let conversation = TestHelpers.sampleConversation(title: "Preview Save")
-        try await store.save(conversation)
-
-        let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
-        _ = await manager.loadingTask?.value
-        var placeholder = try #require(manager.conversations.first)
-        #expect(placeholder.messages.isEmpty == true)
-        #expect(placeholder.metadataPreview != nil)
-
-        placeholder.title = "Renamed Preview Save"
-        placeholder.updatedAt = Date().addingTimeInterval(60)
-        let saveTask = manager.saveImmediately(placeholder)
-        _ = await saveTask.value
-
-        let persisted = try #require(try await store.loadConversation(id: conversation.id))
-        #expect(persisted.title == "Renamed Preview Save")
-        #expect(persisted.messages.count == conversation.messages.count)
-    }
-
-    @Test
-    @MainActor
-    func `later metadata placeholder save replaces pending debounced save`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-metadata-debounce-latest-key"
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
-        let conversation = TestHelpers.sampleConversation(title: "Original Debounced")
-        try await store.save(conversation)
-
-        let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(500))
-        _ = await manager.loadingTask?.value
-
-        var firstEdit = try #require(manager.conversations.first)
-        firstEdit.title = "First Pending Title"
-        firstEdit.updatedAt = Date().addingTimeInterval(10)
-        manager.save(firstEdit)
-
-        try await Task.sleep(for: .milliseconds(100))
-
-        var secondEdit = firstEdit
-        secondEdit.title = "Second Pending Title"
-        secondEdit.temperature = 0.42
-        secondEdit.updatedAt = Date().addingTimeInterval(20)
-        manager.conversations = [secondEdit]
-        manager.save(secondEdit)
-
-        var persistedConversation: Conversation?
-        for _ in 0 ..< 200 {
-            persistedConversation = try await store.loadConversation(id: conversation.id)
-            if persistedConversation?.title == "Second Pending Title" {
-                break
-            }
-            try await Task.sleep(for: .milliseconds(10))
+            let hydrated = await manager.ensureConversationLoaded(conversation.id)
+            #expect(hydrated?.messages.count == conversation.messages.count)
+            #expect(manager.conversations.first?.messages.count == conversation.messages.count)
         }
 
-        let persisted = try #require(persistedConversation)
-        #expect(persisted.title == "Second Pending Title")
-        #expect(persisted.temperature == 0.42)
-        #expect(persisted.messages.count == conversation.messages.count)
-    }
+        @Test
+        @MainActor
+        func `hydrating metadata placeholder before export includes message history`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-export-hydration-key"
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+            let conversation = TestHelpers.sampleConversation(title: "Export Hydration")
+            try await store.save(conversation)
 
-    @Test
-    @MainActor
-    func `lazy hydration preserves newer placeholder metadata edits`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-lazy-merge-newer-edits-key"
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
-        let conversation = TestHelpers.sampleConversation(title: "Original Title")
-        try await store.save(conversation)
+            let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
+            _ = await manager.loadingTask?.value
 
-        let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
-        _ = await manager.loadingTask?.value
+            let placeholder = try #require(manager.conversations.first)
+            #expect(placeholder.messages.isEmpty == true)
+            #expect(ConversationExporter.generateMarkdown(for: placeholder).contains("Hello") == false)
 
-        let index = try #require(manager.conversations.firstIndex(where: { $0.id == conversation.id }))
-        manager.conversations[index].title = "Edited Before Hydration"
-        manager.conversations[index].updatedAt = Date().addingTimeInterval(60)
+            let hydrated = try #require(await manager.ensureConversationLoaded(conversation.id))
+            let markdown = ConversationExporter.generateMarkdown(for: hydrated)
 
-        let hydrated = await manager.ensureConversationLoaded(conversation.id)
+            #expect(markdown.contains("Hello"))
+            #expect(markdown.contains("Hi there"))
+        }
 
-        #expect(hydrated?.title == "Edited Before Hydration")
-        #expect(hydrated?.messages.count == conversation.messages.count)
-        #expect(manager.conversations[index].title == "Edited Before Hydration")
-    }
+        @Test
+        @MainActor
+        func `metadata-only search preserves matches from the middle of long history`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            var conversation = Conversation(title: "Long Search")
+            conversation.addMessage(Message(role: .user, content: String(repeating: "head ", count: 2000)))
+            conversation.addMessage(Message(role: .assistant, content: "middle-only-needle"))
+            conversation.addMessage(Message(role: .user, content: String(repeating: "tail ", count: 2000)))
+            try await store.save(conversation)
 
-    @Test
-    @MainActor
-    func `lazy hydration preserves a newer available model selection`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let store = TestHelpers.makeTestStore(directory: directory)
-        let unavailableModel = "removed-\(UUID().uuidString)"
-        let selectedModel = "selected-\(UUID().uuidString)"
-        AIService.shared.customModels.insert(selectedModel, at: 0)
-        var conversation = TestHelpers.sampleConversation(title: "Model Race", model: unavailableModel)
-        conversation.updatedAt = Date(timeIntervalSinceReferenceDate: 100)
-        try await store.save(conversation)
-        let loadGate = ConversationStaleLoadGate(store: store)
-        let manager = ConversationManager(
-            store: store,
-            saveDebounceDuration: .milliseconds(0),
-            conversationLoader: { conversationId in
-                try await loadGate.load(conversationId)
+            let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
+            _ = await manager.loadingTask?.value
+            #expect(manager.searchConversations(query: "middle-only-needle").isEmpty)
+
+            let results = await manager.searchConversationsAsync(
+                query: "middle-only-needle",
+                conversations: manager.conversations
+            )
+
+            #expect(results.map(\.id) == [conversation.id])
+            #expect(results.first?.messages.isEmpty == true)
+        }
+
+        @Test
+        @MainActor
+        func `selecting metadata placeholder lazy loads full conversation`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-selected-lazy-load-key"
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+            let conversation = TestHelpers.sampleConversation(title: "Lazy Selected")
+            try await store.save(conversation)
+
+            let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
+            _ = await manager.loadingTask?.value
+
+            #expect(manager.conversations.first?.messages.isEmpty == true)
+            manager.selectedConversationId = conversation.id
+
+            for _ in 0 ..< 20 {
+                if manager.conversations.first?.messages.count == conversation.messages.count {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(25))
             }
-        )
-        _ = await manager.loadingTask?.value
 
-        _ = manager.conversation(byId: conversation.id)
-        await loadGate.waitUntilStarted()
-        let index = try #require(manager.conversations.firstIndex(where: { $0.id == conversation.id }))
-        manager.conversations[index].model = selectedModel
-        manager.conversations[index].updatedAt = Date(timeIntervalSinceReferenceDate: 200)
-        await loadGate.release()
-        let hydrated = try #require(await manager.ensureConversationLoaded(conversation.id))
+            #expect(manager.conversations.first?.messages.count == conversation.messages.count)
+        }
 
-        #expect(hydrated.model == selectedModel)
-        #expect(manager.conversations[index].model == selectedModel)
-    }
+        @Test
+        @MainActor
+        func `deleting during lazy hydration cannot recreate the conversation`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            var conversation = TestHelpers.sampleConversation(title: "Delete During Hydration")
+            conversation.model = "missing-model-for-delete-race"
+            try await store.save(conversation)
+            let loadGate = ConversationStaleLoadGate(store: store)
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                conversationLoader: { conversationId in
+                    try await loadGate.load(conversationId)
+                }
+            )
+            _ = await manager.loadingTask?.value
+            let placeholder = try #require(manager.conversations.first)
 
-    @Test
-    @MainActor
-    func `reload conversations removes stale non-dirty conversations`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-reconcile-key"
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+            _ = manager.conversation(byId: conversation.id)
+            await loadGate.waitUntilStarted()
+            manager.deleteConversation(placeholder)
 
-        let kept = TestHelpers.sampleConversation(title: "Kept")
-        try await store.save([kept])
+            for _ in 0 ..< 100 where try await store.loadConversation(id: conversation.id) != nil {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(try await store.loadConversation(id: conversation.id) == nil)
 
-        let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
-        _ = await manager.loadingTask?.value
+            await loadGate.release()
+            try await Task.sleep(for: .milliseconds(100))
 
-        #expect(manager.conversations.count == 1)
-        #expect(manager.conversations.first?.id == kept.id)
+            #expect(try await store.loadConversation(id: conversation.id) == nil)
+            #expect(!manager.conversations.contains { $0.id == conversation.id })
+        }
 
-        let stale = TestHelpers.sampleConversation(title: "Stale")
-        manager.conversations.append(stale)
-        #expect(manager.conversations.count == 2)
+        @Test
+        @MainActor
+        func `sync recreation authorization reaches the newest coalesced save`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let original = TestHelpers.sampleConversation(title: "Original")
+            try await store.save(original)
 
-        await manager.reloadConversations()
+            let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
+            _ = await manager.loadingTask?.value
+            let placeholder = try #require(manager.conversations.first)
+            manager.deleteConversation(placeholder)
 
-        #expect(manager.conversations.contains(where: { $0.id == kept.id }))
-        #expect(!manager.conversations.contains(where: { $0.id == stale.id }))
-    }
+            var recreation = original
+            recreation.title = "Recreated from sync"
+            recreation.messages = []
+            manager.insertConversationFromSync(recreation, allowsRecreation: true)
+            let inserted = try #require(manager.conversation(byId: original.id))
+            manager.addMessage(to: inserted, message: Message(role: .user, content: "Synced message"))
+            await manager.flushPendingSaves()
 
-    @Test
-    @MainActor
-    func `reload conversations preserves dirty in-memory conversations not yet on disk`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-dirty-wins-key"
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+            let persisted = try #require(try await store.loadConversation(id: original.id))
+            #expect(persisted.title == "Recreated from sync")
+            #expect(persisted.messages.map(\.content) == ["Synced message"])
+        }
 
-        let manager = ConversationManager(store: store, saveDebounceDuration: .seconds(10))
-        _ = await manager.loadingTask?.value
+        @Test
+        @MainActor
+        func `stale metadata reload preserves an authorized recreation`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let original = TestHelpers.sampleConversation(title: "Original Before Reload")
+            try await store.save(original)
+            let metadataGate = ConversationReloadMetadataGate(store: store)
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                conversationMetadataLoader: {
+                    try await metadataGate.load()
+                }
+            )
+            _ = await manager.loadingTask?.value
+            let placeholder = try #require(manager.conversations.first)
 
-        let dirty = TestHelpers.sampleConversation(title: "Dirty")
-        manager.conversations = [dirty]
-        manager.save(dirty)
+            let reloadTask = Task { @MainActor in
+                await manager.reloadConversations()
+            }
+            await metadataGate.waitUntilReloadStarted()
 
-        // Give the save() Task time to enqueue the pending save.
-        try await Task.sleep(for: .milliseconds(50))
+            manager.deleteConversation(placeholder)
+            var recreation = original
+            recreation.title = "Recreated During Reload"
+            recreation.updatedAt = Date().addingTimeInterval(1)
+            manager.insertConversationFromSync(recreation, allowsRecreation: true)
+            await manager.flushPendingSaves()
 
-        // Confirm it's not on disk yet (debounce is long)
-        let diskBefore = try await store.loadConversations()
-        #expect(diskBefore.isEmpty)
+            await metadataGate.releaseReload()
+            await reloadTask.value
 
-        await manager.reloadConversations()
+            #expect(manager.conversation(byId: original.id)?.title == "Recreated During Reload")
+            #expect(try await store.loadConversation(id: original.id)?.title == "Recreated During Reload")
+        }
 
-        #expect(manager.conversations.contains(where: { $0.id == dirty.id }))
+        @Test
+        @MainActor
+        func `reload preserves a pending row whose save completes during metadata loading`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let metadataGate = ConversationReloadMetadataGate(store: store)
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .seconds(10),
+                conversationMetadataLoader: {
+                    try await metadataGate.load()
+                }
+            )
+            _ = await manager.loadingTask?.value
 
-        // Clean up pending saves to avoid test cross-talk.
-        manager.clearAllConversations()
-    }
+            manager.createNewConversation(title: "Saved During Reload")
+            let conversationId = try #require(manager.conversations.first?.id)
+            try await Task.sleep(for: .milliseconds(50))
 
-    @Test
-    @MainActor
-    func `reload ignores stale sidecar text for dirty full conversation`() async throws {
-        let directory = try TestHelpers.makeTemporaryDirectory()
-        let keychain = InMemoryKeychainStorage()
-        let keyId = "test-dirty-search-key"
-        let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
-        var conversation = Conversation(title: "Searchable")
-        conversation.addMessage(Message(role: .user, content: "old deleted term"))
-        try await store.save(conversation)
+            let reloadTask = Task { @MainActor in
+                await manager.reloadConversations()
+            }
+            await metadataGate.waitUntilReloadStarted()
 
-        let manager = ConversationManager(store: store, saveDebounceDuration: .seconds(10))
-        _ = await manager.loadingTask?.value
-        let hydrated = try #require(await manager.ensureConversationLoaded(conversation.id))
-        let messageId = try #require(hydrated.messages.first?.id)
+            await manager.flushPendingSaves()
+            #expect(try await store.loadConversation(id: conversationId)?.title == "Saved During Reload")
 
-        #expect(manager.editMessage(in: hydrated, messageId: messageId, newContent: "current replacement"))
-        try await Task.sleep(for: .milliseconds(50))
+            await metadataGate.releaseReload()
+            await reloadTask.value
 
-        await manager.reloadConversations()
+            #expect(manager.conversation(byId: conversationId)?.title == "Saved During Reload")
+        }
 
-        #expect(manager.searchConversations(query: "old deleted term").isEmpty)
-        #expect(manager.searchConversations(query: "current replacement").map(\.id) == [conversation.id])
+        @Test
+        @MainActor
+        func `metadata load started before clear cannot repopulate conversations`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let conversation = TestHelpers.sampleConversation(title: "Stale Metadata")
+            try await store.save(conversation)
+            let metadataGate = ConversationMetadataLoadGate(store: store)
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                conversationMetadataLoader: {
+                    try await metadataGate.load()
+                }
+            )
 
-        let verifiedResults = await manager.verifiedSearchResults(
-            conversations: manager.conversations,
-            query: "old deleted term",
-            metadataSearchTextById: [:],
-            metadataOnlyConversationIds: []
-        )
-        #expect(verifiedResults.isEmpty)
+            await metadataGate.waitUntilStarted()
+            manager.clearAllConversations()
+            await metadataGate.release()
+            _ = await manager.loadingTask?.value
 
-        manager.clearAllConversations()
+            for _ in 0 ..< 100 where try await !(store.loadConversations().isEmpty) {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(try await store.loadConversations().isEmpty)
+            #expect(manager.conversations.isEmpty)
+        }
+
+        @Test
+        @MainActor
+        func `metadata load started before delete cannot restore the deleted row`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let conversation = TestHelpers.sampleConversation(title: "Stale Deleted Metadata")
+            try await store.save(conversation)
+            let metadataGate = ConversationMetadataLoadGate(store: store)
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                conversationMetadataLoader: {
+                    try await metadataGate.load()
+                }
+            )
+
+            await metadataGate.waitUntilStarted()
+            manager.conversations = [conversation]
+            manager.deleteConversation(conversation)
+            await manager.flushPendingSaves()
+            #expect(try await store.loadConversation(id: conversation.id) == nil)
+
+            await metadataGate.release()
+            _ = await manager.loadingTask?.value
+
+            #expect(!manager.conversations.contains { $0.id == conversation.id })
+        }
+
+        @Test
+        @MainActor
+        func `deleting a new row during initial load preserves existing history`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let persisted = TestHelpers.sampleConversation(title: "Persisted Before Startup")
+            try await store.save(persisted)
+            let metadataGate = ConversationMetadataLoadGate(store: store)
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                conversationMetadataLoader: {
+                    try await metadataGate.load()
+                }
+            )
+
+            await metadataGate.waitUntilStarted()
+            let local = TestHelpers.sampleConversation(title: "Created During Startup")
+            manager.conversations = [local]
+            manager.deleteConversation(local)
+            await manager.flushPendingSaves()
+
+            await metadataGate.release()
+            _ = await manager.loadingTask?.value
+
+            #expect(manager.conversations.contains { $0.id == persisted.id })
+            #expect(!manager.conversations.contains { $0.id == local.id })
+        }
+
+        @Test
+        @MainActor
+        func `metadata load schedules background search index warmup`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            var conversation = TestHelpers.sampleConversation(title: "Warm Search")
+            conversation.addMessage(Message(role: .assistant, content: "middle-only warmup content"))
+            try await store.save(conversation)
+            let searchIndexURL = store.searchIndexFileURL(for: conversation.id)
+            #expect(!FileManager.default.fileExists(atPath: searchIndexURL.path))
+
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                searchIndexWarmupDelay: .zero
+            )
+            _ = await manager.loadingTask?.value
+
+            for _ in 0 ..< 100 where !FileManager.default.fileExists(atPath: searchIndexURL.path) {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+
+            #expect(FileManager.default.fileExists(atPath: searchIndexURL.path))
+            manager.clearAllConversations()
+            await manager.flushPendingSaves()
+        }
+
+        @Test
+        @MainActor
+        func `disabled search warmup leaves conversation indexes cold`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            var conversation = TestHelpers.sampleConversation(title: "Cold Search")
+            conversation.addMessage(Message(role: .assistant, content: "content that would be indexed"))
+            try await store.save(conversation)
+            let searchIndexURL = store.searchIndexFileURL(for: conversation.id)
+
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                searchIndexWarmupDelay: .zero,
+                searchIndexWarmupEnabled: false
+            )
+            _ = await manager.loadingTask?.value
+            try await Task.sleep(for: .milliseconds(50))
+
+            #expect(!FileManager.default.fileExists(atPath: searchIndexURL.path))
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        @MainActor
+        func `background search warmup is bounded to recent conversations`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let baseDate = Date()
+            var conversations: [Conversation] = []
+
+            for index in 0 ..< 18 {
+                var conversation = TestHelpers.sampleConversation(title: "Warm \(index)")
+                conversation.updatedAt = baseDate.addingTimeInterval(Double(index))
+                conversations.append(conversation)
+                try await store.save(conversation)
+            }
+
+            let newest = conversations.sorted { $0.updatedAt > $1.updatedAt }
+            let expectedWarmIds = Set(newest.prefix(16).map(\.id))
+            let expectedColdIds = Set(newest.dropFirst(16).map(\.id))
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                searchIndexWarmupDelay: .zero
+            )
+            _ = await manager.loadingTask?.value
+            await manager.waitForSearchIndexWarmup()
+
+            #expect(expectedWarmIds.allSatisfy { conversationId in
+                FileManager.default.fileExists(atPath: store.searchIndexFileURL(for: conversationId).path)
+            })
+            #expect(expectedColdIds.allSatisfy { conversationId in
+                !FileManager.default.fileExists(atPath: store.searchIndexFileURL(for: conversationId).path)
+            })
+
+            manager.clearAllConversations()
+            await manager.flushPendingSaves()
+        }
+
+        @Test
+        @MainActor
+        func `clearing during lazy hydration cannot recreate the conversation`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            var conversation = TestHelpers.sampleConversation(title: "Clear During Hydration")
+            conversation.model = "missing-model-for-clear-race"
+            try await store.save(conversation)
+            let loadGate = ConversationStaleLoadGate(store: store)
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                conversationLoader: { conversationId in
+                    try await loadGate.load(conversationId)
+                }
+            )
+            _ = await manager.loadingTask?.value
+
+            _ = manager.conversation(byId: conversation.id)
+            await loadGate.waitUntilStarted()
+            manager.clearAllConversations()
+
+            for _ in 0 ..< 100 where try await store.loadConversation(id: conversation.id) != nil {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(try await store.loadConversation(id: conversation.id) == nil)
+
+            await loadGate.release()
+            try await Task.sleep(for: .milliseconds(100))
+
+            #expect(try await store.loadConversation(id: conversation.id) == nil)
+            #expect(manager.conversations.isEmpty)
+        }
+
+        @Test
+        @MainActor
+        func `reload cancels stale lazy hydration before publishing messages`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            var original = TestHelpers.sampleConversation(title: "Hydration Version A")
+            original.messages = [Message(role: .user, content: "Version A")]
+            try await store.save(original)
+            let loadGate = ConversationStaleLoadGate(store: store)
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                conversationLoader: { conversationId in
+                    try await loadGate.load(conversationId)
+                }
+            )
+            _ = await manager.loadingTask?.value
+
+            _ = manager.conversation(byId: original.id)
+            await loadGate.waitUntilStarted()
+
+            var updated = original
+            updated.title = "Hydration Version B"
+            updated.messages = [Message(role: .user, content: "Version B")]
+            updated.updatedAt = Date().addingTimeInterval(1)
+            try await store.save(updated)
+            await manager.reloadConversations()
+            await loadGate.release()
+            try await Task.sleep(for: .milliseconds(50))
+
+            #expect(manager.isMetadataOnlyConversation(original.id))
+            let hydrated = try #require(await manager.ensureConversationLoaded(original.id))
+            #expect(hydrated.messages.map(\.content) == ["Version B"])
+        }
+
+        @Test
+        @MainActor
+        func `concurrent lazy hydration callers share one store load`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let conversation = TestHelpers.sampleConversation(title: "Coalesced Hydration")
+            try await store.save(conversation)
+            let loadProbe = ConversationLoadProbe(store: store)
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                conversationLoader: { conversationId in
+                    try await loadProbe.load(conversationId)
+                }
+            )
+            _ = await manager.loadingTask?.value
+
+            _ = manager.conversation(byId: conversation.id)
+            async let first = manager.ensureConversationLoaded(conversation.id)
+            async let second = manager.ensureConversationLoaded(conversation.id)
+            let loaded = await [first, second]
+
+            #expect(loaded.allSatisfy { $0?.messages.count == conversation.messages.count })
+            #expect(await loadProbe.loadCount() == 1)
+        }
+
+        @Test
+        @MainActor
+        func `lazy hydration repairs unavailable model`() async throws {
+            let previousModels = AIService.shared.customModels
+            let previousSelectedModel = AIService.shared.selectedModel
+            defer {
+                AIService.shared.customModels = previousModels
+                AIService.shared.selectedModel = previousSelectedModel
+            }
+
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-lazy-model-repair-key"
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+            let defaultModel = AIService.shared.selectedModel.isEmpty
+                ? "available-model"
+                : AIService.shared.selectedModel
+            let unavailableModel = "removed-\(UUID().uuidString)"
+
+            if !AIService.shared.customModels.contains(defaultModel) {
+                AIService.shared.customModels.insert(defaultModel, at: 0)
+            }
+            AIService.shared.selectedModel = defaultModel
+
+            let conversation = TestHelpers.sampleConversation(title: "Repair", model: unavailableModel)
+            try await store.save(conversation)
+
+            let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
+            _ = await manager.loadingTask?.value
+
+            #expect(manager.conversations.first?.model != unavailableModel)
+            let hydrated = await manager.ensureConversationLoaded(conversation.id)
+
+            #expect(hydrated?.model != unavailableModel)
+            #expect(manager.conversations.first?.model != unavailableModel)
+            await manager.flushPendingSaves()
+            let persisted = try #require(try await store.loadConversation(id: conversation.id))
+            #expect(persisted.model != unavailableModel)
+        }
+
+        @Test
+        @MainActor
+        func `saving metadata placeholder does not persist synthetic preview message`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-synthetic-preview-save-key"
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+            let conversation = TestHelpers.sampleConversation(title: "Preview Save")
+            try await store.save(conversation)
+
+            let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
+            _ = await manager.loadingTask?.value
+            var placeholder = try #require(manager.conversations.first)
+            #expect(placeholder.messages.isEmpty == true)
+            #expect(placeholder.metadataPreview != nil)
+
+            placeholder.title = "Renamed Preview Save"
+            placeholder.updatedAt = Date().addingTimeInterval(60)
+            let saveTask = manager.saveImmediately(placeholder)
+            _ = await saveTask.value
+
+            let persisted = try #require(try await store.loadConversation(id: conversation.id))
+            #expect(persisted.title == "Renamed Preview Save")
+            #expect(persisted.messages.count == conversation.messages.count)
+        }
+
+        @Test
+        @MainActor
+        func `later metadata placeholder save replaces pending debounced save`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-metadata-debounce-latest-key"
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+            let conversation = TestHelpers.sampleConversation(title: "Original Debounced")
+            try await store.save(conversation)
+
+            let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(500))
+            _ = await manager.loadingTask?.value
+
+            var firstEdit = try #require(manager.conversations.first)
+            firstEdit.title = "First Pending Title"
+            firstEdit.updatedAt = Date().addingTimeInterval(10)
+            manager.save(firstEdit)
+
+            try await Task.sleep(for: .milliseconds(100))
+
+            var secondEdit = firstEdit
+            secondEdit.title = "Second Pending Title"
+            secondEdit.temperature = 0.42
+            secondEdit.updatedAt = Date().addingTimeInterval(20)
+            manager.conversations = [secondEdit]
+            manager.save(secondEdit)
+
+            var persistedConversation: Conversation?
+            for _ in 0 ..< 200 {
+                persistedConversation = try await store.loadConversation(id: conversation.id)
+                if persistedConversation?.title == "Second Pending Title" {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+
+            let persisted = try #require(persistedConversation)
+            #expect(persisted.title == "Second Pending Title")
+            #expect(persisted.temperature == 0.42)
+            #expect(persisted.messages.count == conversation.messages.count)
+        }
+
+        @Test
+        @MainActor
+        func `lazy hydration preserves newer placeholder metadata edits`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-lazy-merge-newer-edits-key"
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+            let conversation = TestHelpers.sampleConversation(title: "Original Title")
+            try await store.save(conversation)
+
+            let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
+            _ = await manager.loadingTask?.value
+
+            let index = try #require(manager.conversations.firstIndex(where: { $0.id == conversation.id }))
+            manager.conversations[index].title = "Edited Before Hydration"
+            manager.conversations[index].updatedAt = Date().addingTimeInterval(60)
+
+            let hydrated = await manager.ensureConversationLoaded(conversation.id)
+
+            #expect(hydrated?.title == "Edited Before Hydration")
+            #expect(hydrated?.messages.count == conversation.messages.count)
+            #expect(manager.conversations[index].title == "Edited Before Hydration")
+        }
+
+        @Test
+        @MainActor
+        func `lazy hydration preserves a newer available model selection`() async throws {
+            let previousModels = AIService.shared.customModels
+            let previousSelectedModel = AIService.shared.selectedModel
+            defer {
+                AIService.shared.customModels = previousModels
+                AIService.shared.selectedModel = previousSelectedModel
+            }
+
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let store = TestHelpers.makeTestStore(directory: directory)
+            let unavailableModel = "removed-\(UUID().uuidString)"
+            let selectedModel = "selected-\(UUID().uuidString)"
+            AIService.shared.customModels.insert(selectedModel, at: 0)
+            var conversation = TestHelpers.sampleConversation(title: "Model Race", model: unavailableModel)
+            conversation.updatedAt = Date(timeIntervalSinceReferenceDate: 100)
+            try await store.save(conversation)
+            let loadGate = ConversationStaleLoadGate(store: store)
+            let manager = ConversationManager(
+                store: store,
+                saveDebounceDuration: .milliseconds(0),
+                conversationLoader: { conversationId in
+                    try await loadGate.load(conversationId)
+                }
+            )
+            _ = await manager.loadingTask?.value
+
+            _ = manager.conversation(byId: conversation.id)
+            await loadGate.waitUntilStarted()
+            let index = try #require(manager.conversations.firstIndex(where: { $0.id == conversation.id }))
+            manager.conversations[index].model = selectedModel
+            manager.conversations[index].updatedAt = Date(timeIntervalSinceReferenceDate: 200)
+            await loadGate.release()
+            let hydrated = try #require(await manager.ensureConversationLoaded(conversation.id))
+
+            #expect(hydrated.model == selectedModel)
+            #expect(manager.conversations[index].model == selectedModel)
+        }
+
+        @Test
+        @MainActor
+        func `reload conversations removes stale non-dirty conversations`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-reconcile-key"
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+
+            let kept = TestHelpers.sampleConversation(title: "Kept")
+            try await store.save([kept])
+
+            let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
+            _ = await manager.loadingTask?.value
+
+            #expect(manager.conversations.count == 1)
+            #expect(manager.conversations.first?.id == kept.id)
+
+            let stale = TestHelpers.sampleConversation(title: "Stale")
+            manager.conversations.append(stale)
+            #expect(manager.conversations.count == 2)
+
+            await manager.reloadConversations()
+
+            #expect(manager.conversations.contains(where: { $0.id == kept.id }))
+            #expect(!manager.conversations.contains(where: { $0.id == stale.id }))
+        }
+
+        @Test
+        @MainActor
+        func `reload conversations preserves dirty in-memory conversations not yet on disk`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-dirty-wins-key"
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+
+            let manager = ConversationManager(store: store, saveDebounceDuration: .seconds(10))
+            _ = await manager.loadingTask?.value
+
+            let dirty = TestHelpers.sampleConversation(title: "Dirty")
+            manager.conversations = [dirty]
+            manager.save(dirty)
+
+            // Give the save() Task time to enqueue the pending save.
+            try await Task.sleep(for: .milliseconds(50))
+
+            // Confirm it's not on disk yet (debounce is long)
+            let diskBefore = try await store.loadConversations()
+            #expect(diskBefore.isEmpty)
+
+            await manager.reloadConversations()
+
+            #expect(manager.conversations.contains(where: { $0.id == dirty.id }))
+
+            // Clean up pending saves to avoid test cross-talk.
+            manager.clearAllConversations()
+        }
+
+        @Test
+        @MainActor
+        func `reload ignores stale sidecar text for dirty full conversation`() async throws {
+            let directory = try TestHelpers.makeTemporaryDirectory()
+            let keychain = InMemoryKeychainStorage()
+            let keyId = "test-dirty-search-key"
+            let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
+            var conversation = Conversation(title: "Searchable")
+            conversation.addMessage(Message(role: .user, content: "old deleted term"))
+            try await store.save(conversation)
+
+            let manager = ConversationManager(store: store, saveDebounceDuration: .seconds(10))
+            _ = await manager.loadingTask?.value
+            let hydrated = try #require(await manager.ensureConversationLoaded(conversation.id))
+            let messageId = try #require(hydrated.messages.first?.id)
+
+            #expect(manager.editMessage(in: hydrated, messageId: messageId, newContent: "current replacement"))
+            try await Task.sleep(for: .milliseconds(50))
+
+            await manager.reloadConversations()
+
+            #expect(manager.searchConversations(query: "old deleted term").isEmpty)
+            #expect(manager.searchConversations(query: "current replacement").map(\.id) == [conversation.id])
+
+            let verifiedResults = await manager.verifiedSearchResults(
+                conversations: manager.conversations,
+                query: "old deleted term",
+                metadataSearchTextById: [:],
+                metadataOnlyConversationIds: []
+            )
+            #expect(verifiedResults.isEmpty)
+
+            manager.clearAllConversations()
+        }
     }
 }
 
-extension ConversationManagerTests {
+extension AIServiceGlobalStateTests.ConversationManagerTests {
     // MARK: - Edit Message Tests
 
     @Test
@@ -1315,7 +1344,7 @@ private actor AsyncCompletionProbe {
     }
 }
 
-extension ConversationManagerTests {
+extension AIServiceGlobalStateTests.ConversationManagerTests {
     @Test
     @MainActor
     func `Update message reports whether the target still exists`() throws {

--- a/Tests/AynaTests/ConversationManagerTests.swift
+++ b/Tests/AynaTests/ConversationManagerTests.swift
@@ -267,7 +267,11 @@ extension AIServiceGlobalStateTests {
             let keychain = InMemoryKeychainStorage()
             let keyId = "test-metadata-placeholder-key"
             let store = TestHelpers.makeTestStore(directory: directory, keyIdentifier: keyId, keychain: keychain)
-            let conversation = TestHelpers.sampleConversation(title: "Metadata Only")
+            var conversation = TestHelpers.sampleConversation(title: "Metadata Only")
+            conversation.reasoningConfiguration = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .high
+            )
             try await store.save(conversation)
 
             let manager = ConversationManager(store: store, saveDebounceDuration: .milliseconds(0))
@@ -277,9 +281,14 @@ extension AIServiceGlobalStateTests {
             #expect(manager.conversations.first?.id == conversation.id)
             #expect(manager.conversations.first?.title == "Metadata Only")
             #expect(manager.conversations.first?.messages.isEmpty == true)
+            #expect(
+                manager.conversations.first?.reasoningConfiguration
+                    == conversation.reasoningConfiguration
+            )
 
             let hydrated = await manager.ensureConversationLoaded(conversation.id)
             #expect(hydrated?.messages.count == conversation.messages.count)
+            #expect(hydrated?.reasoningConfiguration == conversation.reasoningConfiguration)
             #expect(manager.conversations.first?.messages.count == conversation.messages.count)
         }
 

--- a/Tests/AynaTests/EncryptedConversationStoreTests.swift
+++ b/Tests/AynaTests/EncryptedConversationStoreTests.swift
@@ -528,6 +528,21 @@ struct EncryptedConversationStoreTests {
     }
 
     @Test
+    func `metadata preview falls back to reasoning for a reasoning-only latest message`() {
+        var conversation = Conversation(title: "Reasoning Preview")
+        conversation.addMessage(Message(role: .assistant, content: "Older assistant reply"))
+        conversation.addMessage(Message(
+            role: .assistant,
+            content: " \n",
+            reasoning: "Compare the constraints first."
+        ))
+
+        let metadata = ConversationMetadata(conversation: conversation)
+
+        #expect(metadata.lastMessagePreview == "Compare the constraints first.")
+    }
+
+    @Test
     func `metadata searchable text includes older messages up to cap`() {
         var conversation = Conversation(title: "Searchable")
         for index in 0 ..< 25 {
@@ -539,6 +554,21 @@ struct EncryptedConversationStoreTests {
 
         #expect(metadata.searchableText.contains("needle-in-first-message"))
         #expect(metadata.messageCount == 25)
+    }
+
+    @Test
+    func `metadata searchable text includes assistant reasoning`() {
+        var conversation = Conversation(title: "Reasoning Search")
+        conversation.addMessage(Message(
+            role: .assistant,
+            content: "Final answer",
+            reasoning: "reasoning-only-search-needle"
+        ))
+
+        let metadata = ConversationMetadata(conversation: conversation)
+
+        #expect(metadata.searchableText.contains("Final answer"))
+        #expect(metadata.searchableText.contains("reasoning-only-search-needle"))
     }
 
     @Test

--- a/Tests/AynaTests/IOSChatViewModelTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelTests.swift
@@ -158,6 +158,63 @@
             viewModel.cancelOwnedOperations()
         }
 
+        @Test(.timeLimit(.minutes(1)))
+        func `single-model reasoning streams into the active assistant and rejects stale callbacks`() async throws {
+            let conversation = Conversation(model: "model-a", systemPromptMode: .disabled)
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = SingleModelReasoningCapturingAIService()
+            configure(aiService, models: [conversation.model])
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            viewModel.messageText = "First question"
+
+            viewModel.sendMessage()
+
+            #expect(aiService.reasoningCallbackCount == 1)
+            let firstAssistantID = try #require(
+                manager.conversation(byId: conversation.id)?.messages.last(where: { $0.role == .assistant })?.id
+            )
+            aiService.emitReasoning(requestIndex: 0, reasoning: "first ")
+            aiService.emitReasoning(requestIndex: 0, reasoning: "reasoning")
+            #expect(await waitUntil {
+                manager.conversation(byId: conversation.id)?.messages.first(where: {
+                    $0.id == firstAssistantID
+                })?.reasoning == "first reasoning"
+            })
+
+            viewModel.cancelGeneration()
+            viewModel.messageText = "Replacement question"
+            viewModel.sendMessage()
+
+            #expect(aiService.reasoningCallbackCount == 2)
+            let secondAssistantID = try #require(
+                manager.conversation(byId: conversation.id)?.messages.last(where: { $0.role == .assistant })?.id
+            )
+            #expect(secondAssistantID != firstAssistantID)
+
+            aiService.emitReasoning(requestIndex: 0, reasoning: "-stale")
+            aiService.emitReasoning(requestIndex: 1, reasoning: "replacement reasoning")
+            #expect(await waitUntil {
+                manager.conversation(byId: conversation.id)?.messages.first(where: {
+                    $0.id == secondAssistantID
+                })?.reasoning == "replacement reasoning"
+            })
+
+            let messages = try #require(manager.conversation(byId: conversation.id)?.messages)
+            #expect(messages.first(where: { $0.id == firstAssistantID })?.reasoning == "first reasoning")
+            viewModel.cancelOwnedOperations()
+        }
+
         @Test
         func `hydrated conversation send remains synchronous`() throws {
             let conversation = Conversation(model: "model-a", systemPromptMode: .disabled)
@@ -650,13 +707,13 @@
 
         override func sendToMultipleModels(
             messages: [Message],
-            models: [String],
+            models _: [String],
             temperature: Double?,
-            onChunk: @escaping @Sendable (String, String) -> Void,
-            onModelComplete: @escaping @Sendable (String) -> Void,
-            onAllComplete: @escaping @Sendable () -> Void,
-            onError: @escaping @Sendable (String, Error) -> Void,
-            onPendingToolCall: (@Sendable (String, String, String, [String: Any]) -> Void)?,
+            onChunk _: @escaping @Sendable (String, String) -> Void,
+            onModelComplete _: @escaping @Sendable (String) -> Void,
+            onAllComplete _: @escaping @Sendable () -> Void,
+            onError _: @escaping @Sendable (String, Error) -> Void,
+            onPendingToolCall _: (@Sendable (String, String, String, [String: Any]) -> Void)?,
             onReasoning: (@Sendable (String, String) -> Void)?
         ) -> AITextBatchRequest {
             reasoningCallbacks.append(onReasoning)
@@ -676,6 +733,63 @@
         func emitReasoning(requestIndex: Int, model: String, reasoning: String) {
             guard reasoningCallbacks.indices.contains(requestIndex) else { return }
             reasoningCallbacks[requestIndex]?(model, reasoning)
+        }
+    }
+
+    @MainActor
+    private final class SingleModelReasoningCapturingAIService: AIService {
+        private typealias ReasoningCallback = @Sendable (String) -> Void
+
+        private var reasoningCallbacks: [ReasoningCallback?] = []
+
+        var reasoningCallbackCount: Int {
+            reasoningCallbacks.count
+        }
+
+        init() {
+            super.init(responseSimulator: { _, _ in })
+        }
+
+        override func sendMessage(
+            messages: [Message],
+            model: String?,
+            temperature: Double?,
+            stream: Bool,
+            tools: [[String: Any]]?,
+            conversationId: UUID?,
+            requestLane: AITextRequestLane,
+            isMultiModelRequest: Bool,
+            onChunk _: @escaping @Sendable (String) -> Void,
+            onComplete _: @escaping @Sendable () -> Void,
+            onError _: @escaping @Sendable (Error) -> Void,
+            onToolCall _: (@Sendable (String, String, [String: Any]) async -> String)?,
+            onToolCallRequested _: (@Sendable (String, String, [String: Any]) -> Void)?,
+            onReasoning: (@Sendable (String) -> Void)?,
+            requestFlightID: RequestFlightID?
+        ) -> AITextRequest {
+            reasoningCallbacks.append(onReasoning)
+            return super.sendMessage(
+                messages: messages,
+                model: model,
+                temperature: temperature,
+                stream: stream,
+                tools: tools,
+                conversationId: conversationId,
+                requestLane: requestLane,
+                isMultiModelRequest: isMultiModelRequest,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in },
+                onToolCall: nil,
+                onToolCallRequested: nil,
+                onReasoning: nil,
+                requestFlightID: requestFlightID
+            )
+        }
+
+        func emitReasoning(requestIndex: Int, reasoning: String) {
+            guard reasoningCallbacks.indices.contains(requestIndex) else { return }
+            reasoningCallbacks[requestIndex]?(reasoning)
         }
     }
 

--- a/Tests/AynaTests/IOSChatViewModelTests.swift
+++ b/Tests/AynaTests/IOSChatViewModelTests.swift
@@ -242,6 +242,133 @@
             viewModel.cancelOwnedOperations()
         }
 
+        @Test
+        func `existing conversation reasoning updates persist and dispatch`() {
+            let originalConfiguration = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .medium
+            )
+            let conversation = Conversation(
+                model: "model-a",
+                systemPromptMode: .disabled,
+                reasoningConfiguration: originalConfiguration
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+
+            let aiService = SendHistoryCapturingAIService()
+            configure(aiService, models: [conversation.model])
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService
+            )
+            #expect(viewModel.selectedModel == conversation.model)
+            #expect(viewModel.selectedModels == [conversation.model])
+            #expect(viewModel.reasoningConfiguration == originalConfiguration)
+
+            let updatedConfiguration = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .high,
+                summary: .concise
+            )
+            viewModel.updateReasoningConfiguration(updatedConfiguration)
+
+            #expect(manager.conversation(byId: conversation.id)?.reasoningConfiguration == updatedConfiguration)
+
+            viewModel.messageText = "Use the configured effort"
+            viewModel.sendMessage()
+
+            #expect(aiService.singleModelReasoningConfigurations == [updatedConfiguration])
+            viewModel.cancelOwnedOperations()
+        }
+
+        @Test
+        func `new multi-model conversation persists and dispatches reasoning`() throws {
+            let models = ["model-a", "model-b"]
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            let aiService = SendHistoryCapturingAIService()
+            configure(aiService, models: models)
+            let viewModel = IOSChatViewModel(
+                conversationManager: manager,
+                aiService: aiService
+            )
+            let configuration = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .low
+            )
+            viewModel.selectedModel = models[0]
+            viewModel.selectedModels = Set(models)
+            viewModel.updateReasoningConfiguration(configuration)
+            viewModel.messageText = "Compare the options"
+
+            viewModel.sendMessage()
+
+            let conversation = try #require(manager.conversations.first)
+            #expect(conversation.reasoningConfiguration == configuration)
+            #expect(aiService.multiModelReasoningConfigurations == [configuration])
+            viewModel.cancelOwnedOperations()
+        }
+
+        @Test(.timeLimit(.minutes(1)))
+        func `tool continuation keeps the reasoning configuration captured by the initial send`() async {
+            let initialConfiguration = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .high
+            )
+            let conversation = Conversation(
+                model: "model-a",
+                systemPromptMode: .disabled,
+                reasoningConfiguration: initialConfiguration
+            )
+            let manager = ConversationManager(
+                store: ScriptedConversationStore(),
+                saveDebounceDuration: .zero,
+                searchIndexWarmupEnabled: false,
+                startsLoadingImmediately: false
+            )
+            manager.conversations = [conversation]
+            let aiService = ToolReasoningCapturingAIService()
+            configure(aiService, models: [conversation.model])
+            let viewModel = IOSChatViewModel(
+                conversationId: conversation.id,
+                conversationManager: manager,
+                aiService: aiService,
+                executeBuiltInTool: { _, _ in ("Tool result", nil) }
+            )
+            viewModel.messageText = "Use a tool"
+
+            viewModel.sendMessage()
+            #expect(aiService.reasoningConfigurations == [initialConfiguration])
+
+            viewModel.updateReasoningConfiguration(
+                ModelReasoningConfiguration(activation: .disabled)
+            )
+            aiService.emitToolRequest(
+                requestIndex: 0,
+                id: "tool-call-1",
+                name: "web_search"
+            )
+            aiService.emitCompletion(requestIndex: 0)
+
+            #expect(await waitUntil { aiService.reasoningConfigurations.count == 2 })
+            #expect(aiService.reasoningConfigurations == [
+                initialConfiguration,
+                initialConfiguration,
+            ])
+            viewModel.cancelOwnedOperations()
+        }
+
         @Test(.timeLimit(.minutes(1)))
         func `failed lazy history load keeps the draft and attachments without sending`() async {
             let conversation = Conversation(model: "model-a", systemPromptMode: .disabled)
@@ -588,7 +715,10 @@
             onToolCall: (@Sendable (String, String, [String: Any]) async -> String)?,
             onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?,
             onReasoning: (@Sendable (String) -> Void)?,
-            requestFlightID: RequestFlightID?
+            onReasoningContinuation: (@Sendable (ReasoningContinuationState) -> Void)?,
+            requestFlightID: RequestFlightID?,
+            reasoningConfiguration: ModelReasoningConfiguration?,
+            reasoningSnapshot: AIReasoningRequestSnapshot?
         ) -> AITextRequest {
             let requestModel = model ?? selectedModel
             capturedRequests.append(
@@ -612,7 +742,10 @@
                 onToolCall: onToolCall,
                 onToolCallRequested: onToolCallRequested,
                 onReasoning: onReasoning,
-                requestFlightID: requestFlightID
+                onReasoningContinuation: onReasoningContinuation,
+                requestFlightID: requestFlightID,
+                reasoningConfiguration: reasoningConfiguration,
+                reasoningSnapshot: reasoningSnapshot
             )
         }
     }
@@ -621,6 +754,8 @@
     private final class SendHistoryCapturingAIService: AIService {
         private(set) var singleModelRequests: [[Message]] = []
         private(set) var multiModelRequests: [[Message]] = []
+        private(set) var singleModelReasoningConfigurations: [ModelReasoningConfiguration?] = []
+        private(set) var multiModelReasoningConfigurations: [ModelReasoningConfiguration?] = []
 
         init() {
             super.init(responseSimulator: { _, _ in })
@@ -641,10 +776,14 @@
             onToolCall: (@Sendable (String, String, [String: Any]) async -> String)?,
             onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?,
             onReasoning: (@Sendable (String) -> Void)?,
-            requestFlightID: RequestFlightID?
+            onReasoningContinuation: (@Sendable (ReasoningContinuationState) -> Void)?,
+            requestFlightID: RequestFlightID?,
+            reasoningConfiguration: ModelReasoningConfiguration?,
+            reasoningSnapshot: AIReasoningRequestSnapshot?
         ) -> AITextRequest {
             if !isMultiModelRequest {
                 singleModelRequests.append(messages)
+                singleModelReasoningConfigurations.append(reasoningConfiguration)
             }
             return super.sendMessage(
                 messages: messages,
@@ -661,7 +800,10 @@
                 onToolCall: onToolCall,
                 onToolCallRequested: onToolCallRequested,
                 onReasoning: onReasoning,
-                requestFlightID: requestFlightID
+                onReasoningContinuation: onReasoningContinuation,
+                requestFlightID: requestFlightID,
+                reasoningConfiguration: reasoningConfiguration,
+                reasoningSnapshot: reasoningSnapshot
             )
         }
 
@@ -674,9 +816,12 @@
             onAllComplete: @escaping @Sendable () -> Void,
             onError: @escaping @Sendable (String, Error) -> Void,
             onPendingToolCall: (@Sendable (String, String, String, [String: Any]) -> Void)?,
-            onReasoning: (@Sendable (String, String) -> Void)?
+            onReasoning: (@Sendable (String, String) -> Void)?,
+            onReasoningContinuation: (@Sendable (String, ReasoningContinuationState) -> Void)?,
+            reasoningConfiguration: ModelReasoningConfiguration?
         ) -> AITextBatchRequest {
             multiModelRequests.append(messages)
+            multiModelReasoningConfigurations.append(reasoningConfiguration)
             return super.sendToMultipleModels(
                 messages: messages,
                 models: models,
@@ -686,8 +831,79 @@
                 onAllComplete: onAllComplete,
                 onError: onError,
                 onPendingToolCall: onPendingToolCall,
-                onReasoning: onReasoning
+                onReasoning: onReasoning,
+                onReasoningContinuation: onReasoningContinuation,
+                reasoningConfiguration: reasoningConfiguration
             )
+        }
+    }
+
+    @MainActor
+    private final class ToolReasoningCapturingAIService: AIService {
+        private typealias CompletionCallback = @Sendable () -> Void
+        private typealias ToolCallback = @Sendable (String, String, [String: Any]) -> Void
+
+        private var completionCallbacks: [CompletionCallback] = []
+        private var toolCallbacks: [ToolCallback?] = []
+        private(set) var reasoningConfigurations: [ModelReasoningConfiguration?] = []
+
+        init() {
+            super.init(responseSimulator: { _, _ in })
+        }
+
+        override func sendMessage(
+            messages: [Message],
+            model: String?,
+            temperature: Double?,
+            stream: Bool,
+            tools: [[String: Any]]?,
+            conversationId: UUID?,
+            requestLane: AITextRequestLane,
+            isMultiModelRequest: Bool,
+            onChunk _: @escaping @Sendable (String) -> Void,
+            onComplete: @escaping @Sendable () -> Void,
+            onError _: @escaping @Sendable (Error) -> Void,
+            onToolCall _: (@Sendable (String, String, [String: Any]) async -> String)?,
+            onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?,
+            onReasoning _: (@Sendable (String) -> Void)?,
+            onReasoningContinuation _: (@Sendable (ReasoningContinuationState) -> Void)?,
+            requestFlightID: RequestFlightID?,
+            reasoningConfiguration: ModelReasoningConfiguration?,
+            reasoningSnapshot: AIReasoningRequestSnapshot?
+        ) -> AITextRequest {
+            reasoningConfigurations.append(reasoningConfiguration)
+            completionCallbacks.append(onComplete)
+            toolCallbacks.append(onToolCallRequested)
+            return super.sendMessage(
+                messages: messages,
+                model: model,
+                temperature: temperature,
+                stream: stream,
+                tools: tools,
+                conversationId: conversationId,
+                requestLane: requestLane,
+                isMultiModelRequest: isMultiModelRequest,
+                onChunk: { _ in },
+                onComplete: {},
+                onError: { _ in },
+                onToolCall: nil,
+                onToolCallRequested: nil,
+                onReasoning: nil,
+                onReasoningContinuation: nil,
+                requestFlightID: requestFlightID,
+                reasoningConfiguration: reasoningConfiguration,
+                reasoningSnapshot: reasoningSnapshot
+            )
+        }
+
+        func emitToolRequest(requestIndex: Int, id: String, name: String) {
+            guard toolCallbacks.indices.contains(requestIndex) else { return }
+            toolCallbacks[requestIndex]?(id, name, [:])
+        }
+
+        func emitCompletion(requestIndex: Int) {
+            guard completionCallbacks.indices.contains(requestIndex) else { return }
+            completionCallbacks[requestIndex]()
         }
     }
 
@@ -714,7 +930,9 @@
             onAllComplete _: @escaping @Sendable () -> Void,
             onError _: @escaping @Sendable (String, Error) -> Void,
             onPendingToolCall _: (@Sendable (String, String, String, [String: Any]) -> Void)?,
-            onReasoning: (@Sendable (String, String) -> Void)?
+            onReasoning: (@Sendable (String, String) -> Void)?,
+            onReasoningContinuation _: (@Sendable (String, ReasoningContinuationState) -> Void)?,
+            reasoningConfiguration: ModelReasoningConfiguration?
         ) -> AITextBatchRequest {
             reasoningCallbacks.append(onReasoning)
             return super.sendToMultipleModels(
@@ -726,7 +944,9 @@
                 onAllComplete: {},
                 onError: { _, _ in },
                 onPendingToolCall: nil,
-                onReasoning: nil
+                onReasoning: nil,
+                onReasoningContinuation: nil,
+                reasoningConfiguration: reasoningConfiguration
             )
         }
 
@@ -765,7 +985,10 @@
             onToolCall _: (@Sendable (String, String, [String: Any]) async -> String)?,
             onToolCallRequested _: (@Sendable (String, String, [String: Any]) -> Void)?,
             onReasoning: (@Sendable (String) -> Void)?,
-            requestFlightID: RequestFlightID?
+            onReasoningContinuation _: (@Sendable (ReasoningContinuationState) -> Void)?,
+            requestFlightID: RequestFlightID?,
+            reasoningConfiguration: ModelReasoningConfiguration?,
+            reasoningSnapshot: AIReasoningRequestSnapshot?
         ) -> AITextRequest {
             reasoningCallbacks.append(onReasoning)
             return super.sendMessage(
@@ -783,7 +1006,10 @@
                 onToolCall: nil,
                 onToolCallRequested: nil,
                 onReasoning: nil,
-                requestFlightID: requestFlightID
+                onReasoningContinuation: nil,
+                requestFlightID: requestFlightID,
+                reasoningConfiguration: reasoningConfiguration,
+                reasoningSnapshot: reasoningSnapshot
             )
         }
 

--- a/Tests/AynaTests/MacChatMessagePresentationTests.swift
+++ b/Tests/AynaTests/MacChatMessagePresentationTests.swift
@@ -7,12 +7,14 @@
     struct MacChatMessagePresentationTests {
         @Test
         func `reasoning-only assistant output remains visible and persistent`() {
-            let message = Message(
+            var message = Message(
                 role: .assistant,
-                content: "",
-                reasoning: "Partial reasoning"
+                content: ""
             )
+            message.appendReasoning("Partial ")
+            message.appendReasoning("reasoning")
 
+            #expect(message.reasoning == "Partial reasoning")
             #expect(MacChatMessagePresentation.isVisible(
                 message,
                 lastMessageID: nil,

--- a/Tests/AynaTests/ModelReasoningSettingsPresentationTests.swift
+++ b/Tests/AynaTests/ModelReasoningSettingsPresentationTests.swift
@@ -316,6 +316,85 @@ struct ModelReasoningSettingsPresentationTests {
 
         #expect(normalized.anthropicMode == .extended)
     }
+
+    @Test
+    func `Multi-model presentation exposes only common activation and effort options`() {
+        let presentation = ChatReasoningSettingsPresentation(
+            models: [
+                ChatReasoningModelContext(
+                    model: "gpt-5",
+                    provider: .openai,
+                    endpointType: .chatCompletions,
+                    endpoint: nil
+                ),
+                ChatReasoningModelContext(
+                    model: "gpt-5.6",
+                    provider: .openai,
+                    endpointType: .responses,
+                    endpoint: nil
+                ),
+            ],
+            configuration: .automatic
+        )
+
+        #expect(presentation.isAvailable)
+        #expect(presentation.activationOptions == [.automatic, .disabled, .enabled])
+        #expect(presentation.effortOptions == [.low, .medium, .high])
+    }
+
+    @Test
+    func `Multi-model normalization clears controls unsupported by any selected model`() {
+        let configuration = ModelReasoningConfiguration(
+            activation: .explicitlyDisabled,
+            effort: .xhigh
+        )
+        let presentation = ChatReasoningSettingsPresentation(
+            models: [
+                ChatReasoningModelContext(
+                    model: "gpt-5",
+                    provider: .openai,
+                    endpointType: .chatCompletions,
+                    endpoint: nil
+                ),
+                ChatReasoningModelContext(
+                    model: "gpt-5.6",
+                    provider: .openai,
+                    endpointType: .responses,
+                    endpoint: nil
+                ),
+            ],
+            configuration: configuration
+        )
+
+        let normalized = presentation.normalizedConfiguration(configuration)
+
+        #expect(normalized.activation == .automatic)
+        #expect(normalized.effort == nil)
+    }
+
+    @Test
+    func `Multi-model reasoning is unavailable when any selected model lacks request controls`() {
+        let presentation = ChatReasoningSettingsPresentation(
+            models: [
+                ChatReasoningModelContext(
+                    model: "gpt-5",
+                    provider: .openai,
+                    endpointType: .chatCompletions,
+                    endpoint: nil
+                ),
+                ChatReasoningModelContext(
+                    model: "apple-intelligence",
+                    provider: .appleIntelligence,
+                    endpointType: .chatCompletions,
+                    endpoint: nil
+                ),
+            ],
+            configuration: .automatic
+        )
+
+        #expect(!presentation.isAvailable)
+        #expect(presentation.effortOptions.isEmpty)
+    }
 }
 
 // swiftlint:enable identifier_name

--- a/Tests/AynaTests/ModelReasoningSettingsPresentationTests.swift
+++ b/Tests/AynaTests/ModelReasoningSettingsPresentationTests.swift
@@ -1,0 +1,321 @@
+@testable import Ayna
+import Testing
+
+// SwiftFormat prefers descriptive Swift Testing function names.
+// swiftlint:disable identifier_name
+
+@Suite("Model reasoning settings presentation")
+struct ModelReasoningSettingsPresentationTests {
+    @Test
+    func `OpenAI chat exposes effort without Responses-only fields`() {
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "gpt-5",
+            provider: .openai,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: .automatic
+        )
+
+        #expect(presentation.isActivationEnabled)
+        #expect(!presentation.activationOptions.contains(.explicitlyDisabled))
+        #expect(presentation.showsEffort)
+        #expect(presentation.effortOptions == [.minimal, .low, .medium, .high])
+        #expect(!presentation.showsOpenAIMode)
+        #expect(!presentation.showsOpenAIContext)
+        #expect(!presentation.showsSummary)
+    }
+
+    @Test
+    func `OpenAI Responses exposes response reasoning fields`() {
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "gpt-5.6",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: nil,
+            configuration: .automatic
+        )
+
+        #expect(presentation.showsEffort)
+        #expect(presentation.activationOptions.contains(.explicitlyDisabled))
+        #expect(presentation.effortOptions == [.none, .low, .medium, .high, .xhigh, .max])
+        #expect(presentation.showsOpenAIMode)
+        #expect(presentation.openAIModeOptions == OpenAIReasoningMode.allCases)
+        #expect(presentation.showsOpenAIContext)
+        #expect(presentation.openAIContextOptions == OpenAIReasoningContext.allCases)
+        #expect(presentation.showsSummary)
+        #expect(presentation.summaryOptions == [.none, .automatic])
+    }
+
+    @Test
+    func `Anthropic adaptive exposes effort and display`() {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.anthropicMode = .adaptive
+
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "claude-sonnet-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: configuration
+        )
+
+        #expect(!presentation.showsAnthropicMode)
+        #expect(presentation.activationOptions.contains(.explicitlyDisabled))
+        #expect(presentation.anthropicModeOptions == [.adaptive])
+        #expect(presentation.showsAnthropicDisplay)
+        #expect(presentation.showsEffort)
+        #expect(!presentation.showsLegacyBudget)
+        #expect(presentation.effortOptions == ReasoningEffort.anthropicValues)
+    }
+
+    @Test
+    func `Anthropic extended exposes legacy budget instead of effort`() {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.activation = .enabled
+        configuration.anthropicMode = .extended
+
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "claude-sonnet-4-5-20250929",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: configuration
+        )
+
+        #expect(!presentation.showsAnthropicMode)
+        #expect(presentation.anthropicModeOptions == [.extended])
+        #expect(presentation.showsAnthropicDisplay)
+        #expect(!presentation.showsEffort)
+        #expect(presentation.showsLegacyBudget)
+    }
+
+    @Test
+    func `Anthropic models with both dialects expose a mode picker when explicitly enabled`() {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.activation = .enabled
+
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "claude-sonnet-4-6",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: configuration
+        )
+
+        #expect(presentation.showsAnthropicMode)
+        #expect(presentation.anthropicModeOptions == AnthropicThinkingMode.allCases)
+    }
+
+    @Test
+    func `Anthropic legacy thinking can expose effort and a fixed budget together`() {
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "claude-opus-4-5-20251101",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: .automatic
+        )
+
+        #expect(presentation.showsEffort)
+        #expect(presentation.effortOptions == [.low, .medium, .high])
+        #expect(presentation.showsLegacyBudget)
+    }
+
+    @Test
+    func `Disabled activation hides provider-specific controls`() {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.activation = .disabled
+
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "gpt-5.6",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: nil,
+            configuration: configuration
+        )
+
+        #expect(presentation.isActivationEnabled)
+        #expect(!presentation.showsEffort)
+        #expect(!presentation.showsOpenAIMode)
+        #expect(!presentation.showsOpenAIContext)
+        #expect(!presentation.showsSummary)
+    }
+
+    @Test
+    func `Anthropic Off preserves only supported effort choices`() {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.activation = .explicitlyDisabled
+        configuration.effort = .xhigh
+
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "claude-opus-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: configuration
+        )
+        let normalized = ModelReasoningSettingsPresentation.normalizedConfiguration(
+            model: "claude-opus-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: configuration
+        )
+
+        #expect(presentation.showsEffort)
+        #expect(presentation.effortOptions == [.low, .medium, .high])
+        #expect(!presentation.showsAnthropicDisplay)
+        #expect(!presentation.showsLegacyBudget)
+        #expect(normalized.effort == nil)
+    }
+
+    @Test(arguments: [
+        (AIProvider.openai, APIEndpointType.imageGeneration),
+        (AIProvider.appleIntelligence, APIEndpointType.chatCompletions),
+    ])
+    func `Unsupported configurations keep activation visible but disabled`(
+        provider: AIProvider,
+        endpointType: APIEndpointType
+    ) {
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "test-model",
+            provider: provider,
+            endpointType: endpointType,
+            endpoint: nil,
+            configuration: .automatic
+        )
+
+        #expect(!presentation.isActivationEnabled)
+        #expect(!presentation.showsEffort)
+        #expect(presentation.unavailableDescription != nil)
+    }
+
+    @Test
+    func `Automatic unknown model hides advanced controls`() {
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "deployment-alias",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: nil,
+            configuration: .automatic
+        )
+
+        #expect(presentation.isActivationEnabled)
+        #expect(!presentation.showsEffort)
+        #expect(!presentation.showsOpenAIMode)
+        #expect(!presentation.showsOpenAIContext)
+        #expect(!presentation.showsSummary)
+        #expect(presentation.unavailableDescription != nil)
+    }
+
+    @Test
+    func `Explicit unknown model uses provider fallback options`() {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.activation = .enabled
+
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "deployment-alias",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: "https://example.com/v1",
+            configuration: configuration
+        )
+
+        #expect(presentation.showsEffort)
+        #expect(presentation.effortOptions == ReasoningEffort.allCases)
+        #expect(presentation.openAIModeOptions == OpenAIReasoningMode.allCases)
+        #expect(presentation.openAIContextOptions == OpenAIReasoningContext.allCases)
+        #expect(presentation.summaryOptions == ReasoningSummaryPreference.allCases)
+    }
+
+    @Test
+    func `Automatic custom endpoint hides advanced controls`() {
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "gpt-5.6",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: "https://example.com/v1",
+            configuration: .automatic
+        )
+
+        #expect(presentation.isActivationEnabled)
+        #expect(!presentation.showsEffort)
+        #expect(presentation.unavailableDescription != nil)
+    }
+
+    @Test
+    func `Always-on Anthropic models do not expose Off`() {
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "claude-fable-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: .automatic
+        )
+
+        #expect(!presentation.activationOptions.contains(.explicitlyDisabled))
+    }
+
+    @Test
+    func `Unknown aliases do not claim explicit disable support`() {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.activation = .enabled
+        let presentation = ModelReasoningSettingsPresentation(
+            model: "deployment-alias",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: "https://example.com/v1",
+            configuration: configuration
+        )
+
+        #expect(!presentation.activationOptions.contains(.explicitlyDisabled))
+    }
+
+    @Test
+    func `Normalization clears values that are invalid for changed capabilities`() {
+        var configuration = ModelReasoningConfiguration(
+            activation: .explicitlyDisabled,
+            effort: .max,
+            openAIMode: .pro,
+            openAIContext: .allTurns,
+            summary: .detailed,
+            anthropicMode: .extended
+        )
+        configuration.legacyBudgetTokens = 1
+
+        let normalized = ModelReasoningSettingsPresentation.normalizedConfiguration(
+            model: "gpt-5",
+            provider: .openai,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: configuration
+        )
+
+        #expect(normalized.activation == .automatic)
+        #expect(normalized.effort == nil)
+        #expect(normalized.openAIMode == nil)
+        #expect(normalized.openAIContext == .automatic)
+        #expect(normalized.summary == .automatic)
+        #expect(normalized.anthropicMode == .adaptive)
+        #expect(normalized.legacyBudgetTokens == ModelReasoningConfiguration.minimumLegacyBudgetTokens)
+    }
+
+    @Test
+    func `Normalization selects the only supported Anthropic mode`() {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.activation = .enabled
+        configuration.anthropicMode = .adaptive
+
+        let normalized = ModelReasoningSettingsPresentation.normalizedConfiguration(
+            model: "claude-sonnet-4-5-20250929",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: configuration
+        )
+
+        #expect(normalized.anthropicMode == .extended)
+    }
+}
+
+// swiftlint:enable identifier_name

--- a/Tests/AynaTests/OpenAIRequestBuilderTests.swift
+++ b/Tests/AynaTests/OpenAIRequestBuilderTests.swift
@@ -2,6 +2,8 @@
 import Foundation
 import Testing
 
+// swiftformat:disable swiftTestingTestCaseNames
+
 @Suite("OpenAIRequestBuilder Tests")
 @MainActor
 struct OpenAIRequestBuilderTests {
@@ -81,6 +83,161 @@ struct OpenAIRequestBuilderTests {
         let input = try #require(body["input"] as? [[String: Any]])
         #expect(input.count == 1)
         #expect(input[0]["role"] as? String == "user")
+    }
+
+    @Test("Responses body omits reasoning and verbosity without a supported configuration")
+    func responsesBodyOmitsReasoningAndVerbosityWithoutSupportedConfiguration() {
+        let body = OpenAIRequestBuilder.buildResponsesBody(
+            model: "gpt-4.1",
+            messages: [Message(role: .user, content: "Hello")]
+        )
+
+        #expect(body["reasoning"] == nil)
+        #expect(body["text"] == nil)
+    }
+
+    @Test("Responses body emits only explicitly resolved reasoning controls")
+    func responsesBodyEmitsOnlyExplicitlyResolvedReasoningControls() throws {
+        let reasoning = ResolvedReasoningConfiguration(
+            dialect: .openAIResponses,
+            effort: .max,
+            openAIMode: .pro,
+            openAIContext: .allTurns,
+            summary: .automatic,
+            anthropicDisplay: .summarized,
+            legacyBudgetTokens: 4096
+        )
+
+        let body = OpenAIRequestBuilder.buildResponsesBody(
+            model: "gpt-5.6-sol",
+            messages: [Message(role: .user, content: "Solve this")],
+            reasoning: reasoning
+        )
+        let wire = try #require(body["reasoning"] as? [String: Any])
+
+        #expect(wire["effort"] as? String == "max")
+        #expect(wire["summary"] as? String == "auto")
+        #expect(wire["context"] as? String == "all_turns")
+        #expect(wire["mode"] as? String == "pro")
+        #expect(body["text"] == nil)
+    }
+
+    @Test("Chat Completions emits effort only for its reasoning dialect")
+    func chatCompletionsEmitsEffortOnlyForItsReasoningDialect() {
+        let chatReasoning = ResolvedReasoningConfiguration(
+            dialect: .openAIChat,
+            effort: .high,
+            openAIMode: nil,
+            openAIContext: .automatic,
+            summary: .none,
+            anthropicDisplay: .summarized,
+            legacyBudgetTokens: 4096
+        )
+        let responsesReasoning = ResolvedReasoningConfiguration(
+            dialect: .openAIResponses,
+            effort: .high,
+            openAIMode: nil,
+            openAIContext: .automatic,
+            summary: .automatic,
+            anthropicDisplay: .summarized,
+            legacyBudgetTokens: 4096
+        )
+
+        let emitted = OpenAIRequestBuilder.buildChatCompletionsBody(
+            messages: [Message(role: .user, content: "Hello")],
+            model: "gpt-5.5",
+            stream: false,
+            reasoning: chatReasoning
+        )
+        let omitted = OpenAIRequestBuilder.buildChatCompletionsBody(
+            messages: [Message(role: .user, content: "Hello")],
+            model: "gpt-5.5",
+            stream: false,
+            reasoning: responsesReasoning
+        )
+
+        #expect(emitted["reasoning_effort"] as? String == "high")
+        #expect(omitted["reasoning_effort"] == nil)
+    }
+
+    @Test
+    func `GPT-5.6 Chat Completions forces none when tools are present`() {
+        let reasoning = ResolvedReasoningConfiguration(
+            dialect: .openAIChat,
+            effort: .high,
+            openAIMode: nil,
+            openAIContext: .automatic,
+            summary: .none,
+            anthropicDisplay: .providerDefault,
+            legacyBudgetTokens: 4096
+        )
+        let tools: [[String: Any]] = [[
+            "type": "function",
+            "function": [
+                "name": "lookup",
+                "parameters": ["type": "object"]
+            ]
+        ]]
+
+        let body = OpenAIRequestBuilder.buildChatCompletionsBody(
+            messages: [Message(role: .user, content: "Hello")],
+            model: "gpt-5.6-sol",
+            stream: false,
+            tools: tools,
+            reasoning: reasoning
+        )
+
+        #expect(body["reasoning_effort"] as? String == "none")
+    }
+
+    @Test
+    func `GPT-5.6 Chat Completions forces none for tools at provider default`() {
+        let tools: [[String: Any]] = [[
+            "type": "function",
+            "function": [
+                "name": "lookup",
+                "parameters": ["type": "object"]
+            ]
+        ]]
+
+        let body = OpenAIRequestBuilder.buildChatCompletionsBody(
+            messages: [Message(role: .user, content: "Hello")],
+            model: "gpt-5.6-sol",
+            stream: false,
+            tools: tools
+        )
+
+        #expect(body["reasoning_effort"] as? String == "none")
+    }
+
+    @Test("Earlier reasoning models keep their configured effort with Chat tools")
+    func earlierReasoningModelsKeepTheirConfiguredEffortWithChatTools() {
+        let reasoning = ResolvedReasoningConfiguration(
+            dialect: .openAIChat,
+            effort: .high,
+            openAIMode: nil,
+            openAIContext: .automatic,
+            summary: .none,
+            anthropicDisplay: .providerDefault,
+            legacyBudgetTokens: 4096
+        )
+        let tools: [[String: Any]] = [[
+            "type": "function",
+            "function": [
+                "name": "lookup",
+                "parameters": ["type": "object"]
+            ]
+        ]]
+
+        let body = OpenAIRequestBuilder.buildChatCompletionsBody(
+            messages: [Message(role: .user, content: "Hello")],
+            model: "gpt-5.5",
+            stream: false,
+            tools: tools,
+            reasoning: reasoning
+        )
+
+        #expect(body["reasoning_effort"] as? String == "high")
     }
 
     @Test
@@ -167,8 +324,117 @@ struct OpenAIRequestBuilderTests {
         #expect(input[1]["call_id"] as? String == call.id)
     }
 
+    @Test("Responses input replays opaque output items unchanged before tool results")
+    func responsesInputReplaysOpaqueOutputItemsUnchangedBeforeToolResults() {
+        let reasoningItem: [String: Any] = [
+            "type": "reasoning",
+            "id": "rs_123",
+            "encrypted_content": "opaque-token",
+            "summary": [["type": "summary_text", "text": "Checked constraints"]]
+        ]
+        let callItem: [String: Any] = [
+            "type": "function_call",
+            "id": "fc_123",
+            "call_id": "call_123",
+            "name": "web_search",
+            "arguments": "{\"query\":\"weather\"}"
+        ]
+        var assistant = Message(role: .assistant, content: "")
+        assistant.model = "gpt-5.6"
+        assistant.toolCalls = [
+            MCPToolCall(
+                id: "call_123",
+                toolName: "web_search",
+                arguments: ["query": AnyCodable("weather")]
+            )
+        ]
+        assistant.reasoningContinuation = ReasoningContinuationState(
+            format: .openAIResponses,
+            items: [AnyCodable(reasoningItem), AnyCodable(callItem)],
+            model: "gpt-5.6"
+        )
+        var result = Message(role: .tool, content: "Sunny")
+        result.toolCalls = [
+            MCPToolCall(
+                id: "call_123",
+                toolName: "web_search",
+                arguments: [:],
+                result: "Sunny"
+            )
+        ]
+
+        let input = OpenAIRequestBuilder.buildResponsesInput(
+            from: [assistant, result],
+            model: "gpt-5.6"
+        )
+
+        #expect(input.map { $0["type"] as? String } == [
+            "reasoning", "function_call", "function_call_output"
+        ])
+        #expect(input[0]["encrypted_content"] as? String == "opaque-token")
+        #expect(input[1]["id"] as? String == "fc_123")
+        #expect(input[2]["call_id"] as? String == "call_123")
+        #expect(input[2]["output"] as? String == "Sunny")
+    }
+
+    @Test("Responses input does not replay opaque state across model changes")
+    func responsesInputDoesNotReplayOpaqueStateAcrossModelChanges() {
+        var assistant = Message(role: .assistant, content: "Final answer", model: "gpt-5.5")
+        assistant.reasoningContinuation = ReasoningContinuationState(
+            format: .openAIResponses,
+            items: [AnyCodable(["type": "reasoning", "id": "rs_old"])],
+            model: "gpt-5.5"
+        )
+
+        let input = OpenAIRequestBuilder.buildResponsesInput(
+            from: [assistant],
+            model: "gpt-5.6"
+        )
+
+        #expect(input.count == 1)
+        #expect(input[0]["type"] as? String == "message")
+        #expect(input[0]["role"] as? String == "assistant")
+    }
+
+    @Test("Responses output preserves every opaque item while delivering summaries and tools")
+    func responsesOutputPreservesEveryOpaqueItemWhileDeliveringSummariesAndTools() throws {
+        let output: [[String: Any]] = [
+            [
+                "type": "reasoning",
+                "id": "rs_123",
+                "encrypted_content": "opaque-token",
+                "summary": [["type": "summary_text", "text": "Checked constraints"]]
+            ],
+            [
+                "type": "function_call",
+                "id": "fc_123",
+                "call_id": "call_123",
+                "name": "web_search",
+                "arguments": "{\"query\":\"weather\"}"
+            ]
+        ]
+        var deliveredReasoning = ""
+        var deliveredContinuation: ReasoningContinuationState?
+        var deliveredToolName: String?
+
+        let result = OpenAIRequestBuilder.deliverResponsesOutput(
+            output,
+            onChunk: { _ in },
+            onReasoning: { deliveredReasoning += $0 },
+            onReasoningContinuation: { deliveredContinuation = $0 },
+            onToolCallRequested: { _, name, _ in deliveredToolName = name }
+        )
+
+        #expect(deliveredReasoning == "Checked constraints")
+        #expect(deliveredToolName == "web_search")
+        #expect(result.hasToolCalls)
+        #expect(result.reasoningContinuation == deliveredContinuation)
+        let replayed = try #require(deliveredContinuation?.items.first?.value as? [String: Any])
+        #expect(replayed["encrypted_content"] as? String == "opaque-token")
+    }
+
     @Test("Responses input requires tool outputs to follow their call in the same round")
-    func responsesInputRequiresOutputsInSameRound() {
+    func responsesInputRequiresToolOutputsToFollowTheirCallInTheSameRound() {
         let call = MCPToolCall(id: "reused", toolName: "web_search", arguments: [:])
         var assistant = Message(role: .assistant, content: "Keep this text")
         assistant.toolCalls = [call]

--- a/Tests/AynaTests/ReasoningConfigurationTests.swift
+++ b/Tests/AynaTests/ReasoningConfigurationTests.swift
@@ -1,0 +1,623 @@
+@testable import Ayna
+import Foundation
+import Testing
+
+// swiftlint:disable identifier_name
+
+@Suite("Reasoning Configuration Tests", .tags(.fast))
+struct ReasoningConfigurationTests {
+    @Test
+    func `Automatic mode recognizes only supported first-party models and endpoints`() {
+        #expect(resolve(model: "gpt-5.6", endpointType: .responses)?.dialect == .openAIResponses)
+        #expect(resolve(model: "gpt-4.1", endpointType: .responses) == nil)
+        #expect(resolve(
+            model: "gpt-5.6",
+            endpointType: .responses,
+            endpoint: "https://gateway.example.com/v1"
+        ) == nil)
+        #expect(resolve(
+            model: "azure-production-deployment",
+            endpointType: .responses,
+            endpoint: "https://example.openai.azure.com/openai/v1"
+        ) == nil)
+    }
+
+    @Test
+    func `Explicit mode opts custom aliases into their configured dialect`() {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.activation = .enabled
+        configuration.effort = .high
+
+        let resolved = ReasoningCapabilityResolver.resolve(
+            model: "azure-production-deployment",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: "https://example.openai.azure.com/openai/v1",
+            configuration: configuration
+        )
+
+        #expect(resolved?.dialect == .openAIResponses)
+        #expect(resolved?.effort == .high)
+    }
+
+    @Test
+    func `Automatic mode removes unsupported model-specific controls`() throws {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.effort = .max
+        configuration.summary = .detailed
+        configuration.openAIContext = .allTurns
+        configuration.openAIMode = .pro
+
+        let resolved = try #require(ReasoningCapabilityResolver.resolve(
+            model: "gpt-5.5",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: nil,
+            configuration: configuration
+        ))
+
+        #expect(resolved.effort == nil)
+        #expect(resolved.summary == .automatic)
+        #expect(resolved.openAIContext == .automatic)
+        #expect(resolved.openAIMode == nil)
+    }
+
+    @Test
+    func `Explicit mode still sanitizes controls for recognized models`() throws {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.activation = .enabled
+        configuration.effort = .max
+        configuration.summary = .detailed
+        configuration.openAIContext = .allTurns
+        configuration.openAIMode = .pro
+
+        let resolved = try #require(ReasoningCapabilityResolver.resolve(
+            model: "gpt-5.5",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: nil,
+            configuration: configuration
+        ))
+
+        #expect(resolved.effort == nil)
+        #expect(resolved.summary == .automatic)
+        #expect(resolved.openAIContext == .automatic)
+        #expect(resolved.openAIMode == nil)
+    }
+
+    @Test
+    func `GPT-5.6 Responses exposes persisted context, modes, and maximum effort`() throws {
+        let profile = try #require(ReasoningCapabilityResolver.capabilities(
+            model: "gpt-5.6-sol",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: nil,
+            configuration: .automatic
+        ))
+
+        #expect(profile.dialect == .openAIResponses)
+        #expect(profile.supportedEfforts.contains(.max))
+        #expect(profile.supportedSummaries == [.none, .automatic])
+        #expect(profile.supportedOpenAIContexts.contains(.allTurns))
+        #expect(profile.supportedOpenAIModes == OpenAIReasoningMode.allCases)
+    }
+
+    @Test
+    func `GPT-5.6 Chat Completions supports maximum effort and disables reasoning for tools`() throws {
+        let profile = try #require(ReasoningCapabilityResolver.capabilities(
+            model: "gpt-5.6-terra",
+            provider: .openai,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: .automatic
+        ))
+
+        #expect(profile.dialect == .openAIChat)
+        #expect(profile.supportedEfforts.contains(.max))
+        #expect(profile.chatCompletionsToolPolicy == .requiresExplicitEffort(.none))
+        #expect(profile.allowsChatCompletionsTools(with: ReasoningEffort.none))
+        #expect(!profile.allowsChatCompletionsTools(with: nil))
+        #expect(!profile.allowsChatCompletionsTools(with: .high))
+        #expect(profile.chatCompletionsEffort(requested: .max, hasTools: false) == .max)
+        #expect(profile.chatCompletionsEffort(
+            requested: .max,
+            hasTools: true
+        ) == ReasoningEffort.none)
+    }
+
+    @Test(arguments: [
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.6-cyber",
+        "gpt-5.5",
+        "gpt-5.5-2026-04-23",
+        "gpt-5.5-pro",
+        "gpt-5.5-pro-2026-04-23",
+        "gpt-5.4",
+        "gpt-5.4-2026-03-05",
+        "gpt-5.4-mini",
+        "gpt-5.4-mini-2026-03-17",
+        "gpt-5.4-nano",
+        "gpt-5.4-nano-2026-03-17",
+        "gpt-5.4-pro",
+        "gpt-5.4-pro-2026-03-05",
+        "gpt-5.3-codex",
+        "gpt-5.2",
+        "gpt-5.2-2025-12-11",
+        "gpt-5.2-pro",
+        "gpt-5.2-pro-2025-12-11",
+        "gpt-5.2-codex",
+        "gpt-5.1",
+        "gpt-5.1-2025-11-13",
+        "gpt-5.1-codex",
+        "gpt-5.1-codex-mini",
+        "gpt-5.1-codex-max",
+        "gpt-5",
+        "gpt-5-2025-08-07",
+        "gpt-5-mini",
+        "gpt-5-mini-2025-08-07",
+        "gpt-5-nano",
+        "gpt-5-nano-2025-08-07",
+        "gpt-5-pro",
+        "gpt-5-pro-2025-10-06",
+        "gpt-5-codex",
+        "o1",
+        "o1-2024-12-17",
+        "o1-pro",
+        "o1-pro-2025-03-19",
+        "o3",
+        "o3-2025-04-16",
+        "o3-mini",
+        "o3-mini-2025-01-31",
+        "o3-pro",
+        "o3-pro-2025-06-10",
+        "o3-deep-research",
+        "o3-deep-research-2025-06-26",
+        "o4-mini",
+        "o4-mini-2025-04-16",
+        "o4-mini-deep-research",
+        "o4-mini-deep-research-2025-06-26",
+        "codex-mini-latest"
+    ])
+    func `OpenAI catalog recognizes documented exact Responses IDs`(model: String) {
+        #expect(openAIModelPolicy(model: model, endpointType: .responses) != nil)
+    }
+
+    @Test
+    func `OpenAI catalog recognizes exact Chat IDs without accepting invented snapshots`() {
+        #expect(openAIModelPolicy(
+            model: "o1-mini-2024-09-12",
+            endpointType: .chatCompletions
+        ) != nil)
+        #expect(openAIModelPolicy(model: "gpt-5.6-20260810", endpointType: .responses) == nil)
+        #expect(openAIModelPolicy(model: "proxy-gpt-5.6", endpointType: .responses) == nil)
+    }
+
+    @Test(arguments: [
+        "gpt-5.5-pro",
+        "gpt-5.5-pro-2026-04-23",
+        "gpt-5.4-pro-2026-03-05",
+        "gpt-5-pro",
+        "gpt-5-pro-2025-10-06",
+        "gpt-5.4-pro",
+        "gpt-5.2-pro",
+        "gpt-5.2-pro-2025-12-11",
+        "gpt-5.3-codex",
+        "gpt-5.2-codex",
+        "gpt-5.1-codex",
+        "gpt-5.1-codex-mini",
+        "gpt-5.1-codex-max",
+        "gpt-5-codex",
+        "o1-pro",
+        "o1-pro-2025-03-19",
+        "o3-pro",
+        "o3-pro-2025-06-10",
+        "o3-deep-research",
+        "o3-deep-research-2025-06-26",
+        "o4-mini-deep-research",
+        "o4-mini-deep-research-2025-06-26",
+        "codex-mini-latest"
+    ])
+    func `Response-only OpenAI models are unavailable on Chat Completions`(model: String) {
+        #expect(openAIModelPolicy(model: model, endpointType: .chatCompletions) == nil)
+    }
+
+    @Test
+    func `Known OpenAI models do not fall back on unsupported endpoints`() {
+        #expect(openAIModelPolicy(model: "o1-mini", endpointType: .responses) == nil)
+
+        var explicitlyEnabled = ModelReasoningConfiguration.automatic
+        explicitlyEnabled.activation = .enabled
+        explicitlyEnabled.effort = .high
+
+        #expect(ReasoningCapabilityResolver.resolve(
+            model: "gpt-5-pro",
+            provider: .openai,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: explicitlyEnabled
+        ) == nil)
+        #expect(ReasoningCapabilityResolver.resolve(
+            model: "o1-mini",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: nil,
+            configuration: explicitlyEnabled
+        ) == nil)
+    }
+
+    @Test
+    func `OpenAI model policies expose documented efforts defaults and disable support`() throws {
+        let newest = try #require(openAIModelPolicy(model: "gpt-5.6", endpointType: .responses))
+        let defaultOnWithDisable = try #require(openAIModelPolicy(
+            model: "gpt-5.5",
+            endpointType: .responses
+        ))
+        let defaultOff = try #require(openAIModelPolicy(model: "gpt-5.4", endpointType: .responses))
+        let olderDefaultOff = try #require(openAIModelPolicy(
+            model: "gpt-5.1",
+            endpointType: .responses
+        ))
+        let pro = try #require(openAIModelPolicy(model: "gpt-5.5-pro", endpointType: .responses))
+        let codex = try #require(openAIModelPolicy(
+            model: "gpt-5.2-codex",
+            endpointType: .responses
+        ))
+        let noDisable = try #require(openAIModelPolicy(model: "gpt-5", endpointType: .responses))
+
+        #expect(newest.providerDefaultBehavior == .enabled)
+        #expect(newest.explicitDisableSupport == .supported)
+        #expect(newest.supportedEfforts == [.none, .low, .medium, .high, .xhigh, .max])
+        #expect(defaultOnWithDisable.providerDefaultBehavior == .enabled)
+        #expect(defaultOnWithDisable.explicitDisableSupport == .supported)
+        #expect(defaultOnWithDisable.supportedEfforts == [.none, .low, .medium, .high, .xhigh])
+        #expect(defaultOff.providerDefaultBehavior == .disabled)
+        #expect(defaultOff.explicitDisableSupport == .supported)
+        #expect(defaultOff.supportedEfforts == [.none, .low, .medium, .high, .xhigh])
+        #expect(olderDefaultOff.providerDefaultBehavior == .disabled)
+        #expect(olderDefaultOff.explicitDisableSupport == .supported)
+        #expect(olderDefaultOff.supportedEfforts == [.none, .low, .medium, .high])
+        #expect(pro.providerDefaultBehavior == .enabled)
+        #expect(pro.explicitDisableSupport == .unsupported)
+        #expect(pro.supportedEfforts == [.medium, .high, .xhigh])
+        #expect(codex.explicitDisableSupport == .unsupported)
+        #expect(codex.supportedEfforts == [.low, .medium, .high, .xhigh])
+        #expect(noDisable.explicitDisableSupport == .unsupported)
+    }
+
+    @Test
+    func `O1 mini remains passive when unsupported outbound controls are selected automatically`() throws {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.effort = .high
+        configuration.summary = .automatic
+
+        let resolved = try #require(ReasoningCapabilityResolver.resolve(
+            model: "o1-mini",
+            provider: .openai,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: configuration
+        ))
+
+        #expect(resolved.effort == nil)
+        #expect(resolved.summary == .none)
+    }
+
+    @Test
+    func `Supported Anthropic models resolve their documented thinking dialect`() throws {
+        let newest = try #require(ReasoningCapabilityResolver.resolve(
+            model: "claude-sonnet-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: .automatic
+        ))
+        let adaptive = try #require(ReasoningCapabilityResolver.resolve(
+            model: "claude-opus-4-8",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: .automatic
+        ))
+        let extended = try #require(ReasoningCapabilityResolver.resolve(
+            model: "claude-sonnet-4-5-20250929",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: .automatic
+        ))
+
+        #expect(newest.dialect == .anthropicAdaptive)
+        #expect(adaptive.dialect == .anthropicAdaptive)
+        #expect(extended.dialect == .anthropicExtended)
+        #expect(newest.anthropicDisplay == .providerDefault)
+    }
+
+    @Test
+    func `Anthropic automatic matching accepts documented IDs only`() {
+        #expect(ReasoningCapabilityResolver.resolve(
+            model: "proxy-claude-sonnet-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: .automatic
+        ) == nil)
+        #expect(ReasoningCapabilityResolver.resolve(
+            model: "claude-sonnet-5-20260701",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: .automatic
+        ) == nil)
+    }
+
+    @Test
+    func `Anthropic models that support both modes honor an explicit legacy selection`() throws {
+        var configuration = ModelReasoningConfiguration.automatic
+        configuration.activation = .enabled
+        configuration.anthropicMode = .extended
+
+        let resolved = try #require(ReasoningCapabilityResolver.resolve(
+            model: "claude-sonnet-4-6",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: configuration
+        ))
+
+        #expect(resolved.dialect == .anthropicExtended)
+    }
+
+    @Test
+    func `Anthropic model policies distinguish default and disable behavior`() throws {
+        let alwaysOn = try #require(anthropicModelPolicy(model: "claude-fable-5"))
+        let alwaysOnBothModes = try #require(anthropicModelPolicy(model: "claude-mythos-preview"))
+        let defaultOnRestrictedDisable = try #require(anthropicModelPolicy(model: "claude-opus-5"))
+        let defaultOn = try #require(anthropicModelPolicy(model: "claude-sonnet-5"))
+        let defaultOffAdaptive = try #require(anthropicModelPolicy(model: "claude-opus-4-8"))
+        let defaultOffBothModes = try #require(anthropicModelPolicy(model: "claude-sonnet-4-6"))
+        let legacyWithEffort = try #require(anthropicModelPolicy(model: "claude-opus-4-5"))
+        let legacyWithoutEffort = try #require(anthropicModelPolicy(model: "claude-sonnet-4-5"))
+
+        #expect(alwaysOn.providerDefaultBehavior == .alwaysEnabled)
+        #expect(alwaysOn.explicitDisableSupport == .unsupported)
+        #expect(alwaysOn.supportedAnthropicModes == [.adaptive])
+        #expect(alwaysOn.supportedEfforts == [.low, .medium, .high, .xhigh, .max])
+
+        #expect(alwaysOnBothModes.providerDefaultBehavior == .alwaysEnabled)
+        #expect(alwaysOnBothModes.explicitDisableSupport == .unsupported)
+        #expect(alwaysOnBothModes.supportedAnthropicModes == AnthropicThinkingMode.allCases)
+        #expect(alwaysOnBothModes.supportedEfforts == [.low, .medium, .high, .max])
+
+        #expect(defaultOnRestrictedDisable.providerDefaultBehavior == .enabled)
+        #expect(defaultOnRestrictedDisable.explicitDisableSupport == .supportedWithEfforts([
+            .low,
+            .medium,
+            .high,
+        ]))
+        #expect(defaultOnRestrictedDisable.supportedAnthropicModes == [.adaptive])
+
+        #expect(defaultOn.providerDefaultBehavior == .enabled)
+        #expect(defaultOn.explicitDisableSupport == .supported)
+        #expect(defaultOn.supportedAnthropicModes == [.adaptive])
+
+        #expect(defaultOffAdaptive.providerDefaultBehavior == .disabled)
+        #expect(defaultOffAdaptive.explicitDisableSupport == .supported)
+        #expect(defaultOffAdaptive.supportedAnthropicModes == [.adaptive])
+
+        #expect(defaultOffBothModes.providerDefaultBehavior == .disabled)
+        #expect(defaultOffBothModes.explicitDisableSupport == .supported)
+        #expect(defaultOffBothModes.supportedAnthropicModes == AnthropicThinkingMode.allCases)
+
+        #expect(legacyWithEffort.supportedAnthropicModes == [.extended])
+        #expect(legacyWithEffort.supportedEfforts == [.low, .medium, .high])
+        #expect(legacyWithEffort.explicitDisableSupport == .supported)
+
+        #expect(legacyWithoutEffort.supportedAnthropicModes == [.extended])
+        #expect(legacyWithoutEffort.supportedEfforts.isEmpty)
+        #expect(legacyWithoutEffort.explicitDisableSupport == .supported)
+    }
+
+    @Test
+    func `Provider default omission and explicit disable resolve differently`() throws {
+        var providerDefault = ModelReasoningConfiguration.automatic
+        providerDefault.activation = .disabled
+
+        #expect(ReasoningCapabilityResolver.resolve(
+            model: "claude-sonnet-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: providerDefault
+        ) == nil)
+
+        var explicitlyDisabled = ModelReasoningConfiguration.automatic
+        explicitlyDisabled.activation = .explicitlyDisabled
+        explicitlyDisabled.effort = .medium
+
+        let openAI = try #require(ReasoningCapabilityResolver.resolve(
+            model: "gpt-5.6",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: nil,
+            configuration: explicitlyDisabled
+        ))
+        let anthropic = try #require(ReasoningCapabilityResolver.resolve(
+            model: "claude-sonnet-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: explicitlyDisabled
+        ))
+        let anthropicRestricted = try #require(ReasoningCapabilityResolver.resolve(
+            model: "claude-opus-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: explicitlyDisabled
+        ))
+
+        #expect(openAI.dialect == .openAIResponses)
+        #expect(openAI.effort == ReasoningEffort.none)
+        #expect(openAI.summary == .none)
+        #expect(anthropic.dialect == .anthropicDisabled)
+        #expect(anthropic.effort == .medium)
+        #expect(anthropicRestricted.dialect == .anthropicDisabled)
+        #expect(anthropicRestricted.effort == .medium)
+
+        #expect(ReasoningCapabilityResolver.resolve(
+            model: "gpt-5",
+            provider: .openai,
+            endpointType: .responses,
+            endpoint: nil,
+            configuration: explicitlyDisabled
+        ) == nil)
+        #expect(ReasoningCapabilityResolver.resolve(
+            model: "claude-fable-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: explicitlyDisabled
+        ) == nil)
+        let legacyAnthropic = try #require(ReasoningCapabilityResolver.resolve(
+            model: "claude-sonnet-4-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: explicitlyDisabled
+        ))
+        #expect(legacyAnthropic.dialect == .anthropicDisabled)
+        #expect(legacyAnthropic.effort == nil)
+
+        explicitlyDisabled.effort = .xhigh
+        let restrictedInvalidEffort = try #require(ReasoningCapabilityResolver.resolve(
+            model: "claude-opus-5",
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: explicitlyDisabled
+        ))
+        #expect(restrictedInvalidEffort.effort == nil)
+    }
+
+    @Test
+    func `Retired Anthropic models are not recognized automatically`() {
+        for model in [
+            "claude-opus-4-1",
+            "claude-opus-4-20250514",
+            "claude-sonnet-4-20250514",
+            "claude-3-7-sonnet-20250219",
+        ] {
+            #expect(ReasoningCapabilityResolver.resolve(
+                model: model,
+                provider: .anthropic,
+                endpointType: .chatCompletions,
+                endpoint: nil,
+                configuration: .automatic
+            ) == nil)
+        }
+    }
+
+    @Test
+    func `Captured provider default survives continuation persistence`() throws {
+        let captured = ReasoningContinuationState(
+            format: .openAIResponses,
+            items: [AnyCodable(["type": "reasoning", "id": "rs_default"])]
+        ).attaching(model: "gpt-5.6", requestConfiguration: nil)
+
+        let data = try JSONEncoder().encode(captured)
+        let decoded = try JSONDecoder().decode(ReasoningContinuationState.self, from: data)
+
+        #expect(decoded.requestConfiguration == nil)
+        #expect(decoded.hasRequestConfigurationSnapshot)
+    }
+
+    @Test
+    func `Reasoning is unavailable for Apple and image-generation requests`() {
+        var enabled = ModelReasoningConfiguration.automatic
+        enabled.activation = .enabled
+
+        #expect(ReasoningCapabilityResolver.resolve(
+            model: "apple-intelligence",
+            provider: .appleIntelligence,
+            endpointType: .chatCompletions,
+            endpoint: nil,
+            configuration: enabled
+        ) == nil)
+        #expect(ReasoningCapabilityResolver.resolve(
+            model: "gpt-image-1",
+            provider: .openai,
+            endpointType: .imageGeneration,
+            endpoint: nil,
+            configuration: enabled
+        ) == nil)
+    }
+
+    @Test
+    func `Opaque continuation state survives persistence without changing provider items`() throws {
+        let state = ReasoningContinuationState(
+            format: .openAIResponses,
+            items: [AnyCodable([
+                "type": "reasoning",
+                "id": "rs_123",
+                "encrypted_content": "opaque-token"
+            ])],
+            model: "gpt-5.6",
+            requestConfiguration: ResolvedReasoningConfiguration(
+                dialect: .openAIResponses,
+                effort: .high,
+                openAIMode: .standard,
+                openAIContext: .allTurns,
+                summary: .automatic,
+                anthropicDisplay: .summarized,
+                legacyBudgetTokens: 4096
+            )
+        )
+
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(ReasoningContinuationState.self, from: data)
+
+        #expect(decoded == state)
+    }
+
+    private func resolve(
+        model: String,
+        endpointType: APIEndpointType,
+        endpoint: String? = nil
+    ) -> ResolvedReasoningConfiguration? {
+        ReasoningCapabilityResolver.resolve(
+            model: model,
+            provider: .openai,
+            endpointType: endpointType,
+            endpoint: endpoint,
+            configuration: .automatic
+        )
+    }
+
+    private func openAIModelPolicy(
+        model: String,
+        endpointType: APIEndpointType
+    ) -> ReasoningCapabilityProfile? {
+        ReasoningCapabilityResolver.modelPolicy(
+            model: model,
+            provider: .openai,
+            endpointType: endpointType
+        )
+    }
+
+    private func anthropicModelPolicy(
+        model: String,
+        mode: AnthropicThinkingMode = .adaptive
+    ) -> ReasoningCapabilityProfile? {
+        ReasoningCapabilityResolver.modelPolicy(
+            model: model,
+            provider: .anthropic,
+            endpointType: .chatCompletions,
+            anthropicMode: mode
+        )
+    }
+}
+
+// swiftlint:enable identifier_name

--- a/Tests/AynaTests/WatchConnectivitySupportTests.swift
+++ b/Tests/AynaTests/WatchConnectivitySupportTests.swift
@@ -2001,6 +2001,129 @@ struct WatchLegacyMetadataCompatibilityTests {
     }
 }
 
+@Suite("Watch reasoning configuration sync tests", .tags(.fast))
+struct WatchReasoningConfigurationSyncTests {
+    @Test
+    @MainActor
+    func `reasoning configuration changes request a coalesced Watch publication`() async {
+        let service = AIService()
+        let originalConfigurations = service.modelReasoningConfigurations
+        let manager = ConversationManager(
+            store: ScriptedConversationStore(),
+            startsLoadingImmediately: false
+        )
+        let model = "reasoning-observer-\(UUID().uuidString)"
+        let expectedConfiguration = reasoningConfiguration(effort: .high)
+        let publicationRequested = FlightTestSignal()
+        let cancellables = WatchConversationSyncObserver.observe(
+            conversationManager: manager,
+            aiService: service,
+            serviceChangeDebounce: .milliseconds(10)
+        ) { _ in
+            guard service.modelReasoningConfigurations[model] == expectedConfiguration else {
+                return
+            }
+            publicationRequested.signal()
+        }
+        defer {
+            cancellables.forEach { $0.cancel() }
+            service.modelReasoningConfigurations = originalConfigurations
+        }
+
+        await Task.yield()
+        service.modelReasoningConfigurations[model] = expectedConfiguration
+
+        #expect(await publicationRequested.wait(timeout: .seconds(1)))
+        withExtendedLifetime(cancellables) {}
+    }
+
+    @Test
+    func `reasoning configurations use property list safe wire values and round trip`() throws {
+        let model = "reasoning-model"
+        let configuration = reasoningConfiguration(effort: .xhigh)
+        let firstEncoding = WatchModelReasoningConfigurationCodec.encode([
+            model: configuration
+        ])
+        let secondEncoding = WatchModelReasoningConfigurationCodec.encode([
+            model: configuration
+        ])
+        let context: [String: Any] = [
+            WatchContextKeys.modelReasoningConfigurations: firstEncoding
+        ]
+
+        #expect(firstEncoding == secondEncoding)
+        #expect(PropertyListSerialization.propertyList(context, isValidFor: .binary))
+        #expect(try #require(WatchModelMetadataPage(context: context)
+                .modelReasoningConfigurations?[model]) == configuration)
+    }
+
+    @Test
+    func `bounded metadata preserves reasoning configurations omitted by the page`() {
+        let retainedModel = "retained-model"
+        let incomingModel = "incoming-model"
+        let retainedConfiguration = reasoningConfiguration(effort: .low)
+        let incomingConfiguration = reasoningConfiguration(effort: .high)
+        var state = WatchModelMetadataState(
+            selectedModel: retainedModel,
+            availableModels: [retainedModel],
+            customModels: [retainedModel],
+            defaultProvider: "openai",
+            modelProviders: [:],
+            modelEndpoints: [:],
+            modelEndpointTypes: [:],
+            modelAPIKeys: [:],
+            modelReasoningConfigurations: [retainedModel: retainedConfiguration]
+        )
+        let boundedPage = WatchModelMetadataPage(
+            selectedModel: incomingModel,
+            availableModels: [incomingModel],
+            customModels: [incomingModel],
+            modelReasoningConfigurations: [incomingModel: incomingConfiguration]
+        )
+        var accumulator = WatchModelMetadataCycleAccumulator()
+
+        accumulator.apply(
+            boundedPage,
+            cycleID: UUID(),
+            completesCycle: true,
+            isAuthoritative: false,
+            to: &state
+        )
+
+        #expect(state.modelReasoningConfigurations == [
+            retainedModel: retainedConfiguration,
+            incomingModel: incomingConfiguration
+        ])
+
+        accumulator.apply(
+            boundedPage,
+            cycleID: UUID(),
+            completesCycle: true,
+            isAuthoritative: true,
+            to: &state
+        )
+
+        #expect(state.modelReasoningConfigurations == [
+            incomingModel: incomingConfiguration
+        ])
+    }
+
+    private func reasoningConfiguration(
+        effort: ReasoningEffort
+    ) -> ModelReasoningConfiguration {
+        ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: effort,
+            openAIMode: .pro,
+            openAIContext: .allTurns,
+            summary: .detailed,
+            anthropicMode: .extended,
+            anthropicDisplay: .omitted,
+            legacyBudgetTokens: 8192
+        )
+    }
+}
+
 @Suite("Watch model removal compatibility tests", .tags(.fast))
 struct WatchModelRemovalCompatibilityTests {
     @Test
@@ -2022,8 +2145,8 @@ struct WatchModelRemovalCompatibilityTests {
     @Test
     func `model removal history rotates epoch before tombstones exceed the context budget`() throws {
         let limit = WatchModelRemovalTracker.maximumRetiredDigestCount
-        let fieldRetirementCount = limit / 5
-        let modelRetirementCount = limit - (fieldRetirementCount * 4)
+        let fieldRetirementCount = limit / 6
+        let modelRetirementCount = limit - (fieldRetirementCount * 5)
         let retiredModels = (0 ..< modelRetirementCount).map { "retired-model-\($0)" }
         let retiredFieldModels = Array(retiredModels.prefix(fieldRetirementCount))
         let retainedModel = "retained-model"
@@ -2035,14 +2158,16 @@ struct WatchModelRemovalCompatibilityTests {
             providerModelIDs: retiredFieldModels + [retainedModel],
             endpointModelIDs: retiredFieldModels,
             endpointTypeModelIDs: retiredFieldModels,
-            apiKeyModelIDs: retiredFieldModels
+            apiKeyModelIDs: retiredFieldModels,
+            reasoningConfigurationModelIDs: retiredFieldModels
         )).isEmpty)
         let atLimit = tracker.publication(inventory: WatchModelMetadataInventory(
             modelIDs: [retainedModel],
             providerModelIDs: [retainedModel],
             endpointModelIDs: [],
             endpointTypeModelIDs: [],
-            apiKeyModelIDs: []
+            apiKeyModelIDs: [],
+            reasoningConfigurationModelIDs: []
         ))
         let atLimitContext: [String: Any] = [
             WatchContextKeys.removedModelDigests: atLimit.removedModelDigests,
@@ -2050,6 +2175,8 @@ struct WatchModelRemovalCompatibilityTests {
             WatchContextKeys.removedModelEndpointDigests: atLimit.removedEndpointDigests,
             WatchContextKeys.removedModelEndpointTypeDigests: atLimit.removedEndpointTypeDigests,
             WatchContextKeys.removedModelAPIKeyDigests: atLimit.removedAPIKeyDigests,
+            WatchContextKeys.removedModelReasoningConfigurationDigests:
+                atLimit.removedReasoningConfigurationDigests,
             WatchContextKeys.modelMetadataEpoch: tracker.epoch.uuidString
         ]
         let encodedAtLimit = try JSONEncoder().encode(tracker)
@@ -2058,6 +2185,7 @@ struct WatchModelRemovalCompatibilityTests {
             + atLimit.removedEndpointDigests.count
             + atLimit.removedEndpointTypeDigests.count
             + atLimit.removedAPIKeyDigests.count
+            + atLimit.removedReasoningConfigurationDigests.count
 
         #expect(retiredCount == limit)
         #expect(tracker.epoch == originalEpoch)
@@ -2069,7 +2197,8 @@ struct WatchModelRemovalCompatibilityTests {
             providerModelIDs: [],
             endpointModelIDs: [],
             endpointTypeModelIDs: [],
-            apiKeyModelIDs: []
+            apiKeyModelIDs: [],
+            reasoningConfigurationModelIDs: []
         ))
         let encodedAfterRotation = try JSONEncoder().encode(tracker)
 
@@ -2077,8 +2206,10 @@ struct WatchModelRemovalCompatibilityTests {
         #expect(tracker.epoch != originalEpoch)
         #expect(tracker.publishedDigests == [WatchModelIdentity.digest(retainedModel)])
         #expect(tracker.publishedProviderDigests.isEmpty)
+        #expect(tracker.publishedReasoningConfigurationDigests.isEmpty)
         #expect(tracker.retiredDigests.isEmpty)
         #expect(tracker.retiredProviderDigests.isEmpty)
+        #expect(tracker.retiredReasoningConfigurationDigests.isEmpty)
         #expect(encodedAfterRotation.count < encodedAtLimit.count)
     }
 
@@ -2086,6 +2217,21 @@ struct WatchModelRemovalCompatibilityTests {
     func `changed bounded metadata invalidates stale values until replacements arrive`() {
         let model = "changed-model"
         let modelDigest = WatchModelIdentity.digest(model)
+        let oldReasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .low
+        )
+        let newReasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .high,
+            summary: .detailed
+        )
+        let oldEncodedReasoning = WatchModelReasoningConfigurationCodec.encode([
+            model: oldReasoningConfiguration
+        ])
+        let newEncodedReasoning = WatchModelReasoningConfigurationCodec.encode([
+            model: newReasoningConfiguration
+        ])
         var tracker = WatchModelRemovalTracker()
         let oldInventory = WatchModelMetadataInventory(
             modelIDs: [model],
@@ -2093,11 +2239,13 @@ struct WatchModelRemovalCompatibilityTests {
             endpointModelIDs: [model],
             endpointTypeModelIDs: [model],
             apiKeyModelIDs: [model],
-            valueDigests: WatchModelMetadataValueDigests(
-                providers: [modelDigest: WatchModelIdentity.digest("openai")],
-                endpoints: [modelDigest: WatchModelIdentity.digest("https://old.example")],
-                endpointTypes: [modelDigest: WatchModelIdentity.digest("responses")],
-                apiKeys: [modelDigest: WatchModelIdentity.digest("old-key")]
+            reasoningConfigurationModelIDs: [model],
+            valueDigests: WatchModelMetadataValueDigests.hashing(
+                providers: [model: "openai"],
+                endpoints: [model: "https://old.example"],
+                endpointTypes: [model: "responses"],
+                apiKeys: [model: "old-key"],
+                reasoningConfigurations: oldEncodedReasoning
             )
         )
         let newInventory = WatchModelMetadataInventory(
@@ -2106,11 +2254,13 @@ struct WatchModelRemovalCompatibilityTests {
             endpointModelIDs: [model],
             endpointTypeModelIDs: [model],
             apiKeyModelIDs: [model],
-            valueDigests: WatchModelMetadataValueDigests(
-                providers: [modelDigest: WatchModelIdentity.digest("anthropic")],
-                endpoints: [modelDigest: WatchModelIdentity.digest("https://new.example")],
-                endpointTypes: [modelDigest: WatchModelIdentity.digest("messages")],
-                apiKeys: [modelDigest: WatchModelIdentity.digest("new-key")]
+            reasoningConfigurationModelIDs: [model],
+            valueDigests: WatchModelMetadataValueDigests.hashing(
+                providers: [model: "anthropic"],
+                endpoints: [model: "https://new.example"],
+                endpointTypes: [model: "messages"],
+                apiKeys: [model: "new-key"],
+                reasoningConfigurations: newEncodedReasoning
             )
         )
 
@@ -2121,6 +2271,7 @@ struct WatchModelRemovalCompatibilityTests {
         #expect(invalidations.removedEndpointDigests == [modelDigest])
         #expect(invalidations.removedEndpointTypeDigests == [modelDigest])
         #expect(invalidations.removedAPIKeyDigests == [modelDigest])
+        #expect(invalidations.removedReasoningConfigurationDigests == [modelDigest])
         #expect(tracker.publication(inventory: newInventory) == invalidations)
 
         var state = WatchModelMetadataState(
@@ -2131,41 +2282,55 @@ struct WatchModelRemovalCompatibilityTests {
             modelProviders: [model: "openai"],
             modelEndpoints: [model: "https://old.example"],
             modelEndpointTypes: [model: "responses"],
-            modelAPIKeys: [model: "old-key"]
+            modelAPIKeys: [model: "old-key"],
+            modelReasoningConfigurations: [model: oldReasoningConfiguration]
         )
         state.merge(WatchModelMetadataPage(
             removedModelProviderDigests: invalidations.removedProviderDigests,
             removedModelEndpointDigests: invalidations.removedEndpointDigests,
             removedModelEndpointTypeDigests: invalidations.removedEndpointTypeDigests,
-            removedModelAPIKeyDigests: invalidations.removedAPIKeyDigests
+            removedModelAPIKeyDigests: invalidations.removedAPIKeyDigests,
+            removedModelReasoningConfigurationDigests: invalidations.removedReasoningConfigurationDigests
         ))
 
         #expect(state.modelProviders[model] == nil)
         #expect(state.modelEndpoints[model] == nil)
         #expect(state.modelEndpointTypes[model] == nil)
         #expect(state.modelAPIKeys[model] == nil)
+        #expect(state.modelReasoningConfigurations[model] == nil)
 
         state.merge(WatchModelMetadataPage(
             modelProviders: [model: "anthropic"],
             modelEndpoints: [model: "https://new.example"],
             modelEndpointTypes: [model: "messages"],
             modelAPIKeys: [model: "new-key"],
+            modelReasoningConfigurations: [model: newReasoningConfiguration],
             removedModelProviderDigests: invalidations.removedProviderDigests,
             removedModelEndpointDigests: invalidations.removedEndpointDigests,
             removedModelEndpointTypeDigests: invalidations.removedEndpointTypeDigests,
-            removedModelAPIKeyDigests: invalidations.removedAPIKeyDigests
+            removedModelAPIKeyDigests: invalidations.removedAPIKeyDigests,
+            removedModelReasoningConfigurationDigests: invalidations.removedReasoningConfigurationDigests
         ))
 
         #expect(state.modelProviders[model] == "anthropic")
         #expect(state.modelEndpoints[model] == "https://new.example")
         #expect(state.modelEndpointTypes[model] == "messages")
         #expect(state.modelAPIKeys[model] == "new-key")
+        #expect(state.modelReasoningConfigurations[model] == newReasoningConfiguration)
     }
 
     @Test
     func `provisional metadata removes retired model credentials immediately`() {
         let removedModel = "removed-model"
         let retainedModel = "retained-model"
+        let removedConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .high
+        )
+        let retainedConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .low
+        )
         var state = WatchModelMetadataState(
             selectedModel: removedModel,
             availableModels: [removedModel, retainedModel],
@@ -2174,7 +2339,11 @@ struct WatchModelRemovalCompatibilityTests {
             modelProviders: [removedModel: "openai", retainedModel: "anthropic"],
             modelEndpoints: [removedModel: "https://removed.example", retainedModel: "https://retained.example"],
             modelEndpointTypes: [removedModel: "responses", retainedModel: "messages"],
-            modelAPIKeys: [removedModel: "revoked-key", retainedModel: "retained-key"]
+            modelAPIKeys: [removedModel: "revoked-key", retainedModel: "retained-key"],
+            modelReasoningConfigurations: [
+                removedModel: removedConfiguration,
+                retainedModel: retainedConfiguration
+            ]
         )
         let epoch = UUID()
         let pageContext: [String: Any] = [
@@ -2193,32 +2362,41 @@ struct WatchModelRemovalCompatibilityTests {
         #expect(state.modelEndpoints[removedModel] == nil)
         #expect(state.modelEndpointTypes[removedModel] == nil)
         #expect(state.modelAPIKeys[removedModel] == nil)
+        #expect(state.modelReasoningConfigurations[removedModel] == nil)
         #expect(state.modelAPIKeys[retainedModel] == "retained-key")
+        #expect(state.modelReasoningConfigurations[retainedModel] == retainedConfiguration)
         #expect(pageContext[WatchContextKeys.modelMetadataEpoch] as? String == epoch.uuidString)
 
         state.resetModelSpecificState()
         #expect(state.selectedModel.isEmpty)
         #expect(state.availableModels.isEmpty)
         #expect(state.modelAPIKeys.isEmpty)
+        #expect(state.modelReasoningConfigurations.isEmpty)
     }
 
     @Test
     func `provisional metadata revokes fields while retaining the model`() {
         let model = "retained-model"
+        let reasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .medium
+        )
         var tracker = WatchModelRemovalTracker()
         _ = tracker.publication(inventory: WatchModelMetadataInventory(
             modelIDs: [model],
             providerModelIDs: [model],
             endpointModelIDs: [model],
             endpointTypeModelIDs: [model],
-            apiKeyModelIDs: [model]
+            apiKeyModelIDs: [model],
+            reasoningConfigurationModelIDs: [model]
         ))
         let removals = tracker.publication(inventory: WatchModelMetadataInventory(
             modelIDs: [model],
             providerModelIDs: [model],
             endpointModelIDs: [],
             endpointTypeModelIDs: [],
-            apiKeyModelIDs: []
+            apiKeyModelIDs: [],
+            reasoningConfigurationModelIDs: []
         ))
         var state = WatchModelMetadataState(
             selectedModel: model,
@@ -2228,7 +2406,8 @@ struct WatchModelRemovalCompatibilityTests {
             modelProviders: [model: "openai"],
             modelEndpoints: [model: "https://removed.example"],
             modelEndpointTypes: [model: "responses"],
-            modelAPIKeys: [model: "revoked-key"]
+            modelAPIKeys: [model: "revoked-key"],
+            modelReasoningConfigurations: [model: reasoningConfiguration]
         )
         state.merge(WatchModelMetadataPage(context: [
             WatchContextKeys.selectedModel: model,
@@ -2237,7 +2416,9 @@ struct WatchModelRemovalCompatibilityTests {
             WatchContextKeys.modelProviders: [model: "openai"],
             WatchContextKeys.removedModelEndpointDigests: removals.removedEndpointDigests,
             WatchContextKeys.removedModelEndpointTypeDigests: removals.removedEndpointTypeDigests,
-            WatchContextKeys.removedModelAPIKeyDigests: removals.removedAPIKeyDigests
+            WatchContextKeys.removedModelAPIKeyDigests: removals.removedAPIKeyDigests,
+            WatchContextKeys.removedModelReasoningConfigurationDigests:
+                removals.removedReasoningConfigurationDigests
         ]))
 
         #expect(state.availableModels == [model])
@@ -2245,6 +2426,58 @@ struct WatchModelRemovalCompatibilityTests {
         #expect(state.modelEndpoints[model] == nil)
         #expect(state.modelEndpointTypes[model] == nil)
         #expect(state.modelAPIKeys[model] == nil)
+        #expect(state.modelReasoningConfigurations[model] == nil)
+    }
+
+    @Test
+    func `persisted removal tracker decodes data written before reasoning sync`() throws {
+        let model = "reasoning-model"
+        let configuration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .high
+        )
+        let encodedConfiguration = WatchModelReasoningConfigurationCodec.encode([
+            model: configuration
+        ])
+        let inventory = WatchModelMetadataInventory(
+            modelIDs: [model],
+            providerModelIDs: [model],
+            endpointModelIDs: [],
+            endpointTypeModelIDs: [],
+            apiKeyModelIDs: [],
+            reasoningConfigurationModelIDs: [model],
+            valueDigests: WatchModelMetadataValueDigests.hashing(
+                providers: [model: "openai"],
+                endpoints: [:],
+                endpointTypes: [:],
+                apiKeys: [:],
+                reasoningConfigurations: encodedConfiguration
+            )
+        )
+        var tracker = WatchModelRemovalTracker()
+        _ = tracker.publication(inventory: inventory)
+        var legacyObject = try #require(JSONSerialization.jsonObject(
+            with: JSONEncoder().encode(tracker)
+        ) as? [String: Any])
+        legacyObject.removeValue(forKey: "publishedReasoningConfigurationDigests")
+        legacyObject.removeValue(forKey: "retiredReasoningConfigurationDigests")
+        var legacyValueDigests = try #require(
+            legacyObject["publishedValueDigests"] as? [String: Any]
+        )
+        legacyValueDigests.removeValue(forKey: "reasoningConfigurations")
+        legacyObject["publishedValueDigests"] = legacyValueDigests
+
+        var restored = try JSONDecoder().decode(
+            WatchModelRemovalTracker.self,
+            from: JSONSerialization.data(withJSONObject: legacyObject)
+        )
+
+        #expect(restored.epoch == tracker.epoch)
+        #expect(restored.publishedProviderDigests == tracker.publishedProviderDigests)
+        #expect(restored.publishedReasoningConfigurationDigests.isEmpty)
+        #expect(restored.retiredReasoningConfigurationDigests.isEmpty)
+        #expect(restored.publication(inventory: inventory)
+            .removedReasoningConfigurationDigests.isEmpty)
     }
 
     private func modelInventory(_ models: [String]) -> WatchModelMetadataInventory {

--- a/Tests/AynaTests/WatchConnectivitySupportTests.swift
+++ b/Tests/AynaTests/WatchConnectivitySupportTests.swift
@@ -188,6 +188,41 @@ struct WatchConnectivitySupportTests {
     }
 
     @Test
+    func `reasoning mismatch prevents legacy create configuration acknowledgement`() {
+        let reasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .high
+        )
+        let conversation = WatchConversation(
+            id: UUID(),
+            title: "Reasoning",
+            model: "reasoning-model",
+            updatedAt: Date(timeIntervalSince1970: 20),
+            createdAt: Date(timeIntervalSince1970: 10),
+            temperature: 0.3,
+            reasoningConfiguration: reasoningConfiguration,
+            resolvedSystemPrompt: "Prompt",
+            watchRevision: 1
+        )
+        let mutation = WatchConversationMutation(
+            revision: 1,
+            conversation: conversation,
+            fields: .fullState
+        )
+        var echo = conversation
+        echo.reasoningConfiguration = .automatic
+
+        let reconciliation = WatchLegacyEchoReconciler.reconcile(
+            mutation,
+            echoedConversations: [echo]
+        )
+
+        #expect(!reconciliation.matchedComponents.contains(.create(revision: 1)))
+        #expect(!reconciliation.matchedComponents.contains(.configuration(revision: 1)))
+        #expect(!reconciliation.canAcknowledgeMutation)
+    }
+
+    @Test
     func `covered or unrelated legacy creates cannot overwrite existing conversations`() {
         let conversationID = UUID()
         let activePeerID = UUID()
@@ -244,6 +279,10 @@ struct WatchConnectivitySupportTests {
     @Test
     func `late legacy create repairs a message placeholder without losing messages`() {
         let conversationID = UUID()
+        let reasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .xhigh
+        )
         let message = Message(
             id: UUID(),
             role: .user,
@@ -266,6 +305,7 @@ struct WatchConnectivitySupportTests {
             updatedAt: Date(timeIntervalSince1970: 10),
             createdAt: Date(timeIntervalSince1970: 10),
             temperature: 0.3,
+            reasoningConfiguration: reasoningConfiguration,
             resolvedSystemPrompt: "Watch prompt",
             watchRevision: 1
         )
@@ -275,6 +315,7 @@ struct WatchConnectivitySupportTests {
         #expect(repaired.title == "Watch title")
         #expect(repaired.model == "watch-model")
         #expect(repaired.temperature == 0.3)
+        #expect(repaired.reasoningConfiguration == reasoningConfiguration)
         #expect(repaired.systemPromptMode == .inheritGlobal)
         #expect(repaired.createdAt == create.createdAt)
         #expect(repaired.updatedAt == message.timestamp)

--- a/Tests/AynaTests/WatchDataModelHostTests.swift
+++ b/Tests/AynaTests/WatchDataModelHostTests.swift
@@ -66,6 +66,13 @@ struct WatchDataModelHostTests {
     @Test
     func `Compact request configuration round trips and clears a retained prompt without touching messages`() throws {
         let conversationID = UUID()
+        let expectedReasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .xhigh,
+            openAIMode: .pro,
+            openAIContext: .allTurns,
+            summary: .detailed
+        )
         let retainedMessage = WatchMessage(from: Message(role: .user, content: "Keep me"))
         var conversation = WatchConversation(
             id: conversationID,
@@ -75,12 +82,17 @@ struct WatchDataModelHostTests {
             updatedAt: Date(timeIntervalSince1970: 2),
             createdAt: Date(timeIntervalSince1970: 1),
             temperature: 1.0,
+            reasoningConfiguration: ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .low
+            ),
             resolvedSystemPrompt: "Old prompt"
         )
         let original = WatchConversationRequestConfiguration(
             id: conversationID,
             model: "new-model",
             temperature: 0.3,
+            reasoningConfiguration: expectedReasoningConfiguration,
             resolvedSystemPrompt: nil
         )
 
@@ -94,8 +106,48 @@ struct WatchDataModelHostTests {
         #expect(decoded == original)
         #expect(conversation.model == "new-model")
         #expect(conversation.temperature == 0.3)
+        #expect(conversation.reasoningConfiguration == expectedReasoningConfiguration)
         #expect(conversation.resolvedSystemPrompt == nil)
         #expect(conversation.messages == [retainedMessage])
+    }
+
+    @Test
+    func `Legacy Watch request configuration and conversation decode automatic reasoning`() throws {
+        let configuration = WatchConversationRequestConfiguration(
+            id: UUID(),
+            model: "legacy-model",
+            temperature: 0.4,
+            reasoningConfiguration: ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .high
+            ),
+            resolvedSystemPrompt: "Legacy prompt"
+        )
+        let conversation = WatchConversation(
+            id: configuration.id,
+            title: "Legacy",
+            model: configuration.model,
+            updatedAt: Date(timeIntervalSince1970: 2),
+            createdAt: Date(timeIntervalSince1970: 1),
+            reasoningConfiguration: configuration.reasoningConfiguration,
+            resolvedSystemPrompt: configuration.resolvedSystemPrompt
+        )
+
+        let legacyConfiguration = try removingReasoningConfiguration(
+            from: JSONEncoder().encode(configuration)
+        )
+        let legacyConversation = try removingReasoningConfiguration(
+            from: JSONEncoder().encode(conversation)
+        )
+
+        #expect(try JSONDecoder().decode(
+            WatchConversationRequestConfiguration.self,
+            from: legacyConfiguration
+        ).reasoningConfiguration == .automatic)
+        #expect(try JSONDecoder().decode(
+            WatchConversation.self,
+            from: legacyConversation
+        ).reasoningConfiguration == .automatic)
     }
 
     @Test
@@ -149,6 +201,10 @@ struct WatchDataModelHostTests {
 
     @Test
     func `Conversation conversion carries temperature prompt revision and effective history`() {
+        let reasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .high
+        )
         let groupID = UUID()
         let userID = UUID()
         let rejectedID = UUID()
@@ -191,6 +247,7 @@ struct WatchDataModelHostTests {
             model: "chosen",
             systemPromptMode: .custom("Be precise"),
             temperature: 0.25,
+            reasoningConfiguration: reasoningConfiguration,
             responseGroups: [group]
         )
 
@@ -201,6 +258,7 @@ struct WatchDataModelHostTests {
         )
 
         #expect(watch.temperature == 0.25)
+        #expect(watch.reasoningConfiguration == reasoningConfiguration)
         #expect(watch.resolvedSystemPrompt == "Be precise")
         #expect(watch.watchRevision == 7)
         #expect(watch.messages.map(\.id) == [userID, selectedID])
@@ -210,8 +268,15 @@ struct WatchDataModelHostTests {
         conversation.pendingAutoSendPrompt = "phone-only"
         let restored = watch.toConversation()
         #expect(restored.temperature == 0.25)
+        #expect(restored.reasoningConfiguration == reasoningConfiguration)
         #expect(restored.systemPromptMode == .inheritGlobal)
         #expect(restored.messages.map(\.id) == [userID, selectedID])
+    }
+
+    private func removingReasoningConfiguration(from data: Data) throws -> Data {
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "reasoningConfiguration")
+        return try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
     }
 
     @Test

--- a/Tests/AynaTests/WatchDataModelHostTests.swift
+++ b/Tests/AynaTests/WatchDataModelHostTests.swift
@@ -42,7 +42,7 @@ struct WatchDataModelHostTests {
     }
 
     @Test
-    func `Watch message exposes reasoning when final content is empty`() {
+    func `Watch message presents reasoning alongside final content`() {
         let reasoningOnly = WatchMessage(
             id: UUID(),
             role: Message.Role.assistant.rawValue,
@@ -58,7 +58,7 @@ struct WatchDataModelHostTests {
         whitespaceReasoning.reasoning = " \n"
 
         #expect(reasoningOnly.visibleContent == "Compare the constraints.")
-        #expect(completed.visibleContent == "Use the smaller option.")
+        #expect(completed.visibleContent == "Compare the constraints.\n\nUse the smaller option.")
         #expect(whitespaceContent.visibleContent == "Compare the constraints.")
         #expect(whitespaceReasoning.visibleContent.isEmpty)
     }

--- a/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
+++ b/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
@@ -12,7 +12,16 @@
     struct WatchSyncChatViewModelNativeTests {
         @Test
         func `Request uses durable prompt, effective history, conversation model, and temperature`() async throws {
-            let fixture = makeViewModelFixture()
+            let expectedReasoningConfiguration = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .high,
+                openAIMode: .pro,
+                openAIContext: .allTurns,
+                summary: .detailed
+            )
+            let fixture = makeViewModelFixture(
+                reasoningConfiguration: expectedReasoningConfiguration
+            )
             let callbacks = FlightTestBox<AIServiceResponseSimulationCallbacks?>(nil)
             let aiService = configuredAIService(model: fixture.conversation.model) { _, value in
                 callbacks.value = value
@@ -33,6 +42,7 @@
             let request = try #require(observed)
             #expect(request.model == fixture.conversation.model)
             #expect(request.temperature == fixture.conversation.temperature)
+            #expect(request.reasoningConfiguration == expectedReasoningConfiguration)
             #expect(request.conversationID == fixture.conversation.id)
             #expect(request.messages.map(\.role) == [.system, .user])
             #expect(request.messages.first?.content == fixture.conversation.resolvedSystemPrompt)
@@ -990,7 +1000,17 @@
 
         @Test
         func `Tool continuation includes final throttled assistant content`() async throws {
-            let fixture = makeViewModelFixture()
+            let expectedReasoningConfiguration = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .high
+            )
+            let changedReasoningConfiguration = ModelReasoningConfiguration(
+                activation: .enabled,
+                effort: .low
+            )
+            let fixture = makeViewModelFixture(
+                reasoningConfiguration: expectedReasoningConfiguration
+            )
             let aiService = configuredCapturingAIService(model: fixture.conversation.model)
             var requests: [WatchChatViewModel.RequestConfiguration] = []
             let viewModel = WatchChatViewModel(
@@ -1005,6 +1025,20 @@
             #expect(viewModel.sendMessage("Prompt") == .started)
             let firstRequest = try #require(aiService.capturedRequests.value.first)
             let onToolCallRequested = try #require(firstRequest.onToolCallRequested)
+            var refreshedConversation = fixture.conversation
+            refreshedConversation.reasoningConfiguration = changedReasoningConfiguration
+            refreshedConversation.updatedAt = Date(timeIntervalSince1970: 2)
+            #expect(fixture.store.applySyncSnapshot(
+                WatchSyncSnapshot(
+                    revision: 2,
+                    conversations: [refreshedConversation],
+                    authoritativeConversationIDs: [refreshedConversation.id]
+                )
+            ) == .applied)
+            #expect(
+                fixture.store.conversation(for: fixture.conversation.id)?.reasoningConfiguration
+                    == changedReasoningConfiguration
+            )
             firstRequest.onChunk("First")
             firstRequest.onChunk(" second")
             onToolCallRequested("current-call", "unavailable_watch_tool", [:])
@@ -1013,6 +1047,15 @@
             #expect(await waitUntil { requests.count == 2 })
             let continuation = try #require(requests.last)
             #expect(continuation.messages.first { $0.role == .assistant }?.content == "First second")
+            #expect(requests.map(\.reasoningConfiguration) == [
+                expectedReasoningConfiguration,
+                expectedReasoningConfiguration,
+            ])
+            let capturedRequests = aiService.capturedRequests.value
+            #expect(capturedRequests.count == 2)
+            #expect(capturedRequests.allSatisfy {
+                $0.reasoningConfiguration == expectedReasoningConfiguration
+            })
             viewModel.cancelRequest()
         }
 
@@ -1505,6 +1548,7 @@
         title: String = "Synced",
         messages: [WatchMessage] = [],
         model: String = "conversation-model",
+        reasoningConfiguration: ModelReasoningConfiguration = .automatic,
         persistenceWriter: ((Data) -> Bool)? = nil
     ) -> ViewModelFixture {
         let suiteName = "WatchChatViewModelNativeTests.\(UUID().uuidString)"
@@ -1527,6 +1571,7 @@
             updatedAt: date,
             createdAt: date,
             temperature: 0.15,
+            reasoningConfiguration: reasoningConfiguration,
             resolvedSystemPrompt: "System prompt"
         )
         store.applySyncSnapshot(
@@ -1695,6 +1740,7 @@
         let onError: @Sendable (Error) -> Void
         let onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?
         let onReasoning: (@Sendable (String) -> Void)?
+        let reasoningConfiguration: ModelReasoningConfiguration?
     }
 
     @MainActor
@@ -1722,6 +1768,7 @@
             onReasoning: (@Sendable (String) -> Void)?,
             onReasoningContinuation: (@Sendable (ReasoningContinuationState) -> Void)?,
             requestFlightID: RequestFlightID?,
+            reasoningConfiguration: ModelReasoningConfiguration?,
             reasoningSnapshot: AIReasoningRequestSnapshot?
         ) -> AITextRequest {
             capturedRequests.update {
@@ -1732,7 +1779,8 @@
                         onComplete: onComplete,
                         onError: onError,
                         onToolCallRequested: onToolCallRequested,
-                        onReasoning: onReasoning
+                        onReasoning: onReasoning,
+                        reasoningConfiguration: reasoningConfiguration
                     )
                 )
             }
@@ -1753,6 +1801,7 @@
                 onReasoning: onReasoning,
                 onReasoningContinuation: onReasoningContinuation,
                 requestFlightID: requestFlightID,
+                reasoningConfiguration: reasoningConfiguration,
                 reasoningSnapshot: reasoningSnapshot
             )
         }

--- a/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
+++ b/Tests/AynaTests/WatchSyncChatViewModelNativeTests.swift
@@ -1720,7 +1720,9 @@
             onToolCall: (@Sendable (String, String, [String: Any]) async -> String)?,
             onToolCallRequested: (@Sendable (String, String, [String: Any]) -> Void)?,
             onReasoning: (@Sendable (String) -> Void)?,
-            requestFlightID: RequestFlightID?
+            onReasoningContinuation: (@Sendable (ReasoningContinuationState) -> Void)?,
+            requestFlightID: RequestFlightID?,
+            reasoningSnapshot: AIReasoningRequestSnapshot?
         ) -> AITextRequest {
             capturedRequests.update {
                 $0.append(
@@ -1749,7 +1751,9 @@
                 onToolCall: onToolCall,
                 onToolCallRequested: onToolCallRequested,
                 onReasoning: onReasoning,
-                requestFlightID: requestFlightID
+                onReasoningContinuation: onReasoningContinuation,
+                requestFlightID: requestFlightID,
+                reasoningSnapshot: reasoningSnapshot
             )
         }
     }

--- a/Tests/AynaTests/WatchSyncProtocolTests.swift
+++ b/Tests/AynaTests/WatchSyncProtocolTests.swift
@@ -73,11 +73,19 @@ struct WatchSyncProtocolTests {
     func `Long model identifiers remain exact through compact configuration build Codable and reconcile`() throws {
         let maximumModelCharacters = 16
         let model = "custom-provider/" + String(repeating: "configuration-segment-", count: 12)
+        let reasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .max,
+            openAIMode: .pro,
+            openAIContext: .allTurns,
+            summary: .detailed
+        )
         #expect(model.count > maximumModelCharacters)
         let phone = Conversation(
             title: "Manifest only",
             model: model,
-            temperature: 0.25
+            temperature: 0.25,
+            reasoningConfiguration: reasoningConfiguration
         )
         var configuration = WatchSyncPayloadConfiguration.default
         configuration.maximumConversations = 0
@@ -108,8 +116,10 @@ struct WatchSyncProtocolTests {
 
         #expect(decoded.conversations.isEmpty)
         #expect(compactConfiguration.model == model)
+        #expect(compactConfiguration.reasoningConfiguration == reasoningConfiguration)
         #expect(settingsByModel[compactConfiguration.model] == "exact-settings")
         #expect(reconciled.model == model)
+        #expect(reconciled.reasoningConfiguration == reasoningConfiguration)
         #expect(reconciled.messages == [retainedMessage])
         #expect(settingsByModel[reconciled.model] == "exact-settings")
     }
@@ -871,14 +881,23 @@ struct WatchSyncProtocolTests {
     }
 
     @Test
-    func `Configuration mutation updates model and temperature without replacing phone prompt`() throws {
+    func `Configuration mutation updates request settings without replacing phone prompt`() throws {
         let conversationID = UUID()
+        let phoneReasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .low
+        )
+        let watchReasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .xhigh
+        )
         var phone = Conversation(
             id: conversationID,
             title: "Phone",
             model: "old-model",
             systemPromptMode: .custom("phone prompt"),
-            temperature: 0.4
+            temperature: 0.4,
+            reasoningConfiguration: phoneReasoningConfiguration
         )
         phone.pendingAutoSendPrompt = "pending"
         let watch = WatchConversation(
@@ -888,6 +907,7 @@ struct WatchSyncProtocolTests {
             updatedAt: Date(timeIntervalSince1970: 2),
             createdAt: Date(timeIntervalSince1970: 1),
             temperature: 0.9,
+            reasoningConfiguration: watchReasoningConfiguration,
             resolvedSystemPrompt: "stale resolved prompt",
             watchRevision: 1
         )
@@ -905,6 +925,7 @@ struct WatchSyncProtocolTests {
 
         #expect(updated.model == "new-model")
         #expect(updated.temperature == 0.9)
+        #expect(updated.reasoningConfiguration == watchReasoningConfiguration)
         #expect(updated.systemPromptMode == .custom("phone prompt"))
         #expect(updated.pendingAutoSendPrompt == "pending")
     }
@@ -1100,6 +1121,10 @@ struct WatchSyncProtocolTests {
     func `Partial legacy coverage suppresses delivered fields but retains unsupported configuration`() throws {
         let conversationID = UUID()
         let messageID = UUID()
+        let localReasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .high
+        )
         let deliveredMessage = WatchMessage(
             id: messageID,
             role: Message.Role.user.rawValue,
@@ -1113,6 +1138,7 @@ struct WatchSyncProtocolTests {
             model: "watch-model",
             updatedAt: Date(timeIntervalSince1970: 2),
             createdAt: Date(timeIntervalSince1970: 1),
+            reasoningConfiguration: localReasoningConfiguration,
             watchRevision: 2
         )
         let pending = WatchConversationMutation(
@@ -1161,6 +1187,7 @@ struct WatchSyncProtocolTests {
         #expect(visible.title == "Phone title")
         #expect(visible.messages == [phoneMessage])
         #expect(visible.model == "watch-model")
+        #expect(visible.reasoningConfiguration == localReasoningConfiguration)
         #expect(result.state.pendingMutations == [pending])
     }
 
@@ -1451,6 +1478,10 @@ struct WatchSyncProtocolTests {
     func `Source replacement preserves a manifest-listed cached body omitted by bounds`() throws {
         let oldSourceID = UUID()
         let newSourceID = UUID()
+        let reasoningConfiguration = ModelReasoningConfiguration(
+            activation: .enabled,
+            effort: .high
+        )
         var cached = makeWatchConversation(title: "Cached body", updatedAt: 20)
         cached.model = "old-model"
         let stale = makeWatchConversation(title: "Old phone only", updatedAt: 10)
@@ -1470,6 +1501,7 @@ struct WatchSyncProtocolTests {
                     id: cached.id,
                     model: "new-model",
                     temperature: 0.2,
+                    reasoningConfiguration: reasoningConfiguration,
                     resolvedSystemPrompt: "new prompt"
                 )
             ],
@@ -1484,6 +1516,7 @@ struct WatchSyncProtocolTests {
         #expect(retained.title == "Cached body")
         #expect(retained.model == "new-model")
         #expect(retained.temperature == 0.2)
+        #expect(retained.reasoningConfiguration == reasoningConfiguration)
         #expect(retained.resolvedSystemPrompt == "new prompt")
     }
 

--- a/Tests/AynaTests/WatchSyncProtocolTests.swift
+++ b/Tests/AynaTests/WatchSyncProtocolTests.swift
@@ -2815,6 +2815,45 @@ struct WatchSyncProtocolTests {
     }
 
     @Test
+    func `Payload builder drops oversized opaque reasoning state without removing the message`() throws {
+        let continuation = ReasoningContinuationState(
+            format: .openAIResponses,
+            items: [AnyCodable([
+                "type": "reasoning",
+                "encrypted_content": String(repeating: "opaque", count: 400)
+            ])]
+        )
+        let conversation = Conversation(
+            id: UUID(),
+            title: "Opaque reasoning",
+            messages: [
+                Message(
+                    role: .assistant,
+                    content: "Keep the visible answer",
+                    reasoningContinuation: continuation
+                ),
+            ],
+            model: "gpt-5.6"
+        )
+        var configuration = WatchSyncPayloadConfiguration(
+            byteBudget: 100_000,
+            maximumConversations: 1,
+            maximumMessagesPerConversation: 1
+        )
+        configuration.maximumReasoningContinuationBytes = 256
+
+        let result = try WatchSyncPayloadBuilder.build(
+            conversations: [conversation],
+            snapshotRevision: 1,
+            configuration: configuration
+        )
+        let message = try #require(result.snapshot.conversations.first?.messages.first)
+
+        #expect(message.content == "Keep the visible answer")
+        #expect(message.reasoningContinuation == nil)
+    }
+
+    @Test
     func `Large durable acknowledgement and tombstone history still produces a bounded snapshot`() throws {
         let conversations = (0 ..< 20).map { index in
             Conversation(


### PR DESCRIPTION
## Summary

- add conservative, endpoint-aware reasoning support for OpenAI Chat Completions, OpenAI Responses, and Anthropic adaptive/extended thinking
- move reasoning configuration out of model settings and into a compact chat composer control with an effort slider and advanced provider controls on macOS and iOS
- persist one reasoning configuration per conversation, intersect supported controls for multi-model chats, and carry the configuration through retries, tool continuations, lazy loading, and Watch sync
- preserve opaque OpenAI and Anthropic reasoning state through tool loops while freezing the originating model, provider, endpoint, and request settings
- keep unsupported, image-generation, Apple Intelligence, and unknown/custom model behavior conservative unless explicitly enabled

## Testing

- `swiftlint --strict` — 0 violations
- `swift build`
- `swift build --triple arm64-apple-ios26.0`
- generic `Ayna-watchOS` device build — arm64 and arm64_32 succeeded
- focused macOS reasoning, persistence, presentation, and iOS view-model suites — 173 tests passed
- focused Watch host suites — 164 tests passed across 16 suites
- native `WatchSyncChatViewModelNativeTests` — 35 tests passed
- changed Watch publication regression rerun independently — passed
- `git diff --check`

## Test runner note

A full parallel `swift test` exercised 1,359 tests across 118 suites. It reported 18 timing/contention issues in existing async-heavy tests under the loaded local runner; all touched reasoning and Watch suites pass independently.
